### PR TITLE
Configure JetStream client for watchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-nats"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f1564b878e64608a4fc8ab74c0b499b566400b9ab6e5097f21ba1945dab5bb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time 0.3.44",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +404,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -572,6 +612,32 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -800,6 +866,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +975,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1444,7 +1538,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -1991,6 +2085,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2836,7 +2954,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -3128,6 +3246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3385,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3926,6 +4065,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tonic"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4286,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "typenum"
@@ -4366,6 +4536,18 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tyrum-watchers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "futures",
+ "testcontainers",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -4661,6 +4843,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [
     "services/planner",
     "services/policy",
     "services/tyrum-wallet",
-    "shared/tyrum-shared"
+    "shared/tyrum-shared",
+    "services/tyrum-watchers",
 ]
 resolver = "2"
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -39,6 +39,9 @@ COPY services/policy/src services/policy/src
 COPY services/tyrum-wallet/Cargo.toml services/tyrum-wallet/Cargo.toml
 COPY services/tyrum-wallet/src services/tyrum-wallet/src
 COPY services/tyrum-wallet/tests services/tyrum-wallet/tests
+COPY services/tyrum-watchers/Cargo.toml services/tyrum-watchers/Cargo.toml
+COPY services/tyrum-watchers/src services/tyrum-watchers/src
+COPY services/tyrum-watchers/tests services/tyrum-watchers/tests
 COPY services/planner/Cargo.toml services/planner/Cargo.toml
 COPY services/planner/migrations services/planner/migrations
 COPY services/planner/src services/planner/src

--- a/Dockerfile.planner
+++ b/Dockerfile.planner
@@ -37,6 +37,9 @@ COPY services/policy/src services/policy/src
 COPY services/tyrum-wallet/Cargo.toml services/tyrum-wallet/Cargo.toml
 COPY services/tyrum-wallet/src services/tyrum-wallet/src
 COPY services/tyrum-wallet/tests services/tyrum-wallet/tests
+COPY services/tyrum-watchers/Cargo.toml services/tyrum-watchers/Cargo.toml
+COPY services/tyrum-watchers/src services/tyrum-watchers/src
+COPY services/tyrum-watchers/tests services/tyrum-watchers/tests
 COPY services/planner/Cargo.toml services/planner/Cargo.toml
 COPY services/planner/migrations services/planner/migrations
 COPY services/planner/src services/planner/src

--- a/Dockerfile.policy
+++ b/Dockerfile.policy
@@ -38,6 +38,9 @@ COPY services/policy/src services/policy/src
 COPY services/tyrum-wallet/Cargo.toml services/tyrum-wallet/Cargo.toml
 COPY services/tyrum-wallet/src services/tyrum-wallet/src
 COPY services/tyrum-wallet/tests services/tyrum-wallet/tests
+COPY services/tyrum-watchers/Cargo.toml services/tyrum-watchers/Cargo.toml
+COPY services/tyrum-watchers/src services/tyrum-watchers/src
+COPY services/tyrum-watchers/tests services/tyrum-watchers/tests
 COPY services/planner/Cargo.toml services/planner/Cargo.toml
 COPY services/planner/migrations services/planner/migrations
 COPY services/planner/src services/planner/src

--- a/Dockerfile.wallet
+++ b/Dockerfile.wallet
@@ -36,6 +36,9 @@ COPY services/executor_android/Cargo.toml services/executor_android/Cargo.toml
 COPY services/executor_android/src services/executor_android/src
 COPY services/policy/Cargo.toml services/policy/Cargo.toml
 COPY services/policy/src services/policy/src
+COPY services/tyrum-watchers/Cargo.toml services/tyrum-watchers/Cargo.toml
+COPY services/tyrum-watchers/src services/tyrum-watchers/src
+COPY services/tyrum-watchers/tests services/tyrum-watchers/tests
 COPY services/planner/Cargo.toml services/planner/Cargo.toml
 COPY services/planner/migrations services/planner/migrations
 COPY services/planner/src services/planner/src

