### PR TITLE
Add watcher registration API (#83)

### DIFF
--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -328,9 +328,11 @@ to keep policy, planner, and API services aligned on envelopes and error handlin
 
 ## 11) Watchers & Proactivity (without types)
 - **Event sources:** email, messages, calls, calendar, files, webhooks (delivery/order), custom signals.
-- **Predicate:** natural‑language or DSL compiled to a check (e.g., overlaps ≥ 15 min, ETA slip ≥ 20 min, unanswered VIP email ≥ 24 h).
+- **Predicate:** natural-language or DSL compiled to a check (e.g., overlaps ≥ 15 min, ETA slip ≥ 20 min, unanswered VIP email ≥ 24 h).
 - **Reaction:** a small plan built from the same primitives (notify, rebook, reschedule).
 - The PA proposes/updates rules; user can tweak or disable any watcher.
+- Registrations persist to the `watchers` Postgres table; planner services join on `watchers.plan_reference` to hydrate execution plans.
+- AuthN/AuthZ is pending for the registration surface; keep route internal until policy gate issues scoped credentials.
 
 ---
 

--- a/services/api/migrations/0004_create_watchers_table.sql
+++ b/services/api/migrations/0004_create_watchers_table.sql
@@ -1,0 +1,33 @@
+-- Persist watcher definitions for planner orchestration.
+CREATE TABLE IF NOT EXISTS watchers (
+    id BIGSERIAL PRIMARY KEY,
+    event_source TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    plan_reference TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (char_length(trim(event_source)) > 0),
+    CHECK (char_length(trim(predicate)) > 0),
+    CHECK (char_length(trim(plan_reference)) > 0),
+    CHECK (char_length(event_source) <= 64),
+    CHECK (char_length(predicate) <= 2048),
+    CHECK (char_length(plan_reference) <= 128),
+    CHECK (
+        status IN ('draft', 'active', 'disabled')
+    ),
+    CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+COMMENT ON TABLE watchers IS 'Registered watcher definitions available for planner evaluation.';
+COMMENT ON COLUMN watchers.event_source IS 'Normalized trigger origin for the watcher (e.g. email, messages, calendar).';
+COMMENT ON COLUMN watchers.predicate IS 'Predicate expression evaluated to determine watcher activation.';
+COMMENT ON COLUMN watchers.plan_reference IS 'Planner plan identifier invoked when a watcher fires.';
+COMMENT ON COLUMN watchers.status IS 'Lifecycle state for the watcher (draft, active, disabled).';
+COMMENT ON COLUMN watchers.metadata IS 'JSON object containing planner-facing metadata for joins.';
+COMMENT ON COLUMN watchers.created_at IS 'Timestamp when the watcher registration was created.';
+COMMENT ON COLUMN watchers.updated_at IS 'Timestamp when the watcher registration was last updated.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS watchers_event_predicate_plan_unique
+    ON watchers (event_source, predicate, plan_reference);

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -4,3 +4,4 @@ pub mod metrics;
 pub mod telegram;
 pub mod telemetry;
 pub mod waitlist;
+pub mod watchers;

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -5,7 +5,13 @@ use anyhow::{Context, Result, anyhow};
 use tyrum_api::{
     account_linking::AccountLinkingRepository,
     ingress::{IngressRepository, IngressRepositoryError},
+    metrics, telegram,
+    telemetry::TelemetryGuard,
     waitlist::{NewWaitlistSignup, WaitlistError, WaitlistRepository},
+    watchers::{
+        RegisterWatcherError, WATCHERS_ROUTE, WatcherRegistrationRequest,
+        WatcherRegistrationResponse, WatcherRepository, process_registration,
+    },
 };
 
 use axum::{
@@ -18,11 +24,8 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tyrum_api::telemetry::TelemetryGuard;
-use validator::Validate;
-
-use tyrum_api::{metrics, telegram};
 use tyrum_shared::telegram::{TelegramNormalizationError, normalize_update};
+use validator::Validate;
 
 const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8080";
 const DEFAULT_DATABASE_URL: &str = "postgres://tyrum:tyrum_dev_password@localhost:5432/tyrum_dev";
@@ -62,6 +65,7 @@ struct AppState {
     waitlist: WaitlistRepository,
     account_linking: AccountLinkingRepository,
     ingress: IngressRepository,
+    watchers: WatcherRepository,
     telegram: telegram::TelegramWebhookVerifier,
 }
 
@@ -167,6 +171,7 @@ fn build_router(state: AppState) -> Router {
             ACCOUNT_LINKING_TOGGLE_ROUTE,
             put(update_account_link_preference),
         )
+        .route(WATCHERS_ROUTE, post(register_watcher))
         .route(TELEGRAM_WEBHOOK_ROUTE, post(telegram_webhook))
         .with_state(state)
 }
@@ -318,6 +323,74 @@ async fn update_account_link_preference(
         ACCOUNT_LINKING_TOGGLE_ROUTE,
         response.status().as_u16(),
     );
+
+    response
+}
+
+#[tracing::instrument(name = "api.watchers.register", skip_all)]
+async fn register_watcher(
+    State(state): State<AppState>,
+    Json(payload): Json<WatcherRegistrationRequest>,
+) -> Response {
+    let mut sanitized = payload.clone();
+    sanitized.sanitize();
+
+    let response = match process_registration(&state.watchers, payload).await {
+        Ok(watcher) => {
+            tracing::info!(
+                event_source = %watcher.event_source,
+                plan_reference = %watcher.plan_reference,
+                "registered watcher definition; auth enforcement pending"
+            );
+            (
+                StatusCode::CREATED,
+                Json(WatcherRegistrationResponse {
+                    status: "created",
+                    watcher,
+                }),
+            )
+                .into_response()
+        }
+        Err(RegisterWatcherError::Validation { message, .. }) => {
+            tracing::warn!(reason = %message, "invalid watcher registration payload");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "invalid_payload",
+                    message,
+                }),
+            )
+                .into_response()
+        }
+        Err(RegisterWatcherError::Duplicate) => {
+            tracing::warn!(
+                event_source = %sanitized.event_source,
+                plan_reference = %sanitized.plan_reference,
+                "duplicate watcher registration attempted"
+            );
+            (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: "duplicate",
+                    message: "Watcher already registered with the same event source, predicate, and plan reference".into(),
+                }),
+            )
+                .into_response()
+        }
+        Err(RegisterWatcherError::Database(error)) => {
+            tracing::error!(reason = %error, "failed to persist watcher registration");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "server_error",
+                    message: "Unable to persist watcher registration".into(),
+                }),
+            )
+                .into_response()
+        }
+    };
+
+    metrics::record_http_request("POST", WATCHERS_ROUTE, response.status().as_u16());
 
     response
 }
