### PR TITLE
Persist capability memories after executor success

### DIFF
--- a/services/planner/migrations/0003_add_capability_memories.sql
+++ b/services/planner/migrations/0003_add_capability_memories.sql
@@ -1,0 +1,35 @@
+-- Capability memories capture selectors and outcomes for successful executor runs.
+CREATE TABLE IF NOT EXISTS capability_memories (
+    id BIGSERIAL PRIMARY KEY,
+    subject_id UUID NOT NULL,
+    capability_type TEXT NOT NULL,
+    capability_identifier TEXT NOT NULL,
+    executor_kind TEXT NOT NULL,
+    selectors JSONB,
+    outcome_metadata JSONB NOT NULL,
+    result_summary TEXT,
+    success_count INTEGER NOT NULL DEFAULT 1 CHECK (success_count > 0),
+    last_success_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE capability_memories IS 'Successful executor flows (selectors, postconditions, costs) for the subject + capability combination.';
+COMMENT ON COLUMN capability_memories.subject_id IS 'Identity this capability memory belongs to.';
+COMMENT ON COLUMN capability_memories.capability_type IS 'High-level capability classification (web, http, android, structured_api).';
+COMMENT ON COLUMN capability_memories.capability_identifier IS 'Vendor or endpoint identifier to scope executor reuse (e.g., domain, API slug).';
+COMMENT ON COLUMN capability_memories.executor_kind IS 'Executor responsible for the successful run.';
+COMMENT ON COLUMN capability_memories.selectors IS 'Selector hints and flow parameters that may contain PII and must be redacted before sharing outside trusted services.';
+COMMENT ON COLUMN capability_memories.outcome_metadata IS 'Structured JSON describing the successful outcome (postconditions, artifacts, costs).';
+COMMENT ON COLUMN capability_memories.result_summary IS 'Human-readable description for debugging and manual audits.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS capability_memories_unique_flow_idx
+    ON capability_memories (subject_id, capability_type, capability_identifier, executor_kind);
+CREATE INDEX IF NOT EXISTS capability_memories_subject_type_idx
+    ON capability_memories (subject_id, capability_type);
+CREATE INDEX IF NOT EXISTS capability_memories_last_success_idx
+    ON capability_memories (subject_id, last_success_at DESC);
+
+ALTER TABLE capability_memories ENABLE ROW LEVEL SECURITY;
+CREATE POLICY capability_memories_rls_placeholder ON capability_memories USING (true) WITH CHECK (true);
+COMMENT ON POLICY capability_memories_rls_placeholder ON capability_memories IS 'TODO: scope capability memories by subject once authz is in place.';

--- a/services/planner/src/bin/audit_demo.rs
+++ b/services/planner/src/bin/audit_demo.rs
@@ -135,8 +135,15 @@ impl DemoRuntime {
                 self.handle_confirm_step(&mut machine, plan_id, subject_id, step_index, primitive)
                     .await?;
             } else {
-                self.handle_executor_step(&mut machine, plan_id, step_index, primitive, &executors)
-                    .await?;
+                self.handle_executor_step(
+                    &mut machine,
+                    plan_id,
+                    subject_id,
+                    step_index,
+                    primitive,
+                    &executors,
+                )
+                .await?;
             }
         }
 
