### PR TITLE
Add planner HTTP skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3343,6 +3343,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
@@ -3528,13 +3544,17 @@ name = "tyrum-planner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
+ "http-body-util",
  "serde",
  "serde_json",
  "sqlx",
  "testcontainers",
  "thiserror 1.0.69",
  "tokio",
+ "tower",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
  "tyrum-memory",

--- a/Dockerfile.planner
+++ b/Dockerfile.planner
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.7
+FROM rust:1.89 AS builder
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=$HTTP_PROXY \
+    http_proxy=$HTTP_PROXY \
+    HTTPS_PROXY=$HTTPS_PROXY \
+    https_proxy=$HTTPS_PROXY \
+    NO_PROXY=$NO_PROXY \
+    no_proxy=$NO_PROXY
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY shared/tyrum-shared/Cargo.toml shared/tyrum-shared/Cargo.toml
+COPY shared/tyrum-shared/src shared/tyrum-shared/src
+COPY services/api/Cargo.toml services/api/Cargo.toml
+COPY services/api/src services/api/src
+COPY services/api/migrations services/api/migrations
+COPY services/memory/Cargo.toml services/memory/Cargo.toml
+COPY services/memory/src services/memory/src
+COPY services/memory/tests services/memory/tests
+COPY services/memory/migrations services/memory/migrations
+COPY services/policy/Cargo.toml services/policy/Cargo.toml
+COPY services/policy/src services/policy/src
+COPY services/planner/Cargo.toml services/planner/Cargo.toml
+COPY services/planner/migrations services/planner/migrations
+COPY services/planner/src services/planner/src
+
+RUN cargo build --locked --release --bin planner_http
+
+FROM debian:bookworm-slim AS runtime
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=$HTTP_PROXY \
+    http_proxy=$HTTP_PROXY \
+    HTTPS_PROXY=$HTTPS_PROXY \
+    https_proxy=$HTTPS_PROXY \
+    NO_PROXY=$NO_PROXY \
+    no_proxy=$NO_PROXY
+RUN set -eux; \
+    printf 'Acquire::ForceIPv4 "true";\n' >/etc/apt/apt.conf.d/99force-ipv4; \
+    useradd --create-home --shell /usr/sbin/nologin appuser; \
+    printf '%s\n' \
+      'deb http://ftp.nl.debian.org/debian bookworm main' \
+      'deb http://ftp.nl.debian.org/debian bookworm-updates main' \
+      'deb http://security.debian.org/debian-security bookworm-security main' \
+      >/etc/apt/sources.list; \
+    apt-get update; \
+    apt-get install --yes --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/planner_http /usr/local/bin/planner_http
+ENV PLANNER_BIND_ADDR=0.0.0.0:8083
+EXPOSE 8083
+USER appuser
+ENTRYPOINT ["/usr/local/bin/planner_http"]

--- a/config/local.env.example
+++ b/config/local.env.example
@@ -10,6 +10,7 @@ NATS_URL=nats://127.0.0.1:4222
 LLM_GATEWAY_URL=http://localhost:8085
 POLICY_GATE_URL=http://localhost:8081
 MEMORY_API_URL=http://localhost:8082
+PLANNER_API_URL=http://localhost:8083
 
 # Observability endpoints
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -21,6 +21,28 @@ services:
       retries: 5
       start_period: 10s
 
+  planner:
+    build:
+      context: ..
+      dockerfile: Dockerfile.planner
+    image: tyrum/planner:local
+    environment:
+      RUST_LOG: info
+      PLANNER_BIND_ADDR: 0.0.0.0:8083
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    depends_on:
+      otel-collector:
+        condition: service_started
+    ports:
+      - "8083:8083"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail http://localhost:8083/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
   api-migrations:
     build:
       context: ..

--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -11,11 +11,11 @@ default = []
 audit-demo = [
     "dep:anyhow",
     "dep:testcontainers",
-    "dep:tokio",
     "dep:tyrum-memory"
 ]
 
 [dependencies]
