### PR TITLE
Add onboarding consent checklist experience

### DIFF
--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -510,6 +510,8 @@ Milestones are cumulative; later milestones build on earlier ones.
   - Rust 2024 service exposes `POST /policy/check` with static spend/PII/legal rules returning structured decisions and unit tests for approve/deny/escalate.
 - **Consent UX stub**
   - Minimal chat prompt + approval button in Next.js wired to mocked policy responses with snapshot test coverage.
+- **Onboarding consent checklist**
+  - `/portal/onboarding/consent` surfaces guardrail toggles and persists selections to `/api/onboarding/consent`, an in-memory stub that returns deterministic audit references until the consent service lands.
 - **Event log foundation**
   - Planner writes append-only action traces with replayable IDs and dedupe guard to Postgres. See `docs/planner_event_log.md` for the schema and API surface.
 - **Telemetry pipeline**

--- a/web/app/api/onboarding/consent/route.test.ts
+++ b/web/app/api/onboarding/consent/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "./route";
+import { resetConsentStore } from "./store";
+
+const ORIGIN = "https://portal.local";
+
+function createRequest(body: unknown) {
+  return new NextRequest(`${ORIGIN}/api/onboarding/consent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("onboarding consent route", () => {
+  beforeEach(() => {
+    resetConsentStore();
+  });
+
+  it("returns a deterministic snapshot when no consent has been recorded", async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+      revision: number;
+      stub: { persistence: string };
+    };
+
+    expect(payload.revision).toBe(0);
+    expect(payload.stub).toMatchObject({
+      persistence: "memory",
+    });
+  });
+
+  it("persists selections and surfaces the audit reference", async () => {
+    const request = createRequest({
+      selections: {
+        shareCalendarSignals: true,
+        allowPlannerAutonomy: false,
+        retainAuditTrail: true,
+      },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    const payload = (await response.json()) as {
+      revision: number;
+      auditReference: string;
+      selections: Record<string, boolean>;
+    };
+
+    expect(payload.revision).toBe(1);
+    expect(payload.auditReference).toBe("CONSENT-STUB-0001");
+    expect(payload.selections).toEqual({
+      shareCalendarSignals: true,
+      allowPlannerAutonomy: false,
+      retainAuditTrail: true,
+    });
+
+    const followUp = await GET();
+    const followUpPayload = (await followUp.json()) as { revision: number };
+    expect(followUpPayload.revision).toBe(1);
+  });
+
+  it("increments the revision deterministically across submissions", async () => {
+    const first = await POST(
+      createRequest({
+        selections: {
+          shareCalendarSignals: false,
+          allowPlannerAutonomy: true,
+          retainAuditTrail: true,
+        },
+      }),
+    );
+    const firstPayload = (await first.json()) as { revision: number };
+    expect(firstPayload.revision).toBe(1);
+
+    const second = await POST(
+      createRequest({
+        selections: {
+          shareCalendarSignals: true,
+          allowPlannerAutonomy: true,
+          retainAuditTrail: true,
+        },
+      }),
+    );
+
+    const secondPayload = (await second.json()) as {
+      revision: number;
+      auditReference: string;
+    };
+
+    expect(secondPayload.revision).toBe(2);
+    expect(secondPayload.auditReference).toBe("CONSENT-STUB-0001-R02");
+  });
+
+  it("rejects invalid payloads", async () => {
+    const request = createRequest({ selections: { foo: "bar" } });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toBe("invalid_selections");
+  });
+});

--- a/web/app/api/onboarding/consent/route.ts
+++ b/web/app/api/onboarding/consent/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  type ConsentSelections,
+  persistConsent,
+  snapshotConsent,
+} from "./store";
+
+function isConsentSelections(payload: unknown): payload is ConsentSelections {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  return (
+    typeof record.shareCalendarSignals === "boolean" &&
+    typeof record.allowPlannerAutonomy === "boolean" &&
+    typeof record.retainAuditTrail === "boolean"
+  );
+}
+
+export async function GET() {
+  return NextResponse.json(snapshotConsent(), { status: 200 });
+}
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "invalid_payload",
+        message: "Request body must be valid JSON with consent selections.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const selections = (payload as { selections?: unknown }).selections;
+
+  if (!isConsentSelections(selections)) {
+    return NextResponse.json(
+      {
+        error: "invalid_selections",
+        message:
+          "Consent selections must include shareCalendarSignals, allowPlannerAutonomy, and retainAuditTrail boolean toggles.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const record = persistConsent(selections);
+
+  return NextResponse.json(
+    {
+      status: "recorded",
+      auditReference: record.auditReference,
+      revision: record.revision,
+      recordedAt: record.recordedAt,
+      selections: record.selections,
+      stub: record.stub,
+    },
+    { status: 201 },
+  );
+}

--- a/web/app/api/onboarding/consent/store.ts
+++ b/web/app/api/onboarding/consent/store.ts
@@ -1,0 +1,82 @@
+export type ConsentToggleKey =
+  | "shareCalendarSignals"
+  | "allowPlannerAutonomy"
+  | "retainAuditTrail";
+
+export type ConsentSelections = Record<ConsentToggleKey, boolean>;
+
+export type ConsentRecord = {
+  id: string;
+  revision: number;
+  auditReference: string;
+  recordedAt: string;
+  selections: ConsentSelections;
+  stub: {
+    persistence: "memory";
+    note: string;
+  };
+};
+
+const CONSENT_RECORD_ID = "onboarding-consent-stub";
+const BASE_AUDIT_REFERENCE = "CONSENT-STUB-0001";
+const BASE_TIMESTAMP = Date.parse("2025-01-20T09:00:00.000Z");
+
+let latestRecord: ConsentRecord | undefined;
+
+function computeRecordedAt(revision: number) {
+  const offsetMilliseconds = (revision - 1) * 60_000;
+  return new Date(BASE_TIMESTAMP + offsetMilliseconds).toISOString();
+}
+
+function buildAuditReference(revision: number) {
+  if (revision === 1) {
+    return BASE_AUDIT_REFERENCE;
+  }
+
+  return `${BASE_AUDIT_REFERENCE}-R${revision.toString().padStart(2, "0")}`;
+}
+
+export function snapshotConsent() {
+  if (latestRecord) {
+    return structuredClone(latestRecord);
+  }
+
+  return {
+    id: CONSENT_RECORD_ID,
+    revision: 0,
+    auditReference: BASE_AUDIT_REFERENCE,
+    recordedAt: new Date(BASE_TIMESTAMP).toISOString(),
+    selections: {
+      shareCalendarSignals: false,
+      allowPlannerAutonomy: false,
+      retainAuditTrail: false,
+    },
+    stub: {
+      persistence: "memory" as const,
+      note: "Replace with onboarding consent service; stub keeps the most recent selections in memory only.",
+    },
+  } satisfies ConsentRecord;
+}
+
+export function persistConsent(selections: ConsentSelections): ConsentRecord {
+  const previousRevision = latestRecord?.revision ?? 0;
+  const revision = previousRevision + 1;
+
+  latestRecord = {
+    id: CONSENT_RECORD_ID,
+    revision,
+    auditReference: buildAuditReference(revision),
+    recordedAt: computeRecordedAt(revision),
+    selections,
+    stub: {
+      persistence: "memory",
+      note: "Replace with onboarding consent service; stub keeps the most recent selections in memory only.",
+    },
+  };
+
+  return structuredClone(latestRecord);
+}
+
+export function resetConsentStore() {
+  latestRecord = undefined;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1192,8 +1192,217 @@ main.consent-container {
   line-height: 1.6;
 }
 
+.portal-onboarding__progress {
+  background: rgba(12, 22, 39, 0.9);
+  border: 1px solid rgba(59, 105, 189, 0.3);
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  box-shadow: 0 16px 32px rgba(5, 9, 20, 0.4);
+}
+
+.portal-onboarding__stepper {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.portal-onboarding__stepper-item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(76, 110, 219, 0.25);
+  background: rgba(10, 18, 34, 0.8);
+}
+
+.portal-onboarding__stepper-item--current {
+  border-color: rgba(96, 165, 250, 0.6);
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.portal-onboarding__stepper-item--pending {
+  opacity: 0.82;
+}
+
+.portal-onboarding__stepper-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  background: rgba(59, 105, 189, 0.35);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+}
+
+.portal-onboarding__stepper-item--current .portal-onboarding__stepper-index {
+  background: rgba(59, 130, 246, 0.4);
+  border-color: rgba(129, 199, 255, 0.6);
+}
+
+.portal-onboarding__stepper-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.portal-onboarding__consent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.portal-onboarding__consent-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.portal-onboarding__consent-header p {
+  margin: 0;
+  color: rgba(214, 229, 255, 0.78);
+  line-height: 1.6;
+}
+
+.portal-onboarding__consent-summary {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, auto));
+  margin: 0;
+}
+
+.portal-onboarding__consent-summary div {
+  background: rgba(15, 25, 45, 0.9);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(59, 105, 189, 0.35);
+}
+
+.portal-onboarding__consent-summary dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.portal-onboarding__consent-summary dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.portal-onboarding__consent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.portal-onboarding__consent-card {
+  background: rgba(11, 19, 35, 0.92);
+  border-radius: 0.9rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(76, 110, 219, 0.28);
+  box-shadow: 0 18px 32px rgba(6, 12, 26, 0.38);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.portal-onboarding__consent-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.portal-onboarding__consent-card p {
+  margin: 0;
+  color: rgba(215, 229, 254, 0.82);
+  line-height: 1.5;
+}
+
+.portal-onboarding__consent-impact {
+  color: rgba(148, 190, 255, 0.85);
+  font-size: 0.9rem;
+}
+
+.portal-onboarding__consent-toggle {
+  align-self: flex-start;
+}
+
+.portal-onboarding__consent-message {
+  margin: 0;
+  padding: 0.9rem 1.1rem;
+  border-radius: 0.85rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.portal-onboarding__consent-message--success {
+  background: rgba(16, 185, 129, 0.12);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: rgba(222, 252, 241, 0.92);
+}
+
+.portal-onboarding__consent-message--error {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: rgba(254, 226, 226, 0.92);
+}
+
+.portal-onboarding__consent-submit {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.9));
+  border: 1px solid rgba(147, 197, 253, 0.45);
+  color: #f8fbff;
+  padding: 0.85rem 1.6rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.portal-onboarding__consent-submit:hover:enabled {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.3);
+}
+
+.portal-onboarding__consent-submit:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 @media (min-width: 720px) {
   .portal-onboarding__steps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .portal-onboarding__stepper {
+    flex-direction: row;
+  }
+
+  .portal-onboarding__stepper-item {
+    flex: 1 1 0;
+  }
+
+  .portal-onboarding__consent-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .portal-onboarding__consent-summary {
+    width: 16rem;
+  }
+
+  .portal-onboarding__consent-list {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/web/app/portal/onboarding/consent/ConsentChecklistPage.test.tsx
+++ b/web/app/portal/onboarding/consent/ConsentChecklistPage.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import ConsentChecklistPage from "./page";
+
+const originalFetch = global.fetch;
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+describe("ConsentChecklistPage", () => {
+  beforeAll(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: originalGetContext,
+    });
+  });
+
+  it("renders the onboarding progress stepper and consent cards", () => {
+    render(<ConsentChecklistPage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: /consent checklist/i })).toBeVisible();
+    expect(
+      screen.getByRole("navigation", { name: /onboarding progress/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { level: 3 })).toHaveLength(3);
+  });
+
+  it("persists consent selections and surfaces the audit reference", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "recorded",
+          auditReference: "CONSENT-STUB-0001",
+          revision: 1,
+          selections: {
+            shareCalendarSignals: true,
+            allowPlannerAutonomy: true,
+            retainAuditTrail: true,
+          },
+        }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    render(<ConsentChecklistPage />);
+
+    const toggles = screen.getAllByRole("checkbox");
+    await user.click(toggles[0]);
+    await user.click(toggles[1]);
+    await user.click(toggles[2]);
+
+    await user.click(screen.getByRole("button", { name: /record consent selections/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/onboarding/consent",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const successMessage = await screen.findByRole("status");
+    expect(successMessage).toHaveTextContent(/consent recorded as consent-stub-0001/i);
+    const summary = screen.getByLabelText(/consent progress summary/i);
+    expect(within(summary).getByText(/recorded/i)).toBeVisible();
+  });
+
+  it("surfaces an accessible error when the API rejects the payload", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: "invalid_selections",
+          message: "Select at least one toggle.",
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    render(<ConsentChecklistPage />);
+
+    await user.click(screen.getByRole("button", { name: /record consent selections/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/select at least one toggle/i);
+    expect(screen.getByRole("button", { name: /record consent selections/i })).toBeEnabled();
+  });
+
+  it("passes an accessibility audit", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "recorded",
+          auditReference: "CONSENT-STUB-0001",
+          revision: 1,
+          selections: {
+            shareCalendarSignals: true,
+            allowPlannerAutonomy: true,
+            retainAuditTrail: true,
+          },
+        }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    const { container } = render(<ConsentChecklistPage />);
+
+    await screen.findByRole("button", { name: /record consent selections/i });
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/web/app/portal/onboarding/consent/page.tsx
+++ b/web/app/portal/onboarding/consent/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+type ConsentToggleKey =
+  | "shareCalendarSignals"
+  | "allowPlannerAutonomy"
+  | "retainAuditTrail";
+
+type ConsentSelections = Record<ConsentToggleKey, boolean>;
+
+type ConsentItem = {
+  key: ConsentToggleKey;
+  title: string;
+  description: string;
+  impact: string;
+};
+
+const CONSENT_ITEMS: ConsentItem[] = [
+  {
+    key: "shareCalendarSignals",
+    title: "Share scheduling signals",
+    description:
+      "Allow Tyrum to read summaries of your calendar holds, cancellations, and travel windows.",
+    impact:
+      "Unlocks proactive conflict detection and lets the planner pre-stage reschedules without committing changes.",
+  },
+  {
+    key: "allowPlannerAutonomy",
+    title: "Approve autopilot guardrails",
+    description:
+      "Permit the planner to act autonomously when spend stays under the caps you set during onboarding.",
+    impact:
+      "Keeps urgent requests moving without manual approval while still escalating anything outside your limits.",
+  },
+  {
+    key: "retainAuditTrail",
+    title: "Retain consent audit trail",
+    description:
+      "Store an auditable history of each consent toggle for 180 days so we can prove enforcement.",
+    impact:
+      "Ensures every guardrail decision is reportable to compliance reviewers and ready for export on request.",
+  },
+];
+
+const INITIAL_SELECTIONS: ConsentSelections = {
+  shareCalendarSignals: false,
+  allowPlannerAutonomy: false,
+  retainAuditTrail: false,
+};
+
+type SubmissionSuccess = {
+  auditReference: string;
+  revision: number;
+};
+
+async function submitConsent(selections: ConsentSelections) {
+  const response = await fetch("/api/onboarding/consent", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ selections }),
+    cache: "no-store",
+  });
+
+  let payload: unknown;
+
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const errorMessage =
+      typeof (payload as { message?: unknown } | null)?.message === "string"
+        ? (payload as { message: string }).message
+        : "Unable to persist consent selections. Try again.";
+    throw new Error(errorMessage);
+  }
+
+  const { auditReference, revision } = (payload ?? {}) as Partial<SubmissionSuccess>;
+
+  if (typeof auditReference !== "string" || typeof revision !== "number") {
+    throw new Error("Consent service returned an unexpected response. Try again.");
+  }
+
+  return { auditReference, revision };
+}
+
+export default function ConsentChecklistPage() {
+  const [selections, setSelections] = useState<ConsentSelections>(INITIAL_SELECTIONS);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<SubmissionSuccess | null>(null);
+
+  const completedToggleCount = useMemo(
+    () => Object.values(selections).filter(Boolean).length,
+    [selections],
+  );
+
+  const handleToggleChange = (key: ConsentToggleKey, value: boolean) => {
+    setSelections((current) => ({
+      ...current,
+      [key]: value,
+    }));
+  };
+
+  const handleSubmit = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await submitConsent(selections);
+      setSuccess(result);
+    } catch (submissionError) {
+      setSuccess(null);
+      setError(
+        submissionError instanceof Error && submissionError.message
+          ? submissionError.message
+          : "Unable to persist consent selections. Try again.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="portal-onboarding" aria-labelledby="consent-checklist-heading">
+      <header className="portal-onboarding__header">
+        <div>
+          <p className="portal-onboarding__eyebrow">Portal</p>
+          <h1 id="consent-checklist-heading">Consent Checklist</h1>
+        </div>
+        <p className="portal-onboarding__lead">
+          Review the guardrails Tyrum needs before we issue your session placeholder. Toggle the
+          approvals you&apos;re comfortable with so we can calibrate autonomy from the first plan.
+        </p>
+      </header>
+
+      <nav
+        aria-label="Onboarding progress"
+        className="portal-onboarding__progress"
+      >
+        <ol className="portal-onboarding__stepper">
+          <li
+            className="portal-onboarding__stepper-item portal-onboarding__stepper-item--current"
+            aria-current="step"
+          >
+            <span className="portal-onboarding__stepper-index">1</span>
+            <span className="portal-onboarding__stepper-label">Consent checklist</span>
+          </li>
+          <li className="portal-onboarding__stepper-item portal-onboarding__stepper-item--pending">
+            <span className="portal-onboarding__stepper-index">2</span>
+            <span className="portal-onboarding__stepper-label">Watcher defaults</span>
+          </li>
+          <li className="portal-onboarding__stepper-item portal-onboarding__stepper-item--pending">
+            <span className="portal-onboarding__stepper-index">3</span>
+            <span className="portal-onboarding__stepper-label">First outcomes</span>
+          </li>
+        </ol>
+      </nav>
+
+      <section
+        className="portal-onboarding__content portal-onboarding__consent"
+        aria-label="Guardrail approvals"
+      >
+        <header className="portal-onboarding__consent-header">
+          <div>
+            <h2>Lock in planner guardrails</h2>
+            <p>
+              Your selections help Tyrum honour consent defaults until we wire the full verification
+              service. We recommend enabling all three toggles before continuing.
+            </p>
+          </div>
+          <dl aria-label="Consent progress summary" className="portal-onboarding__consent-summary">
+            <div>
+              <dt>Selected</dt>
+              <dd>{completedToggleCount} / 3</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{isSubmitting ? "Saving…" : success ? "Recorded" : "Draft"}</dd>
+            </div>
+          </dl>
+        </header>
+
+        <ul className="portal-onboarding__consent-list">
+          {CONSENT_ITEMS.map((item) => {
+            const checked = selections[item.key];
+            const descriptionId = `${item.key}-description`;
+            const impactId = `${item.key}-impact`;
+            return (
+              <li className="portal-onboarding__consent-item" key={item.key}>
+                <article className="portal-onboarding__consent-card">
+                  <header>
+                    <h3>{item.title}</h3>
+                    <p id={descriptionId}>{item.description}</p>
+                  </header>
+                  <p id={impactId} className="portal-onboarding__consent-impact">
+                    {item.impact}
+                  </p>
+                  <label
+                    className="portal-linking__toggle portal-onboarding__consent-toggle"
+                    htmlFor={`consent-toggle-${item.key}`}
+                  >
+                    <input
+                      id={`consent-toggle-${item.key}`}
+                      type="checkbox"
+                      className="portal-linking__checkbox"
+                      checked={checked}
+                      disabled={isSubmitting}
+                      aria-describedby={`${descriptionId} ${impactId}`}
+                      onChange={(event) =>
+                        handleToggleChange(item.key, event.currentTarget.checked)
+                      }
+                    />
+                    <span className="portal-linking__toggle-track" aria-hidden="true">
+                      <span className="portal-linking__toggle-thumb" />
+                    </span>
+                    <span className="portal-linking__toggle-text">
+                      {checked ? "Enabled" : "Enable"}
+                    </span>
+                  </label>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+        {error ? (
+          <p
+            className="portal-onboarding__consent-message portal-onboarding__consent-message--error"
+            role="alert"
+          >
+            {error}
+          </p>
+        ) : null}
+        {success ? (
+          <p
+            className="portal-onboarding__consent-message portal-onboarding__consent-message--success"
+            role="status"
+          >
+            Consent recorded as {success.auditReference} (revision {success.revision}). This stub
+            stores selections in memory only until the consent service ships.
+          </p>
+        ) : null}
+
+        <button
+          type="button"
+          className="portal-onboarding__consent-submit"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Saving consent…" : "Record consent selections"}
+        </button>
+      </section>
+
+      <section className="portal-onboarding__next">
+        <h2>What happens after consent</h2>
+        <p>
+          We&apos;ll light up watcher defaults next so you can confirm how Tyrum monitors spend,
+          privacy, and escalation triggers. Once the verification stub is complete, these toggles
+          will sync to the policy gate and issue your portal session.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add the consent checklist step with three guardrail toggles and accessible copy on /portal/onboarding/consent
- persist selections via /api/onboarding/consent with deterministic in-memory storage and unit coverage
- refine onboarding styles and document the stub for future replacement

## Testing
- npm run test -- ConsentChecklist
- pre-commit run --all-files

Closes #92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a consent checklist UI in the portal with three toggles, backed by a deterministic in-memory consent API and comprehensive tests.
> 
> - **Portal UI**
>   - Adds `web/app/portal/onboarding/consent/page.tsx` rendering a consent checklist with 3 guardrail toggles, progress stepper, submission flow, and accessible status/alert messaging.
>   - Updates styles in `web/app/globals.css` for onboarding progress, consent cards/toggles, messages, and responsive layout.
> - **API**
>   - Introduces `GET`/`POST` in `web/app/api/onboarding/consent/route.ts` validating payloads and returning deterministic `auditReference`/`revision`.
>   - Adds in-memory store `web/app/api/onboarding/consent/store.ts` with revisioning, timestamping, and snapshot defaults.
> - **Tests**
>   - Route tests in `web/app/api/onboarding/consent/route.test.ts` covering empty snapshot, persistence, deterministic revisions, and invalid payloads.
>   - Page tests in `web/app/portal/onboarding/consent/ConsentChecklistPage.test.tsx` covering render, submission success/error, and accessibility (axe).
> - **Docs**
>   - Notes new onboarding consent checklist in `docs/product_concept_v1.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa1b38174ab11302afb844d4859e52dab530f14f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->