### PR TITLE
Add portal account export/delete stubs

### DIFF
--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -382,6 +382,7 @@ Milestones are cumulative; later milestones build on earlier ones.
   - Account linking page shows placeholder integration cards and writes preference toggles to Postgres.
 - **Portal export/delete stubs**
   - Export/delete buttons enqueue mocked audit tasks, display toast status, and return deterministic API responses.
+  - Next.js portal route `/portal/settings` surfaces export and deletion controls with `/api/account/export` and `/api/account/delete` stubs returning deterministic audit references.
 - **Terraform baseline**
   - `terraform plan/apply` stands up staging VPC, Kubernetes cluster, and secrets store without manual steps.
 - **Helm chart deployment**

--- a/web/app/api/account/delete/route.ts
+++ b/web/app/api/account/delete/route.ts
@@ -1,0 +1,5 @@
+import { buildAuditTaskResponse } from "../shared";
+
+export async function POST() {
+  return buildAuditTaskResponse("delete");
+}

--- a/web/app/api/account/export/route.ts
+++ b/web/app/api/account/export/route.ts
@@ -1,0 +1,5 @@
+import { buildAuditTaskResponse } from "../shared";
+
+export async function POST() {
+  return buildAuditTaskResponse("export");
+}

--- a/web/app/api/account/shared.ts
+++ b/web/app/api/account/shared.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+type AccountAction = "export" | "delete";
+
+type AuditTaskStub = {
+  id: string;
+  type: string;
+  auditReference: string;
+  etaSeconds: number;
+  enqueuedAt: string;
+};
+
+const AUDIT_TASKS: Record<AccountAction, AuditTaskStub> = {
+  export: {
+    id: "export-task-stub",
+    type: "account_export",
+    auditReference: "AUDIT-EXPORT-0001",
+    etaSeconds: 120,
+    enqueuedAt: "2025-01-15T11:00:00.000Z",
+  },
+  delete: {
+    id: "delete-task-stub",
+    type: "account_delete",
+    auditReference: "AUDIT-DELETE-0001",
+    etaSeconds: 43200,
+    enqueuedAt: "2025-01-16T08:00:00.000Z",
+  },
+};
+
+export function buildAuditTaskResponse(action: AccountAction) {
+  const task = AUDIT_TASKS[action];
+  return NextResponse.json(
+    {
+      status: "enqueued",
+      task,
+    },
+    { status: 202 },
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -701,3 +701,133 @@ main.consent-container {
     max-width: 24rem;
   }
 }
+
+.portal-settings {
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.portal-settings__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-settings__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.65;
+  margin: 0 0 0.25rem;
+}
+
+.portal-settings__header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
+}
+
+.portal-settings__lead {
+  margin: 0;
+  max-width: 40rem;
+  color: rgba(219, 234, 254, 0.82);
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.portal-settings__toast {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  font-weight: 600;
+  max-width: 38rem;
+  align-self: flex-start;
+}
+
+.portal-settings__toast--info {
+  background: rgba(96, 165, 250, 0.12);
+  border: 1px solid rgba(147, 197, 253, 0.35);
+  color: rgba(219, 234, 254, 0.9);
+}
+
+.portal-settings__toast--success {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(134, 239, 172, 0.4);
+  color: #bbf7d0;
+}
+
+.portal-settings__toast--error {
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(252, 165, 165, 0.35);
+  color: #fecaca;
+}
+
+.portal-settings__actions {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.portal-settings__card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(88, 114, 181, 0.45);
+  background: rgba(9, 13, 28, 0.92);
+  box-shadow: 0 24px 42px rgba(3, 8, 24, 0.35);
+}
+
+.portal-settings__card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.portal-settings__card-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.portal-settings__card-header p {
+  margin: 0;
+  color: rgba(219, 234, 254, 0.78);
+  line-height: 1.5;
+}
+
+.portal-settings__card-footer {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.portal-settings__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.4rem;
+  border-radius: 0.85rem;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #0b1120;
+  background: linear-gradient(135deg, #60a5fa, #2563eb);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.portal-settings__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.35);
+}
+
+.portal-settings__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+}

--- a/web/app/portal/settings/page.test.tsx
+++ b/web/app/portal/settings/page.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AccountSettingsPage from "./page";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var fetch: typeof fetch;
+}
+
+describe("AccountSettingsPage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockFetch = (payload: unknown, init?: { ok?: boolean; status?: number }) => {
+    const ok = init?.ok ?? true;
+    const status = init?.status ?? (ok ? 200 : 500);
+
+    return {
+      ok,
+      status,
+      text: vi.fn().mockResolvedValue(JSON.stringify(payload ?? {})),
+    } as unknown as Response;
+  };
+
+  it("renders the account settings header and description", () => {
+    render(<AccountSettingsPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Account Settings", level: 1 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Control the account lifecycle for your Tyrum workspace. Export archives help you verify that our automation respects consent before requesting deletion.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("queues an export and surfaces a success toast", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockFetch({
+          status: "enqueued",
+          task: { auditReference: "AUDIT-EXPORT-0001" },
+        }),
+      );
+
+    render(<AccountSettingsPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Queue export" }));
+
+    expect(fetchSpy).toHaveBeenCalledWith("/api/account/export", {
+      method: "POST",
+      headers: { accept: "application/json" },
+      cache: "no-store",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Data export enqueued/)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces an error toast when the deletion request fails", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        mockFetch(
+          {
+            message: "Deletion currently unavailable.",
+          },
+          { ok: false, status: 502 },
+        ),
+      );
+
+    render(<AccountSettingsPage />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Queue deletion" }));
+
+    expect(fetchSpy).toHaveBeenCalledWith("/api/account/delete", {
+      method: "POST",
+      headers: { accept: "application/json" },
+      cache: "no-store",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Deletion currently unavailable.",
+      );
+    });
+  });
+});

