### PR TITLE
Integrate planner wallet authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,6 +4308,7 @@ dependencies = [
  "tyrum-discovery",
  "tyrum-memory",
  "tyrum-shared",
+ "tyrum-wallet",
  "url",
  "uuid",
 ]

--- a/docs/planner_event_log.md
+++ b/docs/planner_event_log.md
@@ -52,5 +52,8 @@ validation of step indices. They run as part of `cargo test --all --all-targets`
   raw spend thresholds.
 - The `policy.rules[].detail` fields are scrubbed of digits before persisting so audit trails stay
   actionable while avoiding leakage of configurable caps.
+- Wallet authorizations record a `wallet` audit block with sanitized reasons and append the
+  `Spend guardrail enforced by wallet authorization.` note so reviewers can trace guardrail
+  enforcement without revealing raw spend amounts or card metadata.
 - Use `cargo test -p tyrum-planner policy_denial` to run the regression harness that exercises the
   denial flow and ensures both the planner response and audit payloads include the reason string.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       RUST_LOG: info
       PLANNER_BIND_ADDR: 0.0.0.0:8083
       POLICY_GATE_URL: http://policy:8081
+      WALLET_GATE_URL: http://wallet:8084
       PLANNER_EVENT_LOG_URL: postgres://tyrum:tyrum_dev_password@postgres:5432/tyrum_dev
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc

--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -41,6 +41,7 @@ tower-http = { version = "0.5", features = ["limit"] }
 reqwest = { version = "0.12.23", default-features = false, features = ["json", "rustls-tls"] }
 url = "2"
 tyrum-discovery = { path = "../discovery" }
