### PR TITLE
Extend capability memory persistence

### DIFF
--- a/docs/executors/web_executor.md
+++ b/docs/executors/web_executor.md
@@ -28,6 +28,8 @@ The executor accepts the planner payload described in
 - `fields` – array of `{ selector, value, redact? }` entries that are
   filled via Playwright’s `locator.fill` equivalent. When `redact` is set,
   the summary and DOM excerpt replace the value with `REDACTED`.
+  Selectors that get promoted into `capability_memories.selectors` must strip or
+  hash literal PII (emails, account numbers) before persistence.
 - `submit` – `{ selector, kind?, wait_after_ms? }`. The default `kind` is
   `click`; `submit` triggers `requestSubmit` on the referenced form element.
 - `snapshot_selector` (optional) – CSS selector used to capture a sanitised

--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -286,6 +286,26 @@ to keep policy, planner, and API services aligned on envelopes and error handlin
 - **Policy/Autonomy Model (PAM):** learned consents, quiet hours, escalation style, spending behavior with confidence scores; if low → ask.
 - **Persona & Voice Profile (PVP):** tone, verbosity, initiative, emoji tolerance, language rules, voice params (pace/pitch/warmth), and pronunciation dictionary. (See Appendix B.)
 
+### Capability memory schema & usage
+- Table: `capability_memories` (primary key `id`) keyed by the unique tuple
+  `(subject_id, capability_type, capability_identifier, executor_kind)`. Each
+  row captures the selectors, executor wiring, and outcome metadata for a
+  successful run so the planner can rehydrate a known-good flow.
+- Indexes: `(subject_id, capability_type)` for lookups during planning, plus a
+  timestamp-ordered `(subject_id, last_success_at DESC)` index to promote
+  freshest memories.
+- Fields:
+  - `selectors` – JSON blob with DOM/API selector hints. Treat this as PII‑adjacent:
+    redact literal handles, emails, or account numbers before persisting and only
+    store hashed or templated selectors that the executor can safely reuse.
+  - `outcome_metadata` – structured JSON storing postconditions, costs, receipts,
+    or other artifacts that prove the run succeeded.
+  - `success_count`, `last_success_at`, `result_summary` – track reliability and
+    provide operator context when reviewing audit trails.
+- RLS is enabled (policy TODO) so access stays scoped per subject once authz
+  lands. Planner/Executor integrations must respect the redaction rule above when
+  writing through to this table.
+
 ---
 
 ## 9) Policy & Guardrails

--- a/services/memory/migrations/0002_add_capability_memories.sql
+++ b/services/memory/migrations/0002_add_capability_memories.sql
@@ -1,0 +1,37 @@
+-- Capability memory captures successful executor runs for reuse.
+CREATE TABLE IF NOT EXISTS capability_memories (
+    id BIGSERIAL PRIMARY KEY,
+    subject_id UUID NOT NULL,
+    capability_type TEXT NOT NULL,
+    capability_identifier TEXT NOT NULL,
+    executor_kind TEXT NOT NULL,
+    selectors JSONB,
+    outcome_metadata JSONB NOT NULL,
+    result_summary TEXT,
+    success_count INTEGER NOT NULL DEFAULT 1 CHECK (success_count > 0),
+    last_success_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE capability_memories IS 'Successful executor flows (selectors, postconditions, costs) for the subject + capability combination.';
+COMMENT ON COLUMN capability_memories.subject_id IS 'Identity this capability memory belongs to.';
+COMMENT ON COLUMN capability_memories.capability_type IS 'High-level capability classification (web, http, android, structured_api).';
+COMMENT ON COLUMN capability_memories.capability_identifier IS 'Vendor or endpoint identifier to scope executor reuse (e.g., domain, API slug).';
+COMMENT ON COLUMN capability_memories.executor_kind IS 'Executor responsible for the successful run.';
+COMMENT ON COLUMN capability_memories.selectors IS 'Selector hints and flow parameters that may contain PII and must be redacted before sharing outside trusted services.';
+COMMENT ON COLUMN capability_memories.outcome_metadata IS 'Structured JSON describing the successful outcome (postconditions, artifacts, costs).';
+COMMENT ON COLUMN capability_memories.result_summary IS 'Human-readable description for debugging and manual audits.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS capability_memories_unique_flow_idx
+    ON capability_memories (subject_id, capability_type, capability_identifier, executor_kind);
+
+CREATE INDEX IF NOT EXISTS capability_memories_subject_type_idx
+    ON capability_memories (subject_id, capability_type);
+
+CREATE INDEX IF NOT EXISTS capability_memories_last_success_idx
+    ON capability_memories (subject_id, last_success_at DESC);
+
+ALTER TABLE capability_memories ENABLE ROW LEVEL SECURITY;
+CREATE POLICY capability_memories_rls_placeholder ON capability_memories USING (true) WITH CHECK (true);
+COMMENT ON POLICY capability_memories_rls_placeholder ON capability_memories IS 'TODO: scope capability memories by subject once authz is in place.';

--- a/services/memory/src/bin/main.rs
+++ b/services/memory/src/bin/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use tyrum_memory::{MemoryDal, NewEpisodicEvent, NewFact, NewVectorEmbedding};
+use tyrum_memory::{MemoryDal, NewCapabilityMemory, NewEpisodicEvent, NewFact, NewVectorEmbedding};
 
 #[derive(Debug, Parser)]
 #[command(name = "tyrum-memory", about = "CLI helpers for Tyrum memory stores")]
@@ -99,6 +99,25 @@ async fn insert_sample(
     })
     .await?;
 
