### PR TITLE
Replace Syft action with container invocation

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -382,10 +382,16 @@ jobs:
 
       - name: Generate SBOM
         if: steps.change.outputs.should_build == 'true'
-        uses: anchore/syft-action@v0.19.0
-        with:
-          image: ${{ steps.tags.outputs.primary }}@${{ steps.build.outputs.digest }}
-          output-file: sbom-${{ matrix.id }}.spdx.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="${{ steps.tags.outputs.primary }}@${{ steps.build.outputs.digest }}"
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            ghcr.io/anchore/syft:latest \
+            "$image" \
+            -o "spdx-json=sbom-${{ matrix.id }}.spdx.json"
 
       - name: Upload SBOM
         if: steps.change.outputs.should_build == 'true'


### PR DESCRIPTION
This pull request updates the way the Software Bill of Materials (SBOM) is generated in the `.github/workflows/publish-containers.yml` workflow. Instead of using the `anchore/syft-action`, it now generates the SBOM by directly running the Syft Docker container.

Container publishing workflow improvements:

* Replaced the `anchore/syft-action` GitHub Action with a manual `docker run` command to generate the SBOM, using the latest Syft image from `ghcr.io/anchore/syft`. This change provides more control over the SBOM generation process and ensures the use of the latest Syft version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the Syft GitHub Action with a direct `docker run` of `ghcr.io/anchore/syft:latest` to generate SBOMs in `publish-containers.yml`.
> 
> - **CI / Workflow (`.github/workflows/publish-containers.yml`)**:
>   - **SBOM Generation**: Replace `anchore/syft-action@v0.19.0` with a Bash step invoking `docker run ghcr.io/anchore/syft:latest` to output `spdx-json` (`sbom-${{ matrix.id }}.spdx.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50ce9dac4eea682d0401c4dae53a09802bb5fdc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->