+axum = { version = "0.7", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -32,11 +32,12 @@ thiserror = "1"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v4"] }
 anyhow = { version = "1", optional = true }
-tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread", "time"], optional = true }
+tokio = { version = "1.43", features = ["macros", "net", "rt", "rt-multi-thread", "signal", "time"] }
 testcontainers = { version = "0.18", optional = true }
 tyrum-memory = { path = "../memory", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 tyrum-shared = { path = "../../shared/tyrum-shared" }
+tower-http = { version = "0.5", features = ["limit"] }
 
 [dev-dependencies]
 anyhow = "1"
@@ -53,11 +54,17 @@ sqlx = { version = "0.7", default-features = false, features = [
 testcontainers = "0.18"
 tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread", "time"] }
 tyrum-memory = { path = "../memory" }
+tower = "0.5"
+http-body-util = "0.1"
 
 [[bin]]
 name = "audit_demo"
 path = "src/bin/audit_demo.rs"
 required-features = ["audit-demo"]
+
+[[bin]]
+name = "planner_http"
+path = "src/bin/http_server.rs"
 
 [lints]
 workspace = true

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -1,0 +1,47 @@
+use std::{env, net::SocketAddr};
+
+use tokio::net::TcpListener;
+use tracing_subscriber::{EnvFilter, fmt};
+
+use tyrum_planner::http::{DEFAULT_BIND_ADDR, build_router};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    init_tracing();
+
+    let bind_addr: SocketAddr = env::var("PLANNER_BIND_ADDR")
+        .unwrap_or_else(|_| DEFAULT_BIND_ADDR.to_string())
+        .parse()
+        .expect("invalid PLANNER_BIND_ADDR");
+
+    let app = build_router();
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .expect("bind planner socket");
+
+    tracing::info!(%bind_addr, "planner HTTP server listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .expect("planner HTTP server exited unexpectedly");
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,tyrum_planner=info,planner_http=info"));
+
+    fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .compact()
+        .try_init()
+        .expect("install tracing subscriber");
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        tracing::warn!(%error, "ctrl-c handler failed");
+    }
+    tracing::info!("shutdown signal received");
+}

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -1,0 +1,105 @@
+use axum::{
+    Json, Router,
+    http::StatusCode,
+    routing::{get, post},
+};
+use chrono::Utc;
+use serde::Serialize;
+use serde_json::{Map as JsonMap, Value, json};
+use tower_http::limit::RequestBodyLimitLayer;
+use uuid::Uuid;
+
+use crate::{
+    ActionPrimitive, ActionPrimitiveKind, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
+};
+
+pub const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8083";
+pub const MAX_PLAN_REQUEST_BYTES: usize = 256 * 1024; // 256 KiB safety rail for ingress payloads.
+
+#[derive(Clone, Copy, Serialize)]
+struct HealthResponse {
+    status: &'static str,
+}
+
+#[derive(Clone, Serialize)]
+struct ValidationError {
+    error: &'static str,
+    message: String,
+}
+
+pub fn build_router() -> Router {
+    Router::new()
+        .route("/plan", post(plan))
+        .route("/healthz", get(health))
+        .layer(RequestBodyLimitLayer::new(MAX_PLAN_REQUEST_BYTES))
+}
+
+#[tracing::instrument(skip_all)]
+async fn plan(
+    Json(payload): Json<PlanRequest>,
+) -> Result<Json<PlanResponse>, (StatusCode, Json<ValidationError>)> {
+    tracing::debug!("TODO: add planner auth and policy enforcement");
+
+    if payload.request_id.trim().is_empty() {
+        return Err(bad_request("request_id must not be empty"));
+    }
+
+    if payload.subject_id.trim().is_empty() {
+        return Err(bad_request("subject_id must not be empty"));
+    }
+
+    let response = PlanResponse {
+        plan_id: format!("plan-{}", Uuid::new_v4().simple()),
+        request_id: payload.request_id.clone(),
+        created_at: Utc::now(),
+        trace_id: Some(Uuid::new_v4().to_string()),
+        outcome: PlanOutcome::Success {
+            steps: stub_steps(),
+            summary: PlanSummary {
+                synopsis: Some(format!("Stub plan prepared for {}", payload.subject_id)),
+            },
+        },
+    };
+
+    Ok(Json(response))
+}
+
+#[tracing::instrument(name = "planner.health", skip_all)]
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok" })
+}
+
+fn stub_steps() -> Vec<ActionPrimitive> {
+    let mut research_args = JsonMap::new();
+    research_args.insert(
+        "intent".to_string(),
+        Value::String("collect_clarifying_details".into()),
+    );
+    research_args.insert(
+        "notes".to_string(),
+        Value::String("Review memory and prior commitments".into()),
+    );
+
+    let mut message_args = JsonMap::new();
+    message_args.insert("channel".to_string(), Value::String("internal".into()));
+    message_args.insert(
+        "body".to_string(),
+        Value::String("Queue operator follow-up for confirmation".into()),
+    );
+
+    let research = ActionPrimitive::new(ActionPrimitiveKind::Research, research_args);
+    let follow_up = ActionPrimitive::new(ActionPrimitiveKind::Message, message_args)
+        .with_postcondition(json!({ "status": "queued" }));
+
+    vec![research, follow_up]
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<ValidationError>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ValidationError {
+            error: "invalid_request",
+            message: message.into(),
+        }),
+    )
+}