--- a/docs/infra/nats_jetstream.md
+++ b/docs/infra/nats_jetstream.md
@@ -1,0 +1,23 @@
+# NATS JetStream Runtime
+
+## Overview
+- Provides durable event storage and delivery semantics for watcher workloads (calendar conflicts, VIP follow-ups, delivery ETA slips per product concept §15.1).
+- Backed by the `nats:2.10-alpine` container wired into `infra/docker-compose.yml` with JetStream health probes enabled.
+
+## Local & CI Resources
+- Allocate **≥512 MiB memory** and **≥128 MiB disk** for the JetStream container. CI runners provision 768 MiB headroom to absorb bursts during integration tests.
+- The default compose service exposes ports `4222` (client) and `8222` (monitoring). Ports are published to the host for local debuggability.
+- Health check (`wget --spider http://localhost:8222/healthz?js-enabled`) is required for compose and CI orchestration; keep the monitoring port open.
+
+## Configuration
+- Core environment variables consumed by the new `tyrum-watchers` crate:
+  - `WATCHERS_JETSTREAM_URL` (required): e.g. `nats://nats:4222`.
+  - `WATCHERS_JETSTREAM_STREAM` (optional, default `watchers_events`).
+  - `WATCHERS_JETSTREAM_SUBJECT_PREFIX` (optional, default `watchers.events`).
+  - `WATCHERS_JETSTREAM_SAMPLE_CONSUMER` (optional durable name for round-trip checks).
+  - `WATCHERS_JETSTREAM_CLIENT_NAME` (optional client label surfaced in NATS monitoring).
+- Compose keeps the service unauthenticated for now; local overrides can be applied by exporting the variables above before invoking binaries that depend on the watcher client.
+
+## Security & Follow-Up
+- Authentication and authorization are **TBD**. Future milestones will introduce NATS credentials (user/pass or nkeys) issued via the existing secret manager; do not embed secrets in the repository.
+- When credentials land, update this document and `tyrum-watchers::JetStreamConfig::from_env` to require them, and ensure policy gate reviews the new outbound domain list.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -21,6 +21,26 @@ services:
       retries: 5
       start_period: 10s
 
+  nats:
+    image: nats:2.10-alpine
+    command:
+      - "-js"
+      - "-m"
+      - "8222"
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider -q http://localhost:8222/healthz?js-enabled || exit 1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
   wallet:
     build:
       context: ..

--- a/services/tyrum-watchers/Cargo.toml
+++ b/services/tyrum-watchers/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tyrum-watchers"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+async-nats = "0.44.1"
+futures = "0.3"
+thiserror = "1"
+tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread", "time"] }
+
+[dev-dependencies]
+anyhow = "1"
+testcontainers = "0.18"
+
+[lints]
+workspace = true

