### PR TITLE
Refine ci-iac workflow coverage

### DIFF
--- a/.github/workflows/ci-iac.yml
+++ b/.github/workflows/ci-iac.yml
@@ -63,6 +63,7 @@ jobs:
             fi
           else
             echo "has-terraform=false" >>"$GITHUB_OUTPUT"
+            echo "terraform_files=" >>"$GITHUB_OUTPUT"
             echo "terraform_dirs=" >>"$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- reuse a single discovery step to share Terraform, Compose, and Kubernetes asset lists across the workflow
- split IaC validation into discrete Terraform fmt/validate/tflint, docker compose, and kubeconform steps so failures surface clearly
- pin kubeconform installation to v0.6.7 and add job-level Terraform automation env defaults

## Validation
- `pre-commit run --all-files`

## Acceptance Criteria
- [x] `ci-iac` workflow runs `terraform fmt -check`, `terraform validate`, `tflint`, `docker compose config`, and `kubeconform` on each PR.
- [x] Workflow failures block merges until remedied.

Closes #5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `ci-iac` to share discovered IaC assets across steps, split Terraform fmt/validate/tflint and Compose/Kubeconform checks, and pin kubeconform v0.6.7 with safer filtering.
> 
> - **Workflow**:
>   - Centralizes IaC discovery; exposes `terraform_files`, `terraform_dirs`, `compose_files`, `kube_files`, and booleans via `GITHUB_OUTPUT`.
>   - Adds job env: `TF_IN_AUTOMATION=true`, `TF_INPUT=0`, `KUBECONFORM_VERSION=0.6.7`.
> - **Terraform**:
>   - Splits into discrete steps: `terraform fmt`, `terraform validate`, and `tflint`.
>   - Consumes `terraform_dirs` from discovery; filters entries and handles empty sets gracefully.
> - **Docker Compose**:
>   - Consumes `compose_files` from discovery; filters CRs, validates existence, and de-duplicates before `docker compose config`.
> - **Kubernetes**:
>   - Pins kubeconform install to `v0.6.7`, installs to `$HOME/.local/bin`, adds to `PATH`.
>   - Consumes `kube_files` from discovery; filters/validates file list before `kubeconform --strict`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dab586e8aab1eb4f883b2d5c90ef5ee757ad1f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->