### PR TITLE
Authenticate to Docker Hub only for non-dependabot users

### DIFF
--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -53,6 +53,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Authenticate to Docker Hub
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: docker/login-action@v3
         with:
           registry: docker.io


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Conditionally skip Docker Hub authentication in `.github/workflows/ci-containers.yml` when the actor is `dependabot[bot]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36db1fac8035c112febec1bf0d599f15a0760a38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->