### PR TITLE
Add Docker Hub login to container CI

### DIFF
--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build ${{ matrix.title }} image
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- add docker/login-action to authenticate before container builds so Docker Hub pulls avoid rate limits

## Testing
- not run (workflow change only)

## Risks
- low: CI-only Docker Hub auth step