### PR TITLE
Remove SBOM generation from publish workflow

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -380,27 +380,6 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ steps.revision.outputs.sha }}
 
-      - name: Generate SBOM
-        if: steps.change.outputs.should_build == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          image="${{ steps.tags.outputs.primary }}@${{ steps.build.outputs.digest }}"
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -w /workspace \
-            ghcr.io/anchore/syft:latest \
-            "$image" \
-            -o "spdx-json=sbom-${{ matrix.id }}.spdx.json"
-
-      - name: Upload SBOM
-        if: steps.change.outputs.should_build == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: sbom-${{ matrix.id }}-${{ github.run_id }}
-          path: sbom-${{ matrix.id }}.spdx.json
-          retention-days: 5
-
       - name: Scan image with Trivy
         if: steps.change.outputs.should_build == 'true'
         uses: aquasecurity/trivy-action@0.24.0


### PR DESCRIPTION
This pull request removes the generation and upload of Software Bill of Materials (SBOM) artifacts from the container publishing workflow. The workflow will no longer create or upload SBOM files for built images.

Container publishing workflow simplification:

* Removed the `Generate SBOM` step, which previously used the `ghcr.io/anchore/syft` tool to create SBOM files in SPDX format for each built image.
* Removed the `Upload SBOM` step, which previously uploaded the generated SBOM files as workflow artifacts with a retention period of 5 days.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove SBOM generation and artifact upload steps from the container publish workflow.
> 
> - **CI/CD Workflow (`.github/workflows/publish-containers.yml`)**:
>   - Removed SBOM-related steps:
>     - `Generate SBOM` (Anchore Syft SPDX JSON output)
>     - `Upload SBOM` (artifact upload with retention)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c814e8601e90febc20ed63a51ba88884da50b2b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->