@@ -205,6 +212,7 @@ impl DemoRuntime {
         &self,
         machine: &mut PlanStateMachine,
         plan_id: Uuid,
+        subject_id: Uuid,
         step_index: usize,
         primitive: &ActionPrimitive,
         executors: &MockGenericExecutors,
@@ -212,14 +220,14 @@ impl DemoRuntime {
         let step_number = step_index as i32;
         machine.apply(PlanEvent::StepDispatched { step_index })?;
 
-        let outcome = executors
+        let executor_outcome = executors
             .execute(primitive)
             .await
             .with_context(|| format!("execute plan step {step_index}"))?;
 
         if let Some(expected) = primitive.postcondition.as_ref() {
             ensure!(
-                expected == &outcome.postcondition,
+                expected == &executor_outcome.postcondition,
                 "postcondition mismatch at step {step_index}"
             );
         } else {
@@ -228,24 +236,37 @@ impl DemoRuntime {
 
         let audit_payload = json!({
             "primitive": primitive,
-            "executor": outcome.executor,
-            "result": outcome.postcondition.clone(),
+            "executor": executor_outcome.executor.as_str(),
+            "result": executor_outcome.postcondition.clone(),
         });
 
+        let occurred_at = Utc::now();
         let event = NewPlannerEvent::from_payload(
             Uuid::new_v4(),
             plan_id,
             step_number,
-            Utc::now(),
+            occurred_at,
             &audit_payload,
         )?;
-        let outcome = self.event_log.append(event).await?;
+        let append_outcome = self.event_log.append(event).await?;
         ensure!(
-            matches!(outcome, AppendOutcome::Inserted(_)),
+            matches!(append_outcome, AppendOutcome::Inserted(_)),
             "executor step should append audit event"
         );
 
         machine.apply(PlanEvent::PostconditionSatisfied { step_index })?;
+
+        let _ = self
+            .event_log
+            .record_capability_memory(
+                subject_id,
+                primitive,
+                executor_outcome.executor.as_str(),
+                &executor_outcome.postcondition,
+                occurred_at,
+            )
+            .await
+            .context("record capability memory")?;
         Ok(())
     }
 

--- a/services/planner/src/event_log.rs
+++ b/services/planner/src/event_log.rs
@@ -2,11 +2,14 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Map as JsonMap, Value};
 use sqlx::{PgPool, Row, migrate::MigrateError, postgres::PgPoolOptions};
 use thiserror::Error;
-use tracing::instrument;
+use tracing::{debug, info, instrument, warn};
+use url::Url;
 use uuid::Uuid;
+
+use crate::{ActionPrimitive, ActionPrimitiveKind};
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
@@ -37,6 +40,290 @@ impl EventLogSettings {
         self
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityMemoryResult {
+    Inserted { success_count: i32 },
+    Updated { success_count: i32 },
+    Skipped(CapabilityMemorySkipReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityMemorySkipReason {
+    NonMutatingPrimitive,
+    MissingIdentifier,
+}
+
+impl EventLog {
+    #[instrument(skip_all, fields(subject_id = %subject_id, executor_kind = %executor_kind))]
+    pub async fn record_capability_memory(
+        &self,
+        subject_id: Uuid,
+        primitive: &ActionPrimitive,
+        executor_kind: &str,
+        outcome: &Value,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<CapabilityMemoryResult, EventLogError> {
+        if !primitive.kind.requires_postcondition() {
+            debug!(
+                primitive_kind = ?primitive.kind,
+                "skipping capability memory: primitive is non-mutating"
+            );
+            return Ok(CapabilityMemoryResult::Skipped(
+                CapabilityMemorySkipReason::NonMutatingPrimitive,
+            ));
+        }
+
+        let capability_type = capability_type_label(primitive.kind);
+        let Some(capability_identifier) = derive_capability_identifier(primitive) else {
+            warn!(
+                primitive_kind = ?primitive.kind,
+                "skipping capability memory: missing capability identifier"
+            );
+            return Ok(CapabilityMemoryResult::Skipped(
+                CapabilityMemorySkipReason::MissingIdentifier,
+            ));
+        };
+
+        let selectors = extract_selectors(primitive, outcome).map(|value| sanitize_value(&value));
+        let outcome_metadata = build_outcome_metadata(primitive, outcome);
+        let summary = build_result_summary(&capability_identifier, executor_kind, primitive);
+
+        let row = sqlx::query(
+            r#"
+            INSERT INTO capability_memories (
+                subject_id,
+                capability_type,
+                capability_identifier,
+                executor_kind,
+                selectors,
+                outcome_metadata,
+                result_summary,
+                success_count,
+                last_success_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 1, $8)
+            ON CONFLICT (subject_id, capability_type, capability_identifier, executor_kind)
+            DO UPDATE SET
+                selectors = EXCLUDED.selectors,
+                outcome_metadata = EXCLUDED.outcome_metadata,
+                result_summary = EXCLUDED.result_summary,
+                success_count = capability_memories.success_count + 1,
+                last_success_at = EXCLUDED.last_success_at,
+                updated_at = NOW()
+            RETURNING success_count
+            "#,
+        )
+        .bind(subject_id)
+        .bind(capability_type)
+        .bind(&capability_identifier)
+        .bind(executor_kind)
+        .bind(selectors.clone())
+        .bind(outcome_metadata.clone())
+        .bind(summary.clone())
+        .bind(occurred_at)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let success_count: i32 = row.try_get("success_count")?;
+        let inserted = success_count == 1;
+
+        let selector_keys = selectors
+            .as_ref()
+            .and_then(|value| value.as_object())
+            .map(|object| object.keys().cloned().collect::<Vec<_>>());
+
+        info!(
+            capability_type,
+            capability_identifier,
+            %subject_id,
+            executor_kind,
+            success_count,
+            inserted,
+            selector_keys = ?selector_keys,
+            "capability memory upserted"
+        );
+
+        let result = if inserted {
+            CapabilityMemoryResult::Inserted { success_count }
+        } else {
+            CapabilityMemoryResult::Updated { success_count }
+        };
+
+        Ok(result)
+    }
+}
+
+fn capability_type_label(kind: ActionPrimitiveKind) -> &'static str {
+    match kind {
+        ActionPrimitiveKind::Web => "web",
+        ActionPrimitiveKind::Android => "android",
+        ActionPrimitiveKind::Cli => "cli",
+        ActionPrimitiveKind::Http => "http",
+        ActionPrimitiveKind::Message => "message",
+        ActionPrimitiveKind::Pay => "pay",
+        ActionPrimitiveKind::Store => "store",
+        ActionPrimitiveKind::Watch => "watch",
+        ActionPrimitiveKind::Research => "research",
+        ActionPrimitiveKind::Decide => "decide",
+        ActionPrimitiveKind::Confirm => "confirm",
+    }
+}
+
+fn derive_capability_identifier(primitive: &ActionPrimitive) -> Option<String> {
+    if let Some(identifier) = primitive
+        .args
+        .get("capability_identifier")
+        .and_then(Value::as_str)
+    {
+        return Some(identifier.to_string());
+    }
+
+    if let Some(vendor) = primitive.args.get("vendor").and_then(Value::as_str) {
+        return Some(vendor.to_string());
+    }
+
+    if let Some(url_value) = primitive.args.get("url").and_then(Value::as_str)
+        && let Ok(parsed) = Url::parse(url_value)
+        && let Some(host) = parsed.host_str()
+    {
+        return Some(host.to_string());
+    }
+
+    if let Some(intent) = primitive.args.get("intent").and_then(Value::as_str) {
+        return Some(intent.to_string());
+    }
+
+    None
+}
+
+fn extract_selectors(primitive: &ActionPrimitive, outcome: &Value) -> Option<Value> {
+    const SELECTOR_KEYS: &[&str] = &["selectors", "selector_hints", "flow_hints"];
+    for key in SELECTOR_KEYS {
+        if let Some(value) = primitive.args.get(*key) {
+            return Some(value.clone());
+        }
+    }
+
+    outcome.get("selectors").cloned()
+}
+
+fn build_outcome_metadata(primitive: &ActionPrimitive, outcome: &Value) -> Value {
+    let mut metadata = JsonMap::new();
+    metadata.insert("postcondition".into(), sanitize_value(outcome));
+
+    if let Some(intent) = primitive.args.get("intent").and_then(Value::as_str) {
+        metadata.insert("intent".into(), Value::String(intent.to_string()));
+    }
+
+    if let Some(url) = primitive.args.get("url").and_then(Value::as_str)
+        && let Some(url_metadata) = sanitize_url(url)
+    {
+        metadata.insert("url".into(), url_metadata);
+    }
+
+    Value::Object(metadata)
+}
+
+fn build_result_summary(
+    capability_identifier: &str,
+    executor_kind: &str,
+    primitive: &ActionPrimitive,
+) -> Option<String> {
+    if let Some(intent) = primitive.args.get("intent").and_then(Value::as_str) {
+        return Some(format!("{executor_kind} satisfied intent {intent}"));
+    }
+    Some(format!(
+        "{executor_kind} succeeded for {capability_identifier}"
+    ))
+}
+
+fn sanitize_url(raw: &str) -> Option<Value> {
+    let parsed = Url::parse(raw).ok()?;
+    let mut map = JsonMap::new();
+    if let Some(host) = parsed.host_str() {
+        map.insert("host".into(), Value::String(host.to_string()));
+    }
+    let path = parsed.path();
+    if !path.is_empty() && path != "/" {
+        map.insert("path".into(), Value::String(path.to_string()));
+    }
+    if map.is_empty() {
+        None
+    } else {
+        Some(Value::Object(map))
+    }
+}
+
+fn sanitize_value(value: &Value) -> Value {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => value.clone(),
+        Value::String(text) => Value::String(sanitize_string(text)),
+        Value::Array(items) => Value::Array(items.iter().map(sanitize_value).collect::<Vec<_>>()),
+        Value::Object(map) => {
+            let mut sanitized = JsonMap::new();
+            for (key, val) in map {
+                let lower_key = key.to_ascii_lowercase();
+                if ALWAYS_REDACT_KEYS
+                    .iter()
+                    .any(|flag| lower_key.contains(flag))
+                {
+                    sanitized.insert(key.clone(), Value::String("[redacted]".into()));
+                } else {
+                    sanitized.insert(key.clone(), sanitize_value(val));
+                }
+            }
+            Value::Object(sanitized)
+        }
+    }
+}
+
+fn sanitize_string(value: &str) -> String {
+    if looks_sensitive(value) {
+        "[redacted]".into()
+    } else {
+        value.to_string()
+    }
+}
+
+fn looks_sensitive(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    if trimmed.len() > 128 {
+        return true;
+    }
+
+    if trimmed.contains('@') {
+        return true;
+    }
+
+    let digits_only = trimmed.chars().all(|ch| ch.is_ascii_digit());
+    if digits_only && trimmed.len() >= 6 {
+        return true;
+    }
+
+    let lowercase = trimmed.to_ascii_lowercase();
+    if lowercase.starts_with("bearer ") || lowercase.starts_with("basic ") {
+        return true;
+    }
+
+    false
+}
+
+const ALWAYS_REDACT_KEYS: &[&str] = &[
+    "password",
+    "passcode",
+    "secret",
+    "token",
+    "otp",
+    "auth",
+    "credential",
+    "cvv",
+    "prefill",
+];
 
 /// Planner-facing representation of a new action trace entry.
 #[derive(Clone, Debug, PartialEq)]
@@ -217,12 +504,45 @@ impl EventLog {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::Value;
+    use std::sync::OnceLock;
     use testcontainers::{
         ContainerAsync, GenericImage, ImageExt,
         core::{IntoContainerPort, WaitFor},
         runners::AsyncRunner,
     };
-    use tokio::time::sleep;
+    use tokio::{sync::Mutex, time::sleep};
+
+    static DB_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+
+    #[test]
+    fn derive_identifier_falls_back_for_hostless_url() {
+        let mut args = JsonMap::new();
+        args.insert(
+            "url".into(),
+            Value::String("mailto:alex@example.com".into()),
+        );
+        args.insert("intent".into(), Value::String("book_call".into()));
+
+        let primitive = ActionPrimitive::new(ActionPrimitiveKind::Web, args);
+        assert_eq!(
+            derive_capability_identifier(&primitive),
+            Some("book_call".to_string())
+        );
+    }
+
+    #[test]
+    fn derive_identifier_falls_back_when_url_invalid() {
+        let mut args = JsonMap::new();
+        args.insert("url".into(), Value::String("/relative/path".into()));
+        args.insert("intent".into(), Value::String("book_call".into()));
+
+        let primitive = ActionPrimitive::new(ActionPrimitiveKind::Web, args);
+        assert_eq!(
+            derive_capability_identifier(&primitive),
+            Some("book_call".to_string())
+        );
+    }
 
     const POSTGRES_IMAGE: &str = "pgvector/pgvector";
     const POSTGRES_TAG: &str = "pg16";
@@ -294,6 +614,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn append_inserts_event() {
+        let _guard = DB_GUARD.get_or_init(|| Mutex::new(())).lock().await;
         let (container, event_log) = setup().await;
         let _container = container;
         let plan_id = Uuid::new_v4();
@@ -315,6 +636,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn append_is_idempotent() {
+        let _guard = DB_GUARD.get_or_init(|| Mutex::new(())).lock().await;
         let (container, event_log) = setup().await;
         let _container = container;
         let plan_id = Uuid::new_v4();
@@ -334,6 +656,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn duplicate_plan_step_returns_duplicate() {
+        let _guard = DB_GUARD.get_or_init(|| Mutex::new(())).lock().await;
         let (container, event_log) = setup().await;
         let _container = container;
         let plan_id = Uuid::new_v4();
@@ -356,6 +679,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn events_are_ordered_by_step() {
+        let _guard = DB_GUARD.get_or_init(|| Mutex::new(())).lock().await;
         let (container, event_log) = setup().await;
         let _container = container;
         let plan_id = Uuid::new_v4();
@@ -376,6 +700,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn reject_negative_steps() {
+        let _guard = DB_GUARD.get_or_init(|| Mutex::new(())).lock().await;
         let (container, event_log) = setup().await;
         let _container = container;
         let plan_id = Uuid::new_v4();

--- a/services/planner/src/lib.rs
+++ b/services/planner/src/lib.rs
@@ -6,8 +6,8 @@ pub mod policy;
 pub mod state_machine;
 
 pub use event_log::{
-    AppendOutcome, EventLog, EventLogError, EventLogSettings, NewPlannerEvent,
-    PersistedPlannerEvent,
+    AppendOutcome, CapabilityMemoryResult, CapabilityMemorySkipReason, EventLog, EventLogError,
+    EventLogSettings, NewPlannerEvent, PersistedPlannerEvent,
 };
 pub use policy::{PolicyClient, PolicyDecision, PolicyDecisionKind, PolicyRuleDecision};
 pub use state_machine::{

--- a/services/planner/tests/capability_memory.rs
+++ b/services/planner/tests/capability_memory.rs
@@ -6,8 +6,8 @@ use common::postgres::TestPostgres;
 use serde_json::{Value, json};
 use tyrum_memory::{MemoryDal, NewEpisodicEvent, NewFact};
 use tyrum_planner::{
-    ActionArguments, ActionPrimitive, ActionPrimitiveKind, AppendOutcome, EventLog,
-    NewPlannerEvent, PlanEvent, PlanStateMachine, PlanStatus,
+    ActionArguments, ActionPrimitive, ActionPrimitiveKind, AppendOutcome, CapabilityMemoryResult,
+    EventLog, NewPlannerEvent, PlanEvent, PlanStateMachine, PlanStatus,
 };
 use uuid::Uuid;
 
@@ -49,6 +49,17 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
                 "intent": "book_call",
                 "url": "https://calendar.example.com/slots",
                 "slot": call_slot.clone(),
+                "selector_hints": {
+                    "login_button": "#login",
+                    "email_input": {
+                        "selector": "input[type=\"email\"]",
+                        "prefill": "alex@example.com"
+                    },
+                    "otp_field": {
+                        "selector": "[data-test=\"otp\"]",
+                        "value": "123456"
+                    }
+                }
             })),
         )
         .with_postcondition(json!({
@@ -129,6 +140,7 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
             bail!("expected postcondition for non-confirm primitive at step {step_index}");
         }
 
+        let occurred_at = Utc::now();
         let audit_payload = json!({
             "primitive": primitive,
             "executor": outcome.executor,
@@ -139,7 +151,7 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
             Uuid::new_v4(),
             plan_id,
             step_number,
-            Utc::now(),
+            occurred_at,
             &audit_payload,
         )?;
         assert!(matches!(
@@ -148,6 +160,25 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
         ));
 
         machine.apply(PlanEvent::PostconditionSatisfied { step_index })?;
+
+        let memory_outcome = event_log
+            .record_capability_memory(
+                subject_id,
+                primitive,
+                outcome.executor,
+                &outcome.postcondition,
+                occurred_at,
+            )
+            .await?;
+
+        if primitive.kind == ActionPrimitiveKind::Web {
+            assert!(matches!(
+                memory_outcome,
+                CapabilityMemoryResult::Inserted { success_count: 1 }
+            ));
+        } else {
+            assert!(matches!(memory_outcome, CapabilityMemoryResult::Skipped(_)));
+        }
     }
 
     let success = match machine.status() {
@@ -210,6 +241,35 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
         .find(|event| event.event_type == "message.sent")
         .expect("message event stored");
     assert_eq!(message_event.channel, "email");
+
+    let capability_memories = memory
+        .list_capability_memories_for_subject(subject_id)
+        .await
+        .context("read capability memories")?;
+    assert_eq!(capability_memories.len(), 1);
+
+    let capability = &capability_memories[0];
+    assert_eq!(capability.capability_type, "web");
+    assert_eq!(capability.capability_identifier, "calendar.example.com");
+    assert_eq!(capability.executor_kind, "generic-web");
+    assert_eq!(capability.success_count, 1);
+    assert_eq!(
+        capability.result_summary.as_deref(),
+        Some("generic-web satisfied intent book_call")
+    );
+
+    let selectors = capability.selectors.as_ref().expect("selectors captured");
+    assert_eq!(selectors["login_button"], "#login");
+    assert_eq!(
+        selectors["email_input"]["prefill"],
+        Value::String("[redacted]".into())
+    );
+    assert_eq!(selectors["otp_field"], Value::String("[redacted]".into()));
+
+    assert_eq!(
+        capability.outcome_metadata["postcondition"]["appointment"]["status"],
+        "booked"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary\n- add planner migration for capability_memories so the service can write capability records\n- record capability memory upserts from executor successes with selector redaction and safe logging\n- extend the planner integration test to assert capability memories are persisted and sanitized\n\n## Testing\n- 
running 1 test
test mock_book_call_plan_creates_audit_and_memory_artifacts ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.18s\n- 
running 4 tests
test telegram::tests::verifier_rejects_secret_mismatch ... ok
test telegram::tests::verifier_rejects_bad_signature ... ok
test telegram::tests::verifier_accepts_valid_signature ... ok
test telegram::tests::verifier_accepts_uppercase_signature ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 9 tests
test tests::telegram_webhook_e2e ... ignored, requires docker
test tests::sanitize_opt_trims_and_drops_empty ... ok
test tests::health_endpoint_returns_ok ... ok
test tests::telegram_webhook_rejects_invalid_signature ... ok
test tests::telegram_webhook_accepts_valid_signature ... ok
test tests::waitlist_signup_rejects_duplicates ... ok
test tests::waitlist_signup_persists_email ... ok
test tests::account_linking_list_returns_defaults ... ok
test tests::account_linking_update_persists_toggle ... ok

test result: ok. 8 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.77s


running 2 tests
test insert_message_persists_and_dedupes ... ok
test upsert_thread_persists_and_updates_records ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.21s


running 4 tests
test pipeline::tests::short_circuits_on_first_successful_strategy ... ok
test pipeline::tests::runs_strategies_in_order_when_not_found ... ok
test pipeline::tests::telemetry_records_metrics_for_each_attempt ... ok
test pipeline::tests::telemetry_records_spans_for_each_attempt ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test tests::compose_component_handles_relative_activity ... ok
test tests::locate_accessibility_node_errors_when_missing ... ok
test tests::parse_android_action_launch_app ... ok
test tests::locate_accessibility_node_finds_coordinates ... ok
test tests::parse_android_action_tap_coordinates ... ok
test tests::parse_bounds_returns_center ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test executes_launch_and_tap_primitives ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test tests::rejects_working_directory_escape ... ok
test tests::command_success_captures_output ... ok
test tests::command_failure_reports_exit_code ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test tests::allowed_hosts_default_to_local ... ok
test tests::sanitise_header_pairs_redacts_authorization ... ok
test tests::parse_method_rejects_invalid ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test non_success_status_returns_failure_context ... ok
test redirects_to_disallowed_host_are_not_followed ... ok
test schema_validation_failure_surfaces_error ... ok
test post_request_with_schema_succeeds ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 5 tests
test tests::rejects_non_web_primitives ... ok
test tests::errors_on_missing_url ... ok
test tests::errors_on_invalid_url ... ok
test tests::errors_on_empty_submit_selector ... ok
test tests::retries_transient_failure_and_records_telemetry ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
Failed to install browsers
Error: Failed to download chromium, caused by
Error: ERROR: Playwright does not support chromium on mac15-arm64
    at Object.assert (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/utils.js:86:15)
    at Registry.downloadURL (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/registry.js:346:17)
    at Object.downloadBrowserWithProgressBar (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/browserFetcher.js:84:26)
    at async validateCache (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:129:9)
    at async Object.installBrowsersWithProgressBar (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:80:9)
    at async Object.installBrowsers (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/driver.js:93:5)
    at async Command.<anonymous> (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/cli.js:108:9)
Failed to install browsers
Error: Failed to download webkit, caused by
Error: ERROR: Playwright does not support webkit on mac15-arm64
    at Object.assert (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/utils.js:86:15)
    at Registry.downloadURL (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/utils/registry.js:346:17)
    at Object.downloadBrowserWithProgressBar (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/browserFetcher.js:84:26)
    at async validateCache (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:129:9)
    at async Object.installBrowsersWithProgressBar (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/install/installer.js:80:9)
    at async Object.installBrowsers (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/driver.js:93:5)
    at async Command.<anonymous> (/Users/ron/Library/Caches/ms-playwright/playwright-rust/driver/package/lib/cli/cli.js:108:9)
test form_action_executes_and_captures_confirmation ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.73s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 4 tests
test fact_crud_roundtrip ... ok
test vector_embedding_crud_roundtrip ... ok
test capability_memory_crud_roundtrip ... ok
test episodic_event_crud_roundtrip ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.58s


running 15 tests
test policy::tests::payload_maps_pii_categories ... ok
test state_machine::tests::cancellation_from_ready_has_no_step_index ... ok
test state_machine::tests::cancellation_preserves_active_step_index ... ok
test state_machine::tests::executor_failure_emits_structured_log ... ok
test state_machine::tests::happy_path_through_execution ... ok
test state_machine::tests::invalid_transition_returns_error ... ok
test policy::tests::client_decodes_policy_responses ... ok
test policy::tests::client_surfaces_escalate_and_deny ... ok
test state_machine::tests::policy_denial_short_circuits_plan ... ok
test state_machine::tests::policy_denial_emits_structured_log ... FAILED
test event_log::tests::reject_negative_steps ... ok
test event_log::tests::append_inserts_event ... ok
test event_log::tests::events_are_ordered_by_step ... ok
test event_log::tests::duplicate_plan_step_returns_duplicate ... ok
test event_log::tests::append_is_idempotent ... ok

failures:

---- state_machine::tests::policy_denial_emits_structured_log stdout ----

thread 'state_machine::tests::policy_denial_emits_structured_log' panicked at services/planner/src/state_machine.rs:544:14:
policy denial log emitted
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    state_machine::tests::policy_denial_emits_structured_log

test result: FAILED. 14 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.71s\n- cargo fmt................................................................Passed
cargo clippy.............................................................Passed
cargo test...............................................................Passed
nextjs lint..............................................................Passed
nextjs test..............................................................Passed
github actions lint......................................................Passed
terraform fmt+validate...................................................Passed
docker compose config....................................................Passed
kubernetes manifest validation.......................(no files to check)Skipped
helm lint................................................................Passed\n\n## Playbook\n1. Run 
running 1 test
test mock_book_call_plan_creates_audit_and_memory_artifacts ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.18s to observe the sanitized capability memory log entry and verify selector redaction.\n\nCloses #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upserts sanitized capability memory records after executor successes, adding schema, event log API, demo wiring, and tests.
> 
> - **Database**:
>   - Create `capability_memories` table with JSONB `selectors`/`outcome_metadata`, `result_summary`, counters/timestamps, unique flow index, and RLS policy.
> - **Planner/Event Log**:
>   - Add `EventLog::record_capability_memory` to upsert memories keyed by `(subject_id, capability_type, capability_identifier, executor_kind)`.
>   - Derive `capability_identifier` (from `capability_identifier`/`vendor`/URL host/`intent`), extract `selectors`, build outcome metadata/summary, and sanitize PII (keys like `password`, tokens, emails, long numeric strings, etc.).
>   - New result types: `CapabilityMemoryResult`, `CapabilityMemorySkipReason`; tracing for inserts/updates.
>   - Re-export new types in `lib.rs`.
> - **Demo/Runtime**:
>   - Wire subject ID and call `record_capability_memory` after successful executor steps with event timestamp.
> - **Tests**:
>   - New integration test `capability_memory.rs` validates persistence, upsert behavior, selector redaction, and metadata/summary.
>   - Unit tests for identifier fallback; stabilize DB tests with a global mutex.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3af0158b5d1c575be26221e83981c510d7db2ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->