### PR TITLE
Persist Telegram ingress threads and messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tyrum-shared",
  "validator",
 ]
 

--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -410,6 +410,7 @@ Milestones are cumulative; later milestones build on earlier ones.
   - `X-Telegram-Bot-Api-Secret-Token`: exact match with the BotFather `secret_token` configured during `/setwebhook`.
   - `X-Telegram-Bot-Api-Signature`: `sha256=` prefix followed by the lowercase hex HMAC-SHA256 digest of the raw request body using the same secret token.
 - Invalid or missing headers are rejected with `401 Unauthorized`; nothing is persisted until signature validation succeeds.
+- Normalized payloads are persisted in `ingress_threads` and `ingress_messages`, capturing `pii_fields` so downstream services can redact or encrypt sensitive columns. Field-level encryption is tracked as a follow-up once the policy gate accepts per-column keys.
 - Local smoke example (replace the placeholder secret and payload):
 
 ```bash

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -21,6 +21,19 @@ services:
       retries: 5
       start_period: 10s
 
+  api-migrations:
+    build:
+      context: ..
+      dockerfile: Dockerfile.api
+    image: tyrum/api:local
+    environment:
+      RUST_LOG: info
+      DATABASE_URL: postgres://tyrum:tyrum_dev_password@postgres:5432/tyrum_dev
+      RUN_MIGRATIONS_ONLY: "1"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   api:
     build:
       context: ..
@@ -36,6 +49,8 @@ services:
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-local-telegram-secret}
     depends_on:
+      api-migrations:
+        condition: service_completed_successfully
       policy:
         condition: service_healthy
       postgres:

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -25,6 +25,7 @@ validator = { version = "0.18", features = ["derive"] }
 hex = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
+tyrum-shared = { path = "../../shared/tyrum-shared" }
 
 [dev-dependencies]
 axum = { version = "0.7", features = ["json"] }

--- a/services/api/migrations/0003_create_ingress_threads_messages.sql
+++ b/services/api/migrations/0003_create_ingress_threads_messages.sql
@@ -1,0 +1,90 @@
+-- Persist normalized ingress threads and messages for Telegram conversation replay.
+CREATE TABLE IF NOT EXISTS ingress_threads (
+    source TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT,
+    username TEXT,
+    pii_fields TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ingress_threads_pk PRIMARY KEY (source, thread_id),
+    CHECK (char_length(trim(source)) > 0),
+    CHECK (char_length(trim(thread_id)) > 0),
+    CHECK (kind IN ('private', 'group', 'supergroup', 'channel', 'other')),
+    CHECK (
+        pii_fields <@ ARRAY[
+            'message_caption',
+            'message_text',
+            'sender_first_name',
+            'sender_last_name',
+            'sender_language_code',
+            'sender_username',
+            'thread_title',
+            'thread_username'
+        ]::TEXT[]
+    )
+);
+
+COMMENT ON TABLE ingress_threads IS 'Normalized external chat threads grouped by ingress source.';
+COMMENT ON COLUMN ingress_threads.source IS 'Ingress surface for the thread (e.g. telegram).';
+COMMENT ON COLUMN ingress_threads.thread_id IS 'Identifier of the thread within the ingress source.';
+COMMENT ON COLUMN ingress_threads.kind IS 'Thread classification reported by the ingress surface.';
+COMMENT ON COLUMN ingress_threads.title IS 'Optional title provided by the ingress surface.';
+COMMENT ON COLUMN ingress_threads.username IS 'Username handle associated with the thread when available.';
+COMMENT ON COLUMN ingress_threads.pii_fields IS 'Set of thread fields containing PII requiring redaction downstream.';
+COMMENT ON COLUMN ingress_threads.created_at IS 'Timestamp when the thread record was created.';
+COMMENT ON COLUMN ingress_threads.updated_at IS 'Timestamp when the thread record was last updated.';
+
+CREATE INDEX IF NOT EXISTS ingress_threads_source_kind_idx
+    ON ingress_threads (source, kind);
+
+CREATE TABLE IF NOT EXISTS ingress_messages (
+    source TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    message_id TEXT NOT NULL,
+    content JSONB NOT NULL,
+    sender JSONB,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    edited_at TIMESTAMPTZ,
+    pii_fields TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT ingress_messages_pk PRIMARY KEY (source, thread_id, message_id),
+    CONSTRAINT ingress_messages_thread_fk FOREIGN KEY (source, thread_id)
+        REFERENCES ingress_threads (source, thread_id)
+        ON DELETE CASCADE,
+    CHECK (char_length(trim(source)) > 0),
+    CHECK (char_length(trim(thread_id)) > 0),
+    CHECK (char_length(trim(message_id)) > 0),
+    CHECK (jsonb_typeof(content) = 'object'),
+    CHECK (
+        sender IS NULL
+        OR jsonb_typeof(sender) = 'object'
+    ),
+    CHECK (
+        pii_fields <@ ARRAY[
+            'message_caption',
+            'message_text',
+            'sender_first_name',
+            'sender_last_name',
+            'sender_language_code',
+            'sender_username',
+            'thread_title',
+            'thread_username'
+        ]::TEXT[]
+    )
+);
+
+COMMENT ON TABLE ingress_messages IS 'Normalized ingress messages captured for planner replay and auditing.';
+COMMENT ON COLUMN ingress_messages.source IS 'Ingress surface that emitted the message (e.g. telegram).';
+COMMENT ON COLUMN ingress_messages.thread_id IS 'Thread identifier tying the message to its conversation.';
+COMMENT ON COLUMN ingress_messages.message_id IS 'Identifier of the message within its ingress thread.';
+COMMENT ON COLUMN ingress_messages.content IS 'Normalized message content stored as JSON.';
+COMMENT ON COLUMN ingress_messages.sender IS 'Sender metadata captured for the message when supplied.';
+COMMENT ON COLUMN ingress_messages.occurred_at IS 'Timestamp when the message was created by the ingress surface.';
+COMMENT ON COLUMN ingress_messages.edited_at IS 'Timestamp of the last edit reported by the ingress surface, if any.';
+COMMENT ON COLUMN ingress_messages.pii_fields IS 'Set of message or thread fields containing PII requiring redaction downstream.';
+COMMENT ON COLUMN ingress_messages.created_at IS 'Timestamp when the message record was created.';
+
+CREATE INDEX IF NOT EXISTS ingress_messages_thread_time_idx
+    ON ingress_messages (source, thread_id, occurred_at);

--- a/services/api/src/ingress.rs
+++ b/services/api/src/ingress.rs
@@ -1,0 +1,156 @@
+use serde_json::Value;
+use sqlx::PgPool;
+use thiserror::Error;
+use tracing::instrument;
+
+use tyrum_shared::{MessageSource, NormalizedMessage, NormalizedThread, PiiField, ThreadKind};
+
+#[derive(Debug, Error)]
+pub enum IngressRepositoryError {
+    #[error("ingress message already exists for the given source, thread, and message identifiers")]
+    MessageAlreadyExists,
+    #[error("failed to serialize ingress payload: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("database error: {0}")]
+    Database(sqlx::Error),
+}
+
+/// Repository that persists normalized ingress threads and messages.
+#[derive(Clone)]
+pub struct IngressRepository {
+    pool: PgPool,
+}
+
+impl IngressRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    #[instrument(skip_all)]
+    pub async fn upsert_thread(
+        &self,
+        source: MessageSource,
+        thread: &NormalizedThread,
+    ) -> Result<(), IngressRepositoryError> {
+        let source_value = message_source_str(source);
+        let kind_value = thread_kind_str(thread.kind);
+        let pii_fields = map_pii_fields(&thread.pii_fields);
+
+        sqlx::query(
+            r#"
+            INSERT INTO ingress_threads (source, thread_id, kind, title, username, pii_fields)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT (source, thread_id)
+            DO UPDATE
+            SET kind = EXCLUDED.kind,
+                title = EXCLUDED.title,
+                username = EXCLUDED.username,
+                pii_fields = EXCLUDED.pii_fields,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(source_value)
+        .bind(&thread.id)
+        .bind(kind_value)
+        .bind(&thread.title)
+        .bind(&thread.username)
+        .bind(pii_fields)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(IngressRepositoryError::Database)
+    }
+
+    #[instrument(skip_all)]
+    pub async fn insert_message(
+        &self,
+        message: &NormalizedMessage,
+    ) -> Result<(), IngressRepositoryError> {
+        let source_value = message_source_str(message.source);
+        let content: Value = serde_json::to_value(&message.content)?;
+        let sender: Option<Value> = message
+            .sender
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+        let pii_fields = map_pii_fields(&message.pii_fields);
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO ingress_messages (
+                source,
+                thread_id,
+                message_id,
+                content,
+                sender,
+                occurred_at,
+                edited_at,
+                pii_fields
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            "#,
+        )
+        .bind(source_value)
+        .bind(&message.thread_id)
+        .bind(&message.id)
+        .bind(content)
+        .bind(sender)
+        .bind(message.timestamp)
+        .bind(message.edited_timestamp)
+        .bind(pii_fields)
+        .execute(&self.pool)
+        .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                if let sqlx::Error::Database(db_err) = &error
+                    && db_err.constraint() == Some("ingress_messages_pk")
+                {
+                    return Err(IngressRepositoryError::MessageAlreadyExists);
+                }
+                Err(IngressRepositoryError::Database(error))
+            }
+        }
+    }
+}
+
+fn message_source_str(source: MessageSource) -> &'static str {
+    match source {
+        MessageSource::Telegram => "telegram",
+    }
+}
+
+fn thread_kind_str(kind: ThreadKind) -> &'static str {
+    match kind {
+        ThreadKind::Private => "private",
+        ThreadKind::Group => "group",
+        ThreadKind::Supergroup => "supergroup",
+        ThreadKind::Channel => "channel",
+        ThreadKind::Other => "other",
+    }
+}
+
+fn map_pii_fields(fields: &[PiiField]) -> Vec<String> {
+    fields
+        .iter()
+        .map(|field| pii_field_str(*field).to_string())
+        .collect()
+}
+
+fn pii_field_str(field: PiiField) -> &'static str {
+    match field {
+        PiiField::MessageCaption => "message_caption",
+        PiiField::MessageText => "message_text",
+        PiiField::SenderFirstName => "sender_first_name",
+        PiiField::SenderLastName => "sender_last_name",
+        PiiField::SenderLanguageCode => "sender_language_code",
+        PiiField::SenderUsername => "sender_username",
+        PiiField::ThreadTitle => "thread_title",
+        PiiField::ThreadUsername => "thread_username",
+    }
+}

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod account_linking;
+pub mod ingress;
+pub mod metrics;
+pub mod telegram;
+pub mod telemetry;
+pub mod waitlist;

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env, net::SocketAddr};
 
-use crate::{
+use tyrum_api::{
     account_linking::AccountLinkingRepository,
     waitlist::{NewWaitlistSignup, WaitlistError, WaitlistRepository},
 };
@@ -15,14 +15,10 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use telemetry::TelemetryGuard;
+use tyrum_api::telemetry::TelemetryGuard;
 use validator::Validate;
 
-mod account_linking;
-mod metrics;
-mod telegram;
-mod telemetry;
-mod waitlist;
+use tyrum_api::{metrics, telegram};
 
 const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8080";
 const DEFAULT_DATABASE_URL: &str = "postgres://tyrum:tyrum_dev_password@localhost:5432/tyrum_dev";
@@ -458,6 +454,14 @@ async fn main() {
         .await
         .expect("failed to run waitlist migrations");
 
+    if matches!(
+        env::var("RUN_MIGRATIONS_ONLY"),
+        Ok(value) if matches!(value.as_str(), "1" | "true" | "TRUE" | "True")
+    ) {
+        tracing::info!("database migrations completed; exiting early per RUN_MIGRATIONS_ONLY");
+        return;
+    }
+
     let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
 
     let telegram_secret =
@@ -483,11 +487,6 @@ mod tests {
         ACCOUNT_LINKING_ROUTE, AppState, PLACEHOLDER_INTEGRATIONS, PORTAL_ACCOUNT_ID,
         TELEGRAM_WEBHOOK_ROUTE, WAITLIST_ROUTE, build_router, sanitize_opt,
     };
-    use crate::{
-        account_linking::AccountLinkingRepository,
-        telegram::TelegramWebhookVerifier,
-        waitlist::{NewWaitlistSignup, WaitlistError, WaitlistRepository},
-    };
     use axum::{
         body::Body,
         http::{Request, StatusCode},
@@ -503,6 +502,11 @@ mod tests {
     };
     use tokio::time::sleep;
     use tower::ServiceExt;
+    use tyrum_api::{
+        account_linking::AccountLinkingRepository,
+        telegram::TelegramWebhookVerifier,
+        waitlist::{NewWaitlistSignup, WaitlistError, WaitlistRepository},
+    };
 
     const POSTGRES_IMAGE: &str = "pgvector/pgvector";
     const POSTGRES_TAG: &str = "pg16";

--- a/services/api/src/telegram.rs
+++ b/services/api/src/telegram.rs
@@ -99,7 +99,6 @@ impl TelegramWebhookVerifier {
         }
     }
 
-    #[cfg(test)]
     pub fn expected_signature_header(&self, body: &[u8]) -> String {
         format!(
             "{SIGNATURE_PREFIX}{}",

--- a/services/api/src/waitlist.rs
+++ b/services/api/src/waitlist.rs
@@ -89,7 +89,6 @@ pub struct WaitlistRepository {
 }
 
 impl WaitlistRepository {
-    #[cfg(test)]
     pub fn from_pool(pool: PgPool) -> Self {
         Self { pool }
     }

--- a/services/api/tests/telegram_ingress.rs
+++ b/services/api/tests/telegram_ingress.rs
@@ -1,0 +1,267 @@
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use serde_json::Value;
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use tokio::time::sleep;
+use tyrum_api::ingress::{IngressRepository, IngressRepositoryError};
+use tyrum_shared::{
+    MediaKind, MessageContent, MessageSource, NormalizedMessage, NormalizedThread, PiiField,
+    SenderMetadata, ThreadKind,
+};
+
+const POSTGRES_IMAGE: &str = "pgvector/pgvector";
+const POSTGRES_TAG: &str = "pg16";
+const POSTGRES_USER: &str = "tyrum";
+const POSTGRES_PASSWORD: &str = "tyrum_dev_password";
+const POSTGRES_DB: &str = "tyrum_dev";
+
+struct TestContext {
+    #[allow(dead_code)]
+    container: ContainerAsync<GenericImage>,
+    repository: IngressRepository,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+            .with_exposed_port(5432.tcp())
+            .with_wait_for(WaitFor::message_on_stdout(
+                "database system is ready to accept connections",
+            ));
+
+        let request = image
+            .with_env_var("POSTGRES_USER", POSTGRES_USER)
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", POSTGRES_DB);
+
+        let container = request.start().await.expect("start postgres container");
+        let host_port = container
+            .get_host_port_ipv4(5432.tcp())
+            .await
+            .expect("map postgres port");
+
+        let database_url = format!(
+            "postgres://{}:{}@127.0.0.1:{}/{}",
+            POSTGRES_USER, POSTGRES_PASSWORD, host_port, POSTGRES_DB
+        );
+
+        let pool = connect_with_retry(&database_url).await;
+        run_migrations(&pool).await;
+        let repository = IngressRepository::new(pool);
+
+        Self {
+            container,
+            repository,
+        }
+    }
+}
+
+async fn connect_with_retry(database_url: &str) -> PgPool {
+    let mut attempts = 0;
+    loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .connect(database_url)
+            .await
+        {
+            Ok(pool) => break pool,
+            Err(error) if attempts < 10 && matches!(error, sqlx::Error::Io(_)) => {
+                attempts += 1;
+                sleep(std::time::Duration::from_millis(150)).await;
+            }
+            Err(error) => panic!("connect postgres pool: {error}"),
+        }
+    }
+}
+
+async fn run_migrations(pool: &PgPool) {
+    static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+    MIGRATOR.run(pool).await.expect("run migrations");
+}
+
+fn sample_thread() -> NormalizedThread {
+    NormalizedThread {
+        id: "chat-123".into(),
+        kind: ThreadKind::Supergroup,
+        title: Some("Virtunet Operators".into()),
+        username: Some("virtunet_ops".into()),
+        pii_fields: vec![PiiField::ThreadTitle, PiiField::ThreadUsername],
+    }
+}
+
+fn sample_message() -> NormalizedMessage {
+    NormalizedMessage {
+        id: "42".into(),
+        thread_id: "chat-123".into(),
+        source: MessageSource::Telegram,
+        content: MessageContent::MediaPlaceholder {
+            media_kind: MediaKind::Photo,
+            caption: Some("Receipt".into()),
+        },
+        sender: Some(SenderMetadata {
+            id: "user-9".into(),
+            is_bot: false,
+            first_name: Some("Ron".into()),
+            last_name: Some("Hernaus".into()),
+            username: Some("ronnie".into()),
+            language_code: Some("en".into()),
+        }),
+        timestamp: Utc.with_ymd_and_hms(2025, 10, 1, 10, 0, 0).unwrap(),
+        edited_timestamp: Some(
+            Utc.with_ymd_and_hms(2025, 10, 1, 10, 5, 0)
+                .unwrap()
+                .checked_add_signed(Duration::seconds(30))
+                .unwrap(),
+        ),
+        pii_fields: vec![
+            PiiField::MessageCaption,
+            PiiField::SenderFirstName,
+            PiiField::SenderLastName,
+            PiiField::SenderUsername,
+        ],
+    }
+}
+
+#[tokio::test]
+async fn upsert_thread_persists_and_updates_records() {
+    let ctx = TestContext::new().await;
+    let thread = sample_thread();
+
+    ctx.repository
+        .upsert_thread(MessageSource::Telegram, &thread)
+        .await
+        .expect("insert thread");
+
+    let record = sqlx::query(
+        r#"
+        SELECT kind, title, username, pii_fields, created_at, updated_at
+        FROM ingress_threads
+        WHERE source = $1 AND thread_id = $2
+        "#,
+    )
+    .bind("telegram")
+    .bind(&thread.id)
+    .fetch_one(ctx.repository.pool())
+    .await
+    .expect("fetch thread row");
+
+    assert_eq!(record.try_get::<String, _>("kind").unwrap(), "supergroup");
+    assert_eq!(
+        record.try_get::<Option<String>, _>("title").unwrap(),
+        thread.title
+    );
+    assert_eq!(
+        record.try_get::<Option<String>, _>("username").unwrap(),
+        thread.username
+    );
+
+    let pii: Vec<String> = record.try_get::<Vec<String>, _>("pii_fields").unwrap();
+    assert_eq!(pii, vec!["thread_title", "thread_username"]);
+
+    let created_at: DateTime<Utc> = record.try_get("created_at").unwrap();
+    let original_updated_at: DateTime<Utc> = record.try_get("updated_at").unwrap();
+    assert_eq!(created_at, original_updated_at);
+
+    let mut updated_thread = thread.clone();
+    updated_thread.title = Some("Virtunet Ops".into());
+
+    ctx.repository
+        .upsert_thread(MessageSource::Telegram, &updated_thread)
+        .await
+        .expect("update thread");
+
+    let updated_row = sqlx::query(
+        r#"
+        SELECT title, updated_at
+        FROM ingress_threads
+        WHERE source = $1 AND thread_id = $2
+        "#,
+    )
+    .bind("telegram")
+    .bind(&updated_thread.id)
+    .fetch_one(ctx.repository.pool())
+    .await
+    .expect("fetch updated thread");
+
+    assert_eq!(
+        updated_row.try_get::<Option<String>, _>("title").unwrap(),
+        updated_thread.title
+    );
+    let refreshed_updated_at: DateTime<Utc> = updated_row.try_get("updated_at").unwrap();
+    assert!(refreshed_updated_at >= original_updated_at);
+}
+
+#[tokio::test]
+async fn insert_message_persists_and_dedupes() {
+    let ctx = TestContext::new().await;
+    let thread = sample_thread();
+    ctx.repository
+        .upsert_thread(MessageSource::Telegram, &thread)
+        .await
+        .expect("seed thread");
+
+    let message = sample_message();
+    ctx.repository
+        .insert_message(&message)
+        .await
+        .expect("insert message");
+
+    let row = sqlx::query(
+        r#"
+        SELECT thread_id, message_id, content, sender, occurred_at, edited_at, pii_fields
+        FROM ingress_messages
+        WHERE source = $1 AND thread_id = $2 AND message_id = $3
+        "#,
+    )
+    .bind("telegram")
+    .bind(&message.thread_id)
+    .bind(&message.id)
+    .fetch_one(ctx.repository.pool())
+    .await
+    .expect("fetch message");
+
+    assert_eq!(
+        row.try_get::<String, _>("thread_id").unwrap(),
+        message.thread_id
+    );
+    assert_eq!(row.try_get::<String, _>("message_id").unwrap(), message.id);
+
+    let content: Value = row.try_get("content").unwrap();
+    assert_eq!(content["kind"], "media_placeholder");
+    assert_eq!(content["media_kind"], "photo");
+    assert_eq!(content["caption"], "Receipt");
+
+    let sender: Option<Value> = row.try_get("sender").unwrap();
+    let sender = sender.expect("sender json");
+    assert_eq!(sender["id"], "user-9");
+    assert_eq!(sender["first_name"], "Ron");
+
+    assert_eq!(
+        row.try_get::<DateTime<Utc>, _>("occurred_at").unwrap(),
+        message.timestamp
+    );
+    assert_eq!(
+        row.try_get::<Option<DateTime<Utc>>, _>("edited_at")
+            .unwrap(),
+        message.edited_timestamp
+    );
+
+    let pii: Vec<String> = row.try_get("pii_fields").unwrap();
+    assert_eq!(
+        pii,
+        vec![
+            "message_caption",
+            "sender_first_name",
+            "sender_last_name",
+            "sender_username"
+        ]
+    );
+
+    let duplicate = ctx.repository.insert_message(&message).await;
+    let err = duplicate.expect_err("duplicate message should error");
+    assert!(matches!(err, IngressRepositoryError::MessageAlreadyExists));
+}


### PR DESCRIPTION
## Summary
- add ingress thread/message tables and repository helpers for normalized Telegram payloads
- cover insertion and upsert flows with testcontainers-based integration tests
- update docker compose to run migrations via a dedicated init container and expose new repository APIs

## Testing
- pre-commit run --all-files
- cargo test -p tyrum-api --test telegram_ingress

Closes #61

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add DB schema and repository for normalized Telegram threads/messages, integration tests, and a compose init container to run migrations, wiring in shared types and minor API refinements.
> 
> - **Backend/API**:
>   - **Ingress persistence**: Add migrations creating `ingress_threads` and `ingress_messages` with constraints, comments, and indexes.
>   - **Repository**: Introduce `IngressRepository` with `upsert_thread` and `insert_message`, enum→string/PII mapping, and duplicate detection.
>   - **Crate plumbing**: Expose modules via `lib.rs`, refactor `main.rs` imports to `tyrum_api::*`, add `RUN_MIGRATIONS_ONLY` early-exit path, and depend on `tyrum-shared`.
>   - **Utilities**: Make `TelegramWebhookVerifier::expected_signature_header` and `WaitlistRepository::from_pool` available outside tests.
> - **Infra**:
>   - **docker compose**: Add `api-migrations` init service to run DB migrations; `api` depends on its completion.
> - **Tests**:
>   - **Integration**: New `telegram_ingress` tests (testcontainers) covering thread upsert, message insert, and dedupe.
> - **Docs**:
>   - Note that normalized Telegram payloads are persisted in `ingress_threads`/`ingress_messages` with `pii_fields`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f6cd9da6e2b44bad2fbffade514ce007f5d1c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->