### PR TITLE
Scaffold Playwright executor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,12 +150,13 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -168,7 +169,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -185,16 +186,27 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -214,6 +226,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -229,6 +247,12 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -261,9 +285,9 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http",
+ "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-named-pipe",
  "hyper-rustls 0.26.0",
  "hyper-util",
@@ -272,7 +296,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.22.4",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_derive",
@@ -295,7 +319,7 @@ checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
 dependencies = [
  "serde",
  "serde_repr",
- "serde_with",
+ "serde_with 3.15.0",
 ]
 
 [[package]]
@@ -315,6 +339,26 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -371,7 +415,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -445,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +548,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -515,6 +578,20 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -523,7 +600,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.106",
 ]
 
@@ -537,8 +614,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -610,11 +698,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -737,6 +845,16 @@ name = "find-msvc-tools"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+
+[[package]]
+name = "flate2"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -924,6 +1042,25 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.11.4",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -933,7 +1070,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap 2.11.4",
  "slab",
  "tokio",
@@ -1068,6 +1205,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1079,12 +1227,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1095,8 +1254,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1114,6 +1273,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -1122,9 +1305,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1142,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1157,8 +1340,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -1175,8 +1358,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "rustls 0.23.32",
  "rustls-pki-types",
@@ -1192,11 +1375,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1207,7 +1403,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1226,9 +1422,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1247,7 +1443,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1430,7 +1626,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1468,6 +1664,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1521,7 +1726,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall",
 ]
@@ -1621,6 +1826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1772,7 +1978,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1844,9 +2050,9 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.3.1",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.23",
 ]
 
 [[package]]
@@ -1855,13 +2061,13 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
- "http",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.23",
  "thiserror 2.0.17",
  "tokio",
  "tonic",
@@ -2033,6 +2239,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "playwright"
+version = "0.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45631bc049f37d0cef950da0d60ee35b211ab71180c61aee86880483cf59e28"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "dirs 3.0.2",
+ "futures",
+ "itertools 0.10.5",
+ "log",
+ "paste",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_with 1.14.0",
+ "strong",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "zip",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,7 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -2141,7 +2371,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.32",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2178,9 +2408,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2263,7 +2493,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -2328,6 +2558,46 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
@@ -2338,14 +2608,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.12",
  "hickory-resolver",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-rustls 0.27.7",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -2360,7 +2630,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