+    dal.create_capability_memory(NewCapabilityMemory {
+        subject_id,
+        capability_type: "web".into(),
+        capability_identifier: "example.com.checkout".into(),
+        executor_kind: "executor_web".into(),
+        selectors: Some(json!({
+            "login_button": "#login",
+            "submit_order": "button[data-test=\"submit\"]"
+        })),
+        outcome_metadata: json!({
+            "postconditions": ["order confirmation #12345"],
+            "estimated_cost": "€29.95"
+        }),
+        result_summary: Some("Successful checkout via sample flow".into()),
+        success_count: 1,
+        last_success_at: Utc::now(),
+    })
+    .await?;
+
     Ok(())
 }
 
@@ -110,6 +129,7 @@ async fn show_subject(
     let facts = dal.list_facts_for_subject(subject_id).await?;
     let events = dal.list_episodic_events_for_subject(subject_id).await?;
     let vectors = dal.list_vector_embeddings_for_subject(subject_id).await?;
+    let capability_memories = dal.list_capability_memories_for_subject(subject_id).await?;
 
     if emit_json {
         let payload = json!({
@@ -117,6 +137,7 @@ async fn show_subject(
             "facts": facts,
             "episodic_events": events,
             "vector_embeddings": vectors,
+            "capability_memories": capability_memories,
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
@@ -159,6 +180,22 @@ async fn show_subject(
             println!(
                 "    - {} model={} label={:?}",
                 embedding.embedding_id, embedding.embedding_model, embedding.label
+            );
+        }
+    }
+
+    if capability_memories.is_empty() {
+        println!("  Capability memories: none");
+    } else {
+        println!("  Capability memories:");
+        for memory in capability_memories {
+            println!(
+                "    - [{}] {} ({}) successes={} last_success_at={}",
+                memory.capability_type,
+                memory.capability_identifier,
+                memory.executor_kind,
+                memory.success_count,
+                memory.last_success_at
             );
         }
     }

--- a/services/memory/src/lib.rs
+++ b/services/memory/src/lib.rs
@@ -262,6 +262,185 @@ impl MemoryDal {
         Ok(())
     }
 
+    // --- Capability memory operations -------------------------------------
+
+    pub async fn create_capability_memory(
+        &self,
+        new_memory: NewCapabilityMemory,
+    ) -> Result<CapabilityMemory, MemoryError> {
+        let record = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            INSERT INTO capability_memories (
+                subject_id,
+                capability_type,
+                capability_identifier,
+                executor_kind,
+                selectors,
+                outcome_metadata,
+                result_summary,
+                success_count,
+                last_success_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            "#,
+        )
+        .bind(new_memory.subject_id)
+        .bind(new_memory.capability_type)
+        .bind(new_memory.capability_identifier)
+        .bind(new_memory.executor_kind)
+        .bind(new_memory.selectors)
+        .bind(new_memory.outcome_metadata)
+        .bind(new_memory.result_summary)
+        .bind(new_memory.success_count)
+        .bind(new_memory.last_success_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(record)
+    }
+
+    pub async fn get_capability_memory(
+        &self,
+        memory_id: i64,
+    ) -> Result<Option<CapabilityMemory>, MemoryError> {
+        let record = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            SELECT id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            FROM capability_memories
+            WHERE id = $1
+            "#,
+        )
+        .bind(memory_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(record)
+    }
+
+    pub async fn get_capability_memory_for_flow(
+        &self,
+        subject_id: Uuid,
+        capability_type: &str,
+        capability_identifier: &str,
+        executor_kind: &str,
+    ) -> Result<Option<CapabilityMemory>, MemoryError> {
+        let record = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            SELECT id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            FROM capability_memories
+            WHERE subject_id = $1
+                AND capability_type = $2
+                AND capability_identifier = $3
+                AND executor_kind = $4
+            "#,
+        )
+        .bind(subject_id)
+        .bind(capability_type)
+        .bind(capability_identifier)
+        .bind(executor_kind)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(record)
+    }
+
+    pub async fn list_capability_memories_for_subject(
+        &self,
+        subject_id: Uuid,
+    ) -> Result<Vec<CapabilityMemory>, MemoryError> {
+        let records = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            SELECT id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            FROM capability_memories
+            WHERE subject_id = $1
+            ORDER BY last_success_at DESC, id DESC
+            "#,
+        )
+        .bind(subject_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(records)
+    }
+
+    pub async fn list_capability_memories_for_subject_and_type(
+        &self,
+        subject_id: Uuid,
+        capability_type: &str,
+    ) -> Result<Vec<CapabilityMemory>, MemoryError> {
+        let records = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            SELECT id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            FROM capability_memories
+            WHERE subject_id = $1
+                AND capability_type = $2
+            ORDER BY last_success_at DESC, id DESC
+            "#,
+        )
+        .bind(subject_id)
+        .bind(capability_type)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(records)
+    }
+
+    pub async fn update_capability_memory(
+        &self,
+        memory_id: i64,
+        changes: CapabilityMemoryChanges,
+    ) -> Result<CapabilityMemory, MemoryError> {
+        let record = sqlx::query_as::<_, CapabilityMemory>(
+            r#"
+            UPDATE capability_memories
+            SET selectors = $1,
+                outcome_metadata = $2,
+                result_summary = $3,
+                success_count = $4,
+                last_success_at = $5,
+                updated_at = NOW()
+            WHERE id = $6
+            RETURNING id, subject_id, capability_type, capability_identifier,
+                executor_kind, selectors, outcome_metadata, result_summary,
+                success_count, last_success_at, created_at, updated_at
+            "#,
+        )
+        .bind(changes.selectors)
+        .bind(changes.outcome_metadata)
+        .bind(changes.result_summary)
+        .bind(changes.success_count)
+        .bind(changes.last_success_at)
+        .bind(memory_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        record.ok_or_else(|| MemoryError::not_found("capability_memory", memory_id))
+    }
+
+    pub async fn delete_capability_memory(&self, memory_id: i64) -> Result<(), MemoryError> {
+        let rows = sqlx::query("DELETE FROM capability_memories WHERE id = $1")
+            .bind(memory_id)
+            .execute(&self.pool)
+            .await?;
+
+        if rows.rows_affected() == 0 {
+            return Err(MemoryError::not_found("capability_memory", memory_id));
+        }
+
+        Ok(())
+    }
+
     // --- Vector embedding operations --------------------------------------
 
     pub async fn create_vector_embedding(
@@ -468,6 +647,44 @@ pub struct VectorEmbeddingChanges {
     pub embedding_model: String,
     pub label: Option<String>,
     pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, PartialEq)]
+pub struct CapabilityMemory {
+    pub id: i64,
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+    pub selectors: Option<serde_json::Value>,
+    pub outcome_metadata: serde_json::Value,
+    pub result_summary: Option<String>,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewCapabilityMemory {
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+    pub selectors: Option<serde_json::Value>,
+    pub outcome_metadata: serde_json::Value,
+    pub result_summary: Option<String>,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapabilityMemoryChanges {
+    pub selectors: Option<serde_json::Value>,
+    pub outcome_metadata: serde_json::Value,
+    pub result_summary: Option<String>,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
 }
 
 impl<'r> sqlx::FromRow<'r, PgRow> for VectorEmbedding {

--- a/services/memory/tests/dal.rs
+++ b/services/memory/tests/dal.rs
@@ -9,8 +9,8 @@ use testcontainers::{
     runners::AsyncRunner,
 };
 use tyrum_memory::{
-    EpisodicEventChanges, MemoryDal, MemoryError, NewEpisodicEvent, NewFact, NewVectorEmbedding,
-    VectorEmbeddingChanges,
+    CapabilityMemoryChanges, EpisodicEventChanges, MemoryDal, MemoryError, NewCapabilityMemory,
+    NewEpisodicEvent, NewFact, NewVectorEmbedding, VectorEmbeddingChanges,
 };
 use uuid::Uuid;
 
@@ -165,6 +165,104 @@ async fn episodic_event_crud_roundtrip() {
         .expect("delete event");
 
     let err = ctx.dal.delete_episodic_event(event_id).await.unwrap_err();
+    assert!(matches!(err, MemoryError::NotFound { .. }));
+}
+
+#[tokio::test]
+async fn capability_memory_crud_roundtrip() {
+    let ctx = TestContext::new().await;
+    let subject_id = Uuid::new_v4();
+
+    let created = ctx
+        .dal
+        .create_capability_memory(NewCapabilityMemory {
+            subject_id,
+            capability_type: "web".into(),
+            capability_identifier: "example.com.checkout".into(),
+            executor_kind: "executor_web".into(),
+            selectors: Some(json!({ "login_button": "#login" })),
+            outcome_metadata: json!({
+                "postconditions": ["order confirmation"],
+                "cost_eur": 29.95
+            }),
+            result_summary: Some("Initial success".into()),
+            success_count: 1,
+            last_success_at: Utc::now(),
+        })
+        .await
+        .expect("create capability memory");
+    assert_eq!(created.capability_type, "web");
+
+    let fetched = ctx
+        .dal
+        .get_capability_memory(created.id)
+        .await
+        .expect("fetch capability memory")
+        .expect("memory present");
+    assert_eq!(fetched.capability_identifier, "example.com.checkout");
+
+    let lookup = ctx
+        .dal
+        .get_capability_memory_for_flow(subject_id, "web", "example.com.checkout", "executor_web")
+        .await
+        .expect("lookup capability memory")
+        .expect("flow present");
+    assert_eq!(lookup.id, created.id);
+
+    let listed_all = ctx
+        .dal
+        .list_capability_memories_for_subject(subject_id)
+        .await
+        .expect("list capability memories");
+    assert_eq!(listed_all.len(), 1);
+
+    let listed_type = ctx
+        .dal
+        .list_capability_memories_for_subject_and_type(subject_id, "web")
+        .await
+        .expect("list capability memories by type");
+    assert_eq!(listed_type.len(), 1);
+
+    let updated = ctx
+        .dal
+        .update_capability_memory(
+            created.id,
+            CapabilityMemoryChanges {
+                selectors: Some(json!({ "checkout_button": ".checkout" })),
+                outcome_metadata: json!({
+                    "postconditions": ["order confirmation", "receipt artifact"],
+                    "cost_eur": 24.99
+                }),
+                result_summary: Some("Updated flow with cached selectors".into()),
+                success_count: 3,
+                last_success_at: Utc::now(),
+            },
+        )
+        .await
+        .expect("update capability memory");
+    assert_eq!(updated.success_count, 3);
+    assert_eq!(
+        updated.result_summary.as_deref(),
+        Some("Updated flow with cached selectors")
+    );
+
+    ctx.dal
+        .delete_capability_memory(created.id)
+        .await
+        .expect("delete capability memory");
+
+    let missing = ctx
+        .dal
+        .get_capability_memory(created.id)
+        .await
+        .expect("fetch deleted capability memory");
+    assert!(missing.is_none());
+
+    let err = ctx
+        .dal
+        .delete_capability_memory(created.id)
+        .await
+        .unwrap_err();
     assert!(matches!(err, MemoryError::NotFound { .. }));
 }
 


### PR DESCRIPTION
## Summary
- create the capability_memories table with subject/type indexes and row-level security placeholders
- add DAL CRUD helpers plus testcontainers coverage for capability memories
- document capability memory schema, selector redaction expectations, and surface the data via the memory CLI

## Testing
- pre-commit run --all-files
- cargo test -p tyrum-memory capability_memory

Closes #78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce capability memories storage with schema and indexes, DAL CRUD + tests, CLI surfacing, and docs including selector redaction guidance.
> 
> - **Memory service**:
>   - **Schema**: Add `services/memory/migrations/0002_add_capability_memories.sql` creating `capability_memories` with unique flow index, subject/type index, last-success index, and RLS placeholder.
>   - **DAL**: Implement CRUD in `services/memory/src/lib.rs` with `CapabilityMemory`, `NewCapabilityMemory`, `CapabilityMemoryChanges` and list/lookup helpers.
>   - **CLI**: Update `services/memory/src/bin/main.rs` to insert a sample capability memory and include `capability_memories` in `ShowSubject` output (JSON and human-readable).
>   - **Tests**: Add `capability_memory_crud_roundtrip` in `services/memory/tests/dal.rs` using testcontainers; wire new types into tests.
> - **Docs**:
>   - `docs/product_concept_v1.md`: Add "Capability memory schema & usage" detailing keys, indexes, fields, and RLS; emphasize redaction/hashing of PII in `selectors`.
>   - `docs/executors/web_executor.md`: Note that selectors promoted to `capability_memories.selectors` must strip/hash literal PII before persistence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d18ab728e155fb18b8641e5bf30e305fe26e639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->