### PR TITLE
Implement planner audit logging hook (#66)

### DIFF
--- a/config/local.env.example
+++ b/config/local.env.example
@@ -9,6 +9,7 @@ REDIS_URL=redis://localhost:6379/0
 NATS_URL=nats://127.0.0.1:4222
 LLM_GATEWAY_URL=http://localhost:8085
 POLICY_GATE_URL=http://localhost:8081
+PLANNER_EVENT_LOG_URL=postgres://tyrum:tyrum_dev_password@localhost:5432/tyrum_dev
 MEMORY_API_URL=http://localhost:8082
 PLANNER_API_URL=http://localhost:8083
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -30,11 +30,14 @@ services:
       RUST_LOG: info
       PLANNER_BIND_ADDR: 0.0.0.0:8083
       POLICY_GATE_URL: http://policy:8081
+      PLANNER_EVENT_LOG_URL: postgres://tyrum:tyrum_dev_password@postgres:5432/tyrum_dev
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
     depends_on:
       otel-collector:
         condition: service_started
+      postgres:
+        condition: service_healthy
     ports:
       - "8083:8083"
     healthcheck:

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -6,6 +6,9 @@ use tracing_subscriber::{EnvFilter, fmt};
 
 use tyrum_planner::http::{DEFAULT_BIND_ADDR, PlannerState, build_router};
 use tyrum_planner::policy::PolicyClient;
+use tyrum_planner::{EventLog, EventLogSettings};
+
+const EVENT_LOG_URL_ENV: &str = "PLANNER_EVENT_LOG_URL";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -20,7 +23,17 @@ async fn main() {
     let policy_client =
         PolicyClient::new(Url::parse(&policy_url).expect("invalid POLICY_GATE_URL"));
 
-    let app = build_router(PlannerState { policy_client });
+    let event_log_url =
+        env::var(EVENT_LOG_URL_ENV).unwrap_or_else(|_| panic!("{} must be set", EVENT_LOG_URL_ENV));
+    let event_log = EventLog::connect(EventLogSettings::new(event_log_url))
+        .await
+        .expect("connect planner event log");
+    event_log.migrate().await.expect("run planner migrations");
+
+    let app = build_router(PlannerState {
+        policy_client,
+        event_log,
+    });
     let listener = TcpListener::bind(bind_addr)
         .await
         .expect("bind planner socket");

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -12,9 +12,10 @@ use uuid::Uuid;
 
 use crate::policy::{PolicyClient, PolicyDecision, PolicyDecisionKind, PolicyRuleDecision};
 use crate::{
-    ActionArguments, ActionPrimitive, ActionPrimitiveKind, PlanError, PlanErrorCode,
-    PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
+    ActionArguments, ActionPrimitive, ActionPrimitiveKind, EventLog, NewPlannerEvent, PlanError,
+    PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
 };
+use tyrum_shared::{MessageSource, PiiField, ThreadKind};
 
 pub const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8083";
 pub const MAX_PLAN_REQUEST_BYTES: usize = 256 * 1024; // 256 KiB safety rail for ingress payloads.
@@ -33,6 +34,7 @@ struct ValidationError {
 #[derive(Clone)]
 pub struct PlannerState {
     pub policy_client: PolicyClient,
+    pub event_log: EventLog,
 }
 
 pub fn build_router(state: PlannerState) -> Router {
@@ -42,6 +44,8 @@ pub fn build_router(state: PlannerState) -> Router {
         .layer(RequestBodyLimitLayer::new(MAX_PLAN_REQUEST_BYTES))
         .with_state(state)
 }
+
+const DECISION_AUDIT_STEP_INDEX: i32 = i32::MAX;
 
 #[tracing::instrument(skip_all)]
 async fn plan(
@@ -58,25 +62,69 @@ async fn plan(
         return Err(bad_request("subject_id must not be empty"));
     }
 
+    let plan_uuid = Uuid::new_v4();
     let policy_result = state.policy_client.check(&payload).await;
 
-    match policy_result {
-        Ok(decision) => handle_policy_decision(&payload, decision),
+    let (outcome, policy_audit) = match policy_result {
+        Ok(decision) => {
+            let outcome = build_outcome_for_decision(&payload, &decision);
+            let rule_outcomes: Vec<String> = decision
+                .rules
+                .iter()
+                .map(|rule| format!("{:?}:{:?}", rule.rule, rule.outcome))
+                .collect();
+            tracing::info!(
+                decision = ?decision.decision,
+                rules = ?rule_outcomes,
+                "policy decision received"
+            );
+            (outcome, PolicyAudit::from_decision(&decision))
+        }
         Err(error) => {
             tracing::warn!(error = %error, "policy check failed");
-            Ok(Json(make_plan_response(
-                &payload,
-                PlanOutcome::Failure {
-                    error: PlanError {
-                        code: PlanErrorCode::Internal,
-                        message: "Policy gate unavailable".into(),
-                        detail: Some(error.to_string()),
-                        retryable: true,
-                    },
+            let reason = error.to_string();
+            let outcome = PlanOutcome::Failure {
+                error: PlanError {
+                    code: PlanErrorCode::Internal,
+                    message: "Policy gate unavailable".into(),
+                    detail: Some(reason.clone()),
+                    retryable: true,
                 },
-            )))
+            };
+            (outcome, PolicyAudit::unavailable(reason))
+        }
+    };
+
+    let plan_id = format_plan_id(plan_uuid);
+    let audit_event =
+        PlannerDecisionAudit::new(plan_uuid, &plan_id, &payload, policy_audit, &outcome);
+
+    match NewPlannerEvent::from_payload(
+        Uuid::new_v4(),
+        plan_uuid,
+        DECISION_AUDIT_STEP_INDEX,
+        Utc::now(),
+        &audit_event,
+    ) {
+        Ok(event) => {
+            if let Err(error) = state.event_log.append(event).await {
+                tracing::error!(
+                    plan_id = plan_id.as_str(),
+                    %error,
+                    "failed to append planner audit event"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::error!(
+                plan_id = plan_id.as_str(),
+                %error,
+                "failed to encode planner audit payload"
+            );
         }
     }
+
+    Ok(Json(make_plan_response(plan_id, &payload, outcome)))
 }
 
 #[tracing::instrument(name = "planner.health", skip_all)]
@@ -119,9 +167,13 @@ fn bad_request(message: impl Into<String>) -> (StatusCode, Json<ValidationError>
     )
 }
 
-fn make_plan_response(request: &PlanRequest, outcome: PlanOutcome) -> PlanResponse {
+fn make_plan_response(
+    plan_id: String,
+    request: &PlanRequest,
+    outcome: PlanOutcome,
+) -> PlanResponse {
     PlanResponse {
-        plan_id: format!("plan-{}", Uuid::new_v4().simple()),
+        plan_id,
         request_id: request.request_id.clone(),
         created_at: Utc::now(),
         trace_id: Some(Uuid::new_v4().to_string()),
@@ -129,46 +181,8 @@ fn make_plan_response(request: &PlanRequest, outcome: PlanOutcome) -> PlanRespon
     }
 }
 
-fn handle_policy_decision(
-    request: &PlanRequest,
-    decision: PolicyDecision,
-) -> Result<Json<PlanResponse>, (StatusCode, Json<ValidationError>)> {
-    let rule_outcomes: Vec<String> = decision
-        .rules
-        .iter()
-        .map(|rule| format!("{:?}:{:?}", rule.rule, rule.outcome))
-        .collect();
-    tracing::info!(
-        decision = ?decision.decision,
-        rules = ?rule_outcomes,
-        "policy decision received"
-    );
-
-    let response = match decision.decision {
-        PolicyDecisionKind::Approve => make_plan_response(
-            request,
-            PlanOutcome::Success {
-                steps: stub_steps(),
-                summary: PlanSummary {
-                    synopsis: Some(format!("Stub plan prepared for {}", request.subject_id)),
-                },
-            },
-        ),
-        PolicyDecisionKind::Escalate => make_plan_response(
-            request,
-            PlanOutcome::Escalate {
-                escalation: build_policy_escalation(&decision),
-            },
-        ),
-        PolicyDecisionKind::Deny => make_plan_response(
-            request,
-            PlanOutcome::Failure {
-                error: build_policy_failure(&decision),
-            },
-        ),
-    };
-
-    Ok(Json(response))
+fn format_plan_id(plan_uuid: Uuid) -> String {
+    format!("plan-{}", plan_uuid.simple())
 }
 
 fn build_policy_escalation(decision: &PolicyDecision) -> PlanEscalation {
@@ -251,5 +265,211 @@ fn build_policy_failure(decision: &PolicyDecision) -> PlanError {
         message: "Policy gate denied the plan".into(),
         detail,
         retryable: false,
+    }
+}
+
+fn build_outcome_for_decision(request: &PlanRequest, decision: &PolicyDecision) -> PlanOutcome {
+    match decision.decision {
+        PolicyDecisionKind::Approve => PlanOutcome::Success {
+            steps: stub_steps(),
+            summary: PlanSummary {
+                synopsis: Some(format!("Stub plan prepared for {}", request.subject_id)),
+            },
+        },
+        PolicyDecisionKind::Escalate => PlanOutcome::Escalate {
+            escalation: build_policy_escalation(decision),
+        },
+        PolicyDecisionKind::Deny => PlanOutcome::Failure {
+            error: build_policy_failure(decision),
+        },
+    }
+}
+
+#[derive(Serialize)]
+struct PlannerDecisionAudit {
+    plan_id: String,
+    plan_uuid: Uuid,
+    request: RedactedRequest,
+    policy: PolicyAudit,
+    outcome: PlanOutcomeAudit,
+}
+
+impl PlannerDecisionAudit {
+    fn new(
+        plan_uuid: Uuid,
+        plan_id: &str,
+        request: &PlanRequest,
+        policy: PolicyAudit,
+        outcome: &PlanOutcome,
+    ) -> Self {
+        Self {
+            plan_id: plan_id.to_owned(),
+            plan_uuid,
+            request: RedactedRequest::from_plan_request(request),
+            policy,
+            outcome: PlanOutcomeAudit::from(outcome),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct RedactedRequest {
+    request_id: String,
+    subject_id: String,
+    tags: Vec<String>,
+    trigger: RedactedTrigger,
+}
+
+impl RedactedRequest {
+    fn from_plan_request(request: &PlanRequest) -> Self {
+        Self {
+            request_id: request.request_id.clone(),
+            subject_id: request.subject_id.clone(),
+            tags: request.tags.clone(),
+            trigger: RedactedTrigger::from_trigger(&request.trigger),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct RedactedTrigger {
+    thread_id: String,
+    thread_kind: ThreadKind,
+    message_id: String,
+    message_source: MessageSource,
+    thread_pii_fields: Vec<PiiField>,
+    message_pii_fields: Vec<PiiField>,
+}
+
+impl RedactedTrigger {
+    fn from_trigger(trigger: &tyrum_shared::NormalizedThreadMessage) -> Self {
+        // We intentionally omit thread/message fields flagged as PII and record only
+        // identifiers plus declared PII categories so audit trails remain traceable
+        // without storing personal data verbatim.
+        Self {
+            thread_id: trigger.thread.id.clone(),
+            thread_kind: trigger.thread.kind,
+            message_id: trigger.message.id.clone(),
+            message_source: trigger.message.source,
+            thread_pii_fields: trigger.thread.pii_fields.clone(),
+            message_pii_fields: trigger.message.pii_fields.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PolicyAudit {
+    Evaluated {
+        decision: String,
+        rules: Vec<PolicyRuleAudit>,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+impl PolicyAudit {
+    fn from_decision(decision: &PolicyDecision) -> Self {
+        let rules = decision
+            .rules
+            .iter()
+            .map(|rule| PolicyRuleAudit {
+                rule: format!("{:?}", rule.rule),
+                outcome: format!("{:?}", rule.outcome),
+                detail: rule.detail.clone(),
+            })
+            .collect();
+
+        Self::Evaluated {
+            decision: format!("{:?}", decision.decision),
+            rules,
+        }
+    }
+
+    fn unavailable(reason: String) -> Self {
+        Self::Unavailable { reason }
+    }
+}
+
+#[derive(Serialize)]
+struct PolicyRuleAudit {
+    rule: String,
+    outcome: String,
+    detail: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PlanOutcomeAudit {
+    Success {
+        step_count: usize,
+        steps: Vec<LoggedStep>,
+        summary_present: bool,
+    },
+    Escalate {
+        step_index: usize,
+        action_kind: ActionPrimitiveKind,
+        arg_keys: Vec<String>,
+        rationale_present: bool,
+    },
+    Failure {
+        code: PlanErrorCode,
+        retryable: bool,
+        detail_present: bool,
+    },
+}
+
+impl From<&PlanOutcome> for PlanOutcomeAudit {
+    fn from(outcome: &PlanOutcome) -> Self {
+        match outcome {
+            PlanOutcome::Success { steps, summary } => PlanOutcomeAudit::Success {
+                step_count: steps.len(),
+                steps: steps
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, step)| LoggedStep::from_step(idx, step))
+                    .collect(),
+                summary_present: summary
+                    .synopsis
+                    .as_ref()
+                    .is_some_and(|synopsis| !synopsis.is_empty()),
+            },
+            PlanOutcome::Escalate { escalation } => PlanOutcomeAudit::Escalate {
+                step_index: escalation.step_index,
+                action_kind: escalation.action.kind,
+                arg_keys: escalation.action.args.keys().cloned().collect(),
+                rationale_present: escalation
+                    .rationale
+                    .as_ref()
+                    .is_some_and(|value| !value.is_empty()),
+            },
+            PlanOutcome::Failure { error } => PlanOutcomeAudit::Failure {
+                code: error.code,
+                retryable: error.retryable,
+                detail_present: error.detail.as_ref().is_some_and(|value| !value.is_empty()),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LoggedStep {
+    step_index: usize,
+    kind: ActionPrimitiveKind,
+    arg_keys: Vec<String>,
+    has_postcondition: bool,
+    has_idempotency_key: bool,
+}
+
+impl LoggedStep {
+    fn from_step(index: usize, step: &ActionPrimitive) -> Self {
+        Self {
+            step_index: index,
+            kind: step.kind,
+            arg_keys: step.args.keys().cloned().collect(),
+            has_postcondition: step.postcondition.is_some(),
+            has_idempotency_key: step.idempotency_key.is_some(),
+        }
     }
 }

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use axum::{
     Json, Router,
     body::Body,
@@ -5,12 +7,13 @@ use axum::{
     routing::post,
 };
 use chrono::Utc;
+use common::postgres::TestPostgres;
 use http_body_util::BodyExt;
 use reqwest::Url;
 use tokio::{net::TcpListener, task::JoinHandle};
 use tower::ServiceExt;
 use tyrum_planner::{
-    PlanOutcome, PlanRequest, PlanResponse,
+    EventLog, PlanOutcome, PlanRequest, PlanResponse,
     http::{MAX_PLAN_REQUEST_BYTES, PlannerState, build_router},
     policy::PolicyClient,
 };
@@ -62,7 +65,7 @@ async fn plan_returns_stub_response() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "approve",
         "rules": [
             {
@@ -84,7 +87,7 @@ async fn plan_returns_stub_response() {
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -123,13 +126,13 @@ async fn plan_rejects_oversized_payloads() {
 
     let body = serde_json::to_vec(&payload).expect("serialize oversized request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "approve",
         "rules": [],
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -151,7 +154,7 @@ async fn plan_escalates_on_policy_escalation() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "escalate",
         "rules": [
             {
@@ -163,7 +166,7 @@ async fn plan_escalates_on_policy_escalation() {
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -195,7 +198,7 @@ async fn plan_returns_failure_on_policy_denial() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "deny",
         "rules": [
             {
@@ -207,7 +210,7 @@ async fn plan_returns_failure_on_policy_denial() {
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -240,7 +243,7 @@ async fn plan_escalation_includes_context_when_rules_do_not_match() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "escalate",
         "rules": [
             {
@@ -252,7 +255,7 @@ async fn plan_escalation_includes_context_when_rules_do_not_match() {
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -282,7 +285,7 @@ async fn plan_failure_includes_details_when_rules_do_not_match() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (policy_client, server) = mock_policy(serde_json::json!({
+    let (state, server, _postgres) = planner_state(serde_json::json!({
         "decision": "deny",
         "rules": [
             {
@@ -294,7 +297,7 @@ async fn plan_failure_includes_details_when_rules_do_not_match() {
     }))
     .await;
 
-    let response = build_router(PlannerState { policy_client })
+    let response = build_router(state)
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -343,4 +346,22 @@ async fn mock_policy(response: serde_json::Value) -> (PolicyClient, JoinHandle<(
 
     let client = PolicyClient::new(url);
     (client, server)
+}
+
+async fn planner_state(
+    policy_response: serde_json::Value,
+) -> (PlannerState, JoinHandle<()>, TestPostgres) {
+    let (policy_client, server) = mock_policy(policy_response).await;
+    let postgres = TestPostgres::start().await.expect("start postgres fixture");
+    let event_log = EventLog::from_pool(postgres.pool().clone());
+    event_log.migrate().await.expect("migrate planner schema");
+
+    (
+        PlannerState {
+            policy_client,
+            event_log,
+        },
+        server,
+        postgres,
+    )
 }

--- a/services/planner/tests/plan_audit.rs
+++ b/services/planner/tests/plan_audit.rs
@@ -1,0 +1,202 @@
+mod common;
+
+use axum::{Json, Router, body::Body, http::Request, routing::post};
+use chrono::Utc;
+use common::postgres::TestPostgres;
+use http_body_util::BodyExt;
+use reqwest::Url;
+use serde_json::json;
+use sqlx::Row;
+use tokio::{net::TcpListener, task::JoinHandle};
+use tower::ServiceExt;
+use tyrum_planner::{
+    EventLog, PlanOutcome, PlanRequest, PlanResponse,
+    http::{PlannerState, build_router},
+    policy::PolicyClient,
+};
+use tyrum_shared::{
+    MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
+    PiiField, SenderMetadata, ThreadKind,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn planner_appends_audit_event_with_redacted_payload() {
+    let postgres = TestPostgres::start().await.expect("start postgres fixture");
+    let pool = postgres.pool().clone();
+
+    let event_log = EventLog::from_pool(pool.clone());
+    event_log.migrate().await.expect("migrate planner schema");
+
+    let (policy_client, server) = mock_policy(json!({
+        "decision": "approve",
+        "rules": [
+            {
+                "rule": "spend_limit",
+                "outcome": "approve",
+                "detail": "No spend requested",
+            },
+            {
+                "rule": "pii_guardrail",
+                "outcome": "approve",
+                "detail": "PII safe",
+            }
+        ],
+    }))
+    .await;
+
+    let state = PlannerState {
+        policy_client,
+        event_log: event_log.clone(),
+    };
+
+    let request = sample_request();
+    let body = serde_json::to_vec(&request).expect("serialize plan request");
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
+
+    let plan_uuid = plan
+        .plan_id
+        .strip_prefix("plan-")
+        .and_then(|suffix| Uuid::parse_str(suffix).ok())
+        .expect("parse plan uuid");
+
+    let rows = sqlx::query("SELECT plan_id, step_index, action FROM planner_events")
+        .fetch_all(&pool)
+        .await
+        .expect("fetch planner events");
+
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    let stored_plan: Uuid = row.try_get("plan_id").expect("plan_id");
+    let step_index: i32 = row.try_get("step_index").expect("step_index");
+    let action: serde_json::Value = row.try_get("action").expect("action payload");
+
+    assert_eq!(stored_plan, plan_uuid);
+    assert_eq!(step_index, i32::MAX);
+
+    assert_eq!(
+        action.get("plan_id").and_then(|value| value.as_str()),
+        Some(plan.plan_id.as_str())
+    );
+    let recorded_plan_uuid = action
+        .get("plan_uuid")
+        .and_then(|value| value.as_str())
+        .expect("plan_uuid in audit payload");
+    assert_eq!(recorded_plan_uuid, plan_uuid.to_string());
+
+    // Ensure audit payload excludes message/thread PII while keeping traceable metadata.
+    let request_json = action
+        .get("request")
+        .and_then(|value| value.as_object())
+        .expect("request audit payload");
+    let trigger = request_json
+        .get("trigger")
+        .and_then(|value| value.as_object())
+        .expect("trigger audit payload");
+
+    assert_eq!(trigger.get("thread_id").unwrap().as_str(), Some("thread-1"));
+    assert_eq!(trigger.get("message_id").unwrap().as_str(), Some("msg-1"));
+    assert!(
+        trigger
+            .get("thread_pii_fields")
+            .unwrap()
+            .to_string()
+            .contains("thread_username")
+    );
+    assert!(
+        trigger
+            .get("message_pii_fields")
+            .unwrap()
+            .to_string()
+            .contains("message_text")
+    );
+
+    let payload_text = action.to_string();
+    assert!(!payload_text.contains("alex"));
+    assert!(!payload_text.contains("Plan espresso tasting"));
+
+    match plan.outcome {
+        PlanOutcome::Success { .. } => {}
+        other => panic!("expected success outcome, got {other:?}"),
+    }
+}
+
+fn sample_request() -> PlanRequest {
+    PlanRequest {
+        request_id: "req-123".into(),
+        subject_id: "subject-456".into(),
+        trigger: NormalizedThreadMessage {
+            thread: NormalizedThread {
+                id: "thread-1".into(),
+                kind: ThreadKind::Private,
+                title: None,
+                username: Some("alex".into()),
+                pii_fields: vec![PiiField::ThreadUsername],
+            },
+            message: NormalizedMessage {
+                id: "msg-1".into(),
+                thread_id: "thread-1".into(),
+                source: MessageSource::Telegram,
+                content: MessageContent::Text {
+                    text: "Plan espresso tasting".into(),
+                },
+                sender: Some(SenderMetadata {
+                    id: "sender-9".into(),
+                    is_bot: false,
+                    first_name: Some("Alex".into()),
+                    last_name: None,
+                    username: Some("alex".into()),
+                    language_code: Some("en".into()),
+                }),
+                timestamp: Utc::now(),
+                edited_timestamp: None,
+                pii_fields: vec![PiiField::MessageText],
+            },
+        },
+        locale: Some("en-US".into()),
+        timezone: Some("America/Los_Angeles".into()),
+        tags: vec!["telegram".into()],
+    }
+}
+
+async fn mock_policy(response: serde_json::Value) -> (PolicyClient, JoinHandle<()>) {
+    let body = response;
+    let app = Router::new().route(
+        "/policy/check",
+        post(move || {
+            let response = body.clone();
+            async move { Json(response) }
+        }),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind policy listener");
+    let addr = listener.local_addr().expect("obtain policy addr");
+    let url = Url::parse(&format!("http://{}", addr)).expect("construct policy url");
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("policy server failed");
+    });
+
+    let client = PolicyClient::new(url);
+    (client, server)
+}


### PR DESCRIPTION
## Summary
- wire the planner HTTP service to persist sanitized audit events for every `/plan` request
- redact PII in stored payloads while keeping traceable identifiers and document the approach in code
- add a Postgres-backed integration test and update local/docker env vars for the planner event log

## Acceptance Criteria
- [x] Planner appends a `planner_events` row for every `/plan` request, including policy outcome metadata.
- [x] Integration test uses Postgres (testcontainers) to assert event persistence after a request.
- [x] Logged payload excludes sensitive PII while preserving traceability.

## Testing
- pre-commit run --all-files
- cargo test -p tyrum-planner --test plan_audit

Closes #66

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Planner now writes a redacted audit event for each /plan request to a Postgres-backed event log, with supporting env/config and tests.
> 
> - **Planner Service**:
>   - Wire `services/planner` to Postgres event log: add `EventLog` to `PlannerState`, connect via `PLANNER_EVENT_LOG_URL`, run migrations, and append a decision audit event per `/plan`.
>   - Redact PII in audit payloads while preserving identifiers (`RedactedRequest`, `RedactedTrigger`, `PolicyAudit`, `PlanOutcomeAudit`).
>   - Refactor response building: stable `plan_id` from UUID (`format_plan_id`) and `build_outcome_for_decision`.
> - **Tests**:
>   - New integration test `services/planner/tests/plan_audit.rs` verifies event persistence and redaction.
>   - Update existing HTTP tests to construct `PlannerState` with `EventLog` using a Postgres test fixture.
> - **Infra/Config**:
>   - Add `PLANNER_EVENT_LOG_URL` to `config/local.env.example` and `infra/docker-compose.yml` (planner depends on healthy `postgres`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9629f344fa9cd082a8bc6eba68c63f4f746501f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->