+tyrum-wallet = { path = "../tyrum-wallet" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -7,9 +7,10 @@ use tracing_subscriber::{EnvFilter, fmt};
 use tyrum_discovery::DefaultDiscoveryPipeline;
 use tyrum_planner::http::{DEFAULT_BIND_ADDR, PlannerState, build_router};
 use tyrum_planner::policy::PolicyClient;
-use tyrum_planner::{EventLog, EventLogSettings};
+use tyrum_planner::{EventLog, EventLogSettings, WalletClient};
 
 const EVENT_LOG_URL_ENV: &str = "PLANNER_EVENT_LOG_URL";
+const WALLET_GATE_URL_ENV: &str = "WALLET_GATE_URL";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -24,6 +25,11 @@ async fn main() {
     let policy_client =
         PolicyClient::new(Url::parse(&policy_url).expect("invalid POLICY_GATE_URL"));
 
+    let wallet_url = env::var(WALLET_GATE_URL_ENV)
+        .unwrap_or_else(|_| panic!("{} must be set", WALLET_GATE_URL_ENV));
+    let wallet_client =
+        WalletClient::new(Url::parse(&wallet_url).expect("invalid WALLET_GATE_URL"));
+
     let event_log_url =
         env::var(EVENT_LOG_URL_ENV).unwrap_or_else(|_| panic!("{} must be set", EVENT_LOG_URL_ENV));
     let event_log = EventLog::connect(EventLogSettings::new(event_log_url))
@@ -35,6 +41,7 @@ async fn main() {
         policy_client,
         event_log,
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
+        wallet_client,
     });
     let listener = TcpListener::bind(bind_addr)
         .await

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -13,6 +13,7 @@ use tower_http::limit::RequestBodyLimitLayer;
 use uuid::Uuid;
 
 use crate::policy::{PolicyClient, PolicyDecision, PolicyDecisionKind, PolicyRuleDecision};
+use crate::wallet::{AuthorizationDecision, SpendAuthorization, WalletClient};
 use crate::{
     ActionArguments, ActionPrimitive, ActionPrimitiveKind, EventLog, NewPlannerEvent, PlanError,
     PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
@@ -41,6 +42,7 @@ pub struct PlannerState {
     pub policy_client: PolicyClient,
     pub event_log: EventLog,
     pub discovery: Arc<dyn DiscoveryPipeline + Send + Sync>,
+    pub wallet_client: WalletClient,
 }
 
 pub fn build_router(state: PlannerState) -> Router {
@@ -52,6 +54,7 @@ pub fn build_router(state: PlannerState) -> Router {
 }
 
 const DECISION_AUDIT_STEP_INDEX: i32 = i32::MAX;
+const WALLET_GUARDRAIL_NOTE: &str = "Spend guardrail enforced by wallet authorization.";
 
 #[tracing::instrument(skip_all)]
 async fn plan(
@@ -69,9 +72,11 @@ async fn plan(
     }
 
     let plan_uuid = Uuid::new_v4();
+    let plan_id = format_plan_id(plan_uuid);
+    let spend_directive = extract_spend_directive(&payload);
     let policy_result = state.policy_client.check(&payload).await;
 
-    let (outcome, policy_audit, discovery_audit) = match policy_result {
+    let (outcome, policy_audit, discovery_audit, wallet_audit) = match policy_result {
         Ok(decision) => {
             let rule_outcomes: Vec<String> = decision
                 .rules
@@ -84,13 +89,76 @@ async fn plan(
                 "policy decision received"
             );
 
-            let (outcome, discovery_audit) =
-                build_outcome_for_decision(&payload, &decision, state.discovery.as_ref());
+            let (mut outcome, discovery_audit) = build_outcome_for_decision(
+                &payload,
+                &decision,
+                state.discovery.as_ref(),
+                spend_directive.as_ref(),
+            );
+
+            let mut wallet_audit = WalletAudit::skipped();
+
+            if let PlanOutcome::Success { steps, .. } = &mut outcome {
+                if let Some(spend) = first_spend_request(steps) {
+                    let authorization = SpendAuthorization {
+                        request_id: Some(plan_id.clone()),
+                        amount_minor_units: spend.amount_minor_units,
+                        currency: spend.currency.clone(),
+                        merchant_name: spend.merchant.clone(),
+                    };
+
+                    match state.wallet_client.authorize(&authorization).await {
+                        Ok(response) => {
+                            let sanitized_reason = sanitize_detail(&response.reason);
+                            let decision = response.decision;
+                            wallet_audit =
+                                WalletAudit::evaluated(decision, sanitized_reason.clone());
+
+                            match decision {
+                                AuthorizationDecision::Approve => {
+                                    tracing::info!("wallet approved spend");
+                                }
+                                AuthorizationDecision::Escalate => {
+                                    tracing::info!("wallet escalated spend");
+                                    outcome = PlanOutcome::Escalate {
+                                        escalation: build_wallet_escalation(
+                                            spend.step_index,
+                                            &sanitized_reason,
+                                        ),
+                                    };
+                                }
+                                AuthorizationDecision::Deny => {
+                                    tracing::info!("wallet denied spend");
+                                    outcome = PlanOutcome::Failure {
+                                        error: build_wallet_denial_error(&sanitized_reason),
+                                    };
+                                }
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(%error, "wallet authorization failed");
+                            let detail = sanitize_detail(&error.to_string());
+                            wallet_audit = WalletAudit::errored(detail.clone());
+                            outcome = PlanOutcome::Failure {
+                                error: PlanError {
+                                    code: PlanErrorCode::Internal,
+                                    message: "Wallet service unavailable".into(),
+                                    detail: Some(detail),
+                                    retryable: true,
+                                },
+                            };
+                        }
+                    }
+                } else {
+                    wallet_audit = WalletAudit::skipped();
+                }
+            }
 
             (
                 outcome,
                 PolicyAudit::from_decision(&decision),
                 discovery_audit,
+                wallet_audit,
             )
         }
         Err(error) => {
@@ -108,17 +176,18 @@ async fn plan(
                 outcome,
                 PolicyAudit::unavailable(reason),
                 DiscoveryAudit::skipped(),
+                WalletAudit::skipped(),
             )
         }
     };
 
-    let plan_id = format_plan_id(plan_uuid);
     let audit_event = PlannerDecisionAudit::new(
         plan_uuid,
         &plan_id,
         &payload,
         policy_audit,
         discovery_audit,
+        wallet_audit,
         &outcome,
     );
 
@@ -270,6 +339,7 @@ fn build_outcome_for_decision(
     request: &PlanRequest,
     decision: &PolicyDecision,
     discovery: &dyn DiscoveryPipeline,
+    spend_directive: Option<&SpendDirective>,
 ) -> (PlanOutcome, DiscoveryAudit) {
     match decision.decision {
         PolicyDecisionKind::Approve => {
@@ -302,8 +372,8 @@ fn build_outcome_for_decision(
                 }
                 _ => (
                     PlanOutcome::Success {
-                        steps: build_plan_steps(request, &outcome),
-                        summary: plan_summary_for(request, &outcome),
+                        steps: build_plan_steps(request, &outcome, spend_directive),
+                        summary: plan_summary_for(request, &outcome, spend_directive),
                     },
                     DiscoveryAudit::from_outcome(&outcome),
                 ),
@@ -361,7 +431,11 @@ fn log_discovery_outcome(request: &DiscoveryRequest, outcome: &DiscoveryOutcome)
     }
 }
 
-fn build_plan_steps(request: &PlanRequest, outcome: &DiscoveryOutcome) -> Vec<ActionPrimitive> {
+fn build_plan_steps(
+    request: &PlanRequest,
+    outcome: &DiscoveryOutcome,
+    spend_directive: Option<&SpendDirective>,
+) -> Vec<ActionPrimitive> {
     let mut steps = Vec::new();
     steps.push(research_step());
 
@@ -375,12 +449,20 @@ fn build_plan_steps(request: &PlanRequest, outcome: &DiscoveryOutcome) -> Vec<Ac
         DiscoveryOutcome::RetryLater { .. } => {}
     }
 
+    if let Some(spend) = spend_directive {
+        steps.push(wallet_pay_step(spend));
+    }
+
     steps.push(follow_up_step(request));
 
     steps
 }
 
-fn plan_summary_for(request: &PlanRequest, outcome: &DiscoveryOutcome) -> PlanSummary {
+fn plan_summary_for(
+    request: &PlanRequest,
+    outcome: &DiscoveryOutcome,
+    spend_directive: Option<&SpendDirective>,
+) -> PlanSummary {
     let synopsis = match outcome {
         DiscoveryOutcome::Found(connector) => format!(
             "Discovered {} capability for {}",
@@ -391,6 +473,12 @@ fn plan_summary_for(request: &PlanRequest, outcome: &DiscoveryOutcome) -> PlanSu
             format!("Falling back to automation for {}", request.subject_id)
         }
         DiscoveryOutcome::RetryLater { .. } => "Discovery deferred".to_string(),
+    };
+
+    let synopsis = if let Some(spend) = spend_directive {
+        format!("{synopsis}; collect authorized spend in {}", spend.currency)
+    } else {
+        synopsis
     };
 
     PlanSummary {
@@ -463,6 +551,136 @@ fn follow_up_step(request: &PlanRequest) -> ActionPrimitive {
     }))
 }
 
+#[derive(Clone, Debug)]
+struct SpendDirective {
+    amount_minor_units: u64,
+    currency: String,
+    merchant: Option<String>,
+}
+
+fn extract_spend_directive(request: &PlanRequest) -> Option<SpendDirective> {
+    request
+        .tags
+        .iter()
+        .find_map(|tag| parse_spend_tag(tag.as_str()))
+}
+
+fn parse_spend_tag(tag: &str) -> Option<SpendDirective> {
+    let remainder = tag.strip_prefix("spend:")?;
+    let mut parts = remainder.split(':');
+
+    let amount_str = parts.next()?;
+    let currency = parts.next()?.to_uppercase();
+    let amount_minor_units = amount_str.parse::<u64>().ok()?;
+    let merchant_raw = parts.next();
+    let merchant = merchant_raw
+        .map(|value| value.replace('_', " "))
+        .filter(|value| !value.is_empty());
+
+    Some(SpendDirective {
+        amount_minor_units,
+        currency,
+        merchant,
+    })
+}
+
+fn wallet_pay_step(directive: &SpendDirective) -> ActionPrimitive {
+    let mut args = JsonMap::new();
+    args.insert(
+        "amount_minor_units".to_string(),
+        json!(directive.amount_minor_units),
+    );
+    args.insert("currency".to_string(), json!(directive.currency));
+
+    if let Some(merchant) = &directive.merchant {
+        args.insert("merchant".to_string(), json!(merchant));
+    }
+
+    ActionPrimitive::new(ActionPrimitiveKind::Pay, args).with_postcondition(json!({
+        "status": "authorized",
+        "provider": "wallet_stub",
+    }))
+}
+
+#[derive(Clone, Debug)]
+struct SpendRequest {
+    step_index: usize,
+    amount_minor_units: u64,
+    currency: String,
+    merchant: Option<String>,
+}
+
+fn first_spend_request(steps: &[ActionPrimitive]) -> Option<SpendRequest> {
+    steps.iter().enumerate().find_map(|(idx, step)| {
+        if step.kind != ActionPrimitiveKind::Pay {
+            return None;
+        }
+
+        let amount_minor_units = step
+            .args
+            .get("amount_minor_units")
+            .and_then(Value::as_u64)?;
+        let currency = step
+            .args
+            .get("currency")
+            .and_then(Value::as_str)?
+            .to_string();
+        let merchant = step
+            .args
+            .get("merchant")
+            .and_then(Value::as_str)
+            .map(|value| value.to_string());
+
+        Some(SpendRequest {
+            step_index: idx,
+            amount_minor_units,
+            currency,
+            merchant,
+        })
+    })
+}
+
+fn guardrail_message(reason: &str) -> String {
+    if reason.is_empty() {
+        WALLET_GUARDRAIL_NOTE.to_string()
+    } else {
+        format!("{reason}\n{WALLET_GUARDRAIL_NOTE}")
+    }
+}
+
+fn build_wallet_escalation(step_index: usize, sanitized_reason: &str) -> PlanEscalation {
+    let rationale = guardrail_message(sanitized_reason);
+    let context = json!({
+        "decision": "escalate",
+        "reason": sanitized_reason,
+        "note": WALLET_GUARDRAIL_NOTE,
+    });
+
+    let args = ActionArguments::from_iter([
+        (
+            "prompt".into(),
+            json!("Confirm wallet spend before continuing execution."),
+        ),
+        ("context".into(), context),
+    ]);
+
+    PlanEscalation {
+        step_index,
+        action: ActionPrimitive::new(ActionPrimitiveKind::Confirm, args),
+        rationale: Some(rationale),
+        expires_at: None,
+    }
+}
+
+fn build_wallet_denial_error(sanitized_reason: &str) -> PlanError {
+    PlanError {
+        code: PlanErrorCode::PolicyDenied,
+        message: "Wallet authorization denied".into(),
+        detail: Some(guardrail_message(sanitized_reason)),
+        retryable: false,
+    }
+}
+
 fn strategy_label(strategy: DiscoveryStrategy) -> &'static str {
     match strategy {
         DiscoveryStrategy::Mcp => "mcp",
@@ -486,6 +704,7 @@ struct PlannerDecisionAudit {
     request: RedactedRequest,
     policy: PolicyAudit,
     discovery: DiscoveryAudit,
+    wallet: WalletAudit,
     outcome: PlanOutcomeAudit,
 }
 
@@ -496,6 +715,7 @@ impl PlannerDecisionAudit {
         request: &PlanRequest,
         policy: PolicyAudit,
         discovery: DiscoveryAudit,
+        wallet: WalletAudit,
         outcome: &PlanOutcome,
     ) -> Self {
         Self {
@@ -504,6 +724,7 @@ impl PlannerDecisionAudit {
             request: RedactedRequest::from_plan_request(request),
             policy,
             discovery,
+            wallet,
             outcome: PlanOutcomeAudit::from(outcome),
         }
     }
@@ -631,6 +852,40 @@ impl PolicyRuleAudit {
             rule: format!("{:?}", rule.rule),
             outcome: format!("{:?}", rule.outcome),
             detail: sanitize_detail(&rule.detail),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum WalletAudit {
+    Evaluated {
+        decision: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    Errored {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    Skipped,
+}
+
+impl WalletAudit {
+    fn skipped() -> Self {
+        Self::Skipped
+    }
+
+    fn evaluated(decision: AuthorizationDecision, reason: String) -> Self {
+        Self::Evaluated {
+            decision: format!("{decision:?}"),
+            reason: (!reason.is_empty()).then_some(reason),
+        }
+    }
+
+    fn errored(error: String) -> Self {
+        Self::Errored {
+            error: (!error.is_empty()).then_some(error),
         }
     }
 }

--- a/services/planner/src/lib.rs
+++ b/services/planner/src/lib.rs
@@ -4,6 +4,7 @@ pub mod event_log;
 pub mod http;
 pub mod policy;
 pub mod state_machine;
+pub mod wallet;
 
 pub use event_log::{
     AppendOutcome, CapabilityMemoryResult, CapabilityMemorySkipReason, EventLog, EventLogError,
@@ -17,3 +18,4 @@ pub use tyrum_shared::planner::{
     ActionArguments, ActionPostcondition, ActionPrimitive, ActionPrimitiveKind, PlanError,
     PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
 };
+pub use wallet::{AuthorizationDecision, SpendAuthorization, WalletClient, WalletClientError};

--- a/services/planner/src/wallet.rs
+++ b/services/planner/src/wallet.rs
@@ -1,0 +1,89 @@
+use reqwest::{Client, StatusCode, Url};
+use thiserror::Error;
+
+use tyrum_wallet::{MerchantContext, SpendAuthorizeRequest, SpendAuthorizeResponse};
+
+/// Input parameters required to authorize a spend with the wallet service.
+#[derive(Clone, Debug)]
+pub struct SpendAuthorization {
+    pub request_id: Option<String>,
+    pub amount_minor_units: u64,
+    pub currency: String,
+    pub merchant_name: Option<String>,
+}
+
+/// Thin async client for the Tyrum wallet authorization service.
+#[derive(Clone)]
+pub struct WalletClient {
+    http: Client,
+    base_url: Url,
+}
+
+impl WalletClient {
+    /// Construct a wallet client targeting the provided base URL.
+    pub fn new(base_url: Url) -> Self {
+        let http = Client::builder()
+            .user_agent("tyrum-planner")
+            .build()
+            .expect("construct wallet client");
+
+        Self { http, base_url }
+    }
+
+    /// Execute an authorization call against the wallet service.
+    pub async fn authorize(
+        &self,
+        payload: &SpendAuthorization,
+    ) -> Result<SpendAuthorizeResponse, WalletClientError> {
+        let url = self
+            .base_url
+            .join("/spend/authorize")
+            .map_err(|error| WalletClientError::InvalidUrl { error })?;
+
+        let merchant = payload.merchant_name.as_ref().map(|name| MerchantContext {
+            name: Some(name.clone()),
+            ..MerchantContext::default()
+        });
+
+        let request = SpendAuthorizeRequest {
+            request_id: payload.request_id.clone(),
+            card_id: None,
+            amount_minor_units: payload.amount_minor_units,
+            currency: payload.currency.clone(),
+            merchant,
+        };
+
+        let response = self
+            .http
+            .post(url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|error| WalletClientError::Transport { error })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            return Err(WalletClientError::UnexpectedStatus { status });
+        }
+
+        response
+            .json::<SpendAuthorizeResponse>()
+            .await
+            .map_err(|error| WalletClientError::Decode { error })
+    }
+}
+
+/// Errors surfaced when calling the wallet authorization service.
+#[derive(Debug, Error)]
+pub enum WalletClientError {
+    #[error("invalid wallet URL: {error}")]
+    InvalidUrl { error: url::ParseError },
+    #[error("wallet transport error: {error}")]
+    Transport { error: reqwest::Error },
+    #[error("wallet returned unexpected status {status}")]
+    UnexpectedStatus { status: StatusCode },
+    #[error("failed to decode wallet response: {error}")]
+    Decode { error: reqwest::Error },
+}
+
+pub use tyrum_wallet::AuthorizationDecision;

--- a/services/planner/tests/common/mod.rs
+++ b/services/planner/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod policy;
 pub mod postgres;
+pub mod wallet;

--- a/services/planner/tests/common/wallet.rs
+++ b/services/planner/tests/common/wallet.rs
@@ -1,0 +1,26 @@
+use axum::Router;
+use reqwest::Url;
+use tokio::{net::TcpListener, task::JoinHandle};
+use tyrum_planner::WalletClient;
+use tyrum_wallet::{Thresholds, build_router};
+
+#[allow(dead_code)]
+pub async fn start_wallet_stub(thresholds: Thresholds) -> (WalletClient, JoinHandle<()>) {
+    let router: Router = build_router(thresholds);
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind wallet listener");
+    let addr = listener.local_addr().expect("wallet socket address");
+    let url = Url::parse(&format!("http://{}", addr)).expect("wallet client url");
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("wallet server failed");
+    });
+
+    let client = WalletClient::new(url);
+
+    (client, server)
+}

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 use chrono::Utc;
 use common::postgres::TestPostgres;
+use common::wallet::start_wallet_stub;
 use http_body_util::BodyExt;
 use reqwest::Url;
 use tokio::{net::TcpListener, task::JoinHandle};
@@ -27,6 +28,7 @@ use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
     PiiField, SenderMetadata, ThreadKind,
 };
+use tyrum_wallet::Thresholds;
 
 fn sample_request() -> PlanRequest {
     PlanRequest {
@@ -157,7 +159,8 @@ async fn plan_returns_stub_response() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) = planner_state(approving_policy_payload()).await;
+    let (state, policy_server, wallet_server, _postgres) =
+        planner_state(approving_policy_payload()).await;
 
     let response = build_router(state)
         .oneshot(
@@ -171,7 +174,8 @@ async fn plan_returns_stub_response() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -218,7 +222,7 @@ async fn discovery_pipeline_uses_mcp_capability() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) =
+    let (state, policy_server, wallet_server, _postgres) =
         planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
 
     let response = build_router(state)
@@ -233,7 +237,8 @@ async fn discovery_pipeline_uses_mcp_capability() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -280,7 +285,7 @@ async fn discovery_pipeline_uses_structured_api_capability() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) =
+    let (state, policy_server, wallet_server, _postgres) =
         planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
 
     let response = build_router(state)
@@ -295,7 +300,8 @@ async fn discovery_pipeline_uses_structured_api_capability() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -340,7 +346,7 @@ async fn discovery_pipeline_uses_generic_http_capability() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) =
+    let (state, policy_server, wallet_server, _postgres) =
         planner_state_with_pipeline(approving_policy_payload(), pipeline_trait).await;
 
     let response = build_router(state)
@@ -355,7 +361,8 @@ async fn discovery_pipeline_uses_generic_http_capability() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -398,7 +405,7 @@ async fn plan_rejects_oversized_payloads() {
 
     let body = serde_json::to_vec(&payload).expect("serialize oversized request");
 
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+    let (state, policy_server, wallet_server, _postgres) = planner_state(serde_json::json!({
         "decision": "approve",
         "rules": [],
     }))
@@ -416,7 +423,8 @@ async fn plan_rejects_oversized_payloads() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 }
@@ -426,7 +434,7 @@ async fn plan_escalates_on_policy_escalation() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+    let (state, policy_server, wallet_server, _postgres) = planner_state(serde_json::json!({
         "decision": "escalate",
         "rules": [
             {
@@ -450,7 +458,8 @@ async fn plan_escalates_on_policy_escalation() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -470,7 +479,7 @@ async fn plan_returns_failure_on_policy_denial() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+    let (state, policy_server, wallet_server, _postgres) = planner_state(serde_json::json!({
         "decision": "deny",
         "rules": [
             {
@@ -494,7 +503,8 @@ async fn plan_returns_failure_on_policy_denial() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -515,7 +525,7 @@ async fn plan_escalation_includes_context_when_rules_do_not_match() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+    let (state, policy_server, wallet_server, _postgres) = planner_state(serde_json::json!({
         "decision": "escalate",
         "rules": [
             {
@@ -539,7 +549,8 @@ async fn plan_escalation_includes_context_when_rules_do_not_match() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -557,7 +568,7 @@ async fn plan_failure_includes_details_when_rules_do_not_match() {
     let payload = sample_request();
     let body = serde_json::to_vec(&payload).expect("serialize plan request");
 
-    let (state, server, _postgres) = planner_state(serde_json::json!({
+    let (state, policy_server, wallet_server, _postgres) = planner_state(serde_json::json!({
         "decision": "deny",
         "rules": [
             {
@@ -581,7 +592,8 @@ async fn plan_failure_includes_details_when_rules_do_not_match() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -622,15 +634,20 @@ async fn mock_policy(response: serde_json::Value) -> (PolicyClient, JoinHandle<(
 
 async fn planner_state(
     policy_response: serde_json::Value,
-) -> (PlannerState, JoinHandle<()>, TestPostgres) {
+) -> (PlannerState, JoinHandle<()>, JoinHandle<()>, TestPostgres) {
     planner_state_with_pipeline(policy_response, Arc::new(DefaultDiscoveryPipeline::new())).await
 }
 
 async fn planner_state_with_pipeline(
     policy_response: serde_json::Value,
     discovery: Arc<dyn DiscoveryPipeline + Send + Sync>,
-) -> (PlannerState, JoinHandle<()>, TestPostgres) {
+) -> (PlannerState, JoinHandle<()>, JoinHandle<()>, TestPostgres) {
     let (policy_client, server) = mock_policy(policy_response).await;
+    let thresholds = Thresholds {
+        auto_approve_minor_units: 10_000,
+        hard_deny_minor_units: 50_000,
+    };
+    let (wallet_client, wallet_server) = start_wallet_stub(thresholds).await;
     let postgres = TestPostgres::start().await.expect("start postgres fixture");
     let event_log = EventLog::from_pool(postgres.pool().clone());
     event_log.migrate().await.expect("migrate planner schema");
@@ -640,8 +657,10 @@ async fn planner_state_with_pipeline(
             policy_client,
             event_log,
             discovery,
+            wallet_client,
         },
         server,
+        wallet_server,
         postgres,
     )
 }

--- a/services/planner/tests/plan_audit.rs
+++ b/services/planner/tests/plan_audit.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::{body::Body, http::Request};
 use chrono::Utc;
-use common::{policy::mock_policy, postgres::TestPostgres};
+use common::{policy::mock_policy, postgres::TestPostgres, wallet::start_wallet_stub};
 use http_body_util::BodyExt;
 use serde_json::json;
 use sqlx::Row;
@@ -18,6 +18,7 @@ use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
     PiiField, SenderMetadata, ThreadKind,
 };
+use tyrum_wallet::Thresholds;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -28,7 +29,7 @@ async fn planner_appends_audit_event_with_redacted_payload() {
     let event_log = EventLog::from_pool(pool.clone());
     event_log.migrate().await.expect("migrate planner schema");
 
-    let (policy_client, server) = mock_policy(json!({
+    let (policy_client, policy_server) = mock_policy(json!({
         "decision": "approve",
         "rules": [
             {
@@ -45,10 +46,17 @@ async fn planner_appends_audit_event_with_redacted_payload() {
     }))
     .await;
 
+    let (wallet_client, wallet_server) = start_wallet_stub(Thresholds {
+        auto_approve_minor_units: 10_000,
+        hard_deny_minor_units: 50_000,
+    })
+    .await;
+
     let state = PlannerState {
         policy_client,
         event_log: event_log.clone(),
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
+        wallet_client,
     };
 
     let request = sample_request();
@@ -66,7 +74,8 @@ async fn planner_appends_audit_event_with_redacted_payload() {
         .await
         .expect("receive response");
 
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
@@ -136,6 +145,16 @@ async fn planner_appends_audit_event_with_redacted_payload() {
         discovery.get("status").and_then(|value| value.as_str()),
         Some("not_found"),
         "default pipeline should record not_found discovery"
+    );
+
+    let wallet = action
+        .get("wallet")
+        .and_then(|value| value.as_object())
+        .expect("wallet audit block present");
+    assert_eq!(
+        wallet.get("status").and_then(|value| value.as_str()),
+        Some("skipped"),
+        "wallet audit should be skipped when no spend directive is present"
     );
 
     let payload_text = action.to_string();

--- a/services/planner/tests/policy_denial.rs
+++ b/services/planner/tests/policy_denial.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::{body::Body, http::Request};
 use chrono::Utc;
-use common::{policy::mock_policy, postgres::TestPostgres};
+use common::{policy::mock_policy, postgres::TestPostgres, wallet::start_wallet_stub};
 use http_body_util::BodyExt;
 use serde_json::json;
 use sqlx::Row;
@@ -18,6 +18,7 @@ use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
     PiiField, SenderMetadata, ThreadKind,
 };
+use tyrum_wallet::Thresholds;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -29,7 +30,7 @@ async fn policy_denial_is_logged_and_sanitized() {
     event_log.migrate().await.expect("migrate planner schema");
 
     let denial_detail = "Amount €123.45 exceeds hard limit €500.00.";
-    let (policy_client, server) = mock_policy(json!({
+    let (policy_client, policy_server) = mock_policy(json!({
         "decision": "deny",
         "rules": [
             {
@@ -41,10 +42,17 @@ async fn policy_denial_is_logged_and_sanitized() {
     }))
     .await;
 
+    let (wallet_client, wallet_server) = start_wallet_stub(Thresholds {
+        auto_approve_minor_units: 10_000,
+        hard_deny_minor_units: 50_000,
+    })
+    .await;
+
     let state = PlannerState {
         policy_client,
         event_log: event_log.clone(),
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
+        wallet_client,
     };
 
     let request = sample_request();
@@ -64,7 +72,8 @@ async fn policy_denial_is_logged_and_sanitized() {
 
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let plan: PlanResponse = serde_json::from_slice(&bytes).expect("decode plan response");
-    server.abort();
+    policy_server.abort();
+    wallet_server.abort();
 
     let failure = match plan.outcome {
         PlanOutcome::Failure { error } => {
@@ -142,6 +151,16 @@ async fn policy_denial_is_logged_and_sanitized() {
         discovery.get("status").and_then(|value| value.as_str()),
         Some("skipped"),
         "discovery should be skipped for policy denials"
+    );
+
+    let wallet = action
+        .get("wallet")
+        .and_then(|value| value.as_object())
+        .expect("wallet audit block present");
+    assert_eq!(
+        wallet.get("status").and_then(|value| value.as_str()),
+        Some("skipped"),
+        "wallet audit should be skipped when no spend directive is present"
     );
 
     let outcome = action

--- a/services/planner/tests/wallet_integration.rs
+++ b/services/planner/tests/wallet_integration.rs
@@ -1,0 +1,300 @@
+mod common;
+
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use serde_json::json;
+use sqlx::Row;
+use tower::ServiceExt;
+use tyrum_discovery::DefaultDiscoveryPipeline;
+use tyrum_planner::{
+    ActionPrimitiveKind, EventLog, PlanOutcome, PlanRequest,
+    http::{PlannerState, build_router},
+};
+use tyrum_shared::{
+    MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
+    PiiField, SenderMetadata, ThreadKind,
+};
+use tyrum_wallet::Thresholds;
+
+use common::{policy::mock_policy, postgres::TestPostgres, wallet::start_wallet_stub};
+
+fn spend_request(amount_minor_units: u64) -> PlanRequest {
+    PlanRequest {
+        request_id: format!("req-{amount_minor_units}"),
+        subject_id: "subject-wallet".into(),
+        trigger: NormalizedThreadMessage {
+            thread: NormalizedThread {
+                id: "thread-wallet".into(),
+                kind: ThreadKind::Private,
+                title: None,
+                username: Some("wallet_user".into()),
+                pii_fields: vec![PiiField::ThreadUsername],
+            },
+            message: NormalizedMessage {
+                id: "msg-wallet".into(),
+                thread_id: "thread-wallet".into(),
+                source: MessageSource::Telegram,
+                content: MessageContent::Text {
+                    text: "Book tasting and settle deposit".into(),
+                },
+                sender: Some(SenderMetadata {
+                    id: "sender-wallet".into(),
+                    is_bot: false,
+                    first_name: Some("Jamie".into()),
+                    last_name: None,
+                    username: Some("wallet_user".into()),
+                    language_code: Some("en".into()),
+                }),
+                timestamp: Utc::now(),
+                edited_timestamp: None,
+                pii_fields: vec![PiiField::MessageText],
+            },
+        },
+        locale: Some("en-US".into()),
+        timezone: Some("Europe/Amsterdam".into()),
+        tags: vec![format!("spend:{amount_minor_units}:EUR:espresso_bar")],
+    }
+}
+
+fn policy_approve_payload() -> serde_json::Value {
+    json!({
+        "decision": "approve",
+        "rules": [
+            {
+                "rule": "spend_limit",
+                "outcome": "approve",
+                "detail": "Spend within policy",
+            },
+            {
+                "rule": "pii_guardrail",
+                "outcome": "approve",
+                "detail": "PII safe",
+            },
+            {
+                "rule": "legal_compliance",
+                "outcome": "approve",
+                "detail": "No legal concerns",
+            }
+        ],
+    })
+}
+
+fn wallet_thresholds() -> Thresholds {
+    Thresholds {
+        auto_approve_minor_units: 10_000,
+        hard_deny_minor_units: 50_000,
+    }
+}
+
+async fn planner_state() -> (
+    PlannerState,
+    tokio::task::JoinHandle<()>,
+    tokio::task::JoinHandle<()>,
+    TestPostgres,
+) {
+    let (policy_client, policy_server) = mock_policy(policy_approve_payload()).await;
+    let (wallet_client, wallet_server) = start_wallet_stub(wallet_thresholds()).await;
+    let postgres = TestPostgres::start().await.expect("start postgres fixture");
+    let event_log = EventLog::from_pool(postgres.pool().clone());
+    event_log.migrate().await.expect("migrate planner schema");
+
+    let state = PlannerState {
+        policy_client,
+        event_log,
+        discovery: Arc::new(DefaultDiscoveryPipeline::new()),
+        wallet_client,
+    };
+
+    (state, policy_server, wallet_server, postgres)
+}
+
+#[tokio::test]
+async fn wallet_authorization_approve_returns_success() {
+    let (state, policy_server, wallet_server, postgres) = planner_state().await;
+
+    let request = spend_request(7_500);
+    let body = serde_json::to_vec(&request).expect("serialize plan request");
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    policy_server.abort();
+    wallet_server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: tyrum_planner::PlanResponse = serde_json::from_slice(&bytes).expect("decode plan");
+
+    let steps = match plan.outcome {
+        PlanOutcome::Success { steps, .. } => steps,
+        other => panic!("expected success, got {other:?}"),
+    };
+
+    assert_eq!(steps.len(), 4, "research, fallback, pay, follow-up");
+    assert_eq!(steps[2].kind, ActionPrimitiveKind::Pay);
+
+    let row = sqlx::query("SELECT action FROM planner_events")
+        .fetch_one(postgres.pool())
+        .await
+        .expect("fetch planner audit");
+    let action: serde_json::Value = row.try_get("action").expect("action payload");
+    let wallet = action
+        .get("wallet")
+        .and_then(|value| value.as_object())
+        .expect("wallet audit block");
+    assert_eq!(
+        wallet.get("status").and_then(|value| value.as_str()),
+        Some("evaluated")
+    );
+    assert_eq!(
+        wallet.get("decision").and_then(|value| value.as_str()),
+        Some("Approve")
+    );
+    let reason = wallet
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .expect("wallet reason");
+    assert!(
+        !reason.chars().any(|character| character.is_ascii_digit()),
+        "wallet reason should be sanitized: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn wallet_authorization_escalates_plan() {
+    let (state, policy_server, wallet_server, postgres) = planner_state().await;
+
+    let request = spend_request(20_000);
+    let body = serde_json::to_vec(&request).expect("serialize plan request");
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    policy_server.abort();
+    wallet_server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: tyrum_planner::PlanResponse = serde_json::from_slice(&bytes).expect("decode plan");
+
+    let escalation = match plan.outcome {
+        PlanOutcome::Escalate { escalation } => escalation,
+        other => panic!("expected escalate outcome, got {other:?}"),
+    };
+
+    let rationale = escalation.rationale.expect("rationale present");
+    assert!(
+        !rationale
+            .chars()
+            .any(|character| character.is_ascii_digit()),
+        "escalation rationale should be sanitized: {rationale}"
+    );
+
+    let row = sqlx::query("SELECT action FROM planner_events")
+        .fetch_one(postgres.pool())
+        .await
+        .expect("fetch planner audit");
+    let action: serde_json::Value = row.try_get("action").expect("action payload");
+    let wallet = action
+        .get("wallet")
+        .and_then(|value| value.as_object())
+        .expect("wallet audit block");
+    assert_eq!(
+        wallet.get("status").and_then(|value| value.as_str()),
+        Some("evaluated")
+    );
+    assert_eq!(
+        wallet.get("decision").and_then(|value| value.as_str()),
+        Some("Escalate")
+    );
+    let reason = wallet
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .expect("wallet reason");
+    assert!(
+        !reason.chars().any(|character| character.is_ascii_digit()),
+        "wallet reason should be sanitized: {reason}"
+    );
+}
+
+#[tokio::test]
+async fn wallet_authorization_denies_plan() {
+    let (state, policy_server, wallet_server, postgres) = planner_state().await;
+
+    let request = spend_request(60_000);
+    let body = serde_json::to_vec(&request).expect("serialize plan request");
+
+    let response = build_router(state)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/plan")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .expect("construct request"),
+        )
+        .await
+        .expect("receive response");
+
+    policy_server.abort();
+    wallet_server.abort();
+
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let plan: tyrum_planner::PlanResponse = serde_json::from_slice(&bytes).expect("decode plan");
+
+    let error = match plan.outcome {
+        PlanOutcome::Failure { error } => error,
+        other => panic!("expected failure outcome, got {other:?}"),
+    };
+
+    let detail = error.detail.expect("denial reason present");
+    assert!(
+        !detail.chars().any(|character| character.is_ascii_digit()),
+        "denial detail should be sanitized: {detail}"
+    );
+
+    let row = sqlx::query("SELECT action FROM planner_events")
+        .fetch_one(postgres.pool())
+        .await
+        .expect("fetch planner audit");
+    let action: serde_json::Value = row.try_get("action").expect("action payload");
+    let wallet = action
+        .get("wallet")
+        .and_then(|value| value.as_object())
+        .expect("wallet audit block");
+    assert_eq!(
+        wallet.get("status").and_then(|value| value.as_str()),
+        Some("evaluated")
+    );
+    assert_eq!(
+        wallet.get("decision").and_then(|value| value.as_str()),
+        Some("Deny")
+    );
+    let reason = wallet
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .expect("wallet reason");
+    assert!(
+        !reason.chars().any(|character| character.is_ascii_digit()),
+        "wallet reason should be sanitized: {reason}"
+    );
+}

--- a/services/tyrum-wallet/src/lib.rs
+++ b/services/tyrum-wallet/src/lib.rs
@@ -63,7 +63,7 @@ fn read_limit(var: &str, default: u64) -> u64 {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SpendAuthorizeRequest {
     #[serde(default)]
     pub request_id: Option<String>,
@@ -75,7 +75,7 @@ pub struct SpendAuthorizeRequest {
     pub merchant: Option<MerchantContext>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct MerchantContext {
     pub name: Option<String>,


### PR DESCRIPTION
## Summary
- call the wallet service when plans include pay primitives and surface approve/escalate/deny outcomes with sanitized audit logging
- wire wallet configuration into the planner binary and compose stack, documenting the new audit trail behaviour
- add wallet integration tests plus supporting helpers to exercise approve/escalate/deny flows via the stub service

## Testing
- pre-commit run --all-files
- cargo test -p tyrum-planner --test wallet_integration
- cargo test

Closes #81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds wallet spend authorization to the planner (approve/escalate/deny) with sanitized audit logging, pay-step generation, config/env wiring, compose service, and integration tests.
> 
> - **Planner**:
>   - **Wallet Integration**: Add `wallet` module and `WalletClient`; parse `spend:*` tags into spend directives, append `Pay` step, and call `/spend/authorize`.
>   - **Outcomes**: On wallet `Approve` keep plan; `Escalate` returns `PlanOutcome::Escalate` with confirm action; `Deny` returns `PlanOutcome::Failure`.
>   - **Audit**: Extend decision audit with `wallet` block (evaluated/errored/skipped), sanitize reasons, and include guardrail note; continue to sanitize policy details.
>   - **HTTP Server**: Require `WALLET_GATE_URL`; inject `WalletClient` into `PlannerState`.
>   - **Plan Summary/Steps**: Include `Pay` step and synopsis note when spend directive present.
> - **Infra**:
>   - Add `wallet` service and healthcheck; set `WALLET_GATE_URL` for planner in `docker-compose.yml`.
> - **Docs**:
>   - Document wallet authorization audit behavior in `docs/planner_event_log.md`.
> - **Deps**:
>   - Add `tyrum-wallet` dependency to planner; export wallet types; derive `Serialize` for wallet request structs.
> - **Tests**:
>   - Add wallet stub, helpers, and `wallet_integration` tests covering approve/escalate/deny; update existing tests to include wallet audit and wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9831e9e2ff098a2c4c4b67e41fce445ba35a7ac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->