### PR TITLE
Implement onboarding verification stub (#93)

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -13,6 +13,8 @@ jobs:
   web:
     name: Web checks
     runs-on: [self-hosted, Linux, X64]
+    env:
+      PORTAL_SESSION_SECRET: ci-portal-session-secret
     permissions:
       contents: read
     steps:

--- a/config/local.env.example
+++ b/config/local.env.example
@@ -24,3 +24,6 @@ TELEMETRY_EXPORTER=http://localhost:4318
 TELEGRAM_BOT_TOKEN=replace-with-botfather-token
 TELEGRAM_WEBHOOK_URL=https://<subdomain>.ngrok.app/api/telegram/webhook
 TELEGRAM_WEBHOOK_SECRET=replace-with-webhook-secret
+
+# Portal session verification stub (Next.js portal)
+PORTAL_SESSION_SECRET=replace-with-portal-session-secret

--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -340,6 +340,7 @@ to keep policy, planner, and API services aligned on envelopes and error handlin
 - The PA proposes/updates rules; user can tweak or disable any watcher.
 - Registrations persist to the `watchers` Postgres table; planner services join on `watchers.plan_reference` to hydrate execution plans.
 - AuthN/AuthZ is pending for the registration surface; keep route internal until policy gate issues scoped credentials.
+- **Portal verification stub:** deterministic session cookies derive from `PORTAL_SESSION_SECRET` and expire after 1 hour. Manual QA: (1) capture consent via `POST /api/onboarding/consent` with stub payload, (2) call `POST /api/onboarding/verify` to receive the session cookie, (3) confirm `/portal` routes load while tampered cookies redirect to the landing CTA. Document that the stub precedes real auth.
 
 ---
 

--- a/web/app/api/onboarding/verify/OnboardingVerify.route.test.ts
+++ b/web/app/api/onboarding/verify/OnboardingVerify.route.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+import { VERIFICATION_TOKEN_FIXTURES } from "./fixtures";
+import {
+  persistConsent,
+  resetConsentStore,
+  type ConsentSelections,
+} from "../consent/store";
+import {
+  PORTAL_SESSION_COOKIE,
+  PORTAL_SESSION_SECRET_ENV,
+  clearPortalSessionSecretForTesting,
+  setPortalSessionSecretForTesting,
+} from "../../../lib/portal-auth";
+
+const ORIGIN = "https://example.com";
+
+function createPostRequest() {
+  return new NextRequest(`${ORIGIN}/api/onboarding/verify`, {
+    method: "POST",
+  });
+}
+
+const CONSENT_SELECTIONS: ConsentSelections = {
+  shareCalendarSignals: true,
+  allowPlannerAutonomy: false,
+  retainAuditTrail: true,
+};
+
+describe("OnboardingVerify route", () => {
+  const originalSecret = process.env[PORTAL_SESSION_SECRET_ENV];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-02-01T10:00:00.000Z"));
+    setPortalSessionSecretForTesting(VERIFICATION_TOKEN_FIXTURES.secret);
+  });
+
+  afterEach(() => {
+    clearPortalSessionSecretForTesting();
+    if (originalSecret === undefined) {
+      delete process.env[PORTAL_SESSION_SECRET_ENV];
+    } else {
+      process.env[PORTAL_SESSION_SECRET_ENV] = originalSecret;
+    }
+
+    resetConsentStore();
+    vi.useRealTimers();
+  });
+
+  it("stamps a deterministic session cookie once consent is recorded", async () => {
+    persistConsent(CONSENT_SELECTIONS);
+    const request = createPostRequest();
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload).toEqual({
+      status: "verified",
+      token: VERIFICATION_TOKEN_FIXTURES.success,
+      expiresAt: "2025-02-01T11:00:00.000Z",
+      revision: 1,
+      auditReference: "CONSENT-STUB-0001",
+    });
+
+    const cookie = response.cookies.get(PORTAL_SESSION_COOKIE);
+    expect(cookie?.value).toBe(VERIFICATION_TOKEN_FIXTURES.success);
+    expect(cookie?.httpOnly).toBe(true);
+    expect(cookie?.secure).toBe(true);
+    expect(cookie?.sameSite).toBe("lax");
+    expect(cookie?.maxAge).toBe(60 * 60);
+  });
+
+  it("rejects verification when consent has not been captured", async () => {
+    const request = createPostRequest();
+    const response = await POST(request);
+
+    expect(response.status).toBe(409);
+    const payload = await response.json();
+
+    expect(payload).toEqual({
+      error: "consent_not_recorded",
+      message:
+        "Consent selections must be captured before the portal session can be verified.",
+    });
+
+    expect(response.cookies.get(PORTAL_SESSION_COOKIE)).toBeUndefined();
+  });
+
+  it("reports missing secret configuration", async () => {
+    setPortalSessionSecretForTesting(undefined);
+    persistConsent(CONSENT_SELECTIONS);
+
+    const response = await POST(createPostRequest());
+
+    expect(response.status).toBe(500);
+    const payload = await response.json();
+    expect(payload).toEqual({
+      error: "configuration_error",
+      message:
+        "PORTAL_SESSION_SECRET must be configured for portal verification stubs.",
+    });
+  });
+});

