### PR TITLE
Hydrate planner primitives from capability memory

### DIFF
--- a/docs/planner_event_log.md
+++ b/docs/planner_event_log.md
@@ -83,6 +83,17 @@ replay.
 2. Provides `append` to insert entries with idempotent handling.
 3. Exposes `events_for_plan` to stream traces back when deriving audit or replay artefacts.
 
+## Capability Memory Hydration
+- Before dispatching any mutating primitive, the planner consults the capability memory store using a
+  connection shared with the event log (via `CapabilityMemoryService`).
+- Each lookup emits a `planner.capability_memory.lookup` span capturing `subject_id`,
+  `capability_identifier`, `executor_kind`, `hit` (true/false), and `latency_ms`.
+- When a lookup hits, the planner merges the stored `selectors` into the primitive's `selector_hints`
+  (without overwriting caller-provided hints) and attaches a `capability_memory` payload containing
+  the latest `success_count`, `last_success_at`, `outcome_metadata`, and `result_summary`.
+- Misses leave the primitive unchanged, but the span still records `hit=false` so telemetry consumers
+  can track cache effectiveness.
+
 Unit tests spin up an ephemeral Postgres container to assert insertion, dedupe, ordering, and
 validation of step indices. They run as part of `cargo test --all --all-targets` via the
 `pre-commit` hook.

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -6,6 +6,8 @@ use tokio::net::TcpListener;
 use tracing_subscriber::{EnvFilter, fmt};
 
 use tyrum_discovery::DefaultDiscoveryPipeline;
+use tyrum_memory::MemoryDal;
+use tyrum_planner::capability_memory::CapabilityMemoryService;
 use tyrum_planner::http::{DEFAULT_BIND_ADDR, PlannerState, build_router};
 use tyrum_planner::policy::PolicyClient;
 use tyrum_planner::{EventLog, EventLogSettings, ProfileStore, WalletClient};
