### PR TITLE
Add consent UX stub

### DIFF
--- a/web/app/consent/__snapshots__/page.test.tsx.snap
+++ b/web/app/consent/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ConsentReviewPage > renders the consent chat shell 1`] = `
+<main
+  class="consent-container"
+>
+  <section
+    aria-labelledby="consent-heading"
+    class="consent-panel"
+  >
+    <header
+      class="consent-header"
+    >
+      <h1
+        id="consent-heading"
+      >
+        Consent Review
+      </h1>
+      <p>
+        Review what the planner will share and approve the guardrails before the automation proceeds.
+      </p>
+    </header>
+    <div
+      aria-label="Consent conversation"
+      aria-live="polite"
+      class="consent-chat"
+      role="log"
+    >
+      <article
+        aria-label="Planner message"
+        class="chat-bubble chat-planner"
+      >
+        <span
+          class="chat-author"
+        >
+          Planner
+        </span>
+        <p>
+          I can confirm your calendar gaps and vendor preferences. Ready for me to book the flight hold and follow up with loyalty support?
+        </p>
+      </article>
+      <article
+        aria-label="Planner message"
+        class="chat-bubble chat-planner"
+      >
+        <span
+          class="chat-author"
+        >
+          Planner
+        </span>
+        <p>
+          Spend cap: $300. Data shared: departure time, preferred airlines, and loyalty IDs. Escalation trigger: anything over budget or missing authorization.
+        </p>
+      </article>
+    </div>
+    <footer
+      class="consent-actions"
+    >
+      <button
+        aria-live="polite"
+        class="approve-button"
+        type="button"
+      >
+        Approve and continue
+      </button>
+      <dl
+        aria-label="Policy response summary"
+        class="decision-callout"
+      >
+        <dt>
+          Audit reference
+        </dt>
+        <dd>
+          Pending
+        </dd>
+        <dt>
+          Status
+        </dt>
+        <dd>
+          Awaiting response
+        </dd>
+      </dl>
+    </footer>
+  </section>
+</main>
+`;

--- a/web/app/consent/mockPolicy.ts
+++ b/web/app/consent/mockPolicy.ts
@@ -1,0 +1,23 @@
+export type PolicyDecisionStatus = "approved" | "denied" | "escalated";
+
+export interface PolicyDecision {
+  status: PolicyDecisionStatus;
+  reason: string;
+  evidence: string;
+}
+
+/**
+ * requestConsentApproval simulates a policy decision by returning
+ * a mocked approval payload. The promise timing matches a network
+ * round-trip so the UX can show progress states without waiting
+ * on real services yet.
+ */
+export async function requestConsentApproval(): Promise<PolicyDecision> {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+
+  return {
+    status: "approved",
+    reason: "Planned spend sits within budget guardrails and vendor scope.",
+    evidence: "policy-mock-001",
+  };
+}

--- a/web/app/consent/page.test.tsx
+++ b/web/app/consent/page.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ConsentReviewPage from "./page";
+import * as mockPolicy from "./mockPolicy";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConsentReviewPage", () => {
+  it("renders the consent chat shell", () => {
+    const { container } = render(<ConsentReviewPage />);
+    expect(screen.getByRole("heading", { name: /consent review/i })).toBeVisible();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("routes approval clicks through the mocked policy response", async () => {
+    const decision = {
+      status: "approved" as const,
+      reason: "All guardrails satisfied in mock policy.",
+      evidence: "test-policy-123",
+    };
+    const policySpy = vi
+      .spyOn(mockPolicy, "requestConsentApproval")
+      .mockResolvedValue(decision);
+
+    const user = userEvent.setup();
+    render(<ConsentReviewPage />);
+
+    await user.click(screen.getByRole("button", { name: /approve and continue/i }));
+
+    expect(policySpy).toHaveBeenCalledTimes(1);
+
+    const log = await screen.findByRole("log");
+    const policyMessage = within(log).getByText((content) => content.includes(decision.evidence));
+    expect(policyMessage).toBeVisible();
+
+    const summary = screen.getByLabelText(/policy response summary/i);
+    expect(within(summary).getByText(decision.evidence)).toBeVisible();
+    expect(within(summary).getByText(/Approved/i)).toBeVisible();
+
+    expect(screen.getByRole("button", { name: /Approved/i })).toBeDisabled();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("surfaces an error when the policy request fails", async () => {
+    const policySpy = vi
+      .spyOn(mockPolicy, "requestConsentApproval")
+      .mockRejectedValue(new Error("Mock policy outage"));
+
+    const user = userEvent.setup();
+    render(<ConsentReviewPage />);
+
+    await user.click(screen.getByRole("button", { name: /approve and continue/i }));
+
+    expect(policySpy).toHaveBeenCalledTimes(1);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/mock policy outage/i);
+
+    const log = screen.getByRole("log");
+    expect(within(log).getByText(/policy decision: failed/i)).toBeVisible();
+
+    const summary = screen.getByLabelText(/policy response summary/i);
+    expect(within(summary).getAllByText(/Unavailable/i)).toHaveLength(2);
+
+    expect(screen.getByRole("button", { name: /approve and continue/i })).toBeEnabled();
+  });
+});

--- a/web/app/consent/page.tsx
+++ b/web/app/consent/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React, { useMemo, useRef, useState } from "react";
+import type { PolicyDecision } from "./mockPolicy";
+import { requestConsentApproval } from "./mockPolicy";
+
+type MessageAuthor = "planner" | "user" | "policy";
+
+interface ChatMessage {
+  id: string;
+  author: MessageAuthor;
+  body: string;
+}
+
+const AUTHOR_LABEL: Record<MessageAuthor, string> = {
+  planner: "Planner",
+  user: "You",
+  policy: "Policy Engine",
+};
+
+const INITIAL_MESSAGES: ChatMessage[] = [
+  {
+    id: "planner-intro",
+    author: "planner",
+    body: "I can confirm your calendar gaps and vendor preferences. Ready for me to book the flight hold and follow up with loyalty support?",
+  },
+  {
+    id: "planner-scope",
+    author: "planner",
+    body: "Spend cap: $300. Data shared: departure time, preferred airlines, and loyalty IDs. Escalation trigger: anything over budget or missing authorization.",
+  },
+];
+
+const STATUS_LABEL: Record<PolicyDecision["status"], string> = {
+  approved: "Approved",
+  denied: "Denied",
+  escalated: "Escalated",
+};
+
+function formatPolicyDecision(decision: PolicyDecision) {
+  return `Policy decision: ${STATUS_LABEL[decision.status]}. ${decision.reason} Evidence: ${decision.evidence}.`;
+}
+
+export default function ConsentReviewPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>(INITIAL_MESSAGES);
+  const [decision, setDecision] = useState<PolicyDecision | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const messageIdRef = useRef(0);
+
+  const nextMessageId = () => {
+    messageIdRef.current += 1;
+    return `message-${messageIdRef.current}`;
+  };
+
+  const hasUserAction = useMemo(
+    () => messages.some((message) => message.author === "user"),
+    [messages],
+  );
+
+  const handleApprove = async () => {
+    if (isProcessing || decision) {
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+
+    if (!hasUserAction) {
+      setMessages((current) => [
+        ...current,
+        {
+          id: nextMessageId(),
+          author: "user",
+          body: "Approve this plan and keep an audit trail.",
+        },
+      ]);
+    }
+
+    try {
+      const policyDecision = await requestConsentApproval();
+      setDecision(policyDecision);
+      setMessages((current) => [
+        ...current,
+        {
+          id: nextMessageId(),
+          author: "policy",
+          body: formatPolicyDecision(policyDecision),
+        },
+      ]);
+    } catch (policyError) {
+      setDecision(null);
+      setError(
+        policyError instanceof Error
+          ? policyError.message || "Policy decision unavailable. Try again."
+          : "Policy decision unavailable. Try again.",
+      );
+      setMessages((current) => [
+        ...current,
+        {
+          id: nextMessageId(),
+          author: "policy",
+          body: "Policy decision: Failed. Mock policy service is unavailable. Please retry.",
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const auditLabel = decision ? decision.evidence : error ? "Unavailable" : "Pending";
+  const statusLabel = decision
+    ? STATUS_LABEL[decision.status]
+    : error
+      ? "Unavailable"
+      : "Awaiting response";
+
+  return (
+    <main className="consent-container">
+      <section className="consent-panel" aria-labelledby="consent-heading">
+        <header className="consent-header">
+          <h1 id="consent-heading">Consent Review</h1>
+          <p>
+            Review what the planner will share and approve the guardrails before the
+            automation proceeds.
+          </p>
+        </header>
+
+        <div className="consent-chat" role="log" aria-live="polite" aria-label="Consent conversation">
+          {messages.map((message) => (
+            <article
+              key={message.id}
+              className={`chat-bubble chat-${message.author}`}
+              aria-label={`${AUTHOR_LABEL[message.author]} message`}
+            >
+              <span className="chat-author">{AUTHOR_LABEL[message.author]}</span>
+              <p>{message.body}</p>
+            </article>
+          ))}
+        </div>
+
+        <footer className="consent-actions">
+          <button
+            type="button"
+            className="approve-button"
+            onClick={handleApprove}
+            disabled={isProcessing || Boolean(decision)}
+            aria-live="polite"
+          >
+            {decision ? "Approved" : isProcessing ? "Approving…" : "Approve and continue"}
+          </button>
+
+          <dl className="decision-callout" aria-label="Policy response summary">
+            <dt>Audit reference</dt>
+            <dd>{auditLabel}</dd>
+            <dt>Status</dt>
+            <dd>{statusLabel}</dd>
+          </dl>
+          {error ? (
+            <p className="decision-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </footer>
+      </section>
+    </main>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -39,3 +39,136 @@ p,
 ul {
   padding-left: 1.5rem;
 }
+
+main.consent-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at top, rgba(60, 72, 107, 0.25), transparent 55%);
+}
+
+.consent-panel {
+  width: min(48rem, 100%);
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 30px 60px rgba(7, 10, 17, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.consent-header p {
+  margin: 0;
+  color: rgba(239, 245, 255, 0.72);
+}
+
+.consent-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.chat-bubble {
+  border-radius: 1rem;
+  padding: 0.9rem 1.1rem;
+  background: rgba(30, 41, 69, 0.85);
+  align-self: flex-start;
+  max-width: 32rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  box-shadow: 0 18px 40px rgba(6, 9, 15, 0.45);
+}
+
+.chat-bubble p {
+  margin: 0;
+}
+
+.chat-user {
+  align-self: flex-end;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.35);
+}
+
+.chat-policy {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(30, 58, 95, 0.8);
+}
+
+.chat-author {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.consent-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.approve-button {
+  align-self: flex-start;
+  padding: 0.9rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #0b1120;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.approve-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
+.approve-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(34, 197, 94, 0.35);
+}
+
+.decision-callout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.25rem 1rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.9rem;
+  background: rgba(10, 16, 28, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  font-size: 0.95rem;
+  width: fit-content;
+}
+
+.decision-callout dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.decision-callout dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.decision-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(248, 113, 113, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: rgba(254, 226, 226, 0.92);
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- render a dedicated consent review chat surface with planner, user, and policy bubbles
- wire the approval action to the mocked policy decision payload with audit callouts
- cover the experience with snapshot and interaction tests to lock behaviour

## Acceptance Criteria
- [x] Next.js renders a chat-style prompt with an approval button that calls mocked policy responses.
- [x] Snapshot or component tests assert the rendered state and interaction contract.

## Testing
- pre-commit run --all-files
- npm --prefix web run lint
- npm --prefix web run test -- --runInBand

Closes #9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a consent review chat page that routes approval to a mocked policy decision and adds styles plus tests (snapshot and interaction).
> 
> - **Consent Review UX**:
>   - Adds `web/app/consent/page.tsx` rendering a chat-style interface with `planner`, `user`, and `policy` messages, approval button, and policy status/audit callout.
>   - Integrates mocked policy flow via `requestConsentApproval` from `web/app/consent/mockPolicy.ts`, handling approved, denied/escalated labels, and error states.
> - **Styles**:
>   - Extends `web/app/globals.css` with consent panel, chat bubbles, action button, callout, and error styles.
> - **Tests**:
>   - Adds `web/app/consent/page.test.tsx` covering rendering, approval flow (mocked policy), and error handling.
>   - Includes snapshot in `web/app/consent/__snapshots__/page.test.tsx.snap`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d303bc968321a9700fac8b75cda0d568327ece83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->