@@ -526,6 +599,7 @@ async fn main() -> Result<()> {
 
     let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
     let ingress = IngressRepository::new(waitlist.pool().clone());
+    let watchers = WatcherRepository::new(waitlist.pool().clone());
 
     let telegram_secret =
         env::var("TELEGRAM_WEBHOOK_SECRET").context("TELEGRAM_WEBHOOK_SECRET must be set")?;
@@ -536,6 +610,7 @@ async fn main() -> Result<()> {
         waitlist,
         account_linking,
         ingress,
+        watchers,
         telegram,
     });
 
@@ -578,6 +653,7 @@ mod tests {
         ingress::IngressRepository,
         telegram::TelegramWebhookVerifier,
         waitlist::{NewWaitlistSignup, WaitlistError, WaitlistRepository},
+        watchers::WatcherRepository,
     };
 
     const POSTGRES_IMAGE: &str = "pgvector/pgvector";
@@ -643,6 +719,7 @@ mod tests {
 
             let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
             let ingress = IngressRepository::new(waitlist.pool().clone());
+            let watchers = WatcherRepository::new(waitlist.pool().clone());
             let telegram =
                 TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
 
@@ -650,6 +727,7 @@ mod tests {
                 waitlist: waitlist.clone(),
                 account_linking: account_linking.clone(),
                 ingress: ingress.clone(),
+                watchers: watchers.clone(),
                 telegram: telegram.clone(),
             });
 