--- a/services/planner/src/lib.rs
+++ b/services/planner/src/lib.rs
@@ -1,6 +1,7 @@
 //! Core primitives shared between the planner service and its dependants.
 
 pub mod event_log;
+pub mod http;
 pub mod state_machine;
 
 pub use event_log::{

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -1,0 +1,110 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use tyrum_planner::{
+    PlanOutcome, PlanRequest, PlanResponse,
+    http::{MAX_PLAN_REQUEST_BYTES, build_router},
+};
+use tyrum_shared::{
+    MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
+    PiiField, SenderMetadata, ThreadKind,
+};
+
+fn sample_request() -> PlanRequest {
+    PlanRequest {
+        request_id: "req-123".into(),
+        subject_id: "subject-456".into(),
+        trigger: NormalizedThreadMessage {
+            thread: NormalizedThread {
+                id: "thread-1".into(),
+                kind: ThreadKind::Private,
+                title: None,
+                username: Some("alex".into()),
+                pii_fields: vec![PiiField::ThreadUsername],
+            },
+            message: NormalizedMessage {
+                id: "msg-1".into(),
+                thread_id: "thread-1".into(),
+                source: MessageSource::Telegram,
+                content: MessageContent::Text {
+                    text: "Plan espresso tasting".into(),
+                },
+                sender: Some(SenderMetadata {
+                    id: "sender-9".into(),
+                    is_bot: false,
+                    first_name: Some("Alex".into()),
+                    last_name: None,
+                    username: Some("alex".into()),
+                    language_code: Some("en".into()),
+                }),
+                timestamp: Utc::now(),
+                edited_timestamp: None,
+                pii_fields: vec![PiiField::MessageText],
+            },
+        },
+        locale: Some("en-US".into()),
+        timezone: Some("America/Los_Angeles".into()),
+        tags: vec!["telegram".into()],
+    }
+}
+
+#[tokio::test]
+async fn plan_returns_stub_response() {
+    let payload = sample_request();
+    let body = serde_json::to_vec(&payload).expect("serialize plan request");
+
+    let response = build_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
+
+    assert!(plan.plan_id.starts_with("plan-"));
+    assert_eq!(plan.request_id, payload.request_id);
+    match plan.outcome {
+        PlanOutcome::Success { steps, summary } => {
+            assert!(steps.len() >= 2);
+            assert!(summary.synopsis.is_some());
+        }
+        outcome => panic!("expected success outcome, got {:?}", outcome),
+    }
+}
+
+#[tokio::test]
+async fn plan_rejects_oversized_payloads() {
+    let mut payload = sample_request();
+    payload.tags = vec![
+        String::from_utf8(vec![b'x'; MAX_PLAN_REQUEST_BYTES + 1]).expect("build oversized tag"),
+    ];
+
+    let body = serde_json::to_vec(&payload).expect("serialize oversized request");
+
+    let response = build_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}


### PR DESCRIPTION
## Summary
- add planner HTTP Axum router with /plan and /healthz stubs leveraging shared contracts
- validate incoming requests, enforce a 256KiB payload limit, and log the auth TODO for follow-up
- add integration coverage plus Dockerfile/compose wiring and local env hint for the planner service

## Acceptance Criteria
- [x] Axum server binary exposes `/plan` that validates `PlanRequest` and returns a stub plan response.
- [x] `/healthz` returns `{ "status": "ok" }` for use in docker-compose and Helm health checks.
- [x] Integration test boots the server in-process and verifies round-trip JSON handling.
- [x] `infra/docker-compose.yml` updated to include the planner service.

## Commands
- `cargo test -p tyrum-planner --test http_server`
- `pre-commit run --all-files`

Closes #64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce planner HTTP service exposing /plan stub and /healthz, with request validation, payload limits, tests, and docker-compose integration.
> 
> - **Planner HTTP service**:
>   - Add `axum` router in `services/planner/src/http.rs` with `POST /plan` (validates `PlanRequest`, returns stub `PlanResponse`) and `GET /healthz`.
>   - Enforce `MAX_PLAN_REQUEST_BYTES = 256 KiB` via `RequestBodyLimitLayer`.
>   - New binary `planner_http` (`services/planner/src/bin/http_server.rs`) with tracing init, bind via `PLANNER_BIND_ADDR`, graceful shutdown.
> - **Infra**:
>   - New `Dockerfile.planner`; add `planner` service to `infra/docker-compose.yml` (port `8083`, healthcheck).
>   - Add `PLANNER_API_URL` to `config/local.env.example`.
> - **Tests**:
>   - Integration tests in `services/planner/tests/http_server.rs` for success path and oversized payload rejection.
> - **Deps**:
>   - Add `axum`, `tower-http` (limit), `tower`, `http-body-util`; adjust `tokio` features; update `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dea703ca0b4548512083c059422ec58e5db6c55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->