@@ -2441,7 +2711,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2483,10 +2753,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2587,7 +2866,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2689,6 +2968,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6093cd8c01b25262b84927e0f7151692158fab02d961e04c979d3903eba7ecc5"
@@ -2702,8 +2991,20 @@ dependencies = [
  "schemars 1.0.4",
  "serde_core",
  "serde_json",
- "serde_with_macros",
- "time",
+ "serde_with_macros 3.15.0",
+ "time 0.3.44",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2773,6 +3074,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
@@ -2936,7 +3243,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.9.4",
  "byteorder",
  "bytes",
  "chrono",
@@ -2980,7 +3287,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.9.4",
  "byteorder",
  "chrono",
  "crc",
@@ -3055,6 +3362,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "strong"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbe0fc7652d95bcd84f61cd036181b395f329ef45b25169b69a42f72cb6975f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +3435,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3129,6 +3457,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3160,17 +3509,17 @@ dependencies = [
  "bollard",
  "bollard-stubs",
  "bytes",
- "dirs",
+ "dirs 5.0.1",
  "docker_credential",
  "either",
  "futures",
  "log",
  "memchr",
  "parse-display",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 3.15.0",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -3225,6 +3574,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -3354,6 +3714,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3378,15 +3739,15 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3417,7 +3778,7 @@ dependencies = [
  "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -3431,10 +3792,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -3447,11 +3808,11 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3618,6 +3979,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tyrum-executor-web"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "playwright",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tyrum-shared",
+ "url",
+]
+
+[[package]]
 name = "tyrum-memory"
 version = "0.1.0"
 dependencies = [
@@ -3642,7 +4020,7 @@ dependencies = [
  "axum",
  "chrono",
  "http-body-util",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "sqlx",
@@ -3835,6 +4213,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -4425,4 +4809,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "thiserror 1.0.69",
+ "time 0.1.45",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "services/api",
     "services/discovery",
     "services/memory",
+    "services/executor_web",
     "services/planner",
     "services/policy",
     "shared/tyrum-shared"

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -24,6 +24,9 @@ COPY services/memory/Cargo.toml services/memory/Cargo.toml
 COPY services/memory/src services/memory/src
 COPY services/memory/tests services/memory/tests
 COPY services/memory/migrations services/memory/migrations
+COPY services/executor_web/Cargo.toml services/executor_web/Cargo.toml
+COPY services/executor_web/src services/executor_web/src
+COPY services/executor_web/tests services/executor_web/tests
 COPY services/policy/Cargo.toml services/policy/Cargo.toml
 COPY services/policy/src services/policy/src
 COPY services/planner/Cargo.toml services/planner/Cargo.toml

--- a/Dockerfile.executor-web
+++ b/Dockerfile.executor-web
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.7
+FROM rust:1.89 AS builder
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=$HTTP_PROXY \
+    http_proxy=$HTTP_PROXY \
+    HTTPS_PROXY=$HTTPS_PROXY \
+    https_proxy=$HTTPS_PROXY \
+    NO_PROXY=$NO_PROXY \
+    no_proxy=$NO_PROXY
+
+WORKDIR /app
+
+# Workspace manifests
+COPY Cargo.toml Cargo.lock ./
+COPY shared/tyrum-shared/Cargo.toml shared/tyrum-shared/Cargo.toml
+COPY shared/tyrum-shared/src shared/tyrum-shared/src
+COPY services/executor_web/Cargo.toml services/executor_web/Cargo.toml
+COPY services/executor_web/src services/executor_web/src
+COPY services/executor_web/tests services/executor_web/tests
+
+RUN cargo build --locked --release --package tyrum-executor-web
+
+FROM mcr.microsoft.com/playwright:v1.48.0-jammy AS runtime
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ENV HTTP_PROXY=$HTTP_PROXY \
+    http_proxy=$HTTP_PROXY \
+    HTTPS_PROXY=$HTTPS_PROXY \
+    https_proxy=$HTTPS_PROXY \
+    NO_PROXY=$NO_PROXY \
+    no_proxy=$NO_PROXY \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    WEB_EXECUTOR_BIND_ADDR=0.0.0.0:8091
+
+# The base image provides a non-root user `pwuser` with browser sandbox
+# privileges configured. Ensure directories exist when the binary caches
+# Playwright assets.
+RUN mkdir -p /home/pwuser/.cache && chown -R pwuser:pwuser /home/pwuser/.cache
+
+WORKDIR /app
+COPY --from=builder /app/target/release/web_executor /usr/local/bin/web_executor
+
+USER pwuser
+EXPOSE 8091
+ENTRYPOINT ["/usr/local/bin/web_executor"]

--- a/Dockerfile.planner
+++ b/Dockerfile.planner
@@ -24,6 +24,9 @@ COPY services/memory/Cargo.toml services/memory/Cargo.toml
 COPY services/memory/src services/memory/src
 COPY services/memory/tests services/memory/tests
 COPY services/memory/migrations services/memory/migrations
+COPY services/executor_web/Cargo.toml services/executor_web/Cargo.toml
+COPY services/executor_web/src services/executor_web/src
+COPY services/executor_web/tests services/executor_web/tests
 COPY services/policy/Cargo.toml services/policy/Cargo.toml
 COPY services/policy/src services/policy/src
 COPY services/planner/Cargo.toml services/planner/Cargo.toml

--- a/Dockerfile.policy
+++ b/Dockerfile.policy
@@ -23,6 +23,9 @@ COPY services/memory/Cargo.toml services/memory/Cargo.toml
 COPY services/memory/src services/memory/src
 COPY services/memory/tests services/memory/tests
 COPY services/memory/migrations services/memory/migrations
+COPY services/executor_web/Cargo.toml services/executor_web/Cargo.toml
+COPY services/executor_web/src services/executor_web/src
+COPY services/executor_web/tests services/executor_web/tests
 COPY services/policy/Cargo.toml services/policy/Cargo.toml
 COPY services/policy/src services/policy/src
 COPY services/planner/Cargo.toml services/planner/Cargo.toml

--- a/docs/executors/web_executor.md
+++ b/docs/executors/web_executor.md
@@ -1,0 +1,25 @@
+# Web Executor Sandbox
+
+The Playwright-backed executor runs inside the `tyrum-executor-web` container.
+It installs the browser runtime during the build stage and launches actions
+through the Rust wrapper exposed by `tyrum-executor-web`. The container is based
+on `mcr.microsoft.com/playwright`, which ships hardened Chromium, Firefox, and
+WebKit builds.
+
+Key guardrails:
+
+- The service binds to `0.0.0.0:8091` (configurable via `WEB_EXECUTOR_BIND_ADDR`)
+  and exposes `GET /healthz` plus `GET /sandbox` for quick telemetry.
+- Browser processes execute in headless mode and inherit the Playwright
+  namespace sandbox. The runtime drops privileges to the `pwuser` account before
+  spawning Playwright, mirroring the upstream security posture.
+- Cached browser assets live under `/home/pwuser/.cache`; the directory is owned
+  by the non-root user to prevent privilege escalation.
+- The Rust crate mirrors the planner contract (`ActionPrimitiveKind::Web`) and
+  currently supports URL navigation plus DOM snapshots. Chromium is preferred,
+  with an automatic WebKit fallback for platforms where Chromium binaries are
+  unavailable (Playwright does not yet ship macOS 15 builds). Postcondition
+  checks and mutating actions will land in follow-up issues (#72+).
+
+See `services/executor_web/src/lib.rs` for the executor entrypoint and
+`infra/docker-compose.yml` to boot the container as part of the local stack.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -47,6 +47,20 @@ services:
       retries: 5
       start_period: 10s
 
+  executor-web:
+    build:
+      context: ..
+      dockerfile: Dockerfile.executor-web
+    image: tyrum/executor-web:local
+    environment:
+      RUST_LOG: info
+      WEB_EXECUTOR_BIND_ADDR: 0.0.0.0:8091
+    depends_on:
+      planner:
+        condition: service_started
+    ports:
+      - "8091:8091"
+
   api-migrations:
     build:
       context: ..

--- a/services/executor_web/Cargo.toml
+++ b/services/executor_web/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "tyrum-executor-web"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors = ["VirtunetBV <oss@virtunet.example>"]
+description = "Generic web executor runtime for Tyrum"
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "web_executor"
+path = "src/bin/web_executor.rs"
+
+[dependencies]
+anyhow = "1"
+axum = { version = "0.7", features = ["json", "macros"] }
+playwright = "0.0.20"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "signal", "time"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tyrum-shared = { path = "../../shared/tyrum-shared" }
+url = { version = "2", features = ["serde"] }
+
+[dev-dependencies]
+anyhow = "1"
+serde_json = "1"
+tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "time"] }

--- a/services/executor_web/src/bin/web_executor.rs
+++ b/services/executor_web/src/bin/web_executor.rs
@@ -1,0 +1,70 @@
+use std::{env, net::SocketAddr};
+
+use anyhow::Context;
+use axum::{Json, Router, routing::get};
+use tokio::signal;
+use tracing::info;
+use tyrum_executor_web::sandbox_constraints;
+
+const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8091";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    let bind_addr = resolve_bind_addr()?;
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .context("bind web executor listener")?;
+
+    let app = Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/sandbox", get(|| async { Json(sandbox_constraints()) }));
+
+    info!(%bind_addr, "web executor listening");
+
+    axum::serve(listener, app.into_make_service())
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("serve web executor")
+}
+
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .compact()
+        .finish()
+        .init();
+}
+
+fn resolve_bind_addr() -> anyhow::Result<SocketAddr> {
+    let bind = env::var("WEB_EXECUTOR_BIND_ADDR").unwrap_or_else(|_| DEFAULT_BIND_ADDR.to_string());
+    bind.parse().context("parse WEB_EXECUTOR_BIND_ADDR")
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut sigterm) = signal(SignalKind::terminate()) {
+            sigterm.recv().await;
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+    info!("shutdown signal received");
+}