--- a/services/tyrum-watchers/src/config.rs
+++ b/services/tyrum-watchers/src/config.rs
@@ -1,0 +1,233 @@
+use std::env;
+
+use crate::error::JetStreamError;
+
+/// Environment variable defining the JetStream server URL.
+pub const URL_ENV: &str = "WATCHERS_JETSTREAM_URL";
+/// Environment variable overriding the JetStream stream name.
+pub const STREAM_ENV: &str = "WATCHERS_JETSTREAM_STREAM";
+/// Environment variable overriding the subject prefix for watcher events.
+pub const SUBJECT_PREFIX_ENV: &str = "WATCHERS_JETSTREAM_SUBJECT_PREFIX";
+/// Environment variable overriding the durable consumer used by sample logic.
+pub const SAMPLE_CONSUMER_ENV: &str = "WATCHERS_JETSTREAM_SAMPLE_CONSUMER";
+/// Environment variable overriding the client name reported to NATS.
+pub const CLIENT_NAME_ENV: &str = "WATCHERS_JETSTREAM_CLIENT_NAME";
+
+const DEFAULT_STREAM_NAME: &str = "watchers_events";
+const DEFAULT_SUBJECT_PREFIX: &str = "watchers.events";
+const DEFAULT_SAMPLE_CONSUMER: &str = "watchers_sample_consumer";
+const DEFAULT_CLIENT_NAME: &str = "tyrum-watchers";
+
+/// Runtime configuration required to connect to JetStream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JetStreamConfig {
+    pub(crate) nats_url: String,
+    pub(crate) stream_name: String,
+    pub(crate) subject_prefix: String,
+    pub(crate) sample_subject: String,
+    pub(crate) sample_consumer: String,
+    pub(crate) client_name: String,
+}
+
+impl JetStreamConfig {
+    /// Builds a configuration instance from explicit values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::InvalidStreamName`] or
+    /// [`JetStreamError::InvalidSubjectPrefix`] when validation fails.
+    pub fn new(
+        nats_url: impl Into<String>,
+        stream_name: impl Into<String>,
+        subject_prefix: impl Into<String>,
+        sample_consumer: impl Into<String>,
+        client_name: impl Into<String>,
+    ) -> Result<Self, JetStreamError> {
+        let nats_url = nats_url.into();
+        let stream_name = stream_name.into();
+        validate_stream_name(&stream_name)?;
+
+        let subject_prefix = subject_prefix.into();
+        validate_subject_prefix(&subject_prefix)?;
+
+        let sample_consumer = sample_consumer.into();
+        validate_consumer_name(&sample_consumer)?;
+
+        let client_name = client_name.into();
+        let sample_subject = format!("{subject_prefix}.sample");
+
+        Ok(Self {
+            nats_url,
+            stream_name,
+            subject_prefix,
+            sample_subject,
+            sample_consumer,
+            client_name,
+        })
+    }
+
+    /// Builds a configuration instance by reading the documented environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::MissingEnv`] when the mandatory server URL is absent,
+    /// [`JetStreamError::InvalidStreamName`] when the provided stream name fails basic
+    /// validation, or [`JetStreamError::InvalidSubjectPrefix`] when the subject prefix
+    /// is empty or contains whitespace.
+    pub fn from_env() -> Result<Self, JetStreamError> {
+        let nats_url =
+            env::var(URL_ENV).map_err(|_| JetStreamError::MissingEnv { key: URL_ENV })?;
+
+        let stream_name = env::var(STREAM_ENV).unwrap_or_else(|_| DEFAULT_STREAM_NAME.to_string());
+        validate_stream_name(&stream_name)?;
+
+        let subject_prefix =
+            env::var(SUBJECT_PREFIX_ENV).unwrap_or_else(|_| DEFAULT_SUBJECT_PREFIX.to_string());
+        validate_subject_prefix(&subject_prefix)?;
+
+        let sample_consumer =
+            env::var(SAMPLE_CONSUMER_ENV).unwrap_or_else(|_| DEFAULT_SAMPLE_CONSUMER.to_string());
+        validate_consumer_name(&sample_consumer)?;
+
+        let client_name =
+            env::var(CLIENT_NAME_ENV).unwrap_or_else(|_| DEFAULT_CLIENT_NAME.to_string());
+
+        Self::new(
+            nats_url,
+            stream_name,
+            subject_prefix,
+            sample_consumer,
+            client_name,
+        )
+    }
+
+    /// Returns the NATS connection URL.
+    #[must_use]
+    pub fn nats_url(&self) -> &str {
+        &self.nats_url
+    }
+
+    /// Returns the configured JetStream stream name.
+    #[must_use]
+    pub fn stream_name(&self) -> &str {
+        &self.stream_name
+    }
+
+    /// Returns the subject prefix used for watcher events.
+    #[must_use]
+    pub fn subject_prefix(&self) -> &str {
+        &self.subject_prefix
+    }
+
+    /// Returns the subject used by the sample publish/consume logic.
+    #[must_use]
+    pub fn sample_subject(&self) -> &str {
+        &self.sample_subject
+    }
+
+    /// Returns the durable consumer name used by the sample logic.
+    #[must_use]
+    pub fn sample_consumer(&self) -> &str {
+        &self.sample_consumer
+    }
+
+    /// Returns the NATS client name that will be announced to the server.
+    #[must_use]
+    pub fn client_name(&self) -> &str {
+        &self.client_name
+    }
+}
+
+fn validate_stream_name(value: &str) -> Result<(), JetStreamError> {
+    if value.trim().is_empty() {
+        return Err(JetStreamError::InvalidStreamName {
+            stream: value.to_string(),
+            reason: "value must not be empty",
+        });
+    }
+
+    if value
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
+    {
+        return Err(JetStreamError::InvalidStreamName {
+            stream: value.to_string(),
+            reason: "only alphanumeric, hyphen, underscore, or dot characters are allowed",
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_subject_prefix(value: &str) -> Result<(), JetStreamError> {
+    if value.trim().is_empty() {
+        return Err(JetStreamError::InvalidSubjectPrefix {
+            subject: value.to_string(),
+            reason: "value must not be empty",
+        });
+    }
+
+    if value.chars().any(char::is_whitespace) {
+        return Err(JetStreamError::InvalidSubjectPrefix {
+            subject: value.to_string(),
+            reason: "whitespace is not allowed in NATS subjects",
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_consumer_name(value: &str) -> Result<(), JetStreamError> {
+    if value.trim().is_empty() {
+        return Err(JetStreamError::InvalidConsumerName {
+            consumer: value.to_string(),
+            reason: "value must not be empty",
+        });
+    }
+
+    if value
+        .chars()
+        .any(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')))
+    {
+        return Err(JetStreamError::InvalidConsumerName {
+            consumer: value.to_string(),
+            reason: "only alphanumeric, hyphen, or underscore characters are allowed",
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consumer_name_accepts_valid_characters() {
+        assert!(validate_consumer_name("Durable_Consumer-01").is_ok());
+    }
+
+    #[test]
+    fn consumer_name_rejects_empty_value() {
+        let err = match validate_consumer_name("") {
+            Err(err) => err,
+            Ok(_) => panic!("expected invalid consumer name error"),
+        };
+        assert!(matches!(
+            err,
+            JetStreamError::InvalidConsumerName { reason, .. } if reason.contains("not be empty")
+        ));
+    }
+
+    #[test]
+    fn consumer_name_rejects_invalid_characters() {
+        let err = match validate_consumer_name("contains.dot") {
+            Err(err) => err,
+            Ok(_) => panic!("expected invalid consumer name error"),
+        };
+        assert!(matches!(
+            err,
+            JetStreamError::InvalidConsumerName { reason, .. } if reason.contains("alphanumeric")
+        ));
+    }
+}

--- a/services/tyrum-watchers/src/error.rs
+++ b/services/tyrum-watchers/src/error.rs
@@ -1,0 +1,104 @@
+use thiserror::Error;
+
+/// Errors raised by the JetStream watcher client utilities.
+#[derive(Debug, Error)]
+pub enum JetStreamError {
+    /// An expected environment variable was not provided.
+    #[error("missing environment variable {key}")]
+    MissingEnv {
+        /// The missing environment variable key.
+        key: &'static str,
+    },
+    /// The configured stream name failed validation.
+    #[error("invalid stream name `{stream}`: {reason}")]
+    InvalidStreamName {
+        /// The invalid stream name that was provided.
+        stream: String,
+        /// Short description of why the value is invalid.
+        reason: &'static str,
+    },
+    /// The configured subject prefix failed validation.
+    #[error("invalid subject prefix `{subject}`: {reason}")]
+    InvalidSubjectPrefix {
+        /// The invalid subject prefix that was provided.
+        subject: String,
+        /// Short description of why the value is invalid.
+        reason: &'static str,
+    },
+    /// The configured consumer name failed validation.
+    #[error("invalid consumer name `{consumer}`: {reason}")]
+    InvalidConsumerName {
+        /// The invalid consumer name that was provided.
+        consumer: String,
+        /// Short description of why the value is invalid.
+        reason: &'static str,
+    },
+    /// Establishing the underlying NATS connection failed.
+    #[error("failed to connect to NATS JetStream")]
+    Connect {
+        /// The source error returned by the async-nats client.
+        #[source]
+        source: async_nats::ConnectError,
+    },
+    /// Creating or fetching the configured JetStream stream failed.
+    #[error("failed to create or fetch stream `{stream}`")]
+    Stream {
+        /// Stream identifier that failed.
+        stream: String,
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::jetstream::context::CreateStreamError,
+    },
+    /// Creating or fetching the configured JetStream consumer failed.
+    #[error("failed to create or fetch consumer `{consumer}`")]
+    Consumer {
+        /// Consumer identifier that failed.
+        consumer: String,
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::jetstream::stream::ConsumerError,
+    },
+    /// Publishing a message to JetStream failed.
+    #[error("failed to publish to subject `{subject}`")]
+    Publish {
+        /// Subject that publish attempted to use.
+        subject: String,
+        /// The source error returned by async-nats.
+        #[source]
+        source: async_nats::jetstream::context::PublishError,
+    },
+    /// Fetching messages for the configured consumer failed.
+    #[error("failed to fetch messages for consumer `{consumer}`")]
+    Fetch {
+        /// Consumer identifier involved in the fetch operation.
+        consumer: String,
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::jetstream::consumer::pull::BatchError,
+    },
+    /// Processing a message pulled from JetStream failed.
+    #[error("failed to process message for consumer `{consumer}`")]
+    Message {
+        /// Consumer identifier involved in the message iteration.
+        consumer: String,
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::Error,
+    },
+    /// Acknowledging a message back to JetStream failed.
+    #[error("failed to acknowledge message for consumer `{consumer}`")]
+    Ack {
+        /// Consumer identifier involved in the acknowledgement.
+        consumer: String,
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::Error,
+    },
+    /// Retrieving JetStream account information failed.
+    #[error("failed to query JetStream account information")]
+    Account {
+        /// The source error from async-nats.
+        #[source]
+        source: async_nats::jetstream::context::AccountError,
+    },
+}

--- a/services/tyrum-watchers/src/jetstream.rs
+++ b/services/tyrum-watchers/src/jetstream.rs
@@ -1,0 +1,202 @@
+use std::{sync::Arc, time::Duration};
+
+use async_nats::{
+    ConnectOptions,
+    jetstream::{
+        self,
+        consumer::{self, AckPolicy, PullConsumer},
+        stream::{Config as StreamConfig, Info as StreamInfo, Stream as JetStream},
+    },
+};
+use futures::StreamExt;
+
+use crate::{config::JetStreamConfig, error::JetStreamError};
+
+type JetStreamStream = JetStream<StreamInfo>;
+
+/// Handles JetStream connectivity and sample publish/consume flows for watchers.
+#[derive(Clone)]
+pub struct JetStreamClient {
+    config: Arc<JetStreamConfig>,
+    _client: async_nats::Client,
+    context: jetstream::Context,
+}
+
+/// Minimal health snapshot for a JetStream account.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JetStreamHealth {
+    /// Optional JetStream domain returned by the server.
+    pub domain: Option<String>,
+    /// Active stream count within the account.
+    pub streams: usize,
+    /// Active consumer count within the account.
+    pub consumers: usize,
+    /// Memory usage reported by JetStream.
+    pub memory_bytes: u64,
+    /// Storage usage reported by JetStream.
+    pub storage_bytes: u64,
+}
+
+impl JetStreamClient {
+    /// Establishes a connection using the provided configuration and ensures the watcher stream exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::Connect`] if the NATS handshake fails or
+    /// [`JetStreamError::Stream`] when the watcher stream cannot be created.
+    pub async fn connect(config: JetStreamConfig) -> Result<Self, JetStreamError> {
+        let client = ConnectOptions::new()
+            .name(config.client_name().to_string())
+            .connect(config.nats_url())
+            .await
+            .map_err(|source| JetStreamError::Connect { source })?;
+
+        let context = jetstream::new(client.clone());
+
+        let instance = Self {
+            context,
+            _client: client,
+            config: Arc::new(config),
+        };
+
+        instance.ensure_stream().await?;
+
+        Ok(instance)
+    }
+
+    /// Queries the JetStream account and returns the reported usage statistics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::Account`] when the JetStream management API cannot
+    /// return account information.
+    pub async fn health_check(&self) -> Result<JetStreamHealth, JetStreamError> {
+        let account = self
+            .context
+            .query_account()
+            .await
+            .map_err(|source| JetStreamError::Account { source })?;
+
+        Ok(JetStreamHealth {
+            domain: account.domain.clone(),
+            streams: account.streams,
+            consumers: account.consumers,
+            memory_bytes: account.memory,
+            storage_bytes: account.storage,
+        })
+    }
+
+    /// Publishes a sample payload to the watcher stream and waits for JetStream acknowledgement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::Stream`] when the watcher stream cannot be created,
+    /// or [`JetStreamError::Publish`] when the JetStream publish API rejects the message.
+    pub async fn publish_sample_event(&self, payload: &[u8]) -> Result<(), JetStreamError> {
+        self.ensure_stream().await?;
+
+        let subject = self.config.sample_subject().to_string();
+
+        let ack = self
+            .context
+            .publish(subject.clone(), payload.to_vec().into())
+            .await
+            .map_err(|source| JetStreamError::Publish {
+                subject: subject.clone(),
+                source,
+            })?;
+
+        ack.await
+            .map_err(|source| JetStreamError::Publish { subject, source })?;
+
+        Ok(())
+    }
+
+    /// Attempts to consume one sample event, acknowledging it back to JetStream when received.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JetStreamError::Stream`] or [`JetStreamError::Consumer`] when the
+    /// infrastructure primitives cannot be provisioned, [`JetStreamError::Fetch`]
+    /// when retrieving messages fails, [`JetStreamError::Message`] for stream errors,
+    /// or [`JetStreamError::Ack`] if acknowledgement cannot be sent.
+    pub async fn consume_sample_event(
+        &self,
+        timeout: Duration,
+    ) -> Result<Option<Vec<u8>>, JetStreamError> {
+        let consumer = self.ensure_sample_consumer().await?;
+        let consumer_name = self.config.sample_consumer().to_string();
+
+        let mut messages = consumer
+            .fetch()
+            .max_messages(1)
+            .expires(timeout)
+            .messages()
+            .await
+            .map_err(|source| JetStreamError::Fetch {
+                consumer: consumer_name.clone(),
+                source,
+            })?;
+
+        if let Some(message) = messages.next().await {
+            let message = message.map_err(|source| JetStreamError::Message {
+                consumer: consumer_name.clone(),
+                source,
+            })?;
+
+            let payload = message.message.payload.clone().to_vec();
+
+            message.ack().await.map_err(|source| JetStreamError::Ack {
+                consumer: consumer_name,
+                source,
+            })?;
+
+            Ok(Some(payload))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn ensure_stream(&self) -> Result<(), JetStreamError> {
+        self.stream().await.map(|_| ())
+    }
+
+    async fn ensure_sample_consumer(&self) -> Result<PullConsumer, JetStreamError> {
+        let stream = self.stream().await?;
+        let consumer_name = self.config.sample_consumer().to_string();
+        let subject = self.config.sample_subject().to_string();
+
+        stream
+            .get_or_create_consumer(
+                &consumer_name,
+                consumer::pull::Config {
+                    durable_name: Some(consumer_name.clone()),
+                    filter_subject: subject,
+                    ack_policy: AckPolicy::Explicit,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|source| JetStreamError::Consumer {
+                consumer: consumer_name,
+                source,
+            })
+    }
+
+    async fn stream(&self) -> Result<JetStreamStream, JetStreamError> {
+        let stream_name = self.config.stream_name().to_string();
+        let subjects = vec![format!("{}.*", self.config.subject_prefix())];
+
+        self.context
+            .get_or_create_stream(StreamConfig {
+                name: stream_name.clone(),
+                subjects,
+                ..StreamConfig::default()
+            })
+            .await
+            .map_err(|source| JetStreamError::Stream {
+                stream: stream_name,
+                source,
+            })
+    }
+}

--- a/services/tyrum-watchers/src/lib.rs
+++ b/services/tyrum-watchers/src/lib.rs
@@ -1,0 +1,9 @@
+//! JetStream client utilities for Tyrum watcher processing.
+
+pub mod config;
+mod error;
+pub mod jetstream;
+
+pub use config::JetStreamConfig;
+pub use error::JetStreamError;
+pub use jetstream::{JetStreamClient, JetStreamHealth};

--- a/services/tyrum-watchers/tests/jetstream.rs
+++ b/services/tyrum-watchers/tests/jetstream.rs
@@ -1,0 +1,91 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor, wait::HttpWaitStrategy},
+    runners::AsyncRunner,
+};
+use tyrum_watchers::{JetStreamClient, JetStreamConfig};
+
+const NATS_IMAGE: &str = "nats";
+const NATS_TAG: &str = "2.10-alpine";
+const NATS_PORT: u16 = 4222;
+
+struct NatsFixture {
+    #[allow(dead_code)]
+    container: ContainerAsync<GenericImage>,
+    url: String,
+}
+
+impl NatsFixture {
+    async fn start() -> Result<Self> {
+        let image = GenericImage::new(NATS_IMAGE, NATS_TAG)
+            .with_exposed_port(NATS_PORT.tcp())
+            .with_wait_for(WaitFor::http(
+                HttpWaitStrategy::new("/healthz?js-enabled=true")
+                    .with_port(8222.tcp())
+                    .with_expected_status_code(200u16),
+            ))
+            .with_cmd(["-js", "-m", "8222"]);
+
+        let container = image
+            .start()
+            .await
+            .context("start nats jetstream container")?;
+        let host_port = container
+            .get_host_port_ipv4(NATS_PORT.tcp())
+            .await
+            .context("map nats port")?;
+
+        let url = format!("nats://127.0.0.1:{host_port}");
+
+        Ok(Self { container, url })
+    }
+}
+
+#[tokio::test]
+async fn jetstream_publish_and_consume_roundtrip() -> Result<()> {
+    let fixture = match NatsFixture::start().await {
+        Ok(fixture) => fixture,
+        Err(err) => {
+            if err
+                .chain()
+                .any(|cause| cause.to_string().contains("No such file or directory"))
+            {
+                eprintln!(
+                    "skipping jetstream_publish_and_consume_roundtrip: docker socket unavailable ({err})"
+                );
+                return Ok(());
+            }
+
+            return Err(err);
+        }
+    };
+
+    let config = JetStreamConfig::new(
+        fixture.url.clone(),
+        "watchers_integration_stream",
+        "watchers.integration",
+        "watchers_integration_consumer",
+        "tyrum-watchers-test",
+    )?;
+    let client = JetStreamClient::connect(config.clone()).await?;
+
+    let health = client.health_check().await?;
+    assert!(
+        health.streams >= 1,
+        "expected at least one stream, got {}",
+        health.streams
+    );
+
+    let payload = br#"{"event":"demo"}"#.to_vec();
+    client.publish_sample_event(&payload).await?;
+
+    let received = client.consume_sample_event(Duration::from_secs(2)).await?;
+    assert_eq!(received, Some(payload));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a dedicated `tyrum-watchers` crate with JetStream configuration, client, and health reporting utilities
- cover publish/consume roundtrip with a Docker-backed integration test and HTTP health gating
- add a JetStream service to docker-compose and document local/CI resource requirements plus security follow-ups

## Acceptance Criteria
- [x] JetStream client wrapper connects using env settings and exposes health checks
- [x] Integration test publishes and consumes an event via JetStream
- [x] NATS JetStream service added to infra/docker-compose with health check

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p tyrum-watchers jetstream
- pre-commit run --all-files

Closes #82

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `tyrum-watchers` with JetStream config/client and tests, adds NATS JetStream service and docs, and wires the crate into the workspace and Docker builds.
> 
> - **Watchers**:
>   - Add `services/tyrum-watchers` crate providing `JetStreamConfig`, `JetStreamClient`, `JetStreamHealth`, and typed `JetStreamError`.
>   - Support sample publish/consume flow and health querying against JetStream.
>   - Integration test (`tests/jetstream.rs`) spins up NATS JetStream via testcontainers and verifies round-trip.
> - **Infra**:
>   - Add `nats:2.10-alpine` service with JetStream enabled and healthcheck in `infra/docker-compose.yml`.
>   - New doc `docs/infra/nats_jetstream.md` detailing local/CI setup, env vars, and follow-ups.
> - **Build/Workspace**:
>   - Register crate in `Cargo.toml` workspace and update service Dockerfiles to include `services/tyrum-watchers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 713e59293b29f33b4c5ba32e6408b43fba50e046. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->