@@ -672,12 +750,14 @@ mod tests {
         let waitlist = WaitlistRepository::from_pool(pool.clone());
         let ingress = IngressRepository::new(pool.clone());
         let account_linking = AccountLinkingRepository::new(pool);
+        let watchers = WatcherRepository::new(waitlist.pool().clone());
         let telegram =
             TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
         let state = AppState {
             waitlist,
             account_linking,
             ingress,
+            watchers,
             telegram,
         };
         let app = build_router(state);

--- a/services/api/src/watchers.rs
+++ b/services/api/src/watchers.rs
@@ -1,0 +1,332 @@
+use std::{borrow::Cow, collections::BTreeSet};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use sqlx::PgPool;
+use thiserror::Error;
+use validator::{Validate, ValidationError, ValidationErrors};
+
+/// Route constant for watcher registrations.
+pub const WATCHERS_ROUTE: &str = "/watchers";
+
+/// Event sources currently accepted for watcher registrations.
+pub const ALLOWED_EVENT_SOURCES: &[&str] = &[
+    "email", "messages", "calls", "calendar", "files", "webhooks", "custom",
+];
+
+/// Persisted watcher definition as stored within the Tyrum API database.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct WatcherRecord {
+    pub id: i64,
+    pub event_source: String,
+    pub predicate: String,
+    pub plan_reference: String,
+    pub status: String,
+    pub metadata: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// API payload submitted by clients when registering a watcher.
+#[derive(Debug, Clone, Deserialize, Validate)]
+pub struct WatcherRegistrationRequest {
+    #[serde(default)]
+    #[validate(
+        length(min = 1, max = 64),
+        custom(function = "validate_event_source_field")
+    )]
+    pub event_source: String,
+    #[serde(default)]
+    #[validate(
+        length(min = 1, max = 2048),
+        custom(function = "validate_predicate_field")
+    )]
+    pub predicate: String,
+    #[serde(default)]
+    #[validate(
+        length(min = 1, max = 128),
+        custom(function = "validate_plan_reference_field")
+    )]
+    pub plan_reference: String,
+    #[serde(default = "default_metadata_value")]
+    #[validate(custom(function = "validate_metadata_field"))]
+    pub metadata: Value,
+}
+
+impl WatcherRegistrationRequest {
+    /// Normalizes payload fields prior to validation/persistence.
+    pub fn sanitize(&mut self) {
+        self.event_source = normalize_event_source(&self.event_source);
+        self.predicate = self.predicate.trim().to_string();
+        self.plan_reference = self.plan_reference.trim().to_string();
+    }
+}
+
+/// API response returned to clients after a registration attempt.
+#[derive(Debug, Clone, Serialize)]
+pub struct WatcherRegistrationResponse {
+    pub status: &'static str,
+    pub watcher: WatcherResponse,
+}
+
+/// Representation of a watcher returned in API responses.
+#[derive(Debug, Clone, Serialize)]
+pub struct WatcherResponse {
+    pub id: i64,
+    pub event_source: String,
+    pub predicate: String,
+    pub plan_reference: String,
+    pub status: String,
+    pub metadata: Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<WatcherRecord> for WatcherResponse {
+    fn from(record: WatcherRecord) -> Self {
+        Self {
+            id: record.id,
+            event_source: record.event_source,
+            predicate: record.predicate,
+            plan_reference: record.plan_reference,
+            status: record.status,
+            metadata: record.metadata,
+            created_at: record.created_at,
+            updated_at: record.updated_at,
+        }
+    }
+}
+
+/// Payload used when creating a new watcher registration.
+#[derive(Debug, Clone)]
+pub struct NewWatcher {
+    pub event_source: String,
+    pub predicate: String,
+    pub plan_reference: String,
+    pub status: String,
+    pub metadata: Value,
+}
+
+impl NewWatcher {
+    pub fn active(
+        event_source: String,
+        predicate: String,
+        plan_reference: String,
+        metadata: Value,
+    ) -> Self {
+        Self {
+            event_source,
+            predicate,
+            plan_reference,
+            status: "active".to_string(),
+            metadata,
+        }
+    }
+}
+
+/// Errors returned when persisting watcher registrations.
+#[derive(Debug, Error)]
+pub enum WatcherRepositoryError {
+    #[error("watcher with the same event source, predicate, and plan reference already exists")]
+    Duplicate,
+    #[error("database error: {0}")]
+    Database(sqlx::Error),
+}
+
+impl From<sqlx::Error> for WatcherRepositoryError {
+    fn from(error: sqlx::Error) -> Self {
+        if let sqlx::Error::Database(db_err) = &error
+            && db_err.constraint() == Some("watchers_event_predicate_plan_unique")
+        {
+            WatcherRepositoryError::Duplicate
+        } else {
+            WatcherRepositoryError::Database(error)
+        }
+    }
+}
+
+/// Repository for storing and retrieving watcher registrations.
+#[derive(Clone)]
+pub struct WatcherRepository {
+    pool: PgPool,
+}
+
+impl WatcherRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Inserts a new watcher registration and returns the stored record.
+    pub async fn insert(
+        &self,
+        watcher: &NewWatcher,
+    ) -> Result<WatcherRecord, WatcherRepositoryError> {
+        let record = sqlx::query_as::<_, WatcherRecord>(
+            r#"
+            INSERT INTO watchers (event_source, predicate, plan_reference, status, metadata)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, event_source, predicate, plan_reference, status, metadata, created_at, updated_at
+            "#,
+        )
+        .bind(&watcher.event_source)
+        .bind(&watcher.predicate)
+        .bind(&watcher.plan_reference)
+        .bind(&watcher.status)
+        .bind(&watcher.metadata)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(record)
+    }
+}
+
+/// Returns the supplied event source lowercased and trimmed.
+pub fn normalize_event_source(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+/// Returns `true` when the supplied event source is one of the supported values.
+pub fn is_allowed_event_source(candidate: &str) -> bool {
+    let normalized = normalize_event_source(candidate);
+    ALLOWED_EVENT_SOURCES.contains(&normalized.as_str())
+}
+
+/// Returns `true` when the metadata value is a JSON object.
+pub fn metadata_is_object(metadata: &Value) -> bool {
+    matches!(metadata, Value::Object(_))
+}
+
+/// Collects the allowed event sources for human-friendly responses.
+pub fn allowed_event_sources() -> BTreeSet<&'static str> {
+    ALLOWED_EVENT_SOURCES.iter().copied().collect()
+}
+
+fn default_metadata_value() -> Value {
+    Value::Object(Map::new())
+}
+
+fn validate_event_source_field(value: &str) -> Result<(), ValidationError> {
+    if is_allowed_event_source(value) {
+        return Ok(());
+    }
+
+    let mut error = ValidationError::new("unsupported_event_source");
+    error.add_param(Cow::Borrowed("value"), &value);
+    let allowed: Vec<_> = allowed_event_sources().into_iter().collect();
+    error.add_param(Cow::Borrowed("allowed"), &allowed);
+    Err(error)
+}
+
+fn validate_predicate_field(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::new("empty_predicate"));
+    }
+
+    if value
+        .chars()
+        .all(|ch| matches!(ch, '\n' | '\r' | '\t') || !ch.is_control())
+    {
+        Ok(())
+    } else {
+        Err(ValidationError::new("invalid_predicate"))
+    }
+}
+
+fn validate_plan_reference_field(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::new("empty_plan_reference"));
+    }
+
+    let allowed = value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '/' | ':' | '.' | '#'));
+    if allowed {
+        Ok(())
+    } else {
+        Err(ValidationError::new("invalid_plan_reference"))
+    }
+}
+
+fn validate_metadata_field(value: &Value) -> Result<(), ValidationError> {
+    if metadata_is_object(value) {
+        Ok(())
+    } else {
+        Err(ValidationError::new("metadata_not_object"))
+    }
+}
+
+/// Converts validation errors into a human-readable message.
+pub fn watcher_validation_message(errors: &ValidationErrors) -> String {
+    if errors
+        .field_errors()
+        .get("event_source")
+        .is_some_and(|field_errors| {
+            field_errors
+                .iter()
+                .any(|err| err.code == "unsupported_event_source")
+        })
+    {
+        let allowed: Vec<_> = allowed_event_sources().into_iter().collect();
+        return format!("event_source must be one of: {}", allowed.join(", "));
+    }
+
+    errors.to_string()
+}
+
+/// Resulting error from attempting to register a new watcher.
+#[derive(Debug, Error)]
+pub enum RegisterWatcherError {
+    #[error("invalid watcher registration payload: {message}")]
+    Validation {
+        message: String,
+        #[source]
+        errors: ValidationErrors,
+    },
+    #[error("watcher already registered with the same definition")]
+    Duplicate,
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl RegisterWatcherError {
+    /// Human-friendly validation message when validation fails.
+    pub fn validation_message(&self) -> Option<&str> {
+        match self {
+            RegisterWatcherError::Validation { message, .. } => Some(message),
+            _ => None,
+        }
+    }
+}
+
+/// Sanitizes, validates, and persists a watcher registration, returning an API response payload.
+pub async fn process_registration(
+    repository: &WatcherRepository,
+    mut payload: WatcherRegistrationRequest,
+) -> Result<WatcherResponse, RegisterWatcherError> {
+    payload.sanitize();
+
+    if let Err(errors) = payload.validate() {
+        let message = watcher_validation_message(&errors);
+        return Err(RegisterWatcherError::Validation { message, errors });
+    }
+
+    let WatcherRegistrationRequest {
+        event_source,
+        predicate,
+        plan_reference,
+        metadata,
+    } = payload;
+
+    let new_watcher = NewWatcher::active(event_source, predicate, plan_reference, metadata);
+
+    match repository.insert(&new_watcher).await {
+        Ok(record) => Ok(WatcherResponse::from(record)),
+        Err(WatcherRepositoryError::Duplicate) => Err(RegisterWatcherError::Duplicate),
+        Err(WatcherRepositoryError::Database(error)) => Err(RegisterWatcherError::Database(error)),
+    }
+}

--- a/services/api/tests/watcher_registration.rs
+++ b/services/api/tests/watcher_registration.rs
@@ -1,0 +1,269 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::State,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use std::time::Duration;
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+use tokio::time::sleep;
+use tower::ServiceExt;
+use tyrum_api::watchers::{
+    RegisterWatcherError, WATCHERS_ROUTE, WatcherRegistrationRequest, WatcherRegistrationResponse,
+    WatcherRepository, process_registration,
+};
+
+const POSTGRES_IMAGE: &str = "pgvector/pgvector";
+const POSTGRES_TAG: &str = "pg16";
+const POSTGRES_USER: &str = "tyrum";
+const POSTGRES_PASSWORD: &str = "tyrum_dev_password";
+const POSTGRES_DB: &str = "tyrum_dev";
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+struct TestContext {
+    #[allow(dead_code)]
+    container: ContainerAsync<GenericImage>,
+    router: Router,
+    repository: WatcherRepository,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+            .with_exposed_port(5432.tcp())
+            .with_wait_for(WaitFor::message_on_stdout(
+                "database system is ready to accept connections",
+            ));
+
+        let request = image
+            .with_env_var("POSTGRES_USER", POSTGRES_USER)
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", POSTGRES_DB);
+
+        let container = request.start().await.expect("start postgres container");
+        let host_port = container
+            .get_host_port_ipv4(5432.tcp())
+            .await
+            .expect("map postgres port");
+
+        let database_url = format!(
+            "postgres://{}:{}@127.0.0.1:{}/{}",
+            POSTGRES_USER, POSTGRES_PASSWORD, host_port, POSTGRES_DB
+        );
+
+        let pool = connect_with_retry(&database_url).await;
+        MIGRATOR.run(&pool).await.expect("run migrations");
+
+        let repository = WatcherRepository::new(pool.clone());
+        let router = build_router(repository.clone());
+
+        Self {
+            container,
+            router,
+            repository,
+        }
+    }
+}
+
+fn build_router(repository: WatcherRepository) -> Router {
+    Router::new()
+        .route(WATCHERS_ROUTE, post(register_watcher_route))
+        .with_state(repository)
+}
+
+#[tracing::instrument(name = "test.watchers.register", skip(repo, payload))]
+async fn register_watcher_route(
+    State(repo): State<WatcherRepository>,
+    Json(payload): Json<WatcherRegistrationRequest>,
+) -> Response {
+    let mut sanitized = payload.clone();
+    sanitized.sanitize();
+
+    match process_registration(&repo, payload).await {
+        Ok(watcher) => (
+            StatusCode::CREATED,
+            Json(WatcherRegistrationResponse {
+                status: "created",
+                watcher,
+            }),
+        )
+            .into_response(),
+        Err(RegisterWatcherError::Validation { message, .. }) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid_payload", "message": message })),
+        )
+            .into_response(),
+        Err(RegisterWatcherError::Duplicate) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "duplicate",
+                "event_source": sanitized.event_source,
+                "plan_reference": sanitized.plan_reference,
+            })),
+        )
+            .into_response(),
+        Err(RegisterWatcherError::Database(error)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "server_error", "message": error.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn connect_with_retry(database_url: &str) -> PgPool {
+    let mut attempts = 0;
+    loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .connect(database_url)
+            .await
+        {
+            Ok(pool) => break pool,
+            Err(error) if attempts < 10 && matches!(error, sqlx::Error::Io(_)) => {
+                attempts += 1;
+                sleep(Duration::from_millis(150)).await;
+            }
+            Err(error) => panic!("connect postgres pool: {error}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn register_watcher_persists_record() {
+    let ctx = TestContext::new().await;
+    let app = ctx.router.clone();
+
+    let payload = json!({
+        "event_source": "EMAIL",
+        "predicate": "subject contains 'VIP'",
+        "plan_reference": "plan://follow-up/v1",
+        "metadata": { "created_by": "tests" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(WATCHERS_ROUTE)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(value["status"], "created");
+    assert_eq!(value["watcher"]["event_source"].as_str().unwrap(), "email");
+
+    let row = sqlx::query(
+        "SELECT event_source, predicate, plan_reference, status, metadata FROM watchers",
+    )
+    .fetch_one(ctx.repository.pool())
+    .await
+    .expect("fetch watcher row");
+
+    assert_eq!(row.try_get::<String, _>("event_source").unwrap(), "email");
+    assert_eq!(
+        row.try_get::<String, _>("predicate").unwrap(),
+        "subject contains 'VIP'"
+    );
+    assert_eq!(
+        row.try_get::<String, _>("plan_reference").unwrap(),
+        "plan://follow-up/v1"
+    );
+    assert_eq!(row.try_get::<String, _>("status").unwrap(), "active");
+    let metadata: Value = row.try_get("metadata").unwrap();
+    assert_eq!(metadata["created_by"], "tests");
+}
+
+#[tokio::test]
+async fn register_watcher_rejects_invalid_source() {
+    let ctx = TestContext::new().await;
+    let app = ctx.router.clone();
+
+    let payload = json!({
+        "event_source": "unknown-surface",
+        "predicate": "always()",
+        "plan_reference": "plan://noop",
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(WATCHERS_ROUTE)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(value["error"], "invalid_payload");
+    assert!(
+        value["message"]
+            .as_str()
+            .unwrap()
+            .contains("event_source must be one of")
+    );
+}
+
+#[tokio::test]
+async fn register_watcher_rejects_duplicates() {
+    let ctx = TestContext::new().await;
+    let app = ctx.router.clone();
+
+    let payload = json!({
+        "event_source": "messages",
+        "predicate": "thread = 'vip'",
+        "plan_reference": "plan://vip-follow-up",
+    });
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(WATCHERS_ROUTE)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let second = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(WATCHERS_ROUTE)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+    let body_bytes = second.into_body().collect().await.unwrap().to_bytes();
+    let value: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(value["error"], "duplicate");
+    assert_eq!(value["plan_reference"], "plan://vip-follow-up");
+}


### PR DESCRIPTION
## Summary
- add Postgres schema for watcher registrations and wire repository
- expose POST /watchers endpoint with validation and persistence
- add integration tests and doc references for planner join path

## Testing
- cargo test -p tyrum-api --test watcher_registration
- RUST_TEST_THREADS=1 pre-commit run --all-files

Closes #83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds POST `/watchers` to register watchers with validation and Postgres persistence, plus migration, wiring, tests, and brief docs updates.
> 
> - **Backend API**:
>   - Expose `POST /watchers` (`WATCHERS_ROUTE`) to register watchers with payload sanitization, validation, and structured error handling.
>   - Add `watchers` module: request/response types, validation (allowed `event_source`, predicate/plan rules), repository with insert and duplicate detection, and `process_registration` helper.
>   - Wire `WatcherRepository` into `AppState` and router; record HTTP metrics; log outcomes.
> - **Database**:
>   - Migration creating `watchers` table with constraints, JSONB `metadata`, lifecycle `status`, timestamps, and unique index on `(event_source, predicate, plan_reference)`.
> - **Tests**:
>   - Integration tests for watcher registration: success persistence, invalid source (400), and duplicate handling (409) using testcontainers Postgres.
> - **Docs**:
>   - Watchers section notes persistence to `watchers` table and pending auth; fixes predicate bullet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 238b294c716d28ebb807aa50f4b6dc7b67842834. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->