### PR TITLE
Align CI workflows with issue #4

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: cargo clippy
         if: steps.detect.outputs.has-workspace == 'true'
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: cargo test
         if: steps.detect.outputs.has-workspace == 'true'
-        run: cargo test --all --all-targets
+        run: cargo test --workspace --all-targets

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -25,53 +25,22 @@ jobs:
         run: |
           set -euo pipefail
           project=""
-          manager=""
-          lockfile=""
 
           if [ -f web/package.json ]; then
             project="web"
-            if [ -f web/pnpm-lock.yaml ]; then
-              manager="pnpm"
-              lockfile="web/pnpm-lock.yaml"
-            elif [ -f web/package-lock.json ]; then
-              manager="npm"
-              lockfile="web/package-lock.json"
-            elif python3 - <<'PY'
-from pathlib import Path
-import json
-
-pkg = Path('web/package.json')
-data = json.loads(pkg.read_text())
-manager = data.get('packageManager', '')
-raise SystemExit(0 if manager.startswith('pnpm@') else 1)
-PY
-            then
-              manager="pnpm"
-            fi
           elif [ -f package.json ]; then
             project="."
-            if [ -f pnpm-lock.yaml ]; then
-              manager="pnpm"
-              lockfile="pnpm-lock.yaml"
-            elif [ -f package-lock.json ]; then
-              manager="npm"
-              lockfile="package-lock.json"
-            elif python3 - <<'PY'
-from pathlib import Path
-import json
-
-pkg = Path('package.json')
-data = json.loads(pkg.read_text())
-manager = data.get('packageManager', '')
-raise SystemExit(0 if manager.startswith('pnpm@') else 1)
-PY
-            then
-              manager="pnpm"
-            fi
           fi
 
           echo "project=${project}" >>"$GITHUB_OUTPUT"
-          echo "package_manager=${manager}" >>"$GITHUB_OUTPUT"
+
+          lockfile=""
+          if [ "${project}" = "web" ]; then
+            lockfile="web/package-lock.json"
+          elif [ "${project}" = "." ]; then
+            lockfile="package-lock.json"
+          fi
+
           echo "lockfile=${lockfile}" >>"$GITHUB_OUTPUT"
 
       - name: No frontend project detected
@@ -83,26 +52,11 @@ PY
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: ${{ steps.detect.outputs.package_manager == 'pnpm' && 'pnpm' || 'npm' }}
+          cache: npm
           cache-dependency-path: ${{ steps.detect.outputs.lockfile }}
 
-      - name: Enable pnpm via corepack
-        if: steps.detect.outputs.package_manager == 'pnpm'
-        run: |
-          set -euo pipefail
-          corepack enable
-          corepack prepare pnpm@latest --activate
-
-      - name: Install dependencies (pnpm)
-        if: steps.detect.outputs.project != '' && steps.detect.outputs.package_manager == 'pnpm'
-        shell: bash
-        working-directory: ${{ steps.detect.outputs.project }}
-        run: |
-          set -euo pipefail
-          pnpm install --frozen-lockfile
-
-      - name: Install dependencies (npm)
-        if: steps.detect.outputs.project != '' && steps.detect.outputs.package_manager != 'pnpm'
+      - name: Install dependencies
+        if: steps.detect.outputs.project != ''
         shell: bash
         working-directory: ${{ steps.detect.outputs.project }}
         run: |
@@ -113,50 +67,38 @@ PY
             npm install
           fi
 
-      - name: Run lint script
+      - name: npm run lint
         if: steps.detect.outputs.project != ''
         shell: bash
         working-directory: ${{ steps.detect.outputs.project }}
         run: |
           set -euo pipefail
           if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts.lint ? 0 : 1);"; then
-            if [ "${{ steps.detect.outputs.package_manager }}" = "pnpm" ]; then
-              pnpm run lint
-            else
-              npm run lint
-            fi
+            npm run lint
           else
             echo "No lint script declared; skipping lint." >>"$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Run test script
+      - name: npm run test -- --runInBand
         if: steps.detect.outputs.project != ''
         shell: bash
         working-directory: ${{ steps.detect.outputs.project }}
         run: |
           set -euo pipefail
           if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts.test ? 0 : 1);"; then
-            if [ "${{ steps.detect.outputs.package_manager }}" = "pnpm" ]; then
-              pnpm run test -- --watch=false
-            else
-              npm run test -- --watch=false
-            fi
+            npm run test -- --runInBand
           else
             echo "No test script declared; skipping web tests." >>"$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Run build script
+      - name: npm run build
         if: steps.detect.outputs.project != ''
         shell: bash
         working-directory: ${{ steps.detect.outputs.project }}
         run: |
           set -euo pipefail
           if node -e "const scripts = require('./package.json').scripts || {}; process.exit(scripts.build ? 0 : 1);"; then
