### PR TITLE
Promote tyrum-memory to planner defaults (#181)

### DIFF
--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["VirtunetBV <oss@virtunet.example>"]
 description = "Planner core utilities for Tyrum"
 
 [features]
-default = []
-audit-demo = ["dep:testcontainers", "dep:tyrum-memory"]
+default = ["dep:tyrum-memory"]
+audit-demo = ["dep:testcontainers"]
 
 [dependencies]
 axum = { version = "0.7", features = ["json"] }


### PR DESCRIPTION
## Summary
- include the `tyrum-memory` client in the planner's default feature set so runtime binaries link capability memory without `audit-demo`
- keep the `audit-demo` feature focused on `testcontainers` for the demo-only binary

## Testing
- cargo check --all --all-targets
- cargo build -p tyrum-planner --bin planner_http
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::cognitive_complexity -D clippy::unwrap_used -D clippy::expect_used
- cargo test --workspace --all-targets
- cargo test -p tyrum-api -- --ignored telegram_webhook_e2e
- pre-commit run --all-files

Closes #181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `tyrum-memory` by default in `tyrum-planner` and scope `audit-demo` to only `testcontainers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3b60a7d042fac05190067af1a35b19651f8b25c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->