### PR TITLE
Add planner failure propagation regression tests

### DIFF
--- a/docs/planner_event_log.md
+++ b/docs/planner_event_log.md
@@ -57,3 +57,14 @@ validation of step indices. They run as part of `cargo test --all --all-targets`
   enforcement without revealing raw spend amounts or card metadata.
 - Use `cargo test -p tyrum-planner policy_denial` to run the regression harness that exercises the
   denial flow and ensures both the planner response and audit payloads include the reason string.
+
+## Troubleshooting Executor Failures
+- Executor and postcondition faults raise `PlanFailureReason::ExecutorFailed` with the failing
+  `step_index` so responders can identify which primitive stalled.
+- Planner responses surface the same detail string, while the event log writes a `failure` outcome
+  block containing the error `code`, sanitized `detail`, and `retryable` flag for downstream replay.
+- Inspect the audit row with `SELECT outcome FROM planner_events WHERE plan_id = ?` to confirm the
+  failure metadata propagated end-to-end; the `code` should match the wire error (`internal` or
+  `executor_unavailable`).
+- Run `cargo test -p tyrum-planner failure_propagation` to exercise the regression harness that asserts
+  executor failures keep the `step_index` and detail intact across planner surfaces.

--- a/services/planner/src/state_machine.rs
+++ b/services/planner/src/state_machine.rs
@@ -462,7 +462,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_denial_short_circuits_plan() {
+    fn policy_denial_failure_propagation_short_circuits_plan() {
         let mut machine = PlanStateMachine::new(1);
         machine
             .apply(PlanEvent::SubmittedForPolicy)
@@ -477,6 +477,7 @@ mod tests {
             PlanStatus::Failed(failure) => {
                 assert!(matches!(failure.reason, PlanFailureReason::PolicyDenied));
                 assert_eq!(failure.detail.as_deref(), Some("missing consent"));
+                assert_eq!(failure.step_index, None);
             }
             other => panic!("expected failure, saw {other:?}"),
         }
@@ -575,6 +576,36 @@ mod tests {
                 .unwrap()
                 .contains("PolicyDenied")
         );
+    }
+
+    #[test]
+    fn executor_failure_propagation_reports_step_index_and_detail() {
+        let mut machine = PlanStateMachine::new(1);
+        machine
+            .apply(PlanEvent::SubmittedForPolicy)
+            .expect("policy submission");
+        machine
+            .apply(PlanEvent::PolicyApproved)
+            .expect("policy approval");
+        machine
+            .apply(PlanEvent::StepDispatched { step_index: 0 })
+            .expect("dispatch step 0");
+
+        machine
+            .apply(PlanEvent::ExecutorFailed {
+                step_index: 0,
+                detail: "playwright crashed".into(),
+            })
+            .expect("executor failure");
+
+        match machine.status() {
+            PlanStatus::Failed(failure) => {
+                assert!(matches!(failure.reason, PlanFailureReason::ExecutorFailed));
+                assert_eq!(failure.step_index, Some(0));
+                assert_eq!(failure.detail.as_deref(), Some("playwright crashed"));
+            }
+            other => panic!("expected executor failure, saw {other:?}"),
+        }
     }
 
     #[test]

--- a/services/planner/tests/policy_denial.rs
+++ b/services/planner/tests/policy_denial.rs
@@ -173,6 +173,16 @@ async fn policy_denial_is_logged_and_sanitized() {
         outcome.get("status").and_then(|value| value.as_str()),
         Some("failure")
     );
+    assert_eq!(
+        outcome.get("code").and_then(|value| value.as_str()),
+        Some("policy_denied"),
+        "failure audit should include policy_denied code"
+    );
+    assert_eq!(
+        outcome.get("retryable").and_then(|value| value.as_bool()),
+        Some(false),
+        "policy denials should not be retryable"
+    );
     let audit_detail = outcome
         .get("detail")
         .and_then(|value| value.as_str())


### PR DESCRIPTION
## Summary
- add failure propagation assertions for policy denials and executor faults in the planner state machine
- extend the policy denial harness to capture outcome codes and retryable flags in the audit log
- document troubleshooting guidance for failure responses in the planner event log playbook

## Testing
- `cargo test -p tyrum-planner failure_propagation`
- `pre-commit run --all-files` *(fails: services/api cargo tests require Docker locally)*

Closes #86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add regression tests asserting failure propagation (step_index/detail, codes/retryable) and document executor failure troubleshooting.
> 
> - **Tests**:
>   - **State Machine (`services/planner/src/state_machine.rs`)**:
>     - Add `executor_failure_propagation_reports_step_index_and_detail` verifying `PlanFailureReason::ExecutorFailed` preserves `step_index` and `detail`.
>     - Strengthen policy denial test to assert `step_index` is `None` on `PolicyDenied` and rename for clarity.
>   - **Integration (`services/planner/tests/policy_denial.rs`)**:
>     - Extend assertions to require outcome `code` = `policy_denied`, `retryable` = `false`, and that the audit `outcome` block includes `code` and `retryable`.
> - **Docs (`docs/planner_event_log.md`)**:
>   - Add “Troubleshooting Executor Failures” section covering surfaced error `code`, sanitized `detail`, `retryable`, `step_index`, SQL inspection, and related regression test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fddb0e37126e608e49591929689d6b707f3a32ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->