--- a/web/app/portal/settings/page.tsx
+++ b/web/app/portal/settings/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+type AuditTaskResponse = {
+  status?: string;
+  task?: {
+    id?: string;
+    type?: string;
+    auditReference?: string;
+    etaSeconds?: number;
+  };
+  message?: string;
+};
+
+type ToastTone = "info" | "success" | "error";
+
+type ToastState = {
+  id: number;
+  message: string;
+  tone: ToastTone;
+};
+
+type AccountAction = "export" | "delete";
+
+const TOAST_TIMEOUT_MS = 4000;
+
+const ACTION_COPY: Record<
+  AccountAction,
+  {
+    heading: string;
+    body: string;
+    cta: string;
+    success: string;
+    inFlight: string;
+    error: string;
+  }
+> = {
+  export: {
+    heading: "Export your data",
+    body:
+      "Request a full export of the data Tyrum has collected. We will package the latest audit trail for review.",
+    cta: "Queue export",
+    success: "Data export enqueued. Audit reference __REF__.",
+    inFlight: "Queuing your export…",
+    error:
+      "We could not queue the export right now. Try again in a few minutes or contact support.",
+  },
+  delete: {
+    heading: "Delete your account",
+    body:
+      "Schedule an account deletion. The execution team will confirm consent before wiping associated data.",
+    cta: "Queue deletion",
+    success: "Account deletion scheduled. Audit reference __REF__.",
+    inFlight: "Submitting your deletion request…",
+    error:
+      "We could not schedule the deletion. Try again shortly or contact support for manual handling.",
+  },
+};
+
+async function parseJsonResponse(response: Response) {
+  const raw = await response.text();
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    return { message: raw };
+  }
+}
+
+export default function AccountSettingsPage() {
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const [pendingAction, setPendingAction] = useState<AccountAction | null>(null);
+  const [toastCounter, setToastCounter] = useState(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!toast) {
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => setToast(null), TOAST_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [toast]);
+
+  const raiseToast = (tone: ToastTone, message: string) => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    setToastCounter((current) => {
+      if (!isMountedRef.current) {
+        return current;
+      }
+
+      const next = current + 1;
+      setToast({ id: next, tone, message });
+      return next;
+    });
+  };
+
+  const triggerAction = async (action: AccountAction) => {
+    if (pendingAction) {
+      return;
+    }
+
+    const config = ACTION_COPY[action];
+    if (!isMountedRef.current) {
+      return;
+    }
+    setPendingAction(action);
+    raiseToast("info", config.inFlight);
+
+    try {
+      const response = await fetch(`/api/account/${action}`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+        },
+        cache: "no-store",
+      });
+
+      const payload = (await parseJsonResponse(response)) as AuditTaskResponse;
+      if (!response.ok) {
+        const message =
+          typeof payload?.message === "string" ? payload.message : config.error;
+        throw new Error(message);
+      }
+
+      if (isMountedRef.current) {
+        const reference =
+          payload?.task?.auditReference ?? payload?.task?.id ?? "AUDIT-REFERENCE";
+        const successMessage = config.success.replace("__REF__", reference);
+        raiseToast("success", successMessage);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message ? error.message : config.error;
+      if (isMountedRef.current) {
+        raiseToast("error", message);
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setPendingAction(null);
+      }
+    }
+  };
+
+  return (
+    <main className="portal-settings" aria-labelledby="settings-heading">
+      <header className="portal-settings__header">
+        <div>
+          <p className="portal-settings__eyebrow">Portal</p>
+          <h1 id="settings-heading">Account Settings</h1>
+        </div>
+        <p className="portal-settings__lead">
+          Control the account lifecycle for your Tyrum workspace. Export archives help you
+          verify that our automation respects consent before requesting deletion.
+        </p>
+      </header>
+
+      {toast ? (
+        <p
+          key={toast.id}
+          className={`portal-settings__toast portal-settings__toast--${toast.tone}`}
+          role={toast.tone === "error" ? "alert" : "status"}
+        >
+          {toast.message}
+        </p>
+      ) : null}
+
+      <section className="portal-settings__actions" aria-label="Account lifecycle actions">
+        {(["export", "delete"] as AccountAction[]).map((action) => {
+          const config = ACTION_COPY[action];
+          const loading = pendingAction === action;
+
+          return (
+            <article className="portal-settings__card" key={action}>
+              <header className="portal-settings__card-header">
+                <h2>{config.heading}</h2>
+                <p>{config.body}</p>
+              </header>
+              <footer className="portal-settings__card-footer">
+                <button
+                  type="button"
+                  className="portal-settings__button"
+                  onClick={() => triggerAction(action)}
+                  disabled={Boolean(pendingAction)}
+                >
+                  {loading ? "Processing…" : config.cta}
+                </button>
+              </footer>
+            </article>
+          );
+        })}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a portal account settings view that exposes export and deletion lifecycle controls with toast updates
- stub `/api/account/export` and `/api/account/delete` endpoints so audit tasks resolve with deterministic references
- document the portal route and cover the new flows with component tests

## Testing
- `npm run lint`
- `npm run test`
- `pre-commit run --all-files`

## Acceptance Criteria
- [x] Export and delete buttons enqueue mocked audit tasks and display toast status updates.
- [x] API stubs return deterministic responses that can be swapped for real implementations later.

Closes #23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `web/app/portal/settings` page exposing export/delete actions with deterministic API stubs, new styles, tests, and docs update.
> 
> - **Portal UI**:
>   - Adds `web/app/portal/settings/page.tsx` Account Settings with export/delete actions, in-flight/Toast feedback, and disabled state handling.
>   - New styles in `web/app/globals.css` for `.portal-settings*` layout, cards, buttons, and toast variants.
> - **API stubs**:
>   - `POST /api/account/export` → `web/app/api/account/export/route.ts`.
>   - `POST /api/account/delete` → `web/app/api/account/delete/route.ts`.
>   - Shared response builder with deterministic audit task refs in `web/app/api/account/shared.ts` returning `202` with `status: "enqueued"` and `task.auditReference`.
> - **Tests**:
>   - `web/app/portal/settings/page.test.tsx` covers header render, successful export toast, and failed deletion error toast; asserts fetch calls to `"/api/account/*"`.
> - **Docs**:
>   - Update `docs/product_concept_v1.md` to document `/portal/settings` route and export/delete API stubs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12cea67f713928f934cee09b36b4111db441f3d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->