--- a/web/app/api/onboarding/verify/fixtures.ts
+++ b/web/app/api/onboarding/verify/fixtures.ts
@@ -1,0 +1,11 @@
+import { computePortalSessionTokenFromSecret } from "../../../lib/portal-auth";
+
+const TEST_SESSION_SECRET = "integration-portal-session-secret";
+const SUCCESS_TOKEN =
+  computePortalSessionTokenFromSecret(TEST_SESSION_SECRET);
+
+export const VERIFICATION_TOKEN_FIXTURES = {
+  secret: TEST_SESSION_SECRET,
+  success: SUCCESS_TOKEN,
+  invalid: `${SUCCESS_TOKEN}-invalid`,
+} as const;

--- a/web/app/api/onboarding/verify/route.ts
+++ b/web/app/api/onboarding/verify/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { snapshotConsent } from "../consent/store";
+import {
+  PORTAL_SESSION_COOKIE,
+  PORTAL_SESSION_MAX_AGE_SECONDS,
+  computePortalSessionTokenFromSecret,
+  requirePortalSessionSecret,
+} from "../../../lib/portal-auth";
+
+type VerificationResponse =
+  | {
+      status: "verified";
+      token: string;
+      expiresAt: string;
+      revision: number;
+      auditReference: string;
+    }
+  | {
+      error: string;
+      message: string;
+    };
+
+function buildExpiresAt() {
+  const expiresAt = new Date(
+    Date.now() + PORTAL_SESSION_MAX_AGE_SECONDS * 1000,
+  );
+
+  return expiresAt.toISOString();
+}
+
+export async function POST() {
+  const consent = snapshotConsent();
+
+  if (consent.revision === 0) {
+    return NextResponse.json<VerificationResponse>(
+      {
+        error: "consent_not_recorded",
+        message:
+          "Consent selections must be captured before the portal session can be verified.",
+      },
+      { status: 409 },
+    );
+  }
+
+  let secret: string;
+  try {
+    secret = requirePortalSessionSecret();
+  } catch (error) {
+    return NextResponse.json<VerificationResponse>(
+      {
+        error: "configuration_error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Portal verification secret is missing.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const token = computePortalSessionTokenFromSecret(secret);
+  const expiresAt = buildExpiresAt();
+
+  const response = NextResponse.json<VerificationResponse>(
+    {
+      status: "verified",
+      token,
+      expiresAt,
+      revision: consent.revision,
+      auditReference: consent.auditReference,
+    },
+    { status: 200 },
+  );
+
+  response.cookies.set({
+    name: PORTAL_SESSION_COOKIE,
+    value: token,
+    httpOnly: true,
+    secure: process.env.NODE_ENV !== "development",
+    sameSite: "lax",
+    path: "/",
+    maxAge: PORTAL_SESSION_MAX_AGE_SECONDS,
+  });
+
+  return response;
+}

--- a/web/app/lib/portal-auth.test.ts
+++ b/web/app/lib/portal-auth.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { isProtectedPortalPath } from "./portal-auth";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PORTAL_SESSION_SECRET_ENV,
+  computePortalSessionTokenFromSecret,
+  isPortalSessionTokenValid,
+  isProtectedPortalPath,
+  clearPortalSessionSecretForTesting,
+  requirePortalSessionSecret,
+  setPortalSessionSecretForTesting,
+} from "./portal-auth";
 
 describe("isProtectedPortalPath", () => {
   it("ignores non-portal routes", () => {
@@ -19,5 +27,46 @@ describe("isProtectedPortalPath", () => {
   it("protects portal root and nested paths", () => {
     expect(isProtectedPortalPath("/portal")).toBe(true);
     expect(isProtectedPortalPath("/portal/inbox")).toBe(true);
+  });
+});
+
+describe("portal session verification", () => {
+  const secret = "test-portals-secret";
+  const originalEnv = process.env[PORTAL_SESSION_SECRET_ENV];
+
+  afterEach(() => {
+    clearPortalSessionSecretForTesting();
+    if (originalEnv === undefined) {
+      delete process.env[PORTAL_SESSION_SECRET_ENV];
+    } else {
+      process.env[PORTAL_SESSION_SECRET_ENV] = originalEnv;
+    }
+  });
+
+  it("derives deterministic tokens from the configured secret", () => {
+    const first = computePortalSessionTokenFromSecret(secret);
+    const second = computePortalSessionTokenFromSecret(secret);
+    const different = computePortalSessionTokenFromSecret(`${secret}-other`);
+
+    expect(first).toBe(second);
+    expect(different).not.toBe(first);
+  });
+
+  it("validates tokens against the current secret", () => {
+    const token = computePortalSessionTokenFromSecret(secret);
+    setPortalSessionSecretForTesting(secret);
+
+    expect(isPortalSessionTokenValid(token)).toBe(true);
+    expect(isPortalSessionTokenValid(`${token}-tampered`)).toBe(false);
+  });
+
+  it("throws when the portal secret is missing", () => {
+    setPortalSessionSecretForTesting(undefined);
+
+    expect(() => {
+      requirePortalSessionSecret();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[Error: PORTAL_SESSION_SECRET must be configured for portal verification stubs.]`,
+    );
   });
 });

--- a/web/app/lib/portal-auth.ts
+++ b/web/app/lib/portal-auth.ts
@@ -1,10 +1,16 @@
 export const PORTAL_SESSION_COOKIE = "tyrum_portal_session";
+export const PORTAL_SESSION_SECRET_ENV = "PORTAL_SESSION_SECRET";
+export const PORTAL_SESSION_TOKEN_PREFIX = "portal-session-verified-";
+export const PORTAL_SESSION_MAX_AGE_SECONDS = 60 * 60;
 export const CTA_REDIRECT_PARAM = "redirect";
 export const CTA_REDIRECT_REASON = "portal-auth";
 export const CTA_FROM_PARAM = "from";
 
 const PROTECTED_PREFIX = "/portal";
 const PUBLIC_PREFIXES = ["/portal/onboarding", "/portal/auth"];
+const STATIC_PORTAL_SESSION_SECRET = process.env.PORTAL_SESSION_SECRET;
+
+let portalSessionSecretOverride: string | undefined | null = null;
 
 export function isProtectedPortalPath(pathname: string): boolean {
   if (!pathname.startsWith(PROTECTED_PREFIX)) {
@@ -14,4 +20,85 @@ export function isProtectedPortalPath(pathname: string): boolean {
   return !PUBLIC_PREFIXES.some((publicPath) => {
     return pathname === publicPath || pathname.startsWith(`${publicPath}/`);
   });
+}
+
+function trimOrUndefined(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function getPortalSessionSecret(): string | undefined {
+  if (portalSessionSecretOverride !== null) {
+    return trimOrUndefined(portalSessionSecretOverride ?? undefined);
+  }
+
+  const staticSecret = trimOrUndefined(STATIC_PORTAL_SESSION_SECRET);
+  if (staticSecret) {
+    return staticSecret;
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    return trimOrUndefined(process.env.PORTAL_SESSION_SECRET);
+  }
+
+  return undefined;
+}
+
+export function requirePortalSessionSecret(): string {
+  const secret = getPortalSessionSecret();
+
+  if (!secret) {
+    throw new Error(
+      `${PORTAL_SESSION_SECRET_ENV} must be configured for portal verification stubs.`,
+    );
+  }
+
+  return secret;
+}
+
+export function setPortalSessionSecretForTesting(secret: string | undefined) {
+  portalSessionSecretOverride = secret ?? undefined;
+}
+
+export function clearPortalSessionSecretForTesting() {
+  portalSessionSecretOverride = null;
+}
+
+function computeDeterministicDigest(input: string) {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+
+  return hash.toString(36).padStart(8, "0");
+}
+
+export function computePortalSessionTokenFromSecret(secret: string): string {
+  return `${PORTAL_SESSION_TOKEN_PREFIX}${computeDeterministicDigest(secret)}`;
+}
+
+export function resolvePortalSessionToken(): string {
+  return computePortalSessionTokenFromSecret(requirePortalSessionSecret());
+}
+
+export function isPortalSessionTokenValid(
+  token: string | undefined,
+): boolean {
+  if (!token) {
+    return false;
+  }
+
+  const secret = getPortalSessionSecret();
+  if (!secret) {
+    return false;
+  }
+
+  return token === computePortalSessionTokenFromSecret(secret);
 }

--- a/web/middleware.test.ts
+++ b/web/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
 import { middleware } from "./middleware";
 import {
@@ -6,7 +6,11 @@ import {
   CTA_REDIRECT_PARAM,
   CTA_REDIRECT_REASON,
   PORTAL_SESSION_COOKIE,
+  PORTAL_SESSION_SECRET_ENV,
+  clearPortalSessionSecretForTesting,
+  setPortalSessionSecretForTesting,
 } from "./app/lib/portal-auth";
+import { VERIFICATION_TOKEN_FIXTURES } from "./app/api/onboarding/verify/fixtures";
 
 const origin = "https://example.com";
 
@@ -25,6 +29,21 @@ function createRequest(path: string, options: RequestOptions = {}) {
 }
 
 describe("middleware", () => {
+  const originalSecret = process.env[PORTAL_SESSION_SECRET_ENV];
+
+  beforeEach(() => {
+    setPortalSessionSecretForTesting(VERIFICATION_TOKEN_FIXTURES.secret);
+  });
+
+  afterEach(() => {
+    clearPortalSessionSecretForTesting();
+    if (originalSecret === undefined) {
+      delete process.env[PORTAL_SESSION_SECRET_ENV];
+    } else {
+      process.env[PORTAL_SESSION_SECRET_ENV] = originalSecret;
+    }
+  });
+
   it("redirects unauthenticated portal traffic to the onboarding CTA", () => {
     const response = middleware(createRequest("/portal/cases"));
 
@@ -42,11 +61,27 @@ describe("middleware", () => {
     expect(redirectUrl.searchParams.get(CTA_FROM_PARAM)).toBe("/portal/cases");
   });
 
-  it("passes through when a session cookie is present", () => {
-    const response = middleware(createRequest("/portal", { cookie: "token" }));
+  it("passes through when a verified session cookie is present", () => {
+    const response = middleware(
+      createRequest("/portal", { cookie: VERIFICATION_TOKEN_FIXTURES.success }),
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("redirects when the portal cookie is invalid", () => {
+    const response = middleware(
+      createRequest("/portal", { cookie: VERIFICATION_TOKEN_FIXTURES.invalid }),
+    );
+
+    expect(response.status).toBe(307);
+    const redirect = response.headers.get("location");
+    const url = new URL(redirect ?? "", origin);
+    expect(url.pathname).toBe("/");
+    expect(url.searchParams.get(CTA_REDIRECT_PARAM)).toBe(
+      CTA_REDIRECT_REASON,
+    );
   });
 
   it("does not guard onboarding or auth routes", () => {

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -4,6 +4,7 @@ import {
   CTA_REDIRECT_PARAM,
   CTA_REDIRECT_REASON,
   PORTAL_SESSION_COOKIE,
+  isPortalSessionTokenValid,
   isProtectedPortalPath,
 } from "./app/lib/portal-auth";
 
@@ -16,7 +17,7 @@ export function middleware(request: NextRequest) {
 
   const sessionCookie = request.cookies.get(PORTAL_SESSION_COOKIE)?.value?.trim();
 
-  if (sessionCookie) {
+  if (isPortalSessionTokenValid(sessionCookie)) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
- add a deterministic onboarding verification route that stamps the portal session cookie once consent is recorded
- validate portal middleware against the derived token and publish fixtures plus coverage for success, missing, and tampered cookies
- document the stubbed expiry/manual checks and surface the session secret in local+ci env configs

## Testing
- 
- cargo fmt................................................................Passed
cargo clippy.............................................................Passed
cargo test...............................................................Passed
nextjs lint..............................................................Passed
nextjs test..............................................................Passed
github actions lint......................................................Passed
terraform fmt+validate...................................................Passed
docker compose config....................................................Passed
kubernetes manifest validation.......................(no files to check)Skipped
helm lint................................................................Passed

Closes #93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a deterministic onboarding verification endpoint that sets a verified portal session cookie, validates middleware against a derived token, and wires env/config with tests and fixtures.
> 
> - **Web/API**:
>   - `POST /web/app/api/onboarding/verify` issues deterministic verification payload and sets `PORTAL_SESSION_COOKIE` with 1h expiry.
> - **Auth Utilities**:
>   - Add `web/app/lib/portal-auth.ts`: secret resolution (`PORTAL_SESSION_SECRET`), deterministic token derivation/validation, and related constants.
> - **Middleware**:
>   - `web/middleware.ts` now validates cookies via `isPortalSessionTokenValid` instead of presence-only.
> - **Tests/Fixtures**:
>   - Add route tests `web/app/api/onboarding/verify/OnboardingVerify.route.test.ts` and fixtures.
>   - Expand `web/app/lib/portal-auth.test.ts` and update `web/middleware.test.ts` for valid/invalid tokens and missing secret.
> - **Config/CI**:
>   - Expose `PORTAL_SESSION_SECRET` in `.github/workflows/ci-web.yml` and `config/local.env.example`.
> - **Docs**:
>   - Note portal verification stub and manual QA in `docs/product_concept_v1.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd6778e7abc0a41aae36b607ba4498bf16987f55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->