### PR TITLE
Document Telegram bot setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ M0 tasks are broken into single-day issues (1 developer each) and tracked in Git
 6. **Follow CI workflows:** Run the same commands locally that GitHub Actions enforces (`cargo fmt/clippy/test`, `npm run lint/test/build`, Terraform/Compose/Kubernetes validations).
 7. **Open PRs:** Reference the issue, list validation steps, attach screenshots/logs, ensure all Actions workflows succeed.
 
+## Telegram Bot Setup
+Follow these steps to provision the Telegram channel safely across local and staging environments.
+
+### 1. Create the bot via BotFather
+- Chat with [@BotFather](https://t.me/BotFather) and run `/newbot` to name the assistant and choose a unique handle.
+- Copy the API token BotFather returns; treat it as a secret and never paste it in chat or commit history.
+- Store the token in your local secrets file (`config/local.env`) and the relevant Secrets Manager envelope for staging/production. See the runbook below for rotation guidance.
+
+### 2. Set the webhook endpoint
+- Staging uses a fixed HTTPS endpoint exposed by the ingestion service (e.g. `https://staging.tyrum.run/api/telegram/webhook`). Set the webhook from BotFather with `/setwebhook` once the service is deployed.
+- For local development, expose your planner ingress over TLS using `ngrok`. Example:
+  ```bash
+  ngrok http http://localhost:8080
+  curl "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+    --data-urlencode "url=https://<subdomain>.ngrok.app/api/telegram/webhook"
+  ```
+  Replace `<subdomain>` with the forwarding host printed by `ngrok`. Repeat the command whenever the tunnel URL changes.
+
+### 3. Wire credentials into applications
+- Copy `config/local.env.example` to `config/local.env` and populate the placeholders for `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_URL` with your BotFather token and the ngrok/staging URL respectively.
+- Next.js code that needs to reference the public webhook can read from `.env.local`:
+  ```dotenv
+  # web/.env.local
+  NEXT_PUBLIC_TELEGRAM_WEBHOOK_URL="https://<subdomain>.ngrok.app/api/telegram/webhook"
+  ```
+- GitHub Actions stores channel credentials in environment-specific secrets (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_URL`). Tokens must remain masked in CI logs and be rotated through AWS Secrets Manager; document rotation events in the staging runbook.
+
 ## Key Documents
 - [Product Concept v1](docs/product_concept_v1.md)
 - [Working Agreements (DoR/DoD)](docs/working_agreements.md)

--- a/config/local.env.example
+++ b/config/local.env.example
@@ -14,3 +14,7 @@ MEMORY_API_URL=http://localhost:8082
 # Observability endpoints
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 TELEMETRY_EXPORTER=http://localhost:4318
+
+# Telegram ingestion (never commit real values)
+TELEGRAM_BOT_TOKEN=replace-with-botfather-token
+TELEGRAM_WEBHOOK_URL=https://<subdomain>.ngrok.app/api/telegram/webhook

--- a/docs/infra/staging_runbook.md
+++ b/docs/infra/staging_runbook.md
@@ -155,6 +155,36 @@ cluster by the Helm chart.
 6. Confirm rotation by checking that pods now reference the latest secret
    resource version (`kubectl describe pod … | grep platform-config`).
 
+### Telegram bot credentials
+- Telegram tokens and webhook URLs live in AWS Secrets Manager under
+  `tyrum-staging/integrations/telegram`. The secret stores `bot_token` and
+  `webhook_url` keys used by the ingestion service.
+- Rotate the token through BotFather, then update Secrets Manager:
+  ```bash
+  aws secretsmanager put-secret-value \
+    --secret-id tyrum-staging/integrations/telegram \
+    --secret-string '{"bot_token":"<new-token>","webhook_url":"https://staging.tyrum.run/api/telegram/webhook"}'
+  ```
+  Never log the raw token; confirm CLI output is redacted before sharing.
+- Sync the Kubernetes secret projecting these values (update the key names if
+  the deployment uses different literals):
+  ```bash
+  SECRET_STRING=$(aws secretsmanager get-secret-value \
+    --secret-id tyrum-staging/integrations/telegram \
+    --query 'SecretString' \
+    --output text)
+
+  kubectl create secret generic tyrum-telegram-ingestor \
+    --namespace tyrum-core \
+    --from-literal=TELEGRAM_BOT_TOKEN="$(jq -r '.bot_token' <<<"$SECRET_STRING")" \
+    --from-literal=TELEGRAM_WEBHOOK_URL="$(jq -r '.webhook_url' <<<"$SECRET_STRING")" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  ```
+- Update GitHub Actions environment secrets (`Settings → Environments → Staging`)
+  for `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_URL` so CI jobs can run smoke
+  checks without leaking credentials. GitHub masks their values automatically;
+  avoid echoing the token in workflows or logs.
+
 ## Observability & Alerting Links
 - Grafana (Control Plane Overview):
   https://grafana.staging.tyrum.run/d/tyrum-control-plane/overview?var-environment=staging


### PR DESCRIPTION
## Summary
- Add a README section walking through BotFather setup, webhook configuration, and local ngrok forwarding.
- Extend `config/local.env.example` and the staging runbook with Telegram token/webhook placeholders and rotation guidance.
- Note GitHub Actions secret usage so CI keeps channel credentials masked and traceable.

## Acceptance Criteria
- [x] `README.md` gains a "Telegram bot setup" section covering BotFather steps, webhook configuration, and local ngrok guidance.
- [x] `config/local.env.example` lists `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_URL` placeholders with comments.
- [x] `docs/infra/staging_runbook.md` references where Telegram secrets live and how to rotate them.

## Testing
- `pre-commit run --all-files`

Closes #58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents Telegram bot setup, adds env placeholders, and details staging token/webhook rotation and CI secrets.
> 
> - **Documentation**:
>   - **`README.md`**: Adds a Telegram Bot Setup section covering BotFather creation, webhook configuration (staging and local via `ngrok`), and wiring credentials into apps/CI.
>   - **`config/local.env.example`**: Introduces `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_URL` placeholders.
>   - **`docs/infra/staging_runbook.md`**: Adds Telegram credentials guidance with AWS Secrets Manager location, rotation steps, Kubernetes secret sync, and GitHub Actions environment secrets updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35ff1096b5f9086405ff315d84aeb62bdacb5d12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->