### PR TITLE
Integrate planner discovery pipeline before executor selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "tyrum-discovery",
  "tyrum-memory",
  "tyrum-shared",
  "url",

--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -40,6 +40,7 @@ tyrum-shared = { path = "../../shared/tyrum-shared" }
 tower-http = { version = "0.5", features = ["limit"] }
 reqwest = { version = "0.12.23", default-features = false, features = ["json", "rustls-tls"] }
 url = "2"
+tyrum-discovery = { path = "../discovery" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -1,9 +1,10 @@
-use std::{env, net::SocketAddr};
+use std::{env, net::SocketAddr, sync::Arc};
 
 use reqwest::Url;
 use tokio::net::TcpListener;
 use tracing_subscriber::{EnvFilter, fmt};
 
+use tyrum_discovery::DefaultDiscoveryPipeline;
 use tyrum_planner::http::{DEFAULT_BIND_ADDR, PlannerState, build_router};
 use tyrum_planner::policy::PolicyClient;
 use tyrum_planner::{EventLog, EventLogSettings};
@@ -33,6 +34,7 @@ async fn main() {
     let app = build_router(PlannerState {
         policy_client,
         event_log,
+        discovery: Arc::new(DefaultDiscoveryPipeline::new()),
     });
     let listener = TcpListener::bind(bind_addr)
         .await

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -1,3 +1,5 @@
+use std::{convert::TryFrom, sync::Arc};
+
 use axum::{
     Json, Router,
     extract::State,
@@ -14,6 +16,9 @@ use crate::policy::{PolicyClient, PolicyDecision, PolicyDecisionKind, PolicyRule
 use crate::{
     ActionArguments, ActionPrimitive, ActionPrimitiveKind, EventLog, NewPlannerEvent, PlanError,
     PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
+};
+use tyrum_discovery::{
+    DiscoveryConnector, DiscoveryOutcome, DiscoveryPipeline, DiscoveryRequest, DiscoveryStrategy,
 };
 use tyrum_shared::{MessageSource, PiiField, ThreadKind};
 
@@ -35,6 +40,7 @@ struct ValidationError {
 pub struct PlannerState {
     pub policy_client: PolicyClient,
     pub event_log: EventLog,
+    pub discovery: Arc<dyn DiscoveryPipeline + Send + Sync>,
 }
 
 pub fn build_router(state: PlannerState) -> Router {
@@ -65,9 +71,8 @@ async fn plan(
     let plan_uuid = Uuid::new_v4();
     let policy_result = state.policy_client.check(&payload).await;
 
-    let (outcome, policy_audit) = match policy_result {
+    let (outcome, policy_audit, discovery_audit) = match policy_result {
         Ok(decision) => {
-            let outcome = build_outcome_for_decision(&payload, &decision);
             let rule_outcomes: Vec<String> = decision
                 .rules
                 .iter()
@@ -78,7 +83,15 @@ async fn plan(
                 rules = ?rule_outcomes,
                 "policy decision received"
             );
-            (outcome, PolicyAudit::from_decision(&decision))
+
+            let (outcome, discovery_audit) =
+                build_outcome_for_decision(&payload, &decision, state.discovery.as_ref());
+
+            (
+                outcome,
+                PolicyAudit::from_decision(&decision),
+                discovery_audit,
+            )
         }
         Err(error) => {
             tracing::warn!(error = %error, "policy check failed");
@@ -91,13 +104,23 @@ async fn plan(
                     retryable: true,
                 },
             };
-            (outcome, PolicyAudit::unavailable(reason))
+            (
+                outcome,
+                PolicyAudit::unavailable(reason),
+                DiscoveryAudit::skipped(),
+            )
         }
     };
 
     let plan_id = format_plan_id(plan_uuid);
-    let audit_event =
-        PlannerDecisionAudit::new(plan_uuid, &plan_id, &payload, policy_audit, &outcome);
+    let audit_event = PlannerDecisionAudit::new(
+        plan_uuid,
+        &plan_id,
+        &payload,
+        policy_audit,
+        discovery_audit,
+        &outcome,
+    );
 
     match NewPlannerEvent::from_payload(
         Uuid::new_v4(),
@@ -130,31 +153,6 @@ async fn plan(
 #[tracing::instrument(name = "planner.health", skip_all)]
 async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
-}
-
-fn stub_steps() -> Vec<ActionPrimitive> {
-    let mut research_args = JsonMap::new();
-    research_args.insert(
-        "intent".to_string(),
-        Value::String("collect_clarifying_details".into()),
-    );
-    research_args.insert(
-        "notes".to_string(),
-        Value::String("Review memory and prior commitments".into()),
-    );
-
-    let mut message_args = JsonMap::new();
-    message_args.insert("channel".to_string(), Value::String("internal".into()));
-    message_args.insert(
-        "body".to_string(),
-        Value::String("Queue operator follow-up for confirmation".into()),
-    );
-
-    let research = ActionPrimitive::new(ActionPrimitiveKind::Research, research_args);
-    let follow_up = ActionPrimitive::new(ActionPrimitiveKind::Message, message_args)
-        .with_postcondition(json!({ "status": "queued" }));
-
-    vec![research, follow_up]
 }
 
 fn bad_request(message: impl Into<String>) -> (StatusCode, Json<ValidationError>) {
@@ -268,20 +266,216 @@ fn build_policy_failure(decision: &PolicyDecision) -> PlanError {
     }
 }
 
-fn build_outcome_for_decision(request: &PlanRequest, decision: &PolicyDecision) -> PlanOutcome {
+fn build_outcome_for_decision(
+    request: &PlanRequest,
+    decision: &PolicyDecision,
+    discovery: &dyn DiscoveryPipeline,
+) -> (PlanOutcome, DiscoveryAudit) {
     match decision.decision {
-        PolicyDecisionKind::Approve => PlanOutcome::Success {
-            steps: stub_steps(),
-            summary: PlanSummary {
-                synopsis: Some(format!("Stub plan prepared for {}", request.subject_id)),
+        PolicyDecisionKind::Approve => {
+            let discovery_request = discovery_request_for(request);
+            let outcome = discovery.discover(&discovery_request);
+            log_discovery_outcome(&discovery_request, &outcome);
+
+            match &outcome {
+                DiscoveryOutcome::RetryLater { retry_after } => {
+                    let (detail, retry_after_ms) = match retry_after {
+                        Some(duration) => {
+                            let millis = duration.as_millis();
+                            let capped = u64::try_from(millis).unwrap_or(u64::MAX);
+                            (Some(format!("retry_after_ms={capped}")), Some(capped))
+                        }
+                        None => (None, None),
+                    };
+
+                    let error = PlanError {
+                        code: PlanErrorCode::ExecutorUnavailable,
+                        message: "Discovery pipeline requested retry".into(),
+                        detail,
+                        retryable: true,
+                    };
+
+                    (
+                        PlanOutcome::Failure { error },
+                        DiscoveryAudit::deferred(retry_after_ms),
+                    )
+                }
+                _ => (
+                    PlanOutcome::Success {
+                        steps: build_plan_steps(request, &outcome),
+                        summary: plan_summary_for(request, &outcome),
+                    },
+                    DiscoveryAudit::from_outcome(&outcome),
+                ),
+            }
+        }
+        PolicyDecisionKind::Escalate => (
+            PlanOutcome::Escalate {
+                escalation: build_policy_escalation(decision),
             },
-        },
-        PolicyDecisionKind::Escalate => PlanOutcome::Escalate {
-            escalation: build_policy_escalation(decision),
-        },
-        PolicyDecisionKind::Deny => PlanOutcome::Failure {
-            error: build_policy_failure(decision),
-        },
+            DiscoveryAudit::skipped(),
+        ),
+        PolicyDecisionKind::Deny => (
+            PlanOutcome::Failure {
+                error: build_policy_failure(decision),
+            },
+            DiscoveryAudit::skipped(),
+        ),
+    }
+}
+
+fn discovery_request_for(request: &PlanRequest) -> DiscoveryRequest {
+    DiscoveryRequest {
+        subject: request.subject_id.clone(),
+    }
+}
+
+fn log_discovery_outcome(request: &DiscoveryRequest, outcome: &DiscoveryOutcome) {
+    let subject = request.sanitized_subject();
+    match outcome {
+        DiscoveryOutcome::Found(connector) => {
+            tracing::info!(
+                target: "tyrum::planner",
+                subject,
+                strategy = strategy_label(connector.strategy),
+                locator = connector.locator.as_str(),
+                "discovery resolved connector"
+            );
+        }
+        DiscoveryOutcome::NotFound => {
+            tracing::info!(
+                target: "tyrum::planner",
+                subject,
+                "discovery returned no connector"
+            );
+        }
+        DiscoveryOutcome::RetryLater { retry_after } => {
+            let retry_ms = retry_after.map(|duration| duration.as_millis());
+            tracing::warn!(
+                target: "tyrum::planner",
+                subject,
+                retry_after_ms = retry_ms,
+                "discovery requested retry"
+            );
+        }
+    }
+}
+
+fn build_plan_steps(request: &PlanRequest, outcome: &DiscoveryOutcome) -> Vec<ActionPrimitive> {
+    let mut steps = Vec::new();
+    steps.push(research_step());
+
+    match outcome {
+        DiscoveryOutcome::Found(connector) => {
+            steps.push(discovered_execution_step(connector));
+        }
+        DiscoveryOutcome::NotFound => {
+            steps.push(fallback_execution_step());
+        }
+        DiscoveryOutcome::RetryLater { .. } => {}
+    }
+
+    steps.push(follow_up_step(request));
+
+    steps
+}
+
+fn plan_summary_for(request: &PlanRequest, outcome: &DiscoveryOutcome) -> PlanSummary {
+    let synopsis = match outcome {
+        DiscoveryOutcome::Found(connector) => format!(
+            "Discovered {} capability for {}",
+            strategy_label(connector.strategy),
+            request.subject_id
+        ),
+        DiscoveryOutcome::NotFound => {
+            format!("Falling back to automation for {}", request.subject_id)
+        }
+        DiscoveryOutcome::RetryLater { .. } => "Discovery deferred".to_string(),
+    };
+
+    PlanSummary {
+        synopsis: Some(synopsis),
+    }
+}
+
+fn research_step() -> ActionPrimitive {
+    let mut research_args = JsonMap::new();
+    research_args.insert(
+        "intent".to_string(),
+        Value::String("collect_clarifying_details".into()),
+    );
+    research_args.insert(
+        "notes".to_string(),
+        Value::String("Review memory and prior commitments".into()),
+    );
+
+    ActionPrimitive::new(ActionPrimitiveKind::Research, research_args)
+}
+
+fn discovered_execution_step(connector: &DiscoveryConnector) -> ActionPrimitive {
+    let mut args = JsonMap::new();
+    args.insert(
+        "executor".to_string(),
+        Value::String(executor_label(connector.strategy).into()),
+    );
+    args.insert(
+        "locator".to_string(),
+        Value::String(connector.locator.clone()),
+    );
+    args.insert(
+        "intent".to_string(),
+        Value::String("execute_discovered_capability".into()),
+    );
+
+    ActionPrimitive::new(ActionPrimitiveKind::Http, args).with_postcondition(json!({
+        "status": "completed",
+        "strategy": strategy_label(connector.strategy),
+    }))
+}
+
+fn fallback_execution_step() -> ActionPrimitive {
+    let mut args = JsonMap::new();
+    args.insert("executor".to_string(), Value::String("generic-web".into()));
+    args.insert(
+        "intent".to_string(),
+        Value::String("fallback_automation".into()),
+    );
+
+    ActionPrimitive::new(ActionPrimitiveKind::Web, args).with_postcondition(json!({
+        "status": "completed",
+        "executor": "generic-web",
+    }))
+}
+
+fn follow_up_step(request: &PlanRequest) -> ActionPrimitive {
+    let mut message_args = JsonMap::new();
+    message_args.insert("channel".to_string(), Value::String("internal".into()));
+    message_args.insert(
+        "body".to_string(),
+        Value::String(format!(
+            "Summarize discovery path for subject {}",
+            request.subject_id
+        )),
+    );
+
+    ActionPrimitive::new(ActionPrimitiveKind::Message, message_args).with_postcondition(json!({
+        "status": "queued"
+    }))
+}
+
+fn strategy_label(strategy: DiscoveryStrategy) -> &'static str {
+    match strategy {
+        DiscoveryStrategy::Mcp => "mcp",
+        DiscoveryStrategy::StructuredApi => "structured_api",
+        DiscoveryStrategy::GenericHttp => "generic_http",
+    }
+}
+
+fn executor_label(strategy: DiscoveryStrategy) -> &'static str {
+    match strategy {
+        DiscoveryStrategy::Mcp => "discovered-mcp",
+        DiscoveryStrategy::StructuredApi => "discovered-structured",
+        DiscoveryStrategy::GenericHttp => "generic-http",
     }
 }
 
@@ -291,6 +485,7 @@ struct PlannerDecisionAudit {
     plan_uuid: Uuid,
     request: RedactedRequest,
     policy: PolicyAudit,
+    discovery: DiscoveryAudit,
     outcome: PlanOutcomeAudit,
 }
 
@@ -300,6 +495,7 @@ impl PlannerDecisionAudit {
         plan_id: &str,
         request: &PlanRequest,
         policy: PolicyAudit,
+        discovery: DiscoveryAudit,
         outcome: &PlanOutcome,
     ) -> Self {
         Self {
@@ -307,6 +503,7 @@ impl PlannerDecisionAudit {
             plan_uuid,
             request: RedactedRequest::from_plan_request(request),
             policy,
+            discovery,
             outcome: PlanOutcomeAudit::from(outcome),
         }
     }
@@ -385,6 +582,39 @@ impl PolicyAudit {
 
     fn unavailable(reason: String) -> Self {
         Self::Unavailable { reason }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum DiscoveryAudit {
+    Resolved { strategy: String, locator: String },
+    NotFound,
+    Deferred { retry_after_ms: Option<u64> },
+    Skipped,
+}
+
+impl DiscoveryAudit {
+    fn from_outcome(outcome: &DiscoveryOutcome) -> Self {
+        match outcome {
+            DiscoveryOutcome::Found(connector) => Self::Resolved {
+                strategy: strategy_label(connector.strategy).into(),
+                locator: connector.locator.clone(),
+            },
+            DiscoveryOutcome::NotFound => Self::NotFound,
+            DiscoveryOutcome::RetryLater { retry_after } => Self::Deferred {
+                retry_after_ms: retry_after
+                    .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)),
+            },
+        }
+    }
+
+    fn deferred(retry_after_ms: Option<u64>) -> Self {
+        Self::Deferred { retry_after_ms }
+    }
+
+    fn skipped() -> Self {
+        Self::Skipped
     }
 }
 

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::sync::{Arc, Mutex};
+
 use axum::{
     Json, Router,
     body::Body,
@@ -12,8 +14,12 @@ use http_body_util::BodyExt;
 use reqwest::Url;
 use tokio::{net::TcpListener, task::JoinHandle};
 use tower::ServiceExt;
+use tyrum_discovery::{
+    DefaultDiscoveryPipeline, DiscoveryConnector, DiscoveryOutcome, DiscoveryPipeline,
+    DiscoveryRequest, DiscoveryStrategy,
+};
 use tyrum_planner::{
-    EventLog, PlanOutcome, PlanRequest, PlanResponse,
+    ActionPrimitiveKind, EventLog, PlanOutcome, PlanRequest, PlanResponse,
     http::{MAX_PLAN_REQUEST_BYTES, PlannerState, build_router},
     policy::PolicyClient,
 };
@@ -60,12 +66,8 @@ fn sample_request() -> PlanRequest {
     }
 }
 
-#[tokio::test]
-async fn plan_returns_stub_response() {
-    let payload = sample_request();
-    let body = serde_json::to_vec(&payload).expect("serialize plan request");
-
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+fn approving_policy_payload() -> serde_json::Value {
+    serde_json::json!({
         "decision": "approve",
         "rules": [
             {
@@ -84,8 +86,78 @@ async fn plan_returns_stub_response() {
                 "detail": "No legal flags",
             },
         ],
-    }))
-    .await;
+    })
+}
+
+fn found_connector(strategy: DiscoveryStrategy, locator: &str) -> DiscoveryOutcome {
+    DiscoveryOutcome::Found(DiscoveryConnector {
+        strategy,
+        locator: locator.to_string(),
+    })
+}
+
+struct MockDiscoveryPipeline {
+    calls: Mutex<Vec<DiscoveryStrategy>>,
+    mcp: DiscoveryOutcome,
+    structured: DiscoveryOutcome,
+    generic: DiscoveryOutcome,
+}
+
+impl MockDiscoveryPipeline {
+    fn new(mcp: DiscoveryOutcome, structured: DiscoveryOutcome, generic: DiscoveryOutcome) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            mcp,
+            structured,
+            generic,
+        }
+    }
+
+    fn record(&self, strategy: DiscoveryStrategy) {
+        let mut guard = self.calls.lock().expect("record discovery call");
+        guard.push(strategy);
+    }
+
+    fn calls(&self) -> Vec<DiscoveryStrategy> {
+        self.calls.lock().expect("read discovery calls").clone()
+    }
+}
+
+impl DiscoveryPipeline for MockDiscoveryPipeline {
+    fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+        assert!(
+            !request.sanitized_subject().is_empty(),
+            "subject should be sanitized"
+        );
+        self.record(DiscoveryStrategy::Mcp);
+        self.mcp.clone()
+    }
+
+    fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+        assert!(
+            !request.sanitized_subject().is_empty(),
+            "subject should be sanitized"
+        );
+        self.record(DiscoveryStrategy::StructuredApi);
+        self.structured.clone()
+    }
+
+    fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+        assert!(
+            !request.sanitized_subject().is_empty(),
+            "subject should be sanitized"
+        );
+        self.record(DiscoveryStrategy::GenericHttp);
+        self.generic.clone()
+    }
+}
+
+#[tokio::test]
+async fn plan_returns_stub_response() {
+    let payload = sample_request();
+    let body = serde_json::to_vec(&payload).expect("serialize plan request");
+
+    let (state, server, _postgres) = planner_state(approving_policy_payload()).await;
 
     let response = build_router(state)
         .oneshot(
@@ -110,11 +182,211 @@ async fn plan_returns_stub_response() {
     assert_eq!(plan.request_id, payload.request_id);
     match plan.outcome {
         PlanOutcome::Success { steps, summary } => {
-            assert!(steps.len() >= 2);
-            assert!(summary.synopsis.is_some());
+            assert_eq!(
+                steps.len(),
+                3,
+                "planner should emit research, executor, follow-up steps"
+            );
+
+            let executor_step = &steps[1];
+            assert_eq!(executor_step.kind, ActionPrimitiveKind::Web);
+            assert_eq!(
+                executor_step
+                    .args
+                    .get("executor")
+                    .and_then(|value| value.as_str()),
+                Some("generic-web"),
+                "fallback should target generic web executor"
+            );
+
+            let synopsis = summary.synopsis.expect("summary present");
+            assert!(synopsis.contains("Falling back to automation"));
         }
         outcome => panic!("expected success outcome, got {:?}", outcome),
     }
+}
+
+#[tokio::test]
+async fn discovery_pipeline_uses_mcp_capability() {
+    let pipeline = Arc::new(MockDiscoveryPipeline::new(
+        found_connector(DiscoveryStrategy::Mcp, "mcp://capability"),
+        DiscoveryOutcome::NotFound,
+        DiscoveryOutcome::NotFound,
+    ));
+    let pipeline_trait: Arc<dyn DiscoveryPipeline + Send + Sync> = pipeline.clone();
+
+    let payload = sample_request();
+    let body = serde_json::to_vec(&payload).expect("serialize plan request");
+
+    let (state, server, _postgres) =
+        planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
+
+    let (steps, summary) = match plan.outcome {
+        PlanOutcome::Success { steps, summary } => (steps, summary),
+        other => panic!("expected success, got {other:?}"),
+    };
+
+    assert_eq!(steps[1].kind, ActionPrimitiveKind::Http);
+    assert_eq!(
+        steps[1]
+            .args
+            .get("executor")
+            .and_then(|value| value.as_str()),
+        Some("discovered-mcp")
+    );
+    assert_eq!(
+        steps[1]
+            .args
+            .get("locator")
+            .and_then(|value| value.as_str()),
+        Some("mcp://capability")
+    );
+    assert!(
+        summary
+            .synopsis
+            .as_ref()
+            .is_some_and(|text| text.contains("Discovered mcp capability"))
+    );
+
+    assert_eq!(pipeline.calls(), vec![DiscoveryStrategy::Mcp]);
+}
+
+#[tokio::test]
+async fn discovery_pipeline_uses_structured_api_capability() {
+    let pipeline = Arc::new(MockDiscoveryPipeline::new(
+        DiscoveryOutcome::NotFound,
+        found_connector(DiscoveryStrategy::StructuredApi, "https://api.example.com"),
+        DiscoveryOutcome::NotFound,
+    ));
+    let pipeline_trait: Arc<dyn DiscoveryPipeline + Send + Sync> = pipeline.clone();
+
+    let payload = sample_request();
+    let body = serde_json::to_vec(&payload).expect("serialize plan request");
+
+    let (state, server, _postgres) =
+        planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
+
+    let (steps, summary) = match plan.outcome {
+        PlanOutcome::Success { steps, summary } => (steps, summary),
+        other => panic!("expected success, got {other:?}"),
+    };
+
+    assert_eq!(steps[1].kind, ActionPrimitiveKind::Http);
+    assert_eq!(
+        steps[1]
+            .args
+            .get("executor")
+            .and_then(|value| value.as_str()),
+        Some("discovered-structured")
+    );
+    assert_eq!(
+        pipeline.calls(),
+        vec![DiscoveryStrategy::Mcp, DiscoveryStrategy::StructuredApi]
+    );
+    assert!(
+        summary
+            .synopsis
+            .as_ref()
+            .is_some_and(|text| text.contains("Discovered structured_api capability"))
+    );
+}
+
+#[tokio::test]
+async fn discovery_pipeline_uses_generic_http_capability() {
+    let pipeline = Arc::new(MockDiscoveryPipeline::new(
+        DiscoveryOutcome::NotFound,
+        DiscoveryOutcome::NotFound,
+        found_connector(
+            DiscoveryStrategy::GenericHttp,
+            "https://fallback.example.com",
+        ),
+    ));
+    let pipeline_trait: Arc<dyn DiscoveryPipeline + Send + Sync> = pipeline.clone();
+
+    let payload = sample_request();
+    let body = serde_json::to_vec(&payload).expect("serialize plan request");
+
+    let (state, server, _postgres) =
+        planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
+
+    let (steps, summary) = match plan.outcome {
+        PlanOutcome::Success { steps, summary } => (steps, summary),
+        other => panic!("expected success, got {other:?}"),
+    };
+
+    assert_eq!(steps[1].kind, ActionPrimitiveKind::Http);
+    assert_eq!(
+        steps[1]
+            .args
+            .get("executor")
+            .and_then(|value| value.as_str()),
+        Some("generic-http")
+    );
+    assert_eq!(
+        pipeline.calls(),
+        vec![
+            DiscoveryStrategy::Mcp,
+            DiscoveryStrategy::StructuredApi,
+            DiscoveryStrategy::GenericHttp,
+        ]
+    );
+    assert!(
+        summary
+            .synopsis
+            .as_ref()
+            .is_some_and(|text| text.contains("Discovered generic_http capability"))
+    );
 }
 
 #[tokio::test]
@@ -351,6 +623,13 @@ async fn mock_policy(response: serde_json::Value) -> (PolicyClient, JoinHandle<(
 async fn planner_state(
     policy_response: serde_json::Value,
 ) -> (PlannerState, JoinHandle<()>, TestPostgres) {
+    planner_state_with_pipeline(policy_response, Arc::new(DefaultDiscoveryPipeline::new())).await
+}
+
+async fn planner_state_with_pipeline(
+    policy_response: serde_json::Value,
+    discovery: Arc<dyn DiscoveryPipeline + Send + Sync>,
+) -> (PlannerState, JoinHandle<()>, TestPostgres) {
     let (policy_client, server) = mock_policy(policy_response).await;
     let postgres = TestPostgres::start().await.expect("start postgres fixture");
     let event_log = EventLog::from_pool(postgres.pool().clone());
@@ -360,6 +639,7 @@ async fn planner_state(
         PlannerState {
             policy_client,
             event_log,
+            discovery,
         },
         server,
         postgres,

--- a/services/planner/tests/plan_audit.rs
+++ b/services/planner/tests/plan_audit.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::sync::Arc;
+
 use axum::{body::Body, http::Request};
 use chrono::Utc;
 use common::{policy::mock_policy, postgres::TestPostgres};
@@ -7,6 +9,7 @@ use http_body_util::BodyExt;
 use serde_json::json;
 use sqlx::Row;
 use tower::ServiceExt;
+use tyrum_discovery::DefaultDiscoveryPipeline;
 use tyrum_planner::{
     EventLog, PlanOutcome, PlanRequest, PlanResponse,
     http::{PlannerState, build_router},
@@ -45,6 +48,7 @@ async fn planner_appends_audit_event_with_redacted_payload() {
     let state = PlannerState {
         policy_client,
         event_log: event_log.clone(),
+        discovery: Arc::new(DefaultDiscoveryPipeline::new()),
     };
 
     let request = sample_request();
@@ -122,6 +126,16 @@ async fn planner_appends_audit_event_with_redacted_payload() {
             .unwrap()
             .to_string()
             .contains("message_text")
+    );
+
+    let discovery = action
+        .get("discovery")
+        .and_then(|value| value.as_object())
+        .expect("discovery audit block present");
+    assert_eq!(
+        discovery.get("status").and_then(|value| value.as_str()),
+        Some("not_found"),
+        "default pipeline should record not_found discovery"
     );
 
     let payload_text = action.to_string();

--- a/services/planner/tests/policy_denial.rs
+++ b/services/planner/tests/policy_denial.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::sync::Arc;
+
 use axum::{body::Body, http::Request};
 use chrono::Utc;
 use common::{policy::mock_policy, postgres::TestPostgres};
@@ -7,6 +9,7 @@ use http_body_util::BodyExt;
 use serde_json::json;
 use sqlx::Row;
 use tower::ServiceExt;
+use tyrum_discovery::DefaultDiscoveryPipeline;
 use tyrum_planner::{
     EventLog, PlanErrorCode, PlanOutcome, PlanRequest, PlanResponse,
     http::{PlannerState, build_router},
@@ -41,6 +44,7 @@ async fn policy_denial_is_logged_and_sanitized() {
     let state = PlannerState {
         policy_client,
         event_log: event_log.clone(),
+        discovery: Arc::new(DefaultDiscoveryPipeline::new()),
     };
 
     let request = sample_request();
@@ -128,6 +132,16 @@ async fn policy_denial_is_logged_and_sanitized() {
             .chars()
             .any(|character| character.is_ascii_digit()),
         "rule detail should be sanitized: {rule_detail}"
+    );
+
+    let discovery = action
+        .get("discovery")
+        .and_then(|value| value.as_object())
+        .expect("discovery audit block present");
+    assert_eq!(
+        discovery.get("status").and_then(|value| value.as_str()),
+        Some("skipped"),
+        "discovery should be skipped for policy denials"
     );
 
     let outcome = action


### PR DESCRIPTION
## Summary
- invoke the discovery pipeline before executor selection and record sanitized telemetry for audit
- build discovery-aware plan steps with fallback automation paths and persist discovery status in planner events
- add planner integration tests for MCP, structured API, and generic HTTP fallbacks using a scripted pipeline

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features --workspace
- cargo test -p tyrum-planner discovery_pipeline
- cargo test --all --all-targets
- pre-commit run --all-files

Closes #70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce discovery pipeline into planner approval flow to select executors, adjust steps/summary based on outcomes, and persist discovery audit data.
> 
> - **Planner HTTP service**:
>   - Inject `tyrum-discovery` via `PlannerState.discovery` and wire `DefaultDiscoveryPipeline` in `src/bin/http_server.rs`.
>   - On policy `Approve`, run `DiscoveryPipeline.discover(...)` and:
>     - Build steps: `research` → `Http`/`Web` executor (based on `DiscoveryOutcome`) → `follow_up`.
>     - Handle `Found`/`NotFound`/`RetryLater` (retryable failure) and set `PlanSummary` accordingly.
>   - Add discovery logging and replace `stub_steps` with discovery-driven builders.
> - **Audit**:
>   - Extend `PlannerDecisionAudit` with `DiscoveryAudit` (`resolved`/`not_found`/`deferred`/`skipped`).
> - **Tests**:
>   - Add integration tests covering MCP, structured API, and generic HTTP discovery paths with a mock pipeline.
>   - Update audit/denial tests to assert discovery audit status (`not_found`/`skipped`).
> - **Deps**:
>   - Add `tyrum-discovery` dependency and usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b0ac6a96cf53e5d9d6c48e00189ab3dc5e1f1f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->