### PR TITLE
Add discovery telemetry instrumentation (#69)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,7 +3610,11 @@ dependencies = [
 name = "tyrum-discovery"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/docs/telemetry_pipeline.md
+++ b/docs/telemetry_pipeline.md
@@ -28,7 +28,8 @@ All other application services automatically depend on the collector and export 
 3. Open Grafana (`http://localhost:3001`, `admin` / `tyrum`):
    - **Explore → Tempo** to view spans `api.index`, `api.health`, and `policy.check` grouped by `service.name`.
    - **Explore → Loki** to see structured logs from the `tyrum-api` and `tyrum-policy` services.
-   - **Explore → Prometheus** or the Prometheus UI to query `tyrum_api_http_requests_total` and `tyrum_policy_decisions_total` metrics.
+   - **Explore → Prometheus** or the Prometheus UI to query `tyrum_api_http_requests_total`, `tyrum_policy_decisions_total`, `tyrum_discovery_attempt_duration_seconds`, and `tyrum_discovery_attempt_total` metrics.
+   - **Explore → Tempo** to inspect the `discovery.step` spans emitted per capability probe; each span records the `strategy`, `subject`, and `outcome` attributes so retry chains are easy to trace.
 
 ## Notes
 - The collector configuration lives at `config/observability/otel-collector.yaml`; adjust exporters here if additional backends are required.

--- a/services/discovery/Cargo.toml
+++ b/services/discovery/Cargo.toml
@@ -11,7 +11,13 @@ name = "tyrum_discovery"
 path = "src/lib.rs"
 
 [dependencies]
+once_cell = "1.19"
+opentelemetry = { version = "0.31", features = ["metrics"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+
+[dev-dependencies]
+opentelemetry_sdk = { version = "0.31", features = ["metrics", "testing"] }
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [lints]
 workspace = true

--- a/services/discovery/src/lib.rs
+++ b/services/discovery/src/lib.rs
@@ -1,5 +1,7 @@
 //! Discovery pipeline interfaces and default stub implementation.
 
+mod telemetry;
+
 pub mod pipeline;
 
 pub use pipeline::{

--- a/services/discovery/src/pipeline.rs
+++ b/services/discovery/src/pipeline.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use tracing::debug;
 
+use crate::telemetry;
+
 /// Request envelope supplied to discovery strategies.
 ///
 /// The `subject` should be a sanitized descriptor such as a domain, MCP
@@ -42,6 +44,14 @@ impl DiscoveryOutcome {
     fn continues(&self) -> bool {
         matches!(self, DiscoveryOutcome::NotFound)
     }
+
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            DiscoveryOutcome::Found(_) => "found",
+            DiscoveryOutcome::NotFound => "not_found",
+            DiscoveryOutcome::RetryLater { .. } => "retry_later",
+        }
+    }
 }
 
 /// Connector metadata surfaced back to executors.
@@ -65,6 +75,16 @@ pub enum DiscoveryStrategy {
     GenericHttp,
 }
 
+impl DiscoveryStrategy {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            DiscoveryStrategy::Mcp => "mcp",
+            DiscoveryStrategy::StructuredApi => "structured_api",
+            DiscoveryStrategy::GenericHttp => "generic_http",
+        }
+    }
+}
+
 /// Defines the contract for executing discovery strategies in a fixed order.
 pub trait DiscoveryPipeline {
     fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
@@ -78,66 +98,21 @@ pub trait DiscoveryPipeline {
     fn discover(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         debug!(subject = %request.sanitized_subject(), "Starting discovery");
 
-        debug!(
-            subject = %request.sanitized_subject(),
-            strategy = ?DiscoveryStrategy::Mcp,
-            "Running discovery step",
-        );
-        match self.try_mcp(request) {
-            DiscoveryOutcome::NotFound => {
-                debug!(strategy = ?DiscoveryStrategy::Mcp, "Strategy returned NotFound");
-            }
-            outcome => {
-                debug!(
-                    strategy = ?DiscoveryStrategy::Mcp,
-                    outcome = ?outcome,
-                    "Strategy resolved",
-                );
-                return outcome;
-            }
+        let outcome = execute_step(request, DiscoveryStrategy::Mcp, || self.try_mcp(request));
+        if !outcome.continues() {
+            return outcome;
         }
 
-        debug!(
-            subject = %request.sanitized_subject(),
-            strategy = ?DiscoveryStrategy::StructuredApi,
-            "Running discovery step",
-        );
-        match self.try_structured_api(request) {
-            DiscoveryOutcome::NotFound => {
-                debug!(
-                    strategy = ?DiscoveryStrategy::StructuredApi,
-                    "Strategy returned NotFound",
-                );
-            }
-            outcome => {
-                debug!(
-                    strategy = ?DiscoveryStrategy::StructuredApi,
-                    outcome = ?outcome,
-                    "Strategy resolved",
-                );
-                return outcome;
-            }
+        let outcome = execute_step(request, DiscoveryStrategy::StructuredApi, || {
+            self.try_structured_api(request)
+        });
+        if !outcome.continues() {
+            return outcome;
         }
 
-        debug!(
-            subject = %request.sanitized_subject(),
-            strategy = ?DiscoveryStrategy::GenericHttp,
-            "Running discovery step",
-        );
-        let outcome = self.try_generic_http(request);
-        if outcome.continues() {
-            debug!(
-                strategy = ?DiscoveryStrategy::GenericHttp,
-                "Strategy returned NotFound",
-            );
-        } else {
-            debug!(
-                strategy = ?DiscoveryStrategy::GenericHttp,
-                outcome = ?outcome,
-                "Strategy resolved",
-            );
-        }
-        outcome
+        execute_step(request, DiscoveryStrategy::GenericHttp, || {
+            self.try_generic_http(request)
+        })
     }
 }
 
@@ -168,10 +143,54 @@ impl DiscoveryPipeline for DefaultDiscoveryPipeline {
     }
 }
 
+fn execute_step<F>(
+    request: &DiscoveryRequest,
+    strategy: DiscoveryStrategy,
+    attempt: F,
+) -> DiscoveryOutcome
+where
+    F: FnOnce() -> DiscoveryOutcome,
+{
+    debug!(
+        subject = %request.sanitized_subject(),
+        strategy = strategy.as_str(),
+        "Running discovery step",
+    );
+
+    let outcome = telemetry::record_step(strategy, request.sanitized_subject(), attempt);
+
+    if outcome.continues() {
+        debug!(strategy = strategy.as_str(), "Strategy returned NotFound");
+    } else {
+        debug!(strategy = strategy.as_str(), outcome = ?outcome, "Strategy resolved");
+    }
+
+    outcome
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::cell::RefCell;
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
+
+    use once_cell::sync::Lazy;
+    use opentelemetry::{Value, global};
+    use opentelemetry_sdk::metrics::{
+        InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+        data::{AggregatedMetrics, HistogramDataPoint, MetricData, SumDataPoint},
+    };
+    use tracing::subscriber::with_default;
+    use tracing::{
+        Id, Subscriber,
+        field::{Field, Visit},
+    };
+    use tracing_subscriber::{
+        Layer, Registry, layer::Context, layer::SubscriberExt, registry::LookupSpan,
+    };
+
+    static TELEMETRY_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     struct ScriptedPipeline {
         calls: RefCell<Vec<DiscoveryStrategy>>,
@@ -224,6 +243,85 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug, Default)]
+    struct CapturedSpan {
+        name: String,
+        strategy: Option<String>,
+        subject: Option<String>,
+        outcome: Option<String>,
+    }
+
+    struct RecordingLayer {
+        spans: Arc<Mutex<Vec<CapturedSpan>>>,
+    }
+
+    impl RecordingLayer {
+        fn new(spans: Arc<Mutex<Vec<CapturedSpan>>>) -> Self {
+            Self { spans }
+        }
+
+        fn push_span(&self, span: CapturedSpan) {
+            self.spans.lock().unwrap().push(span);
+        }
+    }
+
+    struct FieldVisitor<'a> {
+        span: &'a mut CapturedSpan,
+    }
+
+    impl<'a> FieldVisitor<'a> {
+        fn record_value(&mut self, field: &Field, value: &str) {
+            match field.name() {
+                "strategy" => self.span.strategy = Some(value.to_owned()),
+                "subject" => self.span.subject = Some(value.to_owned()),
+                "outcome" => self.span.outcome = Some(value.to_owned()),
+                _ => {}
+            }
+        }
+    }
+
+    impl<'a> Visit for FieldVisitor<'a> {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.record_value(field, value);
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.record_value(field, &format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for RecordingLayer
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+            if let Some(span) = ctx.span(id) {
+                let mut data = CapturedSpan {
+                    name: attrs.metadata().name().to_string(),
+                    ..CapturedSpan::default()
+                };
+                attrs.record(&mut FieldVisitor { span: &mut data });
+                span.extensions_mut().insert(data);
+            }
+        }
+
+        fn on_record(&self, id: &Id, values: &tracing::span::Record<'_>, ctx: Context<'_, S>) {
+            if let Some(span) = ctx.span(id)
+                && let Some(data) = span.extensions_mut().get_mut::<CapturedSpan>()
+            {
+                values.record(&mut FieldVisitor { span: data });
+            }
+        }
+
+        fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+            if let Some(span) = ctx.span(&id)
+                && let Some(data) = span.extensions_mut().remove::<CapturedSpan>()
+            {
+                self.push_span(data);
+            }
+        }
+    }
+
     #[test]
     fn runs_strategies_in_order_when_not_found() {
         let pipeline = ScriptedPipeline::new(
@@ -267,5 +365,193 @@ mod tests {
             pipeline.calls(),
             vec![DiscoveryStrategy::Mcp, DiscoveryStrategy::StructuredApi],
         );
+    }
+
+    #[test]
+    fn telemetry_records_spans_for_each_attempt() {
+        let _lock = TELEMETRY_GUARD.lock().unwrap();
+        let spans = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default().with(RecordingLayer::new(spans.clone()));
+
+        let pipeline = ScriptedPipeline::new(
+            DiscoveryOutcome::NotFound,
+            DiscoveryOutcome::NotFound,
+            DiscoveryOutcome::RetryLater {
+                retry_after: Some(Duration::from_secs(5)),
+            },
+        );
+
+        with_default(subscriber, || {
+            let _ = pipeline.discover(&request());
+        });
+
+        let captured = spans.lock().unwrap().clone();
+        assert_eq!(captured.len(), 3);
+
+        let strategies: Vec<_> = captured
+            .iter()
+            .map(|span| span.strategy.as_deref().unwrap_or_default())
+            .collect();
+        assert_eq!(strategies, vec!["mcp", "structured_api", "generic_http"]);
+
+        let outcomes: Vec<_> = captured
+            .iter()
+            .map(|span| span.outcome.as_deref().unwrap_or_default())
+            .collect();
+        assert_eq!(outcomes, vec!["not_found", "not_found", "retry_later"]);
+
+        for span in captured {
+            assert_eq!(span.name, "discovery.step");
+            assert_eq!(span.subject.as_deref(), Some("calendar:events"));
+        }
+    }
+
+    #[test]
+    fn telemetry_records_metrics_for_each_attempt() {
+        let _lock = TELEMETRY_GUARD.lock().unwrap();
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone()).build();
+        let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+
+        global::set_meter_provider(meter_provider.clone());
+
+        let connector = DiscoveryConnector {
+            strategy: DiscoveryStrategy::StructuredApi,
+            locator: "structured://crm.accounts".into(),
+        };
+        let pipeline = ScriptedPipeline::new(
+            DiscoveryOutcome::NotFound,
+            DiscoveryOutcome::Found(connector),
+            DiscoveryOutcome::Found(DiscoveryConnector {
+                strategy: DiscoveryStrategy::GenericHttp,
+                locator: "https://example.com".into(),
+            }),
+        );
+
+        let outcome = pipeline.discover(&request());
+        assert!(matches!(outcome, DiscoveryOutcome::Found(_)));
+
+        meter_provider.force_flush().expect("force flush metrics");
+        meter_provider.shutdown().expect("shutdown meter provider");
+        global::set_meter_provider(SdkMeterProvider::builder().build());
+
+        let metrics = exporter.get_finished_metrics().expect("metrics available");
+
+        let mcp_hist = find_histogram_point(
+            &metrics,
+            "tyrum_discovery_attempt_duration_seconds",
+            "mcp",
+            "not_found",
+        )
+        .expect("mcp histogram present");
+        assert_eq!(mcp_hist.count(), 1);
+
+        let structured_hist = find_histogram_point(
+            &metrics,
+            "tyrum_discovery_attempt_duration_seconds",
+            "structured_api",
+            "found",
+        )
+        .expect("structured histogram present");
+        assert_eq!(structured_hist.count(), 1);
+
+        let mcp_sum = find_sum_point(
+            &metrics,
+            "tyrum_discovery_attempt_total",
+            "mcp",
+            "not_found",
+        )
+        .expect("mcp counter present");
+        assert_eq!(mcp_sum.value(), 1);
+
+        let structured_sum = find_sum_point(
+            &metrics,
+            "tyrum_discovery_attempt_total",
+            "structured_api",
+            "found",
+        )
+        .expect("structured counter present");
+        assert_eq!(structured_sum.value(), 1);
+
+        assert!(
+            find_sum_point(
+                &metrics,
+                "tyrum_discovery_attempt_total",
+                "generic_http",
+                "found",
+            )
+            .is_none()
+        );
+    }
+
+    fn find_histogram_point<'a>(
+        metrics: &'a [opentelemetry_sdk::metrics::data::ResourceMetrics],
+        metric_name: &str,
+        strategy: &str,
+        outcome: &str,
+    ) -> Option<&'a HistogramDataPoint<f64>> {
+        metrics
+            .iter()
+            .flat_map(|resource| resource.scope_metrics())
+            .flat_map(|scope| scope.metrics())
+            .find_map(|metric| {
+                if metric.name() != metric_name {
+                    return None;
+                }
+
+                match metric.data() {
+                    AggregatedMetrics::F64(MetricData::Histogram(hist)) => hist
+                        .data_points()
+                        .find(|point| matches_attr(point.attributes(), strategy, outcome)),
+                    _ => None,
+                }
+            })
+    }
+
+    fn find_sum_point<'a>(
+        metrics: &'a [opentelemetry_sdk::metrics::data::ResourceMetrics],
+        metric_name: &str,
+        strategy: &str,
+        outcome: &str,
+    ) -> Option<&'a SumDataPoint<u64>> {
+        metrics
+            .iter()
+            .flat_map(|resource| resource.scope_metrics())
+            .flat_map(|scope| scope.metrics())
+            .find_map(|metric| {
+                if metric.name() != metric_name {
+                    return None;
+                }
+
+                match metric.data() {
+                    AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
+                        .data_points()
+                        .find(|point| matches_attr(point.attributes(), strategy, outcome)),
+                    _ => None,
+                }
+            })
+    }
+
+    fn matches_attr<'a>(
+        attrs: impl Iterator<Item = &'a opentelemetry::KeyValue>,
+        strategy: &str,
+        outcome: &str,
+    ) -> bool {
+        let mut strategy_match = false;
+        let mut outcome_match = false;
+
+        for kv in attrs {
+            if kv.key.as_str() == "discovery.strategy" {
+                if let Value::String(ref value) = kv.value {
+                    strategy_match = value.as_ref() == strategy;
+                }
+            } else if kv.key.as_str() == "discovery.outcome"
+                && let Value::String(ref value) = kv.value
+            {
+                outcome_match = value.as_ref() == outcome;
+            }
+        }
+
+        strategy_match && outcome_match
     }
 }