@@ -43,6 +45,7 @@ async fn main() -> Result<()> {
         .await
         .context("run planner migrations")?;
     let profiles = ProfileStore::new(event_log.pool().clone());
+    let capability_memory = CapabilityMemoryService::new(MemoryDal::new(event_log.pool().clone()));
 
     let app = build_router(PlannerState {
         policy_client,
@@ -50,6 +53,7 @@ async fn main() -> Result<()> {
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
         wallet_client,
         profiles,
+        capability_memory,
     });
     let listener = TcpListener::bind(bind_addr)
         .await

--- a/services/planner/src/capability_memory.rs
+++ b/services/planner/src/capability_memory.rs
@@ -1,0 +1,173 @@
+use std::time::Instant;
+
+use serde_json::{Map as JsonMap, Value, json};
+use tracing::{Span, info_span};
+use uuid::Uuid;
+
+use crate::ActionPrimitive;
+use crate::event_log::{capability_type_label, derive_capability_identifier};
+use tyrum_memory::{CapabilityMemory, MemoryDal, MemoryError};
+
+/// Facade responsible for hydrating action primitives with prior capability memory.
+#[derive(Clone)]
+pub struct CapabilityMemoryService {
+    dal: MemoryDal,
+}
+
+impl CapabilityMemoryService {
+    #[must_use]
+    pub fn new(dal: MemoryDal) -> Self {
+        Self { dal }
+    }
+
+    /// Attempts to hydrate the provided primitives with previously recorded capability memory.
+    pub async fn hydrate_primitives(&self, subject_id: Uuid, steps: &mut [ActionPrimitive]) {
+        for primitive in steps.iter_mut() {
+            if !primitive.kind.requires_postcondition() {
+                continue;
+            }
+
+            let Some(executor_kind) = primitive
+                .args
+                .get("executor")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            else {
+                continue;
+            };
+
+            let Some(capability_identifier) = derive_capability_identifier(primitive) else {
+                continue;
+            };
+
+            let capability_type = capability_type_label(primitive.kind);
+            let span = info_span!(
+                target: "tyrum::planner",
+                "planner.capability_memory.lookup",
+                subject_id = %subject_id,
+                capability_type,
+                capability_identifier = capability_identifier.as_str(),
+                executor_kind = executor_kind.as_str(),
+                hit = tracing::field::Empty,
+                latency_ms = tracing::field::Empty
+            );
+            let _guard = span.enter();
+
+            let started = Instant::now();
+            let lookup = self
+                .dal
+                .get_capability_memory_for_flow(
+                    subject_id,
+                    capability_type,
+                    capability_identifier.as_str(),
+                    executor_kind.as_str(),
+                )
+                .await;
+            let latency = clamp_latency(started.elapsed().as_millis());
+            let mut context = LookupContext {
+                primitive,
+                span: &span,
+                subject_id,
+                capability_identifier: capability_identifier.as_str(),
+                executor_kind: executor_kind.as_str(),
+            };
+            self.handle_lookup_result(&mut context, lookup, latency);
+        }
+    }
+
+    fn handle_lookup_result(
+        &self,
+        context: &mut LookupContext<'_>,
+        lookup: Result<Option<CapabilityMemory>, MemoryError>,
+        latency_ms: i64,
+    ) {
+        context.span.record("latency_ms", latency_ms);
+
+        match lookup {
+            Ok(Some(memory)) => {
+                context.span.record("hit", true);
+                Self::apply_memory(context.primitive, &memory);
+            }
+            Ok(None) => {
+                context.span.record("hit", false);
+            }
+            Err(error) => {
+                context.span.record("hit", false);
+                tracing::warn!(
+                    target: "tyrum::planner",
+                    %error,
+                    subject_id = %context.subject_id,
+                    capability_identifier = context.capability_identifier,
+                    executor_kind = context.executor_kind,
+                    "failed to load capability memory"
+                );
+            }
+        }
+    }
+
+    fn apply_memory(primitive: &mut ActionPrimitive, memory: &CapabilityMemory) {
+        if let Some(selectors) = memory.selectors.clone() {
+            match primitive.args.get_mut("selector_hints") {
+                Some(existing) if existing.is_object() && selectors.is_object() => {
+                    if let (Some(existing_map), Some(memory_map)) =
+                        (existing.as_object_mut(), selectors.as_object())
+                    {
+                        for (key, value) in memory_map {
+                            existing_map.entry(key.clone()).or_insert(value.clone());
+                        }
+                    }
+                }
+                Some(_) => {
+                    // Existing selector hints are present but not an object; do not overwrite.
+                }
+                None => {
+                    primitive
+                        .args
+                        .insert("selector_hints".into(), selectors.clone());
+                }
+            }
+        }
+
+        let mut payload = JsonMap::new();
+        payload.insert(
+            "capability_type".into(),
+            Value::String(memory.capability_type.clone()),
+        );
+        payload.insert(
+            "capability_identifier".into(),
+            Value::String(memory.capability_identifier.clone()),
+        );
+        payload.insert(
+            "executor_kind".into(),
+            Value::String(memory.executor_kind.clone()),
+        );
+        payload.insert("success_count".into(), json!(memory.success_count));
+        payload.insert("last_success_at".into(), json!(memory.last_success_at));
+        payload.insert("outcome_metadata".into(), memory.outcome_metadata.clone());
+        if let Some(summary) = memory.result_summary.as_ref() {
+            payload.insert("result_summary".into(), Value::String(summary.clone()));
+        }
+        if let Some(selectors) = memory.selectors.clone() {
+            payload.insert("selectors".into(), selectors);
+        }
+
+        primitive
+            .args
+            .insert("capability_memory".into(), Value::Object(payload));
+    }
+}
+
+struct LookupContext<'a> {
+    primitive: &'a mut ActionPrimitive,
+    span: &'a Span,
+    subject_id: Uuid,
+    capability_identifier: &'a str,
+    executor_kind: &'a str,
+}
+
+fn clamp_latency(millis: u128) -> i64 {
+    match i64::try_from(millis) {
+        Ok(value) => value,
+        Err(_) => i64::MAX,
+    }
+}

--- a/services/planner/src/event_log.rs
+++ b/services/planner/src/event_log.rs
@@ -162,7 +162,7 @@ impl EventLog {
     }
 }
 