-            if [ "${{ steps.detect.outputs.package_manager }}" = "pnpm" ]; then
-              pnpm run build
-            else
-              npm run build
-            fi
+            npm run build
           else
             echo "No build script declared; skipping web build." >>"$GITHUB_STEP_SUMMARY"
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We ship a fully provisioned VS Code dev container under `.devcontainer/devcontai
 
 1. Install the **Dev Containers** VS Code extension (or `devcontainer` CLI).
 2. Run **Dev Containers: Reopen in Container** from the command palette after opening the repo root.
-3. The container installs Rust (with `rustfmt`/`clippy`), Node 24 with `pnpm`, Terraform 1.6, Docker CLI access, and bootstraps `pre-commit` hooks.
+3. The container installs Rust (with `rustfmt`/`clippy`), Node 24 with npm 10, Terraform 1.6, Docker CLI access, and bootstraps `pre-commit` hooks.
 4. Use the mounted Docker socket to exercise `docker compose -f infra/docker-compose.yml up --build` without leaving the container.
 
 ## 3. Environment Configuration
@@ -32,10 +32,10 @@ Run these commands before opening a pull request. They mirror the required GitHu
 | --- | --- |
 | Repository hygiene | `pre-commit run --all-files` |
 | Rust workspace | `cargo fmt --all`, `cargo clippy --all-targets --all-features`, `cargo test --all --all-targets` |
-| Web portal | `pnpm install --frozen-lockfile` (first run) then `pnpm run lint` and `pnpm run test -- --watch=false` from the portal root |
+| Web portal | `npm install` (first run) then `npm run lint` and `npm run test -- --watch=false` from the portal root |
 | Infrastructure | `terraform fmt -check`, `terraform validate`, `tflint`, `docker compose config`, `kubeconform ./infra` |
 | Containers | `docker compose -f infra/docker-compose.yml up --build` (ensure planner, executors, policy gate, and Postgres boot) |
-| Security baseline | `cargo audit`, `pnpm audit --audit-level high`, `tfsec`, `trivy config .` |
+| Security baseline | `cargo audit`, `npm audit --audit-level high`, `tfsec`, `trivy config .` |
 
 Document the commands you executed in your pull-request description, along with any manual verification (screenshots, logs, trace IDs) required by the Definition of Done.
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ M0 tasks are broken into single-day issues (1 developer each) and tracked in Git
 1. **Read the concept:** Start with `docs/product_concept_v1.md` to understand goals, architecture, and milestones.
 2. **Review the working agreements:** `docs/working_agreements.md` defines Definition of Ready, Definition of Done, and acceptance-criteria expectations.
 3. **Review contributor workflow:** `CONTRIBUTING.md` covers the dev container setup, required environment files, and smoke tests expected before PRs.
-4. **Set up tooling:** Install Docker, Rust 1.78+, Node 24+, `pnpm`, and Terraform 1.6+. Local development will rely on `docker compose` once the services land.
+4. **Set up tooling:** Install Docker, Rust 1.78+, Node 24+ (with npm 10+), and Terraform 1.6+. Local development will rely on `docker compose` once the services land.
 5. **Clone & branch:** Fork/clone the repo, create branches as `<issue-number>-<slug>` (e.g., `issue-18-landing-page`).
-6. **Follow CI workflows:** Run the same commands locally that GitHub Actions enforces (`cargo fmt/clippy/test`, `pnpm lint/test/build`, Terraform/Compose/Kubernetes validations).
+6. **Follow CI workflows:** Run the same commands locally that GitHub Actions enforces (`cargo fmt/clippy/test`, `npm run lint/test/build`, Terraform/Compose/Kubernetes validations).
 7. **Open PRs:** Reference the issue, list validation steps, attach screenshots/logs, ensure all Actions workflows succeed.
 
 ## Key Documents

--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -348,7 +348,7 @@ Milestones are cumulative; later milestones build on earlier ones.
 - **Container build smoke workflow**
   - `ci-containers` builds core Docker images with BuildKit and executes `docker run --rm` health checks on main merges.
 - **Security baseline workflow**
-  - Scheduled `security-baseline` job executes `cargo audit`, `pnpm audit --audit-level high`, `tfsec`, and `trivy config` against the repo, alerting on failures.
+  - Scheduled `security-baseline` job executes `cargo audit`, `npm audit --audit-level high`, `tfsec`, and `trivy config` against the repo, alerting on failures.
 - **Policy check service skeleton**
   - Rust 2024 service exposes `POST /policy/check` with static spend/PII/legal rules returning structured decisions and unit tests for approve/deny/escalate.
 - **Consent UX stub**

--- a/docs/working_agreements.md
+++ b/docs/working_agreements.md
@@ -31,7 +31,7 @@ An issue reaches **Done** only when all criteria below are satisfied:
 - **Manual QA (if required):** High-risk flows (auth, payments, policy enforcement) include manual test notes or screen recordings.
 - **Documentation Updated:** README, `docs/`, API docs, and runbooks reflect new behaviour, flags, or operational steps. Changelog entries are added when externally visible.
 - **Observability Wired:** Metrics, logs, and traces are instrumented or updated. Dashboards/alerts referenced in acceptance criteria are validated.
-- **Security Compliance:** Secrets remain managed via approved vaults; dependency updates pass `cargo audit`, `pnpm audit`, `tfsec`, and `trivy`. Threat considerations are documented for data-sensitive work.
+- **Security Compliance:** Secrets remain managed via approved vaults; dependency updates pass `cargo audit`, `npm audit`, `tfsec`, and `trivy`. Threat considerations are documented for data-sensitive work.
 - **Backwards Compatibility:** Migration scripts are tested with up/down paths; fallback strategies are documented. Feature flags include rollback instructions.
 - **Peer Review Completed:** At least one reviewer signs off. Review conversations are resolved or tracked for follow-up.
 - **Merge & Cleanup:** Feature branches are merged to `main`, stale branches are removed, and the linked GitHub Issue is closed with a completion note.
@@ -40,7 +40,7 @@ An issue reaches **Done** only when all criteria below are satisfied:
 ## 4. Acceptance Criteria Guidelines
 - Write acceptance criteria as bullet points beginning with observable outcomes (e.g., “Given… When… Then…” or “Script X outputs status Y”).
 - Include success AND failure behaviours. Specify expected errors, policy escalations, and retry behaviour.
-- Reference the exact command(s) or endpoints to validate the change (e.g., `cargo test -p planner`, `pnpm test --runInBand`, `terraform plan`).
+- Reference the exact command(s) or endpoints to validate the change (e.g., `cargo test -p planner`, `npm run test -- --runInBand`, `terraform plan`).
 - Quantify non-functional requirements (latency, throughput, Lighthouse score, token usage, cost ceiling).
 - Attach verification artifacts (screenshots, trace IDs, log snippets) to issues or link to the relevant dashboard panel.
 - Update or extend acceptance criteria whenever scope changes during implementation; the issue owner is responsible for keeping them current.

--- a/scripts/pre-commit/npm-lint.sh
+++ b/scripts/pre-commit/npm-lint.sh
@@ -11,49 +11,9 @@ else
   exit 0
 fi
 
-manager="npm"
-if [ -f "${root}/pnpm-lock.yaml" ]; then
-  manager="pnpm"
-elif ROOT="${root}" python3 <<'PY'
-from pathlib import Path
-import json
-import os
-
-pkg = Path(os.environ["ROOT"]) / "package.json"
-data = json.loads(pkg.read_text())
-manager = data.get("packageManager", "")
-raise SystemExit(0 if manager.startswith("pnpm@") else 1)
-PY
-then
-  manager="pnpm"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm not found; install Node.js to run frontend linting." >&2
+  exit 1
 fi
 
-run_with_pnpm() {
-  if ! command -v pnpm >/dev/null 2>&1; then
-    if command -v corepack >/dev/null 2>&1; then
-      corepack enable >/dev/null 2>&1 || true
-      corepack prepare pnpm@latest --activate >/dev/null 2>&1 || true
-    fi
-  fi
-
-  if ! command -v pnpm >/dev/null 2>&1; then
-    echo "pnpm not found; install Node.js 20+ with pnpm (via corepack) to run frontend linting." >&2
-    exit 1
-  fi
-
-  (cd "${root}" && pnpm run lint)
-}
-
-run_with_npm() {
-  if ! command -v npm >/dev/null 2>&1; then
-    echo "npm not found; install Node.js to run frontend linting." >&2
-    exit 1
-  fi
-  npm --prefix "${root}" run lint
-}
-
-if [ "${manager}" = "pnpm" ]; then
-  run_with_pnpm
-else
-  run_with_npm
-fi
+npm --prefix "${root}" run lint

--- a/scripts/pre-commit/npm-test.sh
+++ b/scripts/pre-commit/npm-test.sh
@@ -11,49 +11,9 @@ else
   exit 0
 fi
 
-manager="npm"
-if [ -f "${root}/pnpm-lock.yaml" ]; then
-  manager="pnpm"
-elif ROOT="${root}" python3 <<'PY'
-from pathlib import Path
-import json
-import os
-
-pkg = Path(os.environ["ROOT"]) / "package.json"
-data = json.loads(pkg.read_text())
-manager = data.get("packageManager", "")
-raise SystemExit(0 if manager.startswith("pnpm@") else 1)
-PY
-then
-  manager="pnpm"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm not found; install Node.js to run frontend tests." >&2
+  exit 1
 fi
 
-run_with_pnpm() {
-  if ! command -v pnpm >/dev/null 2>&1; then
-    if command -v corepack >/dev/null 2>&1; then
-      corepack enable >/dev/null 2>&1 || true
-      corepack prepare pnpm@latest --activate >/dev/null 2>&1 || true
-    fi
-  fi
-
-  if ! command -v pnpm >/dev/null 2>&1; then
-    echo "pnpm not found; install Node.js 20+ with pnpm (via corepack) to run frontend tests." >&2
-    exit 1
-  fi
-
-  (cd "${root}" && pnpm run test -- --watch=false)
-}
-
-run_with_npm() {
-  if ! command -v npm >/dev/null 2>&1; then
-    echo "npm not found; install Node.js to run frontend tests." >&2
-    exit 1
-  fi
-  npm --prefix "${root}" run test -- --watch=false
-}
-
-if [ "${manager}" = "pnpm" ]; then
-  run_with_pnpm
-else
-  run_with_npm
-fi
+npm --prefix "${root}" run test -- --runInBand

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run --run"
+    "test": "node ./scripts/run-tests.mjs"
   },
   "dependencies": {
     "next": "15.0.3",

--- a/web/scripts/run-tests.mjs
+++ b/web/scripts/run-tests.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+
+const rawArgs = process.argv.slice(2);
+const forwardedArgs = rawArgs.filter((arg) => arg !== '--runInBand');
+const sequenced = rawArgs.includes('--runInBand');
+
+const hasSubcommand = forwardedArgs.length > 0 && !forwardedArgs[0].startsWith('-');
+
+if (!hasSubcommand) {
+  forwardedArgs.unshift('run');
+}
+
+if (sequenced) {
+  if (!forwardedArgs.some((arg) => arg === '--maxWorkers' || arg.startsWith('--maxWorkers='))) {
+    forwardedArgs.push('--maxWorkers', '1');
+  }
+
+  if (!forwardedArgs.some((arg) => arg === '--minWorkers' || arg.startsWith('--minWorkers='))) {
+    forwardedArgs.push('--minWorkers', '1');
+  }
+
+  const hasFileParallelOverride = forwardedArgs.some((arg) =>
+    arg === '--no-file-parallelism' || arg.startsWith('--fileParallelism')
+  );
+
+  if (!hasFileParallelOverride) {
+    forwardedArgs.push('--no-file-parallelism');
+  }
+}
+
+const require = createRequire(import.meta.url);
+const vitestPackage = require.resolve('vitest/package.json');
+const vitestBin = join(dirname(vitestPackage), 'vitest.mjs');
+
+const child = spawn(process.execPath, [vitestBin, ...forwardedArgs], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ensure the Rust workflow runs `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace --all-targets` on pull requests
- update the web workflow to install with npm and run `npm run lint`, `npm run test -- --runInBand`, and `npm run build`
- add a Vitest wrapper so `npm run test -- --runInBand` forces single-worker execution without flag errors and align docs/hooks on npm tooling

## Testing
- `pre-commit run --all-files`
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`