--- a/services/discovery/src/telemetry.rs
+++ b/services/discovery/src/telemetry.rs
@@ -1,0 +1,113 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use once_cell::sync::OnceCell;
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Histogram},
+};
+use tracing::{field, info_span};
+
+use crate::pipeline::{DiscoveryOutcome, DiscoveryStrategy};
+
+const METER_NAME: &str = "tyrum-discovery";
+const DURATION_METRIC_NAME: &str = "tyrum_discovery_attempt_duration_seconds";
+const COUNT_METRIC_NAME: &str = "tyrum_discovery_attempt_total";
+
+#[derive(Clone)]
+struct MetricsInstruments {
+    duration: Histogram<f64>,
+    count: Counter<u64>,
+}
+
+#[derive(Default)]
+struct MetricsCache {
+    provider: Option<Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>>,
+    instruments: Option<MetricsInstruments>,
+}
+
+static METRICS: OnceCell<Mutex<MetricsCache>> = OnceCell::new();
+
+pub(crate) fn record_step<F>(
+    strategy: DiscoveryStrategy,
+    subject: &str,
+    attempt: F,
+) -> DiscoveryOutcome
+where
+    F: FnOnce() -> DiscoveryOutcome,
+{
+    let span = info_span!(
+        "discovery.step",
+        strategy = strategy.as_str(),
+        subject,
+        outcome = field::Empty,
+        retry_after_ms = field::Empty,
+    );
+    let _guard = span.enter();
+    let start = Instant::now();
+
+    let outcome = attempt();
+    let elapsed = start.elapsed();
+
+    let outcome_label = outcome.label();
+    span.record("outcome", outcome_label);
+
+    if let DiscoveryOutcome::RetryLater {
+        retry_after: Some(delay),
+    } = &outcome
+    {
+        let millis = delay.as_millis().min(i64::MAX as u128) as i64;
+        span.record("retry_after_ms", millis);
+    }
+
+    record_metrics(strategy, &outcome, elapsed);
+
+    outcome
+}
+
+fn record_metrics(strategy: DiscoveryStrategy, outcome: &DiscoveryOutcome, duration: Duration) {
+    let instruments = metrics_instruments();
+
+    let attributes = [
+        KeyValue::new("discovery.strategy", strategy.as_str()),
+        KeyValue::new("discovery.outcome", outcome.label()),
+    ];
+
+    instruments
+        .duration
+        .record(duration.as_secs_f64(), &attributes);
+    instruments.count.add(1, &attributes);
+}
+
+fn metrics_instruments() -> MetricsInstruments {
+    let provider = global::meter_provider();
+    let cache = METRICS.get_or_init(|| Mutex::new(MetricsCache::default()));
+    let mut guard = cache.lock().expect("metrics cache poisoned");
+
+    if guard
+        .provider
+        .as_ref()
+        .is_some_and(|current| Arc::ptr_eq(current, &provider))
+        && let Some(instruments) = &guard.instruments
+    {
+        return instruments.clone();
+    }
+
+    let meter = provider.meter(METER_NAME);
+    let instruments = MetricsInstruments {
+        duration: meter
+            .f64_histogram(DURATION_METRIC_NAME)
+            .with_unit("s")
+            .with_description("Duration of discovery attempts by strategy and outcome")
+            .build(),
+        count: meter
+            .u64_counter(COUNT_METRIC_NAME)
+            .with_description("Count of discovery attempts by strategy and outcome")
+            .build(),
+    };
+
+    guard.provider = Some(provider);
+    guard.instruments = Some(instruments.clone());
+
+    instruments
+}