-fn capability_type_label(kind: ActionPrimitiveKind) -> &'static str {
+pub(crate) fn capability_type_label(kind: ActionPrimitiveKind) -> &'static str {
     match kind {
         ActionPrimitiveKind::Web => "web",
         ActionPrimitiveKind::Android => "android",
@@ -178,7 +178,7 @@ fn capability_type_label(kind: ActionPrimitiveKind) -> &'static str {
     }
 }
 
-fn derive_capability_identifier(primitive: &ActionPrimitive) -> Option<String> {
+pub(crate) fn derive_capability_identifier(primitive: &ActionPrimitive) -> Option<String> {
     if let Some(identifier) = primitive
         .args
         .get("capability_identifier")

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -12,6 +12,7 @@ use serde_json::{Map as JsonMap, Value, json};
 use tower_http::limit::RequestBodyLimitLayer;
 use uuid::Uuid;
 
+use crate::capability_memory::CapabilityMemoryService;
 use crate::policy::{PolicyClient, PolicyDecision, PolicyDecisionKind, PolicyRuleDecision};
 use crate::wallet::{AuthorizationDecision, SpendAuthorization, WalletClient};
 use crate::{
@@ -45,6 +46,7 @@ pub struct PlannerState {
     pub discovery: Arc<dyn DiscoveryPipeline + Send + Sync>,
     pub wallet_client: WalletClient,
     pub profiles: ProfileStore,
+    pub capability_memory: CapabilityMemoryService,
 }
 
 impl PlannerState {
@@ -175,6 +177,7 @@ async fn plan(
         return Err(bad_request("subject_id must not be empty"));
     }
 
+    let subject_uuid = PlannerState::parse_subject_uuid(&payload.subject_id);
     state.enrich_user_context(&mut payload).await;
 
     let plan_uuid = Uuid::new_v4();
@@ -201,6 +204,15 @@ async fn plan(
                 state.discovery.as_ref(),
                 spend_directive.as_ref(),
             );
+
+            if let Some(subject_id) = subject_uuid
+                && let PlanOutcome::Success { steps, .. } = &mut outcome
+            {
+                state
+                    .capability_memory
+                    .hydrate_primitives(subject_id, steps)
+                    .await;
+            }
 
             let mut wallet_audit = WalletAudit::skipped();
 

--- a/services/planner/src/lib.rs
+++ b/services/planner/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core primitives shared between the planner service and its dependants.
 
+pub mod capability_memory;
 pub mod event_log;
 pub mod http;
 pub mod policy;
@@ -7,6 +8,7 @@ pub mod profiles;
 pub mod state_machine;
 pub mod wallet;
 
+pub use capability_memory::CapabilityMemoryService;
 pub use event_log::{
     AppendOutcome, CapabilityMemoryResult, CapabilityMemorySkipReason, EventLog, EventLogError,
     EventLogSettings, NewPlannerEvent, PersistedPlannerEvent,

--- a/services/planner/tests/capability_memory.rs
+++ b/services/planner/tests/capability_memory.rs
@@ -3,14 +3,21 @@
 mod common;
 
 use anyhow::{Context, Result, bail};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use common::postgres::{TestPostgres, docker_available};
 use serde_json::{Value, json};
 use std::convert::TryFrom;
-use tyrum_memory::{MemoryDal, NewEpisodicEvent, NewFact};
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::{
+    Layer,
+    layer::{Context as LayerContext, SubscriberExt},
+    registry::LookupSpan,
+};
+use tyrum_memory::{MemoryDal, NewCapabilityMemory, NewEpisodicEvent, NewFact};
 use tyrum_planner::{
     ActionArguments, ActionPrimitive, ActionPrimitiveKind, AppendOutcome, CapabilityMemoryResult,
-    EventLog, NewPlannerEvent, PlanEvent, PlanStateMachine, PlanStatus,
+    CapabilityMemoryService, EventLog, NewPlannerEvent, PlanEvent, PlanStateMachine, PlanStatus,
 };
 use uuid::Uuid;
 
@@ -282,6 +289,360 @@ async fn mock_book_call_plan_creates_audit_and_memory_artifacts() -> Result<()> 
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capability_memory_hydration_hit_populates_primitive() -> Result<()> {
+    if !docker_available() {
+        eprintln!(
+            "skipping capability_memory_hydration_hit_populates_primitive: docker unavailable"
+        );
+        return Ok(());
+    }
+
+    let postgres = TestPostgres::start()
+        .await
+        .context("start postgres fixture")?;
+    let pool = postgres.pool().clone();
+    let event_log = EventLog::from_pool(pool.clone());
+    event_log
+        .migrate()
+        .await
+        .context("migrate planner schema")?;
+
+    let memory = MemoryDal::new(pool.clone());
+    let subject_id = Uuid::new_v4();
+    let last_success_at = Utc::now();
+
+    memory
+        .create_capability_memory(NewCapabilityMemory {
+            subject_id,
+            capability_type: "web".into(),
+            capability_identifier: "calendar.example.com".into(),
+            executor_kind: "generic-web".into(),
+            selectors: Some(json!({
+                "login_button": "#login",
+                "email_input": { "selector": "input[type=\"email\"]", "prefill": "alex@example.com" },
+                "otp_field": "[data-test=\"otp\"]"
+            })),
+            outcome_metadata: json!({
+                "postcondition": {
+                    "appointment": {
+                        "status": "booked"
+                    }
+                }
+            }),
+            result_summary: Some("generic-web satisfied intent book_call".into()),
+            success_count: 3,
+            last_success_at,
+        })
+        .await
+        .context("seed capability memory")?;
+
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Web,
+        into_args(json!({
+            "executor": "generic-web",
+            "intent": "fallback_automation",
+            "capability_identifier": "calendar.example.com"
+        })),
+    )
+    .with_postcondition(json!({
+        "status": "completed"
+    }));
+
+    let mut steps = vec![primitive];
+    let recorder = LookupRecorder::default();
+    let subscriber = tracing_subscriber::registry().with(recorder.clone());
+    let service = CapabilityMemoryService::new(memory.clone());
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+    service.hydrate_primitives(subject_id, &mut steps).await;
+
+    let enriched = &steps[0];
+    let capability = enriched
+        .args
+        .get("capability_memory")
+        .and_then(Value::as_object)
+        .expect("capability memory attached");
+    assert_eq!(
+        capability
+            .get("capability_identifier")
+            .and_then(Value::as_str),
+        Some("calendar.example.com")
+    );
+    assert_eq!(
+        capability.get("executor_kind").and_then(Value::as_str),
+        Some("generic-web")
+    );
+    assert_eq!(
+        capability.get("success_count").and_then(Value::as_i64),
+        Some(3)
+    );
+    let last_success_value = capability
+        .get("last_success_at")
+        .and_then(Value::as_str)
+        .expect("last_success_at present");
+    let parsed_last_success = DateTime::parse_from_rfc3339(last_success_value)
+        .expect("parse last_success_at")
+        .with_timezone(&Utc);
+    let delta = parsed_last_success
+        .signed_duration_since(last_success_at)
+        .num_nanoseconds()
+        .unwrap_or_default()
+        .abs();
+    assert!(
+        delta <= 1_000,
+        "last_success_at drift exceeded tolerance: {delta}ns"
+    );
+    assert_eq!(
+        capability.get("result_summary").and_then(Value::as_str),
+        Some("generic-web satisfied intent book_call")
+    );
+    assert_eq!(
+        capability.get("outcome_metadata"),
+        Some(&json!({
+            "postcondition": {
+                "appointment": {
+                    "status": "booked"
+                }
+            }
+        }))
+    );
+    let selector_hints = enriched
+        .args
+        .get("selector_hints")
+        .and_then(Value::as_object)
+        .expect("selector hints populated");
+    assert_eq!(selector_hints.get("login_button"), Some(&json!("#login")));
+    assert_eq!(
+        selector_hints.get("otp_field"),
+        Some(&json!("[data-test=\"otp\"]"))
+    );
+
+    let records = recorder.records();
+    assert_eq!(records.len(), 1);
+    let lookup = &records[0];
+    let expected_subject = subject_id.to_string();
+    assert_eq!(
+        lookup.subject_id.as_deref(),
+        Some(expected_subject.as_str())
+    );
+    assert_eq!(
+        lookup.capability_identifier.as_deref(),
+        Some("calendar.example.com")
+    );
+    assert_eq!(lookup.executor_kind.as_deref(), Some("generic-web"));
+    assert_eq!(lookup.capability_type.as_deref(), Some("web"));
+    assert_eq!(lookup.hit, Some(true));
+    assert!(lookup.latency_ms.is_some());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn capability_memory_hydration_miss_logs_lookup() -> Result<()> {
+    if !docker_available() {
+        eprintln!("skipping capability_memory_hydration_miss_logs_lookup: docker unavailable");
+        return Ok(());
+    }
+
+    let postgres = TestPostgres::start()
+        .await
+        .context("start postgres fixture")?;
+    let pool = postgres.pool().clone();
+    let event_log = EventLog::from_pool(pool.clone());
+    event_log
+        .migrate()
+        .await
+        .context("migrate planner schema")?;
+    let memory = MemoryDal::new(pool);
+    let service = CapabilityMemoryService::new(memory.clone());
+
+    let subject_id = Uuid::new_v4();
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Web,
+        into_args(json!({
+            "executor": "generic-web",
+            "intent": "fallback_automation",
+            "capability_identifier": "calendar.example.com"
+        })),
+    )
+    .with_postcondition(json!({
+        "status": "completed"
+    }));
+    let mut steps = vec![primitive];
+
+    let recorder = LookupRecorder::default();
+    let subscriber = tracing_subscriber::registry().with(recorder.clone());
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+    service.hydrate_primitives(subject_id, &mut steps).await;
+
+    let enriched = &steps[0];
+    assert!(
+        enriched.args.get("capability_memory").is_none(),
+        "capability memory should not be attached on cache miss"
+    );
+    assert!(
+        enriched.args.get("selector_hints").is_none(),
+        "selector hints should remain absent on miss"
+    );
+
+    let records = recorder.records();
+    assert_eq!(records.len(), 1);
+    let lookup = &records[0];
+    assert_eq!(lookup.hit, Some(false));
+    assert!(lookup.latency_ms.is_some());
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, Default)]
+struct LookupRecorder {
+    records: std::sync::Arc<std::sync::Mutex<Vec<LookupRecord>>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct LookupRecord {
+    subject_id: Option<String>,
+    capability_identifier: Option<String>,
+    executor_kind: Option<String>,
+    capability_type: Option<String>,
+    hit: Option<bool>,
+    latency_ms: Option<i64>,
+}
+
+impl LookupRecorder {
+    fn records(&self) -> Vec<LookupRecord> {
+        self.records.lock().expect("read lookup records").clone()
+    }
+}
+
+impl<S> Layer<S> for LookupRecorder
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: LayerContext<'_, S>,
+    ) {
+        if attrs.metadata().name() != "planner.capability_memory.lookup" {
+            return;
+        }
+
+        let mut record = LookupRecord::default();
+        attrs.record(&mut LookupVisitor {
+            record: &mut record,
+        });
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(record);
+        }
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: LayerContext<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id)
+            && let Some(record) = span.extensions_mut().get_mut::<LookupRecord>()
+        {
+            values.record(&mut LookupVisitor { record });
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: LayerContext<'_, S>) {
+        if let Some(span) = ctx.span(&id)
+            && let Some(record) = span.extensions_mut().remove::<LookupRecord>()
+        {
+            self.records
+                .lock()
+                .expect("store lookup record")
+                .push(record);
+        }
+    }
+}
+
+struct LookupVisitor<'a> {
+    record: &'a mut LookupRecord,
+}
+
+impl<'a> Visit for LookupVisitor<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "subject_id" => self.record.subject_id = Some(value.to_string()),
+            "capability_identifier" => self.record.capability_identifier = Some(value.to_string()),
+            "executor_kind" => self.record.executor_kind = Some(value.to_string()),
+            "capability_type" => self.record.capability_type = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "hit" {
+            self.record.hit = Some(value);
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if field.name() == "latency_ms" {
+            self.record.latency_ms = Some(value);
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "latency_ms" {
+            let clamped = i64::try_from(value).unwrap_or(i64::MAX);
+            self.record.latency_ms = Some(clamped);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{value:?}");
+        match field.name() {
+            "subject_id" => {
+                if self.record.subject_id.is_none() {
+                    self.record.subject_id = Some(rendered.trim_matches('"').to_string());
+                }
+            }
+            "capability_identifier" => {
+                if self.record.capability_identifier.is_none() {
+                    self.record.capability_identifier =
+                        Some(rendered.trim_matches('"').to_string());
+                }
+            }
+            "executor_kind" => {
+                if self.record.executor_kind.is_none() {
+                    self.record.executor_kind = Some(rendered.trim_matches('"').to_string());
+                }
+            }
+            "capability_type" => {
+                if self.record.capability_type.is_none() {
+                    self.record.capability_type = Some(rendered.trim_matches('"').to_string());
+                }
+            }
+            "hit" => {
+                if self.record.hit.is_none()
+                    && let Ok(parsed) = rendered.parse::<bool>()
+                {
+                    self.record.hit = Some(parsed);
+                }
+            }
+            "latency_ms" => {
+                if self.record.latency_ms.is_none()
+                    && let Ok(parsed) = rendered.parse::<i64>()
+                {
+                    self.record.latency_ms = Some(parsed);
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 struct MockGenericExecutors {

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -23,7 +23,8 @@ use tyrum_discovery::{
 };
 use tyrum_memory::{MemoryDal, PamProfileUpsert};
 use tyrum_planner::{
-    ActionPrimitiveKind, EventLog, PlanOutcome, PlanRequest, PlanResponse, ProfileStore,
+    ActionPrimitiveKind, CapabilityMemoryService, EventLog, PlanOutcome, PlanRequest, PlanResponse,
+    ProfileStore,
     http::{MAX_PLAN_REQUEST_BYTES, PlannerState, build_router},
     policy::PolicyClient,
 };
@@ -627,6 +628,7 @@ async fn planner_injects_pam_profile_reference_from_store() {
         })
         .await
         .expect("seed pam profile");
+    let capability_memory = CapabilityMemoryService::new(memory.clone());
 
     let state = PlannerState {
         policy_client,
@@ -634,6 +636,7 @@ async fn planner_injects_pam_profile_reference_from_store() {
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
         wallet_client,
         profiles,
+        capability_memory,
     };
 
     let mut request = sample_request();
@@ -827,6 +830,7 @@ async fn planner_state_with_pipeline(
     let event_log = EventLog::from_pool(postgres.pool().clone());
     event_log.migrate().await.expect("migrate planner schema");
     let profiles = ProfileStore::new(event_log.pool().clone());
+    let capability_memory = CapabilityMemoryService::new(MemoryDal::new(event_log.pool().clone()));
 
     (
         PlannerState {
@@ -835,6 +839,7 @@ async fn planner_state_with_pipeline(
             discovery,
             wallet_client,
             profiles,
+            capability_memory,
         },
         server,
         wallet_server,

--- a/services/planner/tests/plan_audit.rs
+++ b/services/planner/tests/plan_audit.rs
@@ -16,8 +16,9 @@ use serde_json::json;
 use sqlx::Row;
 use tower::ServiceExt;
 use tyrum_discovery::DefaultDiscoveryPipeline;
+use tyrum_memory::MemoryDal;
 use tyrum_planner::{
-    EventLog, PlanOutcome, PlanRequest, PlanResponse, ProfileStore,
+    CapabilityMemoryService, EventLog, PlanOutcome, PlanRequest, PlanResponse, ProfileStore,
     http::{PlannerState, build_router},
 };
 use tyrum_shared::{
@@ -63,6 +64,7 @@ async fn planner_appends_audit_event_with_redacted_payload() {
     .await;
 
     let profiles = ProfileStore::new(event_log.pool().clone());
+    let capability_memory = CapabilityMemoryService::new(MemoryDal::new(event_log.pool().clone()));
 
     let state = PlannerState {
         policy_client,
@@ -70,6 +72,7 @@ async fn planner_appends_audit_event_with_redacted_payload() {
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
         wallet_client,
         profiles,
+        capability_memory,
     };
 
     let request = sample_request();

--- a/services/planner/tests/policy_denial.rs
+++ b/services/planner/tests/policy_denial.rs
@@ -16,8 +16,10 @@ use serde_json::json;
 use sqlx::Row;
 use tower::ServiceExt;
 use tyrum_discovery::DefaultDiscoveryPipeline;
+use tyrum_memory::MemoryDal;
 use tyrum_planner::{
-    EventLog, PlanErrorCode, PlanOutcome, PlanRequest, PlanResponse, ProfileStore,
+    CapabilityMemoryService, EventLog, PlanErrorCode, PlanOutcome, PlanRequest, PlanResponse,
+    ProfileStore,
     http::{PlannerState, build_router},
 };
 use tyrum_shared::{
@@ -59,6 +61,7 @@ async fn policy_denial_is_logged_and_sanitized() {
     .await;
 
     let profiles = ProfileStore::new(event_log.pool().clone());
+    let capability_memory = CapabilityMemoryService::new(MemoryDal::new(event_log.pool().clone()));
 
     let state = PlannerState {
         policy_client,
@@ -66,6 +69,7 @@ async fn policy_denial_is_logged_and_sanitized() {
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
         wallet_client,
         profiles,
+        capability_memory,
     };
 
     let request = sample_request();

--- a/services/planner/tests/wallet_integration.rs
+++ b/services/planner/tests/wallet_integration.rs
@@ -11,8 +11,9 @@ use serde_json::json;
 use sqlx::Row;
 use tower::ServiceExt;
 use tyrum_discovery::DefaultDiscoveryPipeline;
+use tyrum_memory::MemoryDal;
 use tyrum_planner::{
-    ActionPrimitiveKind, EventLog, PlanOutcome, PlanRequest, ProfileStore,
+    ActionPrimitiveKind, CapabilityMemoryService, EventLog, PlanOutcome, PlanRequest, ProfileStore,
     http::{PlannerState, build_router},
 };
 use tyrum_shared::{
@@ -114,6 +115,7 @@ async fn planner_state() -> (
     let event_log = EventLog::from_pool(postgres.pool().clone());
     event_log.migrate().await.expect("migrate planner schema");
     let profiles = ProfileStore::new(event_log.pool().clone());
+    let capability_memory = CapabilityMemoryService::new(MemoryDal::new(event_log.pool().clone()));
 
     let state = PlannerState {
         policy_client,
@@ -121,6 +123,7 @@ async fn planner_state() -> (
         discovery: Arc::new(DefaultDiscoveryPipeline::new()),
         wallet_client,
         profiles,
+        capability_memory,
     };
 
     (state, policy_server, wallet_server, postgres)


### PR DESCRIPTION
## Summary
- add a capability memory service that hydrates mutating planner primitives before execution and merges stored selectors
- emit planner.capability_memory.lookup telemetry spans capturing lookup outcomes and latency
- extend integration tests and documentation to cover capability memory hit/miss behaviour

## Testing
- cargo test --package tyrum-planner --tests
- pre-commit run --all-files

Closes #180

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `CapabilityMemoryService` to hydrate mutating primitives from stored capability memory, emits `planner.capability_memory.lookup` telemetry, and wires it into the planner HTTP flow with accompanying tests and docs.
> 
> - **Planner service**:
>   - Introduce `CapabilityMemoryService` (`services/planner/src/capability_memory.rs`) to hydrate mutating `ActionPrimitive`s using `tyrum_memory::MemoryDal`.
>   - On policy approve, before execution, call `capability_memory.hydrate_primitives` for successful outcomes in `plan`.
>   - Emit `planner.capability_memory.lookup` spans with `subject_id`, `capability_identifier`, `executor_kind`, `hit`, `latency_ms`.
>   - Merge stored `selectors` into `selector_hints` (non-overwriting) and attach `capability_memory` payload on hits.
> - **Integration**:
>   - Wire service into `PlannerState` and HTTP server bootstrap (`services/planner/src/bin/http_server.rs`, `services/planner/src/http.rs`).
>   - Expose service via `lib.rs` re-exports; make `event_log` helpers `capability_type_label` and `derive_capability_identifier` `pub(crate)`.
> - **Tests**:
>   - Add hydration hit/miss tests with span recording (`services/planner/tests/capability_memory.rs`).
>   - Update HTTP, plan audit, policy denial, and wallet integration tests to construct `PlannerState` with `CapabilityMemoryService`.
> - **Docs**:
>   - Document capability memory hydration behavior and telemetry in `docs/planner_event_log.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b28cbc2532279f89e6ea198bc4895150e9b8a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->