### PR TITLE
Add memory schema tables and pgvector validation

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       start_period: 5s
 
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: tyrum
       POSTGRES_PASSWORD: tyrum_dev_password

--- a/services/planner/migrations/0002_create_memory_schema.sql
+++ b/services/planner/migrations/0002_create_memory_schema.sql
@@ -1,0 +1,86 @@
+-- Foundation for Tyrum memory tables and pgvector support.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Canonical truths remembered about a subject (user, contact, vendor).
+CREATE TABLE IF NOT EXISTS facts (
+    id BIGSERIAL PRIMARY KEY,
+    subject_id UUID NOT NULL,
+    fact_key TEXT NOT NULL,
+    fact_value JSONB NOT NULL,
+    source TEXT NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    confidence REAL NOT NULL DEFAULT 1.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE facts IS 'Canonical facts captured about a single subject with provenance and confidence.';
+COMMENT ON COLUMN facts.subject_id IS 'Identity this fact belongs to (user, team, or contact).';
+COMMENT ON COLUMN facts.fact_key IS 'Stable key describing the fact (e.g., home_address, loyalty_id).';
+COMMENT ON COLUMN facts.fact_value IS 'Structured JSON representation of the fact payload.';
+COMMENT ON COLUMN facts.source IS 'Source system or observation responsible for the fact.';
+COMMENT ON COLUMN facts.observed_at IS 'When the fact was observed or last verified.';
+COMMENT ON COLUMN facts.confidence IS 'Confidence score between 0 and 1 that the fact is still valid.';
+COMMENT ON COLUMN facts.created_at IS 'When the fact record was created in Tyrum memory.';
+
+CREATE INDEX IF NOT EXISTS facts_subject_key_idx ON facts (subject_id, fact_key);
+CREATE INDEX IF NOT EXISTS facts_subject_observed_idx ON facts (subject_id, observed_at DESC);
+
+ALTER TABLE facts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY facts_rls_placeholder ON facts USING (true) WITH CHECK (true);
+COMMENT ON POLICY facts_rls_placeholder ON facts IS 'TODO: tighten once subject scoping and authz are wired.';
+
+-- Event-sourced episodic history for coordination and replay.
+CREATE TABLE IF NOT EXISTS episodic_events (
+    id BIGSERIAL PRIMARY KEY,
+    subject_id UUID NOT NULL,
+    event_id UUID NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    channel TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE episodic_events IS 'Event-sourced episodic memory capturing attempts, messages, and outcomes.';
+COMMENT ON COLUMN episodic_events.subject_id IS 'Identity this event belongs to (user, contact, shared context).';
+COMMENT ON COLUMN episodic_events.event_id IS 'Stable external identifier for deduplication and replay.';
+COMMENT ON COLUMN episodic_events.occurred_at IS 'Timestamp when the event occurred in the real world.';
+COMMENT ON COLUMN episodic_events.channel IS 'Channel or medium (telegram, email, web, executor).';
+COMMENT ON COLUMN episodic_events.event_type IS 'High-level classification of the episodic event (message, attempt, observation).';
+COMMENT ON COLUMN episodic_events.payload IS 'Structured JSON payload for the event.';
+COMMENT ON COLUMN episodic_events.created_at IS 'Inserted-at timestamp for the episodic record.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS episodic_events_event_id_idx ON episodic_events (event_id);
+CREATE INDEX IF NOT EXISTS episodic_events_subject_occurred_idx ON episodic_events (subject_id, occurred_at DESC);
+
+ALTER TABLE episodic_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY episodic_events_rls_placeholder ON episodic_events USING (true) WITH CHECK (true);
+COMMENT ON POLICY episodic_events_rls_placeholder ON episodic_events IS 'TODO: scope episodic access per subject once authz is in place.';
+
+-- Vector embeddings enable semantic recall over unstructured artifacts.
+CREATE TABLE IF NOT EXISTS vector_embeddings (
+    id BIGSERIAL PRIMARY KEY,
+    subject_id UUID NOT NULL,
+    embedding_id UUID NOT NULL,
+    embedding vector NOT NULL,
+    embedding_model TEXT NOT NULL,
+    label TEXT,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE vector_embeddings IS 'Semantic embeddings for unstructured artifacts associated with a subject.';
+COMMENT ON COLUMN vector_embeddings.subject_id IS 'Identity this embedding belongs to.';
+COMMENT ON COLUMN vector_embeddings.embedding_id IS 'External identifier for the source artifact.';
+COMMENT ON COLUMN vector_embeddings.embedding IS 'Vector representation stored via pgvector.';
+COMMENT ON COLUMN vector_embeddings.embedding_model IS 'Embedding model or configuration used to produce the vector.';
+COMMENT ON COLUMN vector_embeddings.label IS 'Optional human-friendly label or context for the embedding.';
+COMMENT ON COLUMN vector_embeddings.metadata IS 'Auxiliary JSON metadata (chunk location, tokens, etc.).';
+COMMENT ON COLUMN vector_embeddings.created_at IS 'Inserted-at timestamp for the embedding.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS vector_embeddings_subject_embedding_idx ON vector_embeddings (subject_id, embedding_id);
+CREATE INDEX IF NOT EXISTS vector_embeddings_subject_created_idx ON vector_embeddings (subject_id, created_at DESC);
+
+ALTER TABLE vector_embeddings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY vector_embeddings_rls_placeholder ON vector_embeddings USING (true) WITH CHECK (true);
+COMMENT ON POLICY vector_embeddings_rls_placeholder ON vector_embeddings IS 'TODO: restrict embedding access per subject once authz is defined.';

--- a/services/planner/src/event_log.rs
+++ b/services/planner/src/event_log.rs
@@ -224,8 +224,8 @@ mod tests {
     };
     use tokio::time::sleep;
 
-    const POSTGRES_IMAGE: &str = "postgres";
-    const POSTGRES_TAG: &str = "16-alpine";
+    const POSTGRES_IMAGE: &str = "pgvector/pgvector";
+    const POSTGRES_TAG: &str = "pg16";
     const POSTGRES_USER: &str = "tyrum";
     const POSTGRES_PASSWORD: &str = "tyrum_dev_password";
     const POSTGRES_DB: &str = "tyrum_dev";

--- a/services/planner/tests/memory_schema.rs
+++ b/services/planner/tests/memory_schema.rs
@@ -1,0 +1,169 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use serde_json::json;
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use uuid::Uuid;
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+const POSTGRES_IMAGE: &str = "pgvector/pgvector";
+const POSTGRES_TAG: &str = "pg16";
+const POSTGRES_USER: &str = "tyrum";
+const POSTGRES_PASSWORD: &str = "tyrum_dev_password";
+const POSTGRES_DB: &str = "tyrum_dev";
+
+#[tokio::test(flavor = "current_thread")]
+async fn pgvector_extension_supports_embedding_roundtrip() {
+    let (container, pool) = setup().await;
+    let _container = container;
+
+    let subject_id = Uuid::new_v4();
+
+    sqlx::query(
+        r#"
+        INSERT INTO facts (subject_id, fact_key, fact_value, source, observed_at)
+        VALUES ($1, $2, $3, $4, $5)
+        "#,
+    )
+    .bind(subject_id)
+    .bind("preferred_greeting")
+    .bind(json!({ "value": "Hey team" }))
+    .bind("unit-test")
+    .bind(Utc::now())
+    .execute(&pool)
+    .await
+    .expect("insert fact");
+
+    sqlx::query(
+        r#"
+        INSERT INTO episodic_events (subject_id, event_id, occurred_at, channel, event_type, payload)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(subject_id)
+    .bind(Uuid::new_v4())
+    .bind(Utc::now())
+    .bind("telegram")
+    .bind("message")
+    .bind(json!({ "content": "Ping" }))
+    .execute(&pool)
+    .await
+    .expect("insert episodic event");
+
+    let embedding_id = Uuid::new_v4();
+    let embedding = [0.25_f32, -0.5_f32, 0.75_f32];
+    let embedding_literal = format!(
+        "[{}]",
+        embedding
+            .iter()
+            .map(|component| component.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    sqlx::query(
+        r#"
+        INSERT INTO vector_embeddings (
+            subject_id,
+            embedding_id,
+            embedding_model,
+            embedding,
+            label,
+            metadata
+        )
+        VALUES ($1, $2, $3, $4::vector, $5, $6)
+        "#,
+    )
+    .bind(subject_id)
+    .bind(embedding_id)
+    .bind("text-embedding-3-small")
+    .bind(embedding_literal)
+    .bind(Some("unit test chunk"))
+    .bind(json!({ "source": "test", "chunk": 0 }))
+    .execute(&pool)
+    .await
+    .expect("insert vector embedding");
+
+    let row = sqlx::query(
+        r#"
+        SELECT
+            embedding::float4[] AS components,
+            metadata
+        FROM vector_embeddings
+        WHERE embedding_id = $1
+        "#,
+    )
+    .bind(embedding_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch embedding");
+
+    let stored_embedding: Vec<f32> = row.try_get("components").expect("vector components");
+    assert_eq!(stored_embedding, embedding);
+
+    let stored_metadata: serde_json::Value = row.try_get("metadata").expect("metadata");
+    assert_eq!(stored_metadata["source"], "test");
+}
+
+async fn setup() -> (ContainerAsync<GenericImage>, PgPool) {
+    let image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+        .with_exposed_port(5432.tcp())
+        .with_wait_for(WaitFor::message_on_stdout(
+            "database system is ready to accept connections",
+        ));
+
+    let request = image
+        .with_env_var("POSTGRES_USER", POSTGRES_USER)
+        .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+        .with_env_var("POSTGRES_DB", POSTGRES_DB);
+
+    let container = request.start().await.expect("start postgres container");
+    let host_port = container
+        .get_host_port_ipv4(5432.tcp())
+        .await
+        .expect("map postgres port");
+
+    let database_url = format!(
+        "postgres://{}:{}@127.0.0.1:{}/{}",
+        POSTGRES_USER, POSTGRES_PASSWORD, host_port, POSTGRES_DB
+    );
+
+    let pool = connect_with_retry(&database_url)
+        .await
+        .expect("connect postgres");
+
+    MIGRATOR.run(&pool).await.expect("run migrations");
+
+    (container, pool)
+}
+
+async fn connect_with_retry(database_url: &str) -> Result<PgPool, sqlx::Error> {
+    let mut attempts = 0;
+    let max_attempts = 10;
+
+    loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(database_url)
+            .await
+        {
+            Ok(pool) => break Ok(pool),
+            Err(err) if attempts < max_attempts => {
+                attempts += 1;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                tracing::warn!(
+                    attempts,
+                    "waiting for postgres to accept connections: {err}"
+                );
+            }
+            Err(err) => break Err(err),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations enabling the pgvector extension plus facts, episodic_events, and vector_embeddings tables with placeholder RLS
- switch local + test Postgres images to pgvector/pgvector so the extension is available everywhere
- exercise the new schema via a testcontainers integration test that stores and reads a sample embedding

## Acceptance Criteria
- [x] Database migrations create `facts`, `episodic_events`, and `vector_embeddings` tables with row-level security placeholders.
- [x] `pgvector` extension is enabled and validated by storing and retrieving a sample embedding row.

## Validation
- [x] cargo test -p tyrum-planner
- [x] pre-commit run --all-files

Closes #13