### PR DESCRIPTION
## Summary
- add structured tracing spans around each discovery strategy execution
- publish OTEL histogram and counter metrics for discovery attempt outcomes
- document the new discovery signals in the telemetry playbook

## Testing
- pre-commit run --all-files
- cargo test -p tyrum-discovery telemetry
- cargo test

Closes #69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add OpenTelemetry spans and metrics to the discovery pipeline, refactor step execution, and document the new telemetry signals.
> 
> - **Discovery Service (`services/discovery`)**:
>   - **Telemetry**:
>     - Add `telemetry` module emitting `discovery.step` spans with `strategy`, `subject`, and `outcome` (and `retry_after_ms` when present).
>     - Record metrics: histogram `tyrum_discovery_attempt_duration_seconds` and counter `tyrum_discovery_attempt_total` with `discovery.strategy` and `discovery.outcome` attributes.
>   - **Pipeline**:
>     - Refactor `discover` to use `execute_step` wrapper; add `DiscoveryOutcome::label()` and `DiscoveryStrategy::as_str()` helpers.
>   - **Dependencies**:
>     - Add `once_cell`, `opentelemetry` (metrics), and dev deps `opentelemetry_sdk`, `tracing-subscriber`.
> - **Docs**:
>   - Update `docs/telemetry_pipeline.md` to include new discovery metrics and spans for Grafana/Tempo/Prometheus validation.
> - **Tests**:
>   - Add span-capture and in-memory metrics tests validating spans and metric points per strategy/outcome.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d05633d874e4a226678de6ae9729853f4f43704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->