### PR TITLE
Guard container workflow for Dependabot runs

### DIFF
--- a/.github/workflows/ci-containers.yml
+++ b/.github/workflows/ci-containers.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Docker Buildx
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Authenticate to Docker Hub
@@ -60,7 +61,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Skip container build for Dependabot
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        run: |
+          echo "Dependabot PR detected; skipping container builds that rely on docker.io authentication." >>"$GITHUB_STEP_SUMMARY"
+
       - name: Build ${{ matrix.title }} image
+        if: ${{ github.actor != 'dependabot[bot]' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -72,6 +79,7 @@ jobs:
           echo "BUILT_IMAGE=$image" >>"$GITHUB_ENV"
 
       - name: Smoke test ${{ matrix.title }} image
+        if: ${{ github.actor != 'dependabot[bot]' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -160,7 +168,7 @@ jobs:
           fi
 
       - name: Remove ${{ matrix.title }} image
-        if: always()
+        if: ${{ always() && github.actor != 'dependabot[bot]' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- gate Docker Buildx setup, docker.io login, build, smoke test, and cleanup steps in the container CI workflow when the run is triggered by dependabot[bot]
- add a summary note explaining why the container job is skipped for Dependabot PRs

## Testing
- not run (workflow change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip container image build, smoke test, and cleanup in `ci-containers` workflow when triggered by `dependabot[bot]`, adding a summary note explaining the skip.
> 
> - **Workflow updates** (`.github/workflows/ci-containers.yml`):
>   - Gate steps with `if: ${{ github.actor != 'dependabot[bot]' }}`:
>     - `Setup Docker Buildx`
>     - `Build ${{ matrix.title }} image`
>     - `Smoke test ${{ matrix.title }} image`
>     - `Remove ${{ matrix.title }} image` (now `always() && github.actor != 'dependabot[bot]'`)
>   - Add step: `Skip container build for Dependabot` that appends a note to `GITHUB_STEP_SUMMARY` when `github.actor == 'dependabot[bot]'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e68add25387c840287140491458f81cf985bf25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->