Closes #4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch frontend from pnpm to npm across CI/hooks/docs, add a Vitest wrapper to support --runInBand, and update Rust CI to use --workspace flags.
> 
> - **CI**:
>   - **Web (`.github/workflows/ci-web.yml`)**: Simplify detection; standardize on npm caching/installs; run `npm run lint`, `npm run test -- --runInBand`, and `npm run build`; remove pnpm/corepack paths.
>   - **Rust (`.github/workflows/ci-rust.yml`)**: Use `--workspace` for `clippy` and `test`.
> - **Pre-commit Hooks**:
>   - Replace pnpm-aware scripts with npm-only: `scripts/pre-commit/npm-lint.sh`, `scripts/pre-commit/npm-test.sh` (tests run `--runInBand`).
> - **Web App**:
>   - Update `web/package.json` test script to `node ./scripts/run-tests.mjs`.
>   - Add `web/scripts/run-tests.mjs` to call Vitest and enforce single-worker when `--runInBand` is passed.
> - **Docs**:
>   - Replace `pnpm` with npm in `README.md`, `CONTRIBUTING.md`, `docs/working_agreements.md`, and `docs/product_concept_v1.md`; update audit commands to `npm audit` and tooling notes (Node with npm 10).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a009536f6f964aceac272329ab36c19eeb8c7fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->