### PR TITLE
Add per-user policy context (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tyrum-shared",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Follow these steps to provision the Telegram channel safely across local and sta
 1. Copy `config/local.env.example` to `config/local.env` if you want CLI access to the services from the host.
 2. From the repo root run `docker compose -f infra/docker-compose.yml up --build` (or `cd infra && docker compose up --build`).
 3. Once the stack has converged you should see:
-   - Policy check service on http://localhost:8081 with `/healthz` returning `{ "status": "ok" }` and `POST /policy/check` evaluating spend/PII/legal guardrails
+   - Policy check service on http://localhost:8081 with `/healthz` returning `{ "status": "ok" }` and `POST /policy/check` evaluating spend/PII/legal guardrails. Planner requests now include a per-user payload (`user_id` plus optional `pam_profile`); when no explicit user context is supplied the client falls back to `PlanRequest.subject_id` so guardrails remain individualized.
    - Rust API on http://localhost:8080 with `/healthz` returning `{ "status": "ok" }`
    - Next.js portal on http://localhost:3000
    - PostgreSQL on `localhost:5432` (`tyrum`/`tyrum_dev_password`)

--- a/docs/policy_service.md
+++ b/docs/policy_service.md
@@ -12,6 +12,11 @@ The planner service consumes `POST /policy/check` via its async client. Configur
 ```jsonc
 {
   "request_id": "optional identifier",
+  "user_id": "stable subject identifier",
+  "pam_profile": {
+    "profile_id": "pam-default",
+    "version": "v1"
+  },
   "spend": {
     "amount_minor_units": 15000,
     "currency": "USD",
@@ -30,7 +35,12 @@ The planner service consumes `POST /policy/check` via its async client. Configur
 }
 ```
 
-All sections are optional; when context is missing the service escalates the corresponding rule so that planners can request confirmation from the user.
+All sections other than `user_id` are optional; when context is missing the service escalates the corresponding rule so that planners can request confirmation from the user. The planner client falls back to the `PlanRequest.subject_id` when no explicit user context is provided.
+
+- `user_id` – Required; trimmed ASCII string up to 128 characters using `[A-Za-z0-9._-]`. Logged only in aggregate metrics to respect PII guidance.
+- `pam_profile.profile_id` – Optional; same character set as `user_id`, up to 64 characters.
+- `pam_profile.version` – Optional semantic version/hint (32 characters max) to help policy caches select the right profile revision.
+- `pam_profile` may be omitted entirely when no learned policy is available; the planner continues to supply `user_id` so guardrails remain per-user.
 
 ## Static Rule Set
 - **Spend:**
@@ -48,11 +58,19 @@ All sections are optional; when context is missing the service escalates the cor
 
 The overall `decision` is `deny` if any rule denies, `escalate` if any rule escalates, and `approve` otherwise.
 
+## Validation & PII Handling
+- Requests lacking a `user_id` are rejected with `400 missing_user_id`. The planner defaults to `PlanRequest.subject_id`, so local testing continues to work even without an explicit user payload.
+- `user_id`, `pam_profile.profile_id`, and `pam_profile.version` must be trimmed ASCII strings limited to the lengths noted above; invalid characters trigger a `400` response with an explicit error code.
+- Identifiers are excluded from request traces and only surface in aggregate metrics to respect PII guardrails.
+- JSON fixtures that cover both shapes live in `services/policy/tests/fixtures/` and can be reused for integration smoke tests.
+
 ## Sample Interaction
 ```json
 // Request
 {
   "request_id": "example-123",
+  "user_id": "subject-123",
+  "pam_profile": { "profile_id": "pam-default", "version": "v1" },
   "spend": { "amount_minor_units": 8750, "currency": "EUR" },
   "pii": { "categories": ["basic_contact"] },
   "legal": { "flags": [] }

--- a/services/planner/src/policy.rs
+++ b/services/planner/src/policy.rs
@@ -77,6 +77,10 @@ pub enum PolicyClientError {
 #[derive(Clone, Debug, Serialize, Default)]
 struct PolicyCheckPayload {
     request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pam_profile: Option<tyrum_shared::planner::PamProfileRef>,
     spend: Option<SpendContext>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pii: Option<PiiContext>,
@@ -108,8 +112,15 @@ impl PolicyCheckPayload {
             })
         };
 
+        let (user_id, pam_profile) = match request.user.as_ref() {
+            Some(context) => (Some(context.user_id.clone()), context.pam_profile.clone()),
+            None => (Some(request.subject_id.clone()), None),
+        };
+
         Self {
             request_id: Some(request.request_id.clone()),
+            user_id,
+            pam_profile,
             spend: None,
             pii,
             legal: None,
@@ -217,13 +228,21 @@ mod tests {
     use tokio::{net::TcpListener, task::JoinHandle};
     use tyrum_shared::{
         MessageContent, MessageSource, NormalizedMessage, NormalizedThread,
-        NormalizedThreadMessage, PiiField, SenderMetadata, ThreadKind,
+        NormalizedThreadMessage, PamProfileRef, PiiField, PlanUserContext, SenderMetadata,
+        ThreadKind,
     };
 
     fn sample_plan_request() -> PlanRequest {
         PlanRequest {
             request_id: "req-42".into(),
             subject_id: "subject-17".into(),
+            user: Some(PlanUserContext {
+                user_id: "subject-17".into(),
+                pam_profile: Some(PamProfileRef {
+                    profile_id: "pam-default".into(),
+                    version: Some("v1".into()),
+                }),
+            }),
             trigger: NormalizedThreadMessage {
                 thread: NormalizedThread {
                     id: "thread-1".into(),
@@ -265,9 +284,23 @@ mod tests {
         let pii = payload.pii.expect("pii context");
         assert!(pii.categories.contains(&PiiCategory::BasicContact));
         assert!(pii.categories.contains(&PiiCategory::Other));
+        assert_eq!(payload.user_id.as_deref(), Some("subject-17"));
+        let pam_profile = payload.pam_profile.expect("pam profile");
+        assert_eq!(pam_profile.profile_id, "pam-default");
+        assert_eq!(pam_profile.version.as_deref(), Some("v1"));
 
         assert!(payload.spend.is_none());
         assert!(payload.legal.is_none());
+    }
+
+    #[test]
+    fn payload_defaults_user_id_when_user_context_missing() {
+        let mut request = sample_plan_request();
+        request.user = None;
+
+        let payload = PolicyCheckPayload::from_plan_request(&request);
+        assert_eq!(payload.user_id.as_deref(), Some("subject-17"));
+        assert!(payload.pam_profile.is_none());
     }
 
     #[tokio::test]

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -28,7 +28,7 @@ use tyrum_planner::{
 };
 use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
-    PiiField, SenderMetadata, ThreadKind,
+    PamProfileRef, PiiField, PlanUserContext, SenderMetadata, ThreadKind,
 };
 use tyrum_wallet::Thresholds;
 
@@ -36,6 +36,13 @@ fn sample_request() -> PlanRequest {
     PlanRequest {
         request_id: "req-123".into(),
         subject_id: "subject-456".into(),
+        user: Some(PlanUserContext {
+            user_id: "subject-456".into(),
+            pam_profile: Some(PamProfileRef {
+                profile_id: "pam-default".into(),
+                version: Some("v1".into()),
+            }),
+        }),
         trigger: NormalizedThreadMessage {
             thread: NormalizedThread {
                 id: "thread-1".into(),

--- a/services/planner/tests/plan_audit.rs
+++ b/services/planner/tests/plan_audit.rs
@@ -18,7 +18,7 @@ use tyrum_planner::{
 };
 use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
-    PiiField, SenderMetadata, ThreadKind,
+    PamProfileRef, PiiField, PlanUserContext, SenderMetadata, ThreadKind,
 };
 use tyrum_wallet::Thresholds;
 use uuid::Uuid;
@@ -173,6 +173,13 @@ fn sample_request() -> PlanRequest {
     PlanRequest {
         request_id: "req-123".into(),
         subject_id: "subject-456".into(),
+        user: Some(PlanUserContext {
+            user_id: "subject-456".into(),
+            pam_profile: Some(PamProfileRef {
+                profile_id: "pam-default".into(),
+                version: Some("v1".into()),
+            }),
+        }),
         trigger: NormalizedThreadMessage {
             thread: NormalizedThread {
                 id: "thread-1".into(),

--- a/services/planner/tests/policy_denial.rs
+++ b/services/planner/tests/policy_denial.rs
@@ -18,7 +18,7 @@ use tyrum_planner::{
 };
 use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
-    PiiField, SenderMetadata, ThreadKind,
+    PamProfileRef, PiiField, PlanUserContext, SenderMetadata, ThreadKind,
 };
 use tyrum_wallet::Thresholds;
 use uuid::Uuid;
@@ -190,6 +190,13 @@ fn sample_request() -> PlanRequest {
     PlanRequest {
         request_id: "req-321".into(),
         subject_id: "subject-999".into(),
+        user: Some(PlanUserContext {
+            user_id: "subject-999".into(),
+            pam_profile: Some(PamProfileRef {
+                profile_id: "pam-high-spend".into(),
+                version: Some("v2".into()),
+            }),
+        }),
         trigger: NormalizedThreadMessage {
             thread: NormalizedThread {
                 id: "thread-2".into(),

--- a/services/planner/tests/wallet_integration.rs
+++ b/services/planner/tests/wallet_integration.rs
@@ -17,7 +17,7 @@ use tyrum_planner::{
 };
 use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
-    PiiField, SenderMetadata, ThreadKind,
+    PamProfileRef, PiiField, PlanUserContext, SenderMetadata, ThreadKind,
 };
 use tyrum_wallet::Thresholds;
 
@@ -27,6 +27,13 @@ fn spend_request(amount_minor_units: u64) -> PlanRequest {
     PlanRequest {
         request_id: format!("req-{amount_minor_units}"),
         subject_id: "subject-wallet".into(),
+        user: Some(PlanUserContext {
+            user_id: "subject-wallet".into(),
+            pam_profile: Some(PamProfileRef {
+                profile_id: "pam-default".into(),
+                version: Some("v1".into()),
+            }),
+        }),
         trigger: NormalizedThreadMessage {
             thread: NormalizedThread {
                 id: "thread-wallet".into(),

--- a/services/policy/Cargo.toml
+++ b/services/policy/Cargo.toml
@@ -20,6 +20,7 @@ opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "metrics", "l
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "logs", "trace", "rt-tokio"] }
 tracing-opentelemetry = "0.32"
 anyhow = "1"
+tyrum-shared = { path = "../../shared/tyrum-shared" }
 
 [dev-dependencies]
 axum = { version = "0.7", features = ["json"] }

--- a/services/policy/src/lib.rs
+++ b/services/policy/src/lib.rs
@@ -1,14 +1,20 @@
 use axum::{
     Json, Router,
+    http::StatusCode,
     routing::{get, post},
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use tyrum_shared::PamProfileRef;
 
 pub mod telemetry;
 
 pub const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8081";
 const AUTO_APPROVE_LIMIT_MINOR: u64 = 10_000;
 const HARD_DENY_LIMIT_MINOR: u64 = 50_000;
+const MAX_USER_IDENTIFIER_LEN: usize = 128;
+const MAX_PAM_PROFILE_LEN: usize = 64;
+const MAX_PAM_VERSION_LEN: usize = 32;
 
 pub fn build_router() -> Router {
     Router::new()
@@ -54,9 +60,40 @@ struct HealthResponse {
 #[serde(default)]
 pub struct PolicyCheckRequest {
     pub request_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_trimmed_option_string")]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub pam_profile: Option<PamProfileRef>,
     pub spend: Option<SpendContext>,
     pub pii: Option<PiiContext>,
     pub legal: Option<LegalContext>,
+}
+
+impl PolicyCheckRequest {
+    fn validate(&self) -> Result<(), RequestValidationError> {
+        let user_id = match self.user_id.as_ref().filter(|value| !value.is_empty()) {
+            Some(value) => value,
+            None => return Err(RequestValidationError::MissingUserId),
+        };
+
+        if !is_valid_identifier(user_id, MAX_USER_IDENTIFIER_LEN) {
+            return Err(RequestValidationError::UserId);
+        }
+
+        if let Some(profile) = &self.pam_profile {
+            if !is_valid_identifier(&profile.profile_id, MAX_PAM_PROFILE_LEN) {
+                return Err(RequestValidationError::PamProfileId);
+            }
+
+            if let Some(version) = profile.version.as_ref()
+                && !is_valid_identifier(version, MAX_PAM_VERSION_LEN)
+            {
+                return Err(RequestValidationError::PamProfileVersion);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -103,8 +140,78 @@ pub enum LegalFlag {
     Other,
 }
 
+#[derive(Debug, Error, PartialEq, Eq)]
+enum RequestValidationError {
+    #[error("user_id is required for policy evaluation")]
+    MissingUserId,
+    #[error("user_id must contain 1-128 ASCII alphanumeric, hyphen, underscore, or dot characters")]
+    UserId,
+    #[error(
+        "pam_profile.profile_id must contain 1-64 ASCII alphanumeric, hyphen, underscore, or dot characters"
+    )]
+    PamProfileId,
+    #[error(
+        "pam_profile.version must contain 1-32 ASCII alphanumeric, hyphen, underscore, or dot characters"
+    )]
+    PamProfileVersion,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct ValidationErrorResponse {
+    error: &'static str,
+    message: &'static str,
+}
+
+impl From<RequestValidationError> for ValidationErrorResponse {
+    fn from(error: RequestValidationError) -> Self {
+        match error {
+            RequestValidationError::MissingUserId => Self {
+                error: "missing_user_id",
+                message: "user_id is required for policy evaluation",
+            },
+            RequestValidationError::UserId => Self {
+                error: "invalid_user_id",
+                message: "user_id must contain 1-128 ASCII alphanumeric, hyphen, underscore, or dot characters",
+            },
+            RequestValidationError::PamProfileId => Self {
+                error: "invalid_pam_profile_id",
+                message: "pam_profile.profile_id must contain 1-64 ASCII alphanumeric, hyphen, underscore, or dot characters",
+            },
+            RequestValidationError::PamProfileVersion => Self {
+                error: "invalid_pam_profile_version",
+                message: "pam_profile.version must contain 1-32 ASCII alphanumeric, hyphen, underscore, or dot characters",
+            },
+        }
+    }
+}
+
+fn deserialize_trimmed_option_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let option = Option::<String>::deserialize(deserializer)?;
+    Ok(option.map(|value| value.trim().to_owned()))
+}
+
+fn is_valid_identifier(value: &str, max_len: usize) -> bool {
+    if value.is_empty() || value.len() > max_len {
+        return false;
+    }
+
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+}
+
 #[tracing::instrument(skip(payload), name = "policy.check")]
-async fn policy_check(Json(payload): Json<PolicyCheckRequest>) -> Json<PolicyDecision> {
+async fn policy_check(
+    Json(payload): Json<PolicyCheckRequest>,
+) -> Result<Json<PolicyDecision>, (StatusCode, Json<ValidationErrorResponse>)> {
+    if let Err(error) = payload.validate() {
+        tracing::warn!(%error, "rejecting policy request due to invalid user context");
+        return Err((StatusCode::BAD_REQUEST, Json(error.into())));
+    }
+
     let spend_decision = evaluate_spend(payload.spend.as_ref());
     let pii_decision = evaluate_pii(payload.pii.as_ref());
     let legal_decision = evaluate_legal(payload.legal.as_ref());
@@ -114,7 +221,7 @@ async fn policy_check(Json(payload): Json<PolicyCheckRequest>) -> Json<PolicyDec
 
     telemetry::record_policy_decision(decision);
 
-    Json(PolicyDecision { decision, rules })
+    Ok(Json(PolicyDecision { decision, rules }))
 }
 
 #[tracing::instrument(name = "policy.health", skip_all)]
@@ -352,6 +459,42 @@ mod tests {
     use serde_json::json;
     use tower::ServiceExt;
 
+    const WITH_USER_FIXTURE: &str = include_str!("../tests/fixtures/policy_check_with_user.json");
+    const WITHOUT_USER_FIXTURE: &str =
+        include_str!("../tests/fixtures/policy_check_without_user.json");
+
+    #[test]
+    fn fixture_with_user_context_parses_and_validates() {
+        let request: PolicyCheckRequest =
+            serde_json::from_str(WITH_USER_FIXTURE).expect("parse fixture");
+        assert_eq!(request.user_id.as_deref(), Some("subject-123"));
+        let profile = request.pam_profile.as_ref().expect("pam profile");
+        assert_eq!(profile.profile_id, "pam-default");
+        assert_eq!(profile.version.as_deref(), Some("v1"));
+        request.validate().expect("fixture validates");
+    }
+
+    #[test]
+    fn fixture_without_user_context_fails_validation() {
+        let request: PolicyCheckRequest =
+            serde_json::from_str(WITHOUT_USER_FIXTURE).expect("parse fixture");
+        assert!(request.user_id.is_none());
+        assert!(request.pam_profile.is_none());
+        let error = request.validate().expect_err("validation should fail");
+        assert_eq!(error, RequestValidationError::MissingUserId);
+    }
+
+    #[test]
+    fn validation_rejects_blank_user_id() {
+        let request: PolicyCheckRequest = serde_json::from_value(json!({
+            "user_id": "   ",
+        }))
+        .expect("parse payload");
+
+        let error = request.validate().expect_err("blank user id rejected");
+        assert_eq!(error, RequestValidationError::MissingUserId);
+    }
+
     #[test]
     fn spend_rule_auto_approves_within_limit() {
         let decision = evaluate_spend(Some(&SpendContext {
@@ -429,9 +572,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn policy_check_rejects_invalid_user_id() {
+        let app = build_router();
+        let payload = json!({
+            "user_id": "subject invalid",
+            "pam_profile": {
+                "profile_id": "pam-default"
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/policy/check")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "invalid_user_id");
+    }
+
+    #[tokio::test]
+    async fn policy_check_rejects_invalid_pam_profile() {
+        let app = build_router();
+        let payload = json!({
+            "user_id": "subject-987",
+            "pam_profile": {
+                "profile_id": "pam default",
+                "version": "v1"
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/policy/check")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "invalid_pam_profile_id");
+    }
+
+    #[tokio::test]
+    async fn policy_check_rejects_blank_user_id() {
+        let app = build_router();
+        let payload = json!({
+            "user_id": "  ",
+            "pam_profile": {
+                "profile_id": "pam-default"
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/policy/check")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "missing_user_id");
+    }
+
+    #[tokio::test]
+    async fn policy_check_rejects_missing_user_id() {
+        let app = build_router();
+        let payload = json!({
+            "pam_profile": {
+                "profile_id": "pam-default"
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/policy/check")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "missing_user_id");
+    }
+
+    #[tokio::test]
     async fn endpoint_returns_overall_approval() {
         let app = build_router();
         let payload = json!({
+            "user_id": "subject-approval",
             "request_id": "req-1",
             "spend": {
                 "amount_minor_units": 8_000,
@@ -465,6 +721,7 @@ mod tests {
     async fn endpoint_returns_overall_escalation_when_any_rule_escalates() {
         let app = build_router();
         let payload = json!({
+            "user_id": "subject-escalate",
             "spend": {
                 "amount_minor_units": 15_000,
                 "currency": "USD",
@@ -497,6 +754,7 @@ mod tests {
     async fn endpoint_returns_overall_denial_when_any_rule_denies() {
         let app = build_router();
         let payload = json!({
+            "user_id": "subject-deny",
             "spend": {
                 "amount_minor_units": 5_000,
                 "currency": "USD"

--- a/services/policy/tests/fixtures/policy_check_with_user.json
+++ b/services/policy/tests/fixtures/policy_check_with_user.json
@@ -1,0 +1,16 @@
+{
+  "request_id": "fixture-req",
+  "user_id": "subject-123",
+  "pam_profile": {
+    "profile_id": "pam-default",
+    "version": "v1"
+  },
+  "pii": {
+    "categories": [
+      "basic_contact"
+    ]
+  },
+  "legal": {
+    "flags": []
+  }
+}

--- a/services/policy/tests/fixtures/policy_check_without_user.json
+++ b/services/policy/tests/fixtures/policy_check_without_user.json
@@ -1,0 +1,9 @@
+{
+  "request_id": "fixture-no-user",
+  "pii": {
+    "categories": []
+  },
+  "legal": {
+    "flags": []
+  }
+}

--- a/services/tyrum-watchers/tests/processor.rs
+++ b/services/tyrum-watchers/tests/processor.rs
@@ -16,7 +16,8 @@ use tokio::{
 };
 use tyrum_shared::{
     MessageContent, MessageSource, NormalizedMessage, NormalizedThread, NormalizedThreadMessage,
-    PlanOutcome, PlanRequest, PlanResponse, PlanSummary, ThreadKind,
+    PamProfileRef, PlanOutcome, PlanRequest, PlanResponse, PlanSummary, PlanUserContext,
+    ThreadKind,
 };
 use tyrum_watchers::{
     JetStreamClient, JetStreamConfig, PlannerClient, RecordedWatcherOutcome, WatcherEvent,
@@ -119,6 +120,13 @@ fn sample_plan_request() -> PlanRequest {
     PlanRequest {
         request_id: "req-789".into(),
         subject_id: "subject-1".into(),
+        user: Some(PlanUserContext {
+            user_id: "subject-1".into(),
+            pam_profile: Some(PamProfileRef {
+                profile_id: "pam-default".into(),
+                version: Some("v1".into()),
+            }),
+        }),
         trigger: NormalizedThreadMessage {
             thread: NormalizedThread {
                 id: thread_id.clone(),

--- a/shared/tyrum-shared/src/lib.rs
+++ b/shared/tyrum-shared/src/lib.rs
@@ -4,8 +4,9 @@ pub mod telegram;
 mod schema;
 
 pub use planner::{
-    ActionArguments, ActionPostcondition, ActionPrimitive, ActionPrimitiveKind, PlanError,
-    PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
+    ActionArguments, ActionPostcondition, ActionPrimitive, ActionPrimitiveKind, PamProfileRef,
+    PlanError, PlanErrorCode, PlanEscalation, PlanOutcome, PlanRequest, PlanResponse, PlanSummary,
+    PlanUserContext,
 };
 
 pub use schema::{

--- a/shared/tyrum-shared/src/planner.rs
+++ b/shared/tyrum-shared/src/planner.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map as JsonMap, Value};
 
 use crate::NormalizedThreadMessage;
@@ -95,6 +95,9 @@ pub struct PlanRequest {
     pub request_id: String,
     /// Stable subject identifier for memory, policy, and wallet lookups.
     pub subject_id: String,
+    /// Optional user context containing PII-safe identifiers and guardrail metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<PlanUserContext>,
     /// Triggering ingress event (thread + message) that the plan responds to.
     pub trigger: NormalizedThreadMessage,
     /// Optional BCP-47 locale hint to shape prompts and output tone.
@@ -106,6 +109,32 @@ pub struct PlanRequest {
     /// Arbitrary caller-provided tags applied to the resulting plan for analytics.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+}
+
+/// Identifiers and guardrail metadata scoped to the requesting user.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanUserContext {
+    /// Stable user identifier shared with downstream guardrail services.
+    #[serde(deserialize_with = "deserialize_trimmed_string")]
+    pub user_id: String,
+    /// Optional Policy/Autonomy Model profile providing learned limits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pam_profile: Option<PamProfileRef>,
+}
+
+/// Reference to a Policy/Autonomy Model profile.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PamProfileRef {
+    /// Canonical profile identifier (e.g., "pam-default").
+    #[serde(deserialize_with = "deserialize_trimmed_string")]
+    pub profile_id: String,
+    /// Optional semantic version or hash to help downstream caches.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_trimmed_option_string"
+    )]
+    pub version: Option<String>,
 }
 
 /// Planner response envelope surfaced to upstream services.
@@ -196,6 +225,22 @@ pub enum PlanErrorCode {
     PolicyDenied,
     ExecutorUnavailable,
     Internal,
+}
+
+fn deserialize_trimmed_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(value.trim().to_owned())
+}
+
+fn deserialize_trimmed_option_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let option = Option::<String>::deserialize(deserializer)?;
+    Ok(option.map(|value| value.trim().to_owned()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add per-user context fields to shared planner schema and policy payloads
- validate user identifiers in policy service and cover fixtures/tests
- document new schema and planner defaults for user_id / pam_profile

## Testing
- cargo check
- cargo test -p tyrum-policy user_context
- pre-commit run --all-files *(cargo-test hook fails: docker daemon for testcontainers unreachable via remote ssh context)*

Closes #85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-user policy context (user_id, pam_profile) to shared schema and planner payloads, and enforces identifier validation in the policy service with docs and tests.
> 
> - **Shared Schema (`shared/tyrum-shared`)**:
>   - Add `PlanUserContext` and `PamProfileRef`; expose in `lib.rs` exports.
>   - Extend `PlanRequest` with optional `user`; add trimmed string deserializers.
> - **Planner (`services/planner`)**:
>   - Include `user_id` and `pam_profile` in policy payload; default `user_id` to `PlanRequest.subject_id` when `user` is absent.
>   - Update tests to assert user mapping and fallback behavior.
> - **Policy Service (`services/policy`)**:
>   - Require and validate `user_id`; validate `pam_profile.profile_id` and `version` (length/charset). Return `400` with explicit error codes on invalid input.
>   - Adjust handler to return `Result` with `(StatusCode, Json)` errors; add parsing/validation helpers and fixtures.
>   - Add `tyrum-shared` dependency; expand unit tests to cover validation paths.
> - **Docs**:
>   - Update `docs/policy_service.md` with `user_id`/`pam_profile` fields, validation rules, and examples.
>   - Note per-user payload behavior in `README.md` local dev section.
> - **Tests/Watchers**:
>   - Update planner/watchers tests to include `PlanUserContext` in sample requests; add policy fixtures (`policy_check_with_user.json`, `policy_check_without_user.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 901bc812fb6eac3c1e8fa82bb672af90a76ed5f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->