--- a/services/executor_web/src/lib.rs
+++ b/services/executor_web/src/lib.rs
@@ -1,0 +1,234 @@
+//! Playwright-backed generic web executor scaffolding.
+//!
+//! The executor spins up a headless Chromium instance via Playwright to
+//! automate web flows described by planner `ActionPrimitive`s. The
+//! implementation focuses on the initial capability: launching a browser,
+//! navigating to a URL, and returning a lightweight page snapshot. Further
+//! primitives (form interactions, postcondition enforcement) will extend this
+//! surface in follow-up issues per the product concept (§15-16).
+
+use std::sync::Arc;
+
+use playwright::{Playwright, api::browser::Browser};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tyrum_shared::planner::{ActionPrimitive, ActionPrimitiveKind};
+use url::Url;
+
+/// Result alias for executor operations.
+pub type Result<T> = std::result::Result<T, WebExecutorError>;
+
+/// Captures the observable state after a web action finishes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebActionOutcome {
+    /// Final URL reported by the page after navigation completes.
+    pub current_url: String,
+    /// Page title extracted via the DOM.
+    pub title: String,
+    /// Raw HTML snapshot of the document body for auditing.
+    pub html: String,
+    /// Browser family used to satisfy the action.
+    pub browser: BrowserFlavor,
+}
+
+/// Execution guardrail describing the sandbox that Playwright enforces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebSandboxConstraints {
+    /// Indicates the browser runs in headless mode without OS-level UI access.
+    pub headless: bool,
+    /// Signals that the process drops root privileges inside the container.
+    pub runs_as_non_root: bool,
+}
+
+impl Default for WebSandboxConstraints {
+    fn default() -> Self {
+        Self {
+            headless: true,
+            runs_as_non_root: true,
+        }
+    }
+}
+
+/// Errors surfaced by the web executor.
+#[derive(Debug, Error)]
+pub enum WebExecutorError {
+    /// Planner requested a primitive the executor cannot handle.
+    #[error("unsupported primitive kind {0:?}")]
+    UnsupportedPrimitive(ActionPrimitiveKind),
+    /// Planner did not include the mandatory `url` argument.
+    #[error("missing required argument '{0}'")]
+    MissingArgument(&'static str),
+    /// Provided URL failed validation.
+    #[error("invalid url '{value}': {source}")]
+    InvalidUrl {
+        /// Parser error from the `url` crate.
+        #[source]
+        source: url::ParseError,
+        /// Original string that failed to parse.
+        value: String,
+    },
+    /// Error reported by Playwright initialization.
+    #[error("playwright initialization failed: {0}")]
+    Playwright(#[from] playwright::Error),
+    /// Error reported by the Playwright driver (async operations).
+    #[error("playwright driver error: {0}")]
+    PlaywrightDriver(#[from] Arc<playwright::Error>),
+    /// None of the supported browser engines could be launched.
+    #[error("unable to launch supported browser: {details}")]
+    BrowserUnavailable { details: String },
+}
+
+/// Enumerates the browser engines supported by the executor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BrowserFlavor {
+    /// Chromium-family browsers (Chrome, Edge).
+    Chromium,
+    /// WebKit (Safari) engine.
+    Webkit,
+}
+
+/// Launches Playwright, opens the requested URL, and captures a page snapshot.
+///
+/// The function validates that the supplied primitive targets the generic web
+/// executor (`ActionPrimitiveKind::Web`) and expects a `url` argument inside
+/// `ActionPrimitive::args`. Callers receive the resulting URL, page title, and
+/// HTML snapshot to evaluate postconditions downstream.
+///
+/// # Errors
+/// * [`WebExecutorError::UnsupportedPrimitive`] when invoked with a non-web
+///   primitive.
+/// * [`WebExecutorError::MissingArgument`] or
+///   [`WebExecutorError::InvalidUrl`] if the planner payload omits or
+///   misconfigures the `url` argument.
+/// * [`WebExecutorError::Playwright`] or [`WebExecutorError::PlaywrightDriver`]
+///   for failures during browser provisioning or navigation.
+pub async fn execute_web_action(action: &ActionPrimitive) -> Result<WebActionOutcome> {
+    ensure_web_primitive(action)?;
+    let target = extract_url(action)?;
+
+    let playwright = Playwright::initialize().await?;
+    let (browser, browser_flavor) = launch_browser(&playwright).await?;
+    let context = browser.context_builder().build().await?;
+    let page = context.new_page().await?;
+
+    page.goto_builder(target.as_str()).goto().await?;
+
+    let title = page.title().await?;
+    let html = page.content().await?;
+    let current_url: String = page.eval("() => window.location.href").await?;
+
+    // Close context and browser to keep future test runs predictable. Ignore
+    // errors during teardown since the main navigation already succeeded.
+    let _ = page.close(None).await;
+    let _ = context.close().await;
+    let _ = browser.close().await;
+
+    Ok(WebActionOutcome {
+        current_url,
+        title,
+        html,
+        browser: browser_flavor,
+    })
+}
+
+/// Returns static sandbox properties enforced by the container runtime.
+pub fn sandbox_constraints() -> WebSandboxConstraints {
+    WebSandboxConstraints::default()
+}
+
+fn ensure_web_primitive(action: &ActionPrimitive) -> Result<()> {
+    if action.kind != ActionPrimitiveKind::Web {
+        return Err(WebExecutorError::UnsupportedPrimitive(action.kind));
+    }
+    Ok(())
+}
+
+fn extract_url(action: &ActionPrimitive) -> Result<Url> {
+    let value = action
+        .args
+        .get("url")
+        .ok_or(WebExecutorError::MissingArgument("url"))?;
+    let url_str = value
+        .as_str()
+        .ok_or(WebExecutorError::MissingArgument("url"))?;
+    Url::parse(url_str).map_err(|source| WebExecutorError::InvalidUrl {
+        source,
+        value: url_str.to_string(),
+    })
+}
+
+async fn launch_browser(playwright: &Playwright) -> Result<(Browser, BrowserFlavor)> {
+    let mut notes = Vec::new();
+
+    // Attempt Chromium first for parity with other runtimes; fall back to
+    // WebKit on platforms where Chromium binaries are unavailable (e.g.,
+    // macOS 15 at the time of writing).
+    if let Err(err) = playwright.install_chromium() {
+        notes.push(format!("chromium install: {err}"));
+    }
+
+    match playwright
+        .chromium()
+        .launcher()
+        .headless(true)
+        .launch()
+        .await
+    {
+        Ok(browser) => return Ok((browser, BrowserFlavor::Chromium)),
+        Err(err) => {
+            notes.push(format!("chromium launch: {err}"));
+        }
+    }
+
+    if let Err(err) = playwright.install_webkit() {
+        notes.push(format!("webkit install: {err}"));
+    }
+
+    match playwright.webkit().launcher().headless(true).launch().await {
+        Ok(browser) => Ok((browser, BrowserFlavor::Webkit)),
+        Err(err) => {
+            notes.push(format!("webkit launch: {err}"));
+            Err(WebExecutorError::BrowserUnavailable {
+                details: notes.join("; "),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tyrum_shared::planner::ActionArguments;
+
+    #[tokio::test]
+    async fn rejects_non_web_primitives() {
+        let primitive =
+            ActionPrimitive::new(ActionPrimitiveKind::Message, ActionArguments::default());
+        let err = execute_web_action(&primitive)
+            .await
+            .expect_err("should fail");
+        assert!(matches!(
+            err,
+            WebExecutorError::UnsupportedPrimitive(ActionPrimitiveKind::Message)
+        ));
+    }
+
+    #[tokio::test]
+    async fn errors_on_missing_url() {
+        let primitive = ActionPrimitive::new(ActionPrimitiveKind::Web, ActionArguments::default());
+        let err = execute_web_action(&primitive)
+            .await
+            .expect_err("missing url");
+        assert!(matches!(err, WebExecutorError::MissingArgument("url")));
+    }
+
+    #[tokio::test]
+    async fn errors_on_invalid_url() {
+        let args = ActionArguments::from_iter([(String::from("url"), json!("not a url"))]);
+        let primitive = ActionPrimitive::new(ActionPrimitiveKind::Web, args);
+        let err = execute_web_action(&primitive).await.expect_err("bad url");
+        assert!(matches!(err, WebExecutorError::InvalidUrl { value, .. } if value == "not a url"));
+    }
+}

--- a/services/executor_web/tests/browser.rs
+++ b/services/executor_web/tests/browser.rs
@@ -1,0 +1,97 @@
+use std::net::SocketAddr;
+
+use anyhow::Context;
+use axum::{Router, response::Html, routing::get};
+use serde_json::json;
+use tokio::task::JoinHandle;
+use tyrum_executor_web::{BrowserFlavor, WebActionOutcome, WebExecutorError, execute_web_action};
+use tyrum_shared::planner::{ActionArguments, ActionPrimitive, ActionPrimitiveKind};
+
+const FIXTURE_HTML: &str = r#"
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Fixture Form</title>
+</head>
+<body>
+    <main>
+        <h1>Book a Call</h1>
+        <form action="/submit" method="post">
+            <label>
+                Name
+                <input name="name" type="text" />
+            </label>
+            <label>
+                Preferred time
+                <input name="slot" type="time" />
+            </label>
+            <button type="submit">Request booking</button>
+        </form>
+    </main>
+</body>
+</html>
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn launches_browser_and_fetches_fixture() -> anyhow::Result<()> {
+    let (addr, handle) = start_fixture_server().await?;
+    let url = format!("http://{addr}");
+
+    let args = ActionArguments::from_iter([(String::from("url"), json!(url))]);
+    let primitive = ActionPrimitive::new(ActionPrimitiveKind::Web, args);
+
+    let outcome = match execute_web_action(&primitive).await {
+        Ok(outcome) => outcome,
+        Err(WebExecutorError::BrowserUnavailable { details }) => {
+            tracing::warn!(%details, "Skipping web executor fixture test; no supported browsers");
+            handle.abort();
+            let _ = handle.await;
+            return Ok(());
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    assert_page_snapshot(&outcome, &url);
+
+    handle.abort();
+    let _ = handle.await;
+
+    Ok(())
+}
+
+fn assert_page_snapshot(outcome: &WebActionOutcome, expected_url: &str) {
+    assert_eq!(outcome.current_url, expected_url);
+    assert_eq!(outcome.title, "Fixture Form");
+    assert!(
+        outcome
+            .html
+            .contains("<form action=\"/submit\" method=\"post\">")
+            && outcome.html.contains("name=\"slot\"")
+    );
+    assert!(
+        matches!(
+            outcome.browser,
+            BrowserFlavor::Chromium | BrowserFlavor::Webkit
+        ),
+        "unexpected browser fallback: {:?}",
+        outcome.browser
+    );
+}
+
+async fn start_fixture_server() -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+    let app = Router::new().route("/", get(|| async { Html(FIXTURE_HTML) }));
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("bind fixture listener")?;
+    let addr = listener.local_addr().context("read listener address")?;
+
+    let handle = tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app.into_make_service()).await {
+            tracing::warn!(%err, "fixture server exited with error");
+        }
+    });
+
+    Ok((addr, handle))
+}


### PR DESCRIPTION
## Summary
- add the `tyrum-executor-web` crate to launch Playwright, capture snapshots, and expose sandbox metadata for planner `Web` actions
- ship a minimal Axum service with health and sandbox endpoints plus docs covering the container guardrails
- add the Playwright runtime to docker compose and an HTML fixture integration test (skips when the host lacks supported browsers)

## Testing
- `cargo test -p tyrum-executor-web -- --ignored`
- `pre-commit run --all-files`

## Acceptance Criteria
- [x] New `tyrum-executor-web` crate exposes `execute_web_action` function and builds successfully.
- [x] Dockerfile/compose service adds Playwright runtime to the local stack.
- [x] Integration test runs against a local HTML fixture verifying the executor can launch the browser and reach a page (skips when Playwright does not publish binaries for the host).

Closes #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `tyrum-executor-web` (Playwright) with health/sandbox HTTP endpoints, Docker/compose integration, docs, and tests to execute planner `Web` actions.
> 
> - **Executor Runtime (new)**:
>   - Adds `services/executor_web` crate (`tyrum-executor-web`) exposing `execute_web_action` to launch Playwright, navigate to a URL, and return page snapshots; includes sandbox metadata helpers.
>   - Ships Axum binary `web_executor` with `GET /healthz` and `GET /sandbox`.
> - **Containerization/Infra**:
>   - New `Dockerfile.executor-web` (multi-stage; Playwright base image) and service `executor-web` in `infra/docker-compose.yml` (bind `0.0.0.0:8091`).
>   - Update other Dockerfiles to copy `services/executor_web` into builds; add workspace member in `Cargo.toml`.
> - **Docs**:
>   - Adds `docs/executors/web_executor.md` describing sandbox guardrails and usage.
> - **Tests**:
>   - Integration test `services/executor_web/tests/browser.rs` using an HTML fixture (skips when browsers unavailable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b049a01aee830bf856dc3ed355c1705b2c7207ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->