### PR TITLE
Add semantic retries to executors (#183)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,6 +4517,7 @@ dependencies = [
  "playwright",
  "serde",
  "serde_json",
+ "strsim 0.11.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/docs/executors/http_executor.md
+++ b/docs/executors/http_executor.md
@@ -23,6 +23,20 @@ and the parsed JSON payload. Non-success status codes are reported via the
 `HttpFailure` error variant while still exposing the sanitised headers and body
 for downstream observability.
 
+## Retry Semantics
+
+- Idempotent methods (`GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`) are retried
+  when upstreams return transient failures (`429`, `5xx`) or when `reqwest`
+  surfaces connection/timeout errors. The policy performs up to three attempts
+  with exponential backoff (200 ms → 400 ms → 800 ms, capped at 2 s).
+- Each retry emits `executor_http.retry` telemetry with the attempt number,
+  failure classification, and (when applicable) the response status. Structured
+  logs with the same target help populate reliability dashboards.
+- After the retry budget is exhausted, the executor returns a
+  `RetriesExhausted` error. The payload includes the attempt count, the
+  per-attempt history (`HttpRetryRecord`), and the final upstream error so the
+  planner can stash the outcome or escalate.
+
 ## Sandbox & Outbound Policy
 
 The executor runs in a Debian-based container listening on

--- a/docs/executors/web_executor.md
+++ b/docs/executors/web_executor.md
@@ -39,5 +39,21 @@ Returned outcomes include the final URL, document title, sanitised DOM excerpt
 and a field summary so postconditions can assert behaviour without leaking form
 data.
 
+## Drift Handling & Retries
+
+- The executor resolves selectors semantically before each attempt. When a
+  referenced element is missing, it derives alternative selectors by
+  normalising CSS attributes (e.g. `data-testid`, `name`, `aria-label`) and
+  comparing them with the planner payload. Suggestions are tried sequentially
+  with exponential backoff (200 ms → 400 ms → 800 ms, capped at three
+  attempts).
+- Each retry emits `executor_web.retry` telemetry with the attempt number and
+  remaining selector candidates. Structured log events (`executor_web.retry`)
+  capture the same context for audit dashboards.
+- If all candidates are exhausted the executor surfaces a
+  `SelectorsExhausted` error containing the retry count and the selectors that
+  were attempted, allowing the planner to persist the drift in capability
+  memory.
+
 See `services/executor_web/src/lib.rs` for the executor entrypoint and
 `infra/docker-compose.yml` to boot the container as part of the local stack.

--- a/services/executor_http/src/lib.rs
+++ b/services/executor_http/src/lib.rs
@@ -11,6 +11,7 @@ use reqwest::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
+use tokio::time::sleep;
 use tracing::{info, warn};
 use tyrum_shared::planner::{ActionArguments, ActionPrimitive, ActionPrimitiveKind};
 use tyrum_shared::{
@@ -26,6 +27,10 @@ const REQUEST_TIMEOUT_SECS: u64 = 15;
 const POOL_IDLE_TIMEOUT_SECS: u64 = 30;
 const ALLOWED_HOSTS_ENV: &str = "HTTP_EXECUTOR_ALLOWED_HOSTS";
 const DEFAULT_ALLOWED_HOSTS: &[&str] = &["localhost", "127.0.0.1", "::1"];
+const MAX_ATTEMPTS: u32 = 3;
+const INITIAL_BACKOFF_MS: u64 = 200;
+const MAX_BACKOFF_MS: u64 = 2_000;
+const BACKOFF_MULTIPLIER: u32 = 2;
 // TODO: add per-host rate limiting once outbound allowlists include remote APIs.
 
 static HTTP_CLIENT: OnceCell<Client> = OnceCell::new();
@@ -46,6 +51,28 @@ pub struct HttpActionOutcome {
     /// Structured postcondition report when assertions were evaluated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub postcondition: Option<PostconditionReport>,
+}
+
+/// Describes the outcome of a retry attempt for observability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpRetryRecord {
+    /// Attempt number recorded (1-indexed).
+    pub attempt: u32,
+    /// Classification of the failure encountered.
+    pub outcome: HttpRetryOutcome,
+}
+
+/// Classification for retry outcomes to aid downstream logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpRetryOutcome {
+    /// Upstream responded with a specific status code.
+    Status(u16),
+    /// Request timed out.
+    Timeout,
+    /// Connection-level failure (DNS, TLS, etc.).
+    Connect,
+    /// Other request-layer failure (message included).
+    Other(String),
 }
 
 /// Sandbox constraints surfaced via the HTTP executor HTTP API.
@@ -170,6 +197,17 @@ pub enum HttpExecutorError {
         /// Structured failure report surfaced to the planner.
         report: PostconditionReport,
     },
+    /// Retry budget exhausted while attempting to satisfy the request.
+    #[error("retry attempts exhausted after {attempts} attempts; last error: {last_error}")]
+    RetriesExhausted {
+        /// Number of attempts that were performed.
+        attempts: u32,
+        /// Snapshot of the retry history.
+        history: Vec<HttpRetryRecord>,
+        /// Final error raised by the upstream service.
+        #[source]
+        last_error: Box<HttpExecutorError>,
+    },
 }
 
 /// Executes the HTTP primitive and returns the validated JSON payload.
@@ -186,30 +224,57 @@ pub async fn execute_http_action(action: &ActionPrimitive) -> Result<HttpActionO
     let context = telemetry::AttemptContext::new(&method, &url);
     let request_headers_for_logging = sanitise_header_pairs(&header_entries);
     let client = http_client();
-    let method_for_request = method.clone();
-    let url_for_request = url.clone();
-    let body_for_request = body.clone();
-    let schema_for_request = schema.clone();
-    let header_map = build_header_map(&header_entries, body_for_request.as_ref());
+    let mut attempt = 1;
+    let mut backoff = Duration::from_millis(INITIAL_BACKOFF_MS);
+    let mut tracker = HttpRetryTracker::default();
 
-    let (result, elapsed) = telemetry::record_attempt(&context, async move {
-        perform_http_request(
-            client,
-            method_for_request,
-            url_for_request,
-            header_map,
-            body_for_request,
-            schema_for_request,
-        )
-        .await
-    })
-    .await;
+    loop {
+        let method_for_request = method.clone();
+        let url_for_request = url.clone();
+        let body_for_request = body.clone();
+        let schema_for_request = schema.clone();
+        let header_map = build_header_map(&header_entries, body_for_request.as_ref());
 
-    match result {
-        Ok(mut outcome) => match evaluate_action_postcondition(action, &outcome) {
-            Ok(Some(report)) => {
-                if report.passed {
-                    outcome.postcondition = Some(report);
+        let (result, elapsed) =
+            telemetry::record_attempt(&context, attempt, MAX_ATTEMPTS, async move {
+                perform_http_request(
+                    client,
+                    method_for_request,
+                    url_for_request,
+                    header_map,
+                    body_for_request,
+                    schema_for_request,
+                )
+                .await
+            })
+            .await;
+
+        match result {
+            Ok(mut outcome) => match evaluate_action_postcondition(action, &outcome) {
+                Ok(Some(report)) => {
+                    if report.passed {
+                        outcome.postcondition = Some(report);
+                        log_http_success(
+                            &method,
+                            &url,
+                            elapsed,
+                            &request_headers_for_logging,
+                            &outcome,
+                        );
+                        return Ok(outcome);
+                    } else {
+                        let err = HttpExecutorError::PostconditionFailed { report };
+                        log_http_failure(
+                            &method,
+                            &url,
+                            elapsed,
+                            &request_headers_for_logging,
+                            &err,
+                        );
+                        return Err(err);
+                    }
+                }
+                Ok(None) => {
                     log_http_success(
                         &method,
                         &url,
@@ -217,31 +282,35 @@ pub async fn execute_http_action(action: &ActionPrimitive) -> Result<HttpActionO
                         &request_headers_for_logging,
                         &outcome,
                     );
-                    Ok(outcome)
-                } else {
-                    let err = HttpExecutorError::PostconditionFailed { report };
-                    log_http_failure(&method, &url, elapsed, &request_headers_for_logging, &err);
-                    Err(err)
+                    return Ok(outcome);
                 }
-            }
-            Ok(None) => {
-                log_http_success(
-                    &method,
-                    &url,
-                    elapsed,
-                    &request_headers_for_logging,
-                    &outcome,
-                );
-                Ok(outcome)
-            }
+                Err(err) => {
+                    log_http_failure(&method, &url, elapsed, &request_headers_for_logging, &err);
+                    return Err(err);
+                }
+            },
             Err(err) => {
                 log_http_failure(&method, &url, elapsed, &request_headers_for_logging, &err);
-                Err(err)
+
+                if let Some(outcome) = classify_retry(&method, &err) {
+                    telemetry::record_retry_event(&context, attempt, &outcome);
+                    tracker.record(attempt, outcome);
+
+                    if attempt >= MAX_ATTEMPTS {
+                        return Err(HttpExecutorError::RetriesExhausted {
+                            attempts: attempt,
+                            history: tracker.into_history(),
+                            last_error: Box::new(err),
+                        });
+                    }
+
+                    sleep(backoff).await;
+                    attempt += 1;
+                    backoff = next_backoff(backoff);
+                } else {
+                    return Err(err);
+                }
             }
-        },
-        Err(err) => {
-            log_http_failure(&method, &url, elapsed, &request_headers_for_logging, &err);
-            Err(err)
         }
     }
 }
@@ -583,6 +652,58 @@ fn require_string(args: &ActionArguments, key: &'static str) -> Result<String> {
             reason: "expected string",
         }),
         None => Err(HttpExecutorError::MissingArgument(key)),
+    }
+}
+
+fn classify_retry(method: &Method, err: &HttpExecutorError) -> Option<HttpRetryOutcome> {
+    if !is_idempotent(method) {
+        return None;
+    }
+
+    match err {
+        HttpExecutorError::HttpFailure { status, .. } => {
+            if *status == 429 || (500..=599).contains(status) {
+                Some(HttpRetryOutcome::Status(*status))
+            } else {
+                None
+            }
+        }
+        HttpExecutorError::Request(inner) if inner.is_timeout() => Some(HttpRetryOutcome::Timeout),
+        HttpExecutorError::Request(inner) if inner.is_connect() => Some(HttpRetryOutcome::Connect),
+        HttpExecutorError::Request(inner) if inner.is_request() => {
+            Some(HttpRetryOutcome::Other(inner.to_string()))
+        }
+        _ => None,
+    }
+}
+
+fn is_idempotent(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::DELETE | Method::PUT | Method::OPTIONS
+    )
+}
+
+fn next_backoff(current: Duration) -> Duration {
+    let multiplied = current
+        .as_millis()
+        .saturating_mul(BACKOFF_MULTIPLIER as u128)
+        .min(MAX_BACKOFF_MS as u128);
+    Duration::from_millis(multiplied as u64)
+}
+
+#[derive(Default)]
+struct HttpRetryTracker {
+    history: Vec<HttpRetryRecord>,
+}
+
+impl HttpRetryTracker {
+    fn record(&mut self, attempt: u32, outcome: HttpRetryOutcome) {
+        self.history.push(HttpRetryRecord { attempt, outcome });
+    }
+
+    fn into_history(self) -> Vec<HttpRetryRecord> {
+        self.history
     }
 }
 

--- a/services/executor_http/src/telemetry.rs
+++ b/services/executor_http/src/telemetry.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::HttpRetryOutcome;
 use once_cell::sync::OnceCell;
 use opentelemetry::{
     KeyValue, global,
@@ -28,6 +29,7 @@ const EXPORT_TIMEOUT_SECS: u64 = 5;
 const METER_NAME: &str = "tyrum-executor-http";
 const DURATION_METRIC_NAME: &str = "tyrum_executor_http_attempt_duration_seconds";
 const COUNT_METRIC_NAME: &str = "tyrum_executor_http_attempt_total";
+const RETRY_COUNT_METRIC_NAME: &str = "executor_http.retry";
 
 #[derive(Clone, Debug)]
 pub struct AttemptContext {
@@ -54,6 +56,8 @@ impl AttemptContext {
 
 pub async fn record_attempt<Fut, T, E>(
     context: &AttemptContext,
+    attempt: u32,
+    max_attempts: u32,
     future: Fut,
 ) -> (Result<T, E>, Duration)
 where
@@ -64,6 +68,8 @@ where
         "executor.http.attempt",
         target_host = context.host(),
         method = context.method(),
+        attempt,
+        max_attempts,
         outcome = field::Empty,
         error = field::Empty,
         duration_ms = field::Empty,
@@ -82,7 +88,7 @@ where
         span.record("error", tracing::field::display(err));
     }
 
-    record_metrics(context, outcome, elapsed);
+    record_metrics(context, attempt, outcome, elapsed);
 
     (result, elapsed)
 }
@@ -100,18 +106,63 @@ struct MetricsCache {
 
 static METRICS: OnceCell<Mutex<MetricsCache>> = OnceCell::new();
 
-fn record_metrics(context: &AttemptContext, outcome: &str, duration: Duration) {
+#[derive(Clone)]
+struct RetryInstruments {
+    count: Counter<u64>,
+}
+
+static RETRIES: OnceCell<Mutex<Option<RetryInstruments>>> = OnceCell::new();
+
+fn record_metrics(context: &AttemptContext, attempt: u32, outcome: &str, duration: Duration) {
     let instruments = metrics_instruments();
     let attributes = [
         KeyValue::new("executor.http.host", context.host().to_string()),
         KeyValue::new("executor.http.method", context.method().to_string()),
         KeyValue::new("executor.http.outcome", outcome.to_string()),
+        KeyValue::new("executor.http.attempt_number", attempt as i64),
     ];
 
     instruments
         .duration
         .record(duration.as_secs_f64(), &attributes);
     instruments.count.add(1, &attributes);
+}
+
+pub fn record_retry_event(context: &AttemptContext, attempt: u32, outcome: &HttpRetryOutcome) {
+    let instruments = retry_instruments();
+
+    let mut attributes = vec![
+        KeyValue::new("executor.http.host", context.host().to_string()),
+        KeyValue::new("executor.http.method", context.method().to_string()),
+        KeyValue::new("executor.http.attempt_number", attempt as i64),
+    ];
+
+    let (kind, status, reason) = retry_outcome_details(outcome);
+    if let Some(code) = status {
+        attributes.push(KeyValue::new("executor.http.retry_status", code as i64));
+    }
+    attributes.push(KeyValue::new("executor.http.retry_kind", kind.to_string()));
+    instruments.count.add(1, &attributes);
+
+    tracing::info!(
+        target: "executor_http.retry",
+        attempt,
+        method = context.method(),
+        host = context.host(),
+        "retry scheduled kind={} status={:?} reason={:?}",
+        kind,
+        status,
+        reason
+    );
+}
+
+fn retry_outcome_details(outcome: &HttpRetryOutcome) -> (&'static str, Option<u16>, Option<&str>) {
+    match outcome {
+        HttpRetryOutcome::Status(code) => ("status", Some(*code), None),
+        HttpRetryOutcome::Timeout => ("timeout", None, None),
+        HttpRetryOutcome::Connect => ("connect", None, None),
+        HttpRetryOutcome::Other(message) => ("other", None, Some(message.as_str())),
+    }
 }
 
 fn metrics_instruments() -> MetricsInstruments {
@@ -143,6 +194,34 @@ fn metrics_instruments() -> MetricsInstruments {
     };
 
     guard.instruments = Some(instruments.clone());
+
+    instruments
+}
+
+fn retry_instruments() -> RetryInstruments {
+    let provider = global::meter_provider();
+    let cache = RETRIES.get_or_init(|| Mutex::new(None));
+    let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("retry metrics cache lock poisoned; continuing");
+            poisoned.into_inner()
+        }
+    };
+
+    if let Some(instruments) = &*guard {
+        return instruments.clone();
+    }
+
+    let meter = provider.meter(METER_NAME);
+    let instruments = RetryInstruments {
+        count: meter
+            .u64_counter(RETRY_COUNT_METRIC_NAME)
+            .with_description("HTTP executor retries scheduled")
+            .build(),
+    };
+
+    *guard = Some(instruments.clone());
 
     instruments
 }

--- a/services/executor_http/tests/http_executor.rs
+++ b/services/executor_http/tests/http_executor.rs
@@ -1,17 +1,26 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
-use std::net::SocketAddr;
+use std::{
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use anyhow::Context;
 use axum::{
     Json, Router,
+    extract::State,
     http::{HeaderName, HeaderValue, StatusCode},
     routing::{get, post},
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::task::JoinHandle;
-use tyrum_executor_http::{HttpActionOutcome, HttpExecutorError, execute_http_action};
+use tyrum_executor_http::{
+    HttpActionOutcome, HttpExecutorError, HttpRetryOutcome, execute_http_action,
+};
 use tyrum_shared::planner::{ActionArguments, ActionPrimitive, ActionPrimitiveKind};
 use tyrum_shared::{AssertionFailureCode, AssertionOutcome};
 
@@ -21,9 +30,24 @@ struct EchoPayload {
     count: u32,
 }
 
+#[derive(Clone)]
+struct FixtureState {
+    flaky_attempts: Arc<AtomicUsize>,
+    failure_attempts: Arc<AtomicUsize>,
+}
+
+impl FixtureState {
+    fn new() -> Self {
+        Self {
+            flaky_attempts: Arc::new(AtomicUsize::new(0)),
+            failure_attempts: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn post_request_with_schema_succeeds() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/echo");
 
     let schema = json!({
@@ -76,7 +100,7 @@ async fn post_request_with_schema_succeeds() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn postcondition_success_returns_report() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/echo");
 
     let primitive = ActionPrimitive::new(
@@ -116,7 +140,7 @@ async fn postcondition_success_returns_report() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn postcondition_failure_surfaces_report() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/echo");
 
     let primitive = ActionPrimitive::new(
@@ -165,7 +189,7 @@ async fn postcondition_failure_surfaces_report() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unsupported_postcondition_returns_error() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/echo");
 
     let primitive = ActionPrimitive::new(
@@ -203,7 +227,7 @@ async fn unsupported_postcondition_returns_error() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn schema_validation_failure_surfaces_error() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/echo");
 
     let primitive = ActionPrimitive::new(
@@ -244,7 +268,7 @@ async fn schema_validation_failure_surfaces_error() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn non_success_status_returns_failure_context() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/fail");
 
     let primitive = ActionPrimitive::new(
@@ -283,7 +307,7 @@ async fn non_success_status_returns_failure_context() -> anyhow::Result<()> {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn redirects_to_disallowed_host_are_not_followed() -> anyhow::Result<()> {
-    let (addr, server) = start_mock_server().await?;
+    let (addr, server, _) = start_mock_server().await?;
     let url = format!("http://{addr}/redirect");
 
     let primitive = ActionPrimitive::new(
@@ -318,6 +342,73 @@ async fn redirects_to_disallowed_host_are_not_followed() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn retry_transient_status_eventually_succeeds() -> anyhow::Result<()> {
+    let (addr, server, state) = start_mock_server().await?;
+    let url = format!("http://{addr}/flaky");
+
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Http,
+        into_args(json!({
+            "method": "GET",
+            "url": url
+        })),
+    );
+
+    let outcome = execute_http_action(&primitive).await?;
+    assert_eq!(outcome.status, StatusCode::OK.as_u16());
+    assert_eq!(outcome.body["ok"], json!(true));
+
+    assert_eq!(state.flaky_attempts.load(Ordering::SeqCst), 2);
+
+    server.abort();
+    let _ = server.await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn retry_exhaustion_reports_history() -> anyhow::Result<()> {
+    let (addr, server, _) = start_mock_server().await?;
+    let url = format!("http://{addr}/unstable");
+
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Http,
+        into_args(json!({
+            "method": "GET",
+            "url": url
+        })),
+    );
+
+    let err = execute_http_action(&primitive)
+        .await
+        .expect_err("persistent failures should exhaust retries");
+
+    match err {
+        HttpExecutorError::RetriesExhausted {
+            attempts,
+            history,
+            last_error,
+        } => {
+            assert!(attempts >= 3);
+            assert_eq!(history.len() as u32, attempts);
+            assert!(history.iter().all(|record| matches!(record.outcome, HttpRetryOutcome::Status(code) if code == StatusCode::SERVICE_UNAVAILABLE.as_u16())));
+            match *last_error {
+                HttpExecutorError::HttpFailure { status, .. } => {
+                    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE.as_u16());
+                }
+                other => panic!("unexpected last error variant: {:?}", other),
+            }
+        }
+        other => panic!("unexpected error variant: {:?}", other),
+    }
+
+    server.abort();
+    let _ = server.await;
+
+    Ok(())
+}
+
 fn into_args(value: Value) -> ActionArguments {
     value
         .as_object()
@@ -325,11 +416,15 @@ fn into_args(value: Value) -> ActionArguments {
         .clone()
 }
 
-async fn start_mock_server() -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
+async fn start_mock_server() -> anyhow::Result<(SocketAddr, JoinHandle<()>, FixtureState)> {
+    let state = FixtureState::new();
     let app = Router::new()
         .route("/echo", post(handle_echo))
         .route("/fail", get(handle_failure))
-        .route("/redirect", get(handle_redirect));
+        .route("/redirect", get(handle_redirect))
+        .route("/flaky", get(handle_flaky))
+        .route("/unstable", get(handle_persistent_failure))
+        .with_state(state.clone());
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
         .await
@@ -342,7 +437,7 @@ async fn start_mock_server() -> anyhow::Result<(SocketAddr, JoinHandle<()>)> {
         }
     });
 
-    Ok((addr, handle))
+    Ok((addr, handle, state))
 }
 
 async fn handle_echo(Json(payload): Json<EchoPayload>) -> impl axum::response::IntoResponse {
@@ -383,6 +478,40 @@ async fn handle_redirect() -> impl axum::response::IntoResponse {
         HeaderValue::from_static("http://example.com/blocked"),
     )];
     (StatusCode::TEMPORARY_REDIRECT, headers, Json(json!({})))
+}
+
+async fn handle_flaky(State(state): State<FixtureState>) -> impl axum::response::IntoResponse {
+    let attempt = state.flaky_attempts.fetch_add(1, Ordering::SeqCst);
+    if attempt == 0 {
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({
+                "ok": false,
+                "attempt": attempt + 1
+            })),
+        )
+    } else {
+        (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "attempt": attempt + 1
+            })),
+        )
+    }
+}
+
+async fn handle_persistent_failure(
+    State(state): State<FixtureState>,
+) -> impl axum::response::IntoResponse {
+    let attempt = state.failure_attempts.fetch_add(1, Ordering::SeqCst);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "ok": false,
+            "attempt": attempt + 1
+        })),
+    )
 }
 
 fn assert_redacted(outcome: &HttpActionOutcome) {

--- a/services/executor_web/Cargo.toml
+++ b/services/executor_web/Cargo.toml
@@ -32,6 +32,7 @@ tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
 tyrum-shared = { path = "../../shared/tyrum-shared" }
 url = { version = "2", features = ["serde"] }
+strsim = "0.11"
 
 [dev-dependencies]
 anyhow = "1"

--- a/services/executor_web/src/lib.rs
+++ b/services/executor_web/src/lib.rs
@@ -7,7 +7,11 @@
 //! primitives (form interactions, postcondition enforcement) will extend this
 //! surface in follow-up issues per the product concept (§15-16).
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
 
 use crate::telemetry::AttemptContext;
 use playwright::{
@@ -16,7 +20,7 @@ use playwright::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::time::sleep;
+use tokio::{sync::Mutex, time::sleep};
 use tyrum_shared::planner::{ActionPrimitive, ActionPrimitiveKind};
 use tyrum_shared::{
     AssertionKind, DomContext as PostconditionDomContext, EvaluationContext, PostconditionError,
@@ -24,6 +28,7 @@ use tyrum_shared::{
 };
 use url::Url;
 
+mod semantic;
 pub mod telemetry;
 
 const MAX_ATTEMPTS: u32 = 3;
@@ -146,10 +151,55 @@ pub enum WebExecutorError {
     /// Postcondition evaluation completed but an assertion failed.
     #[error("postcondition failed")]
     PostconditionFailed { report: PostconditionReport },
+    /// Selector lookup failed but semantic suggestions are available.
+    #[error("selector drift detected; retry scheduled: {details:?}")]
+    SelectorFallback {
+        /// Details about selectors that drifted during this attempt.
+        details: Vec<SelectorRetryDetail>,
+    },
+    /// Selector candidates exhausted across all retries.
+    #[error(
+        "selector resolution exhausted after {attempts} attempts; tried selectors: {attempted:?}"
+    )]
+    SelectorsExhausted {
+        /// Number of attempts that were performed.
+        attempts: u32,
+        /// Summary of selectors that were attempted.
+        attempted: Vec<SelectorAttemptSummary>,
+    },
     /// Test-only helper variant to simulate transient failures.
     #[cfg(test)]
     #[error("transient test failure: {0}")]
     TestTransient(&'static str),
+}
+
+/// Describes the role of a selector that required retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorRole {
+    /// Selector associated with a form field at the given index.
+    Field { index: usize },
+    /// Selector associated with the submission action.
+    Submit,
+}
+
+/// Structured retry detail for telemetry and planner logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectorRetryDetail {
+    /// Role of the selector (field or submit).
+    pub role: SelectorRole,
+    /// Selectors attempted during the failed attempt.
+    pub attempted: Vec<String>,
+    /// Additional selectors suggested for follow-up attempts.
+    pub suggestions: Vec<String>,
+}
+
+/// Summarises selectors attempted across all retries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectorAttemptSummary {
+    /// Role of the selector (field or submit).
+    pub role: SelectorRole,
+    /// Ordered list of selectors that were tried.
+    pub tried: Vec<String>,
 }
 
 /// Enumerates the browser engines supported by the executor.
@@ -180,21 +230,72 @@ pub enum BrowserFlavor {
 pub async fn execute_web_action(action: &ActionPrimitive) -> Result<WebActionOutcome> {
     ensure_web_primitive(action)?;
     let target = extract_url(action)?;
-    let options = parse_web_action_options(action)?;
+    let options = Arc::new(parse_web_action_options(action)?);
     let action_for_retry = action.clone();
     let telemetry_context = AttemptContext::from_url(&target);
+    let telemetry_for_retry = telemetry_context.clone();
+    let supervisor = Arc::new(Mutex::new(SemanticRetrySupervisor::new(&options)));
+    let supervisor_for_retry = supervisor.clone();
+    let target_for_retry = target.clone();
+    let action_context = Arc::new(action_for_retry);
 
-    execute_with_retry(&telemetry_context, move |_attempt| {
-        let target = target.clone();
+    let result = execute_with_retry(&telemetry_context, move |attempt| {
+        let target = target_for_retry.clone();
         let options = options.clone();
-        let action = action_for_retry.clone();
+        let action = action_context.clone();
+        let supervisor = supervisor_for_retry.clone();
+        let telemetry_context = telemetry_for_retry.clone();
         async move {
-            let mut outcome = run_single_attempt(target, options).await?;
-            evaluate_postcondition_report(&action, &mut outcome)?;
-            Ok(outcome)
+            let selectors = {
+                let mut guard = supervisor.lock().await;
+                guard.begin_attempt()?
+            };
+
+            let plan = selectors.into_plan(options.clone());
+            match run_single_attempt(target.clone(), plan).await {
+                Ok(mut outcome) => {
+                    evaluate_postcondition_report(&action, &mut outcome)?;
+                    Ok(outcome)
+                }
+                Err(WebExecutorError::SelectorFallback { details }) => {
+                    let mut guard = supervisor.lock().await;
+                    let new_candidates = guard.register_fallback(&details);
+                    let exhausted = guard.is_exhausted();
+                    let attempts = guard.attempts();
+                    let history = guard.history();
+                    drop(guard);
+
+                    if exhausted {
+                        return Err(WebExecutorError::SelectorsExhausted {
+                            attempts,
+                            attempted: history,
+                        });
+                    }
+
+                    telemetry::record_retry_event(
+                        &telemetry_context,
+                        attempt,
+                        new_candidates as u32,
+                    );
+                    Err(WebExecutorError::SelectorFallback { details })
+                }
+                Err(err) => Err(err),
+            }
         }
     })
-    .await
+    .await;
+
+    match result {
+        Ok(outcome) => Ok(outcome),
+        Err(WebExecutorError::SelectorFallback { .. }) => {
+            let guard = supervisor.lock().await;
+            Err(WebExecutorError::SelectorsExhausted {
+                attempts: guard.attempts(),
+                attempted: guard.history(),
+            })
+        }
+        Err(err) => Err(err),
+    }
 }
 
 #[allow(clippy::cognitive_complexity)]
@@ -250,7 +351,9 @@ fn next_backoff(current: Duration) -> Duration {
 fn is_transient(err: &WebExecutorError) -> bool {
     matches!(
         err,
-        WebExecutorError::Playwright(_) | WebExecutorError::PlaywrightDriver(_)
+        WebExecutorError::Playwright(_)
+            | WebExecutorError::PlaywrightDriver(_)
+            | WebExecutorError::SelectorFallback { .. }
     ) || {
         #[cfg(test)]
         {
@@ -264,7 +367,7 @@ fn is_transient(err: &WebExecutorError) -> bool {
 }
 
 #[allow(clippy::cognitive_complexity)]
-async fn run_single_attempt(target: Url, options: WebActionOptions) -> Result<WebActionOutcome> {
+async fn run_single_attempt(target: Url, plan: ResolvedActionPlan) -> Result<WebActionOutcome> {
     let playwright = match Playwright::initialize().await {
         Ok(driver) => driver,
         Err(err) => {
@@ -278,18 +381,21 @@ async fn run_single_attempt(target: Url, options: WebActionOptions) -> Result<We
 
     page.goto_builder(target.as_str()).goto().await?;
 
-    let auto_redacted = identify_sensitive_fields(&page, &options.fields).await?;
+    ensure_selectors_present(&page, &plan).await?;
 
-    fill_fields(&page, &options.fields).await?;
-    if let Some(submit) = options.submit.as_ref() {
+    let auto_redacted = identify_sensitive_fields(&page, &plan.fields).await?;
+
+    fill_fields(&page, &plan.fields).await?;
+    if let Some(submit) = plan.submit.as_ref() {
         submit_form(&page, submit).await?;
         wait_for_post_submit(&page, submit).await?;
     }
 
     let title = page.title().await?;
     let current_url: String = page.eval("() => window.location.href").await?;
-    let dom_excerpt = capture_dom_excerpt(&page, &options).await?;
-    let submitted_fields = summarize_fields(&options.fields, &auto_redacted);
+    let dom_excerpt =
+        capture_dom_excerpt(&page, plan.snapshot_selector.as_deref(), &plan.fields).await?;
+    let submitted_fields = summarize_fields(&plan.fields, &auto_redacted);
 
     let _ = page.close(None).await;
     let _ = context.close().await;
@@ -350,6 +456,74 @@ fn evaluate_postcondition_report(
 /// Returns static sandbox properties enforced by the container runtime.
 pub fn sandbox_constraints() -> WebSandboxConstraints {
     WebSandboxConstraints::default()
+}
+
+async fn ensure_selectors_present(page: &Page, plan: &ResolvedActionPlan) -> Result<()> {
+    let mut details = Vec::new();
+
+    for field in &plan.fields {
+        match selector_exists(page, &field.selector).await? {
+            SelectorPresence::Present => {}
+            SelectorPresence::Missing => {
+                let suggestions = semantic::suggest_field_selectors(
+                    page,
+                    &field.original_selector,
+                    &field.selector,
+                )
+                .await?;
+                details.push(SelectorRetryDetail {
+                    role: SelectorRole::Field { index: field.index },
+                    attempted: vec![field.selector.clone()],
+                    suggestions,
+                });
+            }
+        }
+    }
+
+    if let Some(submit) = plan.submit.as_ref() {
+        match selector_exists(page, &submit.selector).await? {
+            SelectorPresence::Present => {}
+            SelectorPresence::Missing => {
+                let suggestions = semantic::suggest_submit_selectors(
+                    page,
+                    &submit.original_selector,
+                    &submit.selector,
+                )
+                .await?;
+                details.push(SelectorRetryDetail {
+                    role: SelectorRole::Submit,
+                    attempted: vec![submit.selector.clone()],
+                    suggestions,
+                });
+            }
+        }
+    }
+
+    if details.is_empty() {
+        Ok(())
+    } else {
+        Err(WebExecutorError::SelectorFallback { details })
+    }
+}
+
+enum SelectorPresence {
+    Present,
+    Missing,
+}
+
+async fn selector_exists(page: &Page, selector: &str) -> Result<SelectorPresence> {
+    match page.query_selector(selector).await {
+        Ok(Some(_)) => Ok(SelectorPresence::Present),
+        Ok(None) => Ok(SelectorPresence::Missing),
+        Err(err) => {
+            tracing::debug!(
+                selector,
+                error = %err,
+                "selector query returned error; treating as missing"
+            );
+            Ok(SelectorPresence::Missing)
+        }
+    }
 }
 
 fn ensure_web_primitive(action: &ActionPrimitive) -> Result<()> {
@@ -450,6 +624,253 @@ impl Default for SubmitActionKind {
     }
 }
 
+#[derive(Debug, Clone)]
+struct ResolvedFieldSpec {
+    index: usize,
+    selector: String,
+    original_selector: String,
+    value: String,
+    redact: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedSubmitSpec {
+    selector: String,
+    original_selector: String,
+    kind: SubmitActionKind,
+    wait_after_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedActionPlan {
+    fields: Vec<ResolvedFieldSpec>,
+    submit: Option<ResolvedSubmitSpec>,
+    snapshot_selector: Option<String>,
+}
+
+#[derive(Debug)]
+struct SemanticRetrySupervisor {
+    fields: Vec<SelectorState>,
+    submit: Option<SelectorState>,
+    attempts: u32,
+}
+
+#[derive(Debug)]
+struct SelectorState {
+    queue: VecDeque<String>,
+    attempted: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct AttemptSelectors {
+    field_selectors: Vec<String>,
+    submit_selector: Option<String>,
+}
+
+impl AttemptSelectors {
+    fn into_plan(self, options: Arc<WebActionOptions>) -> ResolvedActionPlan {
+        let fields = options
+            .fields
+            .iter()
+            .enumerate()
+            .zip(self.field_selectors)
+            .map(|((index, spec), selector)| ResolvedFieldSpec {
+                index,
+                original_selector: spec.selector.clone(),
+                selector,
+                value: spec.value.clone(),
+                redact: spec.redact,
+            })
+            .collect::<Vec<_>>();
+
+        let submit = match (options.submit.as_ref(), self.submit_selector) {
+            (Some(spec), Some(selector)) => Some(ResolvedSubmitSpec {
+                original_selector: spec.selector.clone(),
+                selector,
+                kind: spec.kind,
+                wait_after_ms: spec.wait_after_ms,
+            }),
+            _ => None,
+        };
+
+        ResolvedActionPlan {
+            fields,
+            submit,
+            snapshot_selector: options.snapshot_selector.clone(),
+        }
+    }
+}
+
+impl SemanticRetrySupervisor {
+    fn new(options: &WebActionOptions) -> Self {
+        let fields = options
+            .fields
+            .iter()
+            .map(|field| SelectorState::new(field.selector.clone()))
+            .collect();
+        let submit = options
+            .submit
+            .as_ref()
+            .map(|submit| SelectorState::new(submit.selector.clone()));
+
+        Self {
+            fields,
+            submit,
+            attempts: 0,
+        }
+    }
+
+    fn begin_attempt(&mut self) -> Result<AttemptSelectors> {
+        if self.is_exhausted() {
+            return Err(WebExecutorError::SelectorsExhausted {
+                attempts: self.attempts,
+                attempted: self.history(),
+            });
+        }
+
+        self.attempts += 1;
+
+        let field_selectors = self
+            .fields
+            .iter()
+            .map(|state| {
+                state
+                    .current()
+                    .cloned()
+                    .ok_or_else(|| WebExecutorError::SelectorsExhausted {
+                        attempts: self.attempts,
+                        attempted: self.history(),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let submit_selector = match self.submit.as_ref() {
+            Some(state) => Some(state.current().cloned().ok_or_else(|| {
+                WebExecutorError::SelectorsExhausted {
+                    attempts: self.attempts,
+                    attempted: self.history(),
+                }
+            })?),
+            None => None,
+        };
+
+        Ok(AttemptSelectors {
+            field_selectors,
+            submit_selector,
+        })
+    }
+
+    fn register_fallback(&mut self, details: &[SelectorRetryDetail]) -> usize {
+        let mut total_pending = 0;
+
+        for detail in details {
+            match detail.role {
+                SelectorRole::Field { index } => {
+                    if let Some(state) = self.fields.get_mut(index) {
+                        state.advance();
+                        state.record_attempted(&detail.attempted);
+                        state.push_suggestions(&detail.suggestions);
+                        total_pending += state.pending_len();
+                    }
+                }
+                SelectorRole::Submit => {
+                    if let Some(state) = self.submit.as_mut() {
+                        state.advance();
+                        state.record_attempted(&detail.attempted);
+                        state.push_suggestions(&detail.suggestions);
+                        total_pending += state.pending_len();
+                    }
+                }
+            }
+        }
+
+        total_pending
+    }
+
+    fn attempts(&self) -> u32 {
+        self.attempts
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.fields.iter().any(SelectorState::exhausted)
+            || self.submit.as_ref().is_some_and(SelectorState::exhausted)
+    }
+
+    fn history(&self) -> Vec<SelectorAttemptSummary> {
+        let mut summaries = Vec::with_capacity(self.fields.len() + 1);
+
+        for (index, state) in self.fields.iter().enumerate() {
+            summaries.push(SelectorAttemptSummary {
+                role: SelectorRole::Field { index },
+                tried: state.attempted.clone(),
+            });
+        }
+
+        if let Some(state) = self.submit.as_ref() {
+            summaries.push(SelectorAttemptSummary {
+                role: SelectorRole::Submit,
+                tried: state.attempted.clone(),
+            });
+        }
+
+        summaries
+    }
+}
+
+impl SelectorState {
+    fn new(initial: String) -> Self {
+        let mut queue = VecDeque::new();
+        queue.push_back(initial);
+        Self {
+            queue,
+            attempted: Vec::new(),
+        }
+    }
+
+    fn current(&self) -> Option<&String> {
+        self.queue.front()
+    }
+
+    fn advance(&mut self) {
+        if let Some(front) = self.queue.pop_front() {
+            self.attempted.push(front);
+        }
+    }
+
+    fn push_suggestions(&mut self, suggestions: &[String]) -> usize {
+        let mut added = 0;
+        for suggestion in suggestions {
+            if self.contains(suggestion) {
+                continue;
+            }
+            self.queue.push_back(suggestion.clone());
+            added += 1;
+        }
+        added
+    }
+
+    fn contains(&self, candidate: &str) -> bool {
+        self.queue.iter().any(|value| value == candidate)
+            || self.attempted.iter().any(|value| value == candidate)
+    }
+
+    fn record_attempted(&mut self, attempted: &[String]) {
+        for selector in attempted {
+            if !self.attempted.iter().any(|value| value == selector) {
+                self.attempted.push(selector.clone());
+            }
+        }
+    }
+
+    fn exhausted(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    fn pending_len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
 fn parse_web_action_options(action: &ActionPrimitive) -> Result<WebActionOptions> {
     let fields = action
         .args
@@ -503,7 +924,7 @@ fn parse_web_action_options(action: &ActionPrimitive) -> Result<WebActionOptions
     })
 }
 
-async fn fill_fields(page: &Page, fields: &[FormFieldSpec]) -> Result<()> {
+async fn fill_fields(page: &Page, fields: &[ResolvedFieldSpec]) -> Result<()> {
     for field in fields {
         page.fill_builder(&field.selector, &field.value)
             .fill()
@@ -517,7 +938,7 @@ fn parse_selector_argument(value: &serde_json::Value, argument: &'static str) ->
         .map_err(|source| WebExecutorError::InvalidArgument { argument, source })
 }
 
-async fn submit_form(page: &Page, submit: &SubmitActionSpec) -> Result<()> {
+async fn submit_form(page: &Page, submit: &ResolvedSubmitSpec) -> Result<()> {
     match submit.kind {
         SubmitActionKind::Click => {
             page.click_builder(&submit.selector).click().await?;
@@ -552,7 +973,7 @@ async fn submit_form(page: &Page, submit: &SubmitActionSpec) -> Result<()> {
     Ok(())
 }
 
-async fn wait_for_post_submit(page: &Page, submit: &SubmitActionSpec) -> Result<()> {
+async fn wait_for_post_submit(page: &Page, submit: &ResolvedSubmitSpec) -> Result<()> {
     let _ = page
         .wait_for_function_builder("() => document.readyState === 'complete'")
         .wait_for_function()
@@ -565,10 +986,14 @@ async fn wait_for_post_submit(page: &Page, submit: &SubmitActionSpec) -> Result<
     Ok(())
 }
 
-async fn capture_dom_excerpt(page: &Page, options: &WebActionOptions) -> Result<DomExcerpt> {
-    let mut selector = options.snapshot_selector.as_deref().unwrap_or("body");
+async fn capture_dom_excerpt(
+    page: &Page,
+    selector: Option<&str>,
+    fields: &[ResolvedFieldSpec],
+) -> Result<DomExcerpt> {
+    let mut selector = selector.unwrap_or("body");
 
-    let redacted_selectors = redact_selectors(options);
+    let redacted_selectors = redact_selectors(fields);
     let mut html = snapshot_with_selector(page, selector, redacted_selectors.clone()).await;
 
     if selector != "body"
@@ -594,9 +1019,8 @@ async fn capture_dom_excerpt(page: &Page, options: &WebActionOptions) -> Result<
     })
 }
 
-fn redact_selectors(options: &WebActionOptions) -> Vec<String> {
-    options
-        .fields
+fn redact_selectors(fields: &[ResolvedFieldSpec]) -> Vec<String> {
+    fields
         .iter()
         .filter(|field| field.redact)
         .map(|field| field.selector.clone())
@@ -673,7 +1097,7 @@ async fn snapshot_with_selector(
 }
 
 fn summarize_fields(
-    fields: &[FormFieldSpec],
+    fields: &[ResolvedFieldSpec],
     auto_redacted: &HashSet<String>,
 ) -> Vec<SubmittedFieldSummary> {
     fields
@@ -692,7 +1116,7 @@ fn summarize_fields(
 
 async fn identify_sensitive_fields(
     page: &Page,
-    fields: &[FormFieldSpec],
+    fields: &[ResolvedFieldSpec],
 ) -> Result<HashSet<String>> {
     if fields.is_empty() {
         return Ok(HashSet::new());

--- a/services/executor_web/src/semantic.rs
+++ b/services/executor_web/src/semantic.rs
@@ -1,0 +1,291 @@
+use std::{cmp::Ordering, collections::HashSet};
+
+use playwright::api::page::Page;
+use serde::Deserialize;
+use strsim::jaro_winkler;
+
+use crate::{Result, WebExecutorError};
+
+const SIMILARITY_THRESHOLD: f64 = 0.82;
+const MAX_SUGGESTIONS: usize = 5;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FieldProbe {
+    tag: String,
+    id: Option<String>,
+    name: Option<String>,
+    placeholder: Option<String>,
+    aria_label: Option<String>,
+    data_testid: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitProbe {
+    tag: String,
+    id: Option<String>,
+    name: Option<String>,
+    aria_label: Option<String>,
+    data_testid: Option<String>,
+    type_attr: Option<String>,
+}
+
+pub async fn suggest_field_selectors(
+    page: &Page,
+    original_selector: &str,
+    attempted_selector: &str,
+) -> Result<Vec<String>> {
+    let probes: Vec<FieldProbe> = page
+        .evaluate(
+            "(() => {
+                return Array.from(document.querySelectorAll('input, textarea, select')).map((element) => ({
+                    tag: element.tagName.toLowerCase(),
+                    id: element.id || null,
+                    name: element.getAttribute('name') || null,
+                    placeholder: element.getAttribute('placeholder') || null,
+                    ariaLabel: element.getAttribute('aria-label') || null,
+                    dataTestid: element.getAttribute('data-testid') || null
+                }));
+            })",
+            Option::<()>::None,
+        )
+        .await
+        .map_err(WebExecutorError::from)?;
+
+    build_suggestions(
+        original_selector,
+        attempted_selector,
+        probes.iter().flat_map(|probe| {
+            let hints = selector_hints(original_selector);
+            let mut entries = Vec::new();
+
+            if let Some(id) = probe.id.as_ref() {
+                push_candidate(&mut entries, &probe.tag, "id", id, &hints, true);
+            }
+            if let Some(name) = probe.name.as_ref() {
+                push_candidate(&mut entries, &probe.tag, "name", name, &hints, true);
+            }
+            if let Some(data_testid) = probe.data_testid.as_ref() {
+                push_candidate(
+                    &mut entries,
+                    &probe.tag,
+                    "data-testid",
+                    data_testid,
+                    &hints,
+                    true,
+                );
+            }
+            if let Some(aria_label) = probe.aria_label.as_ref() {
+                push_candidate(
+                    &mut entries,
+                    &probe.tag,
+                    "aria-label",
+                    aria_label,
+                    &hints,
+                    true,
+                );
+            }
+            if let Some(placeholder) = probe.placeholder.as_ref() {
+                push_candidate(
+                    &mut entries,
+                    &probe.tag,
+                    "placeholder",
+                    placeholder,
+                    &hints,
+                    false,
+                );
+            }
+
+            entries
+        }),
+    )
+}
+
+pub async fn suggest_submit_selectors(
+    page: &Page,
+    original_selector: &str,
+    attempted_selector: &str,
+) -> Result<Vec<String>> {
+    let probes: Vec<SubmitProbe> = page
+        .evaluate(
+            "(() => {
+                const candidates = new Set();
+                const query = [
+                    'button',
+                    'input[type=\"submit\"]',
+                    'input[type=\"button\"]',
+                    '[role=\"button\"]'
+                ];
+
+                return Array.from(document.querySelectorAll(query.join(','))).map((element) => ({
+                    tag: element.tagName.toLowerCase(),
+                    id: element.id || null,
+                    name: element.getAttribute('name') || null,
+                    ariaLabel: element.getAttribute('aria-label') || null,
+                    dataTestid: element.getAttribute('data-testid') || null,
+                    typeAttr: element.getAttribute('type') || null
+                }));
+            })",
+            Option::<()>::None,
+        )
+        .await
+        .map_err(WebExecutorError::from)?;
+
+    build_suggestions(
+        original_selector,
+        attempted_selector,
+        probes.iter().flat_map(|probe| {
+            let hints = selector_hints(original_selector);
+            let mut entries = Vec::new();
+
+            if let Some(id) = probe.id.as_ref() {
+                push_candidate(&mut entries, &probe.tag, "id", id, &hints, true);
+            }
+            if let Some(name) = probe.name.as_ref() {
+                push_candidate(&mut entries, &probe.tag, "name", name, &hints, true);
+            }
+            if let Some(data_testid) = probe.data_testid.as_ref() {
+                push_candidate(
+                    &mut entries,
+                    &probe.tag,
+                    "data-testid",
+                    data_testid,
+                    &hints,
+                    true,
+                );
+            }
+            if let Some(aria_label) = probe.aria_label.as_ref() {
+                push_candidate(
+                    &mut entries,
+                    &probe.tag,
+                    "aria-label",
+                    aria_label,
+                    &hints,
+                    true,
+                );
+            }
+            if probe
+                .type_attr
+                .as_ref()
+                .is_some_and(|value| value.eq_ignore_ascii_case("submit"))
+            {
+                entries.push((0.99, format!("{}[type=\"submit\"]", probe.tag)));
+            }
+
+            entries
+        }),
+    )
+}
+
+fn build_suggestions<I>(
+    original_selector: &str,
+    attempted_selector: &str,
+    candidates: I,
+) -> Result<Vec<String>>
+where
+    I: IntoIterator<Item = (f64, String)>,
+{
+    let mut seen = HashSet::new();
+    seen.insert(attempted_selector.to_string());
+
+    let mut scored: Vec<(f64, String)> = candidates
+        .into_iter()
+        .filter(|(score, selector)| *score >= SIMILARITY_THRESHOLD && seen.insert(selector.clone()))
+        .collect();
+
+    scored.sort_by(|a, b| match b.0.partial_cmp(&a.0) {
+        Some(order) => order,
+        None => Ordering::Equal,
+    });
+
+    let mut suggestions = scored
+        .into_iter()
+        .map(|(_, selector)| selector)
+        .take(MAX_SUGGESTIONS)
+        .collect::<Vec<_>>();
+
+    if let Some(normalized) = normalized_selector(original_selector)
+        && normalized != attempted_selector
+        && !suggestions.iter().any(|item| item == &normalized)
+    {
+        suggestions.insert(0, normalized);
+    }
+
+    Ok(suggestions)
+}
+
+fn push_candidate(
+    entries: &mut Vec<(f64, String)>,
+    tag: &str,
+    attr: &str,
+    value: &str,
+    hints: &[String],
+    strict: bool,
+) {
+    let score = similarity(value, hints);
+    if score < SIMILARITY_THRESHOLD {
+        return;
+    }
+
+    let literal = escape_attr_value(value);
+    let strict_selector = format!("{tag}[{attr}=\"{literal}\"]");
+    entries.push((score, strict_selector.clone()));
+
+    if !strict {
+        entries.push((score * 0.9, format!("{tag}[{attr}*=\"{literal}\"]")));
+    }
+
+    entries.push((score * 0.85, format!("[{attr}=\"{literal}\"]")));
+}
+
+fn similarity(candidate: &str, hints: &[String]) -> f64 {
+    let normalized = normalize(candidate);
+    hints
+        .iter()
+        .map(|hint| jaro_winkler(&normalized, hint))
+        .fold(0.0, f64::max)
+}
+
+fn selector_hints(selector: &str) -> Vec<String> {
+    let mut hints = selector
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(normalize)
+        .collect::<Vec<_>>();
+    let joined = normalize(selector);
+    hints.push(joined);
+    hints.sort();
+    hints.dedup();
+    hints
+}
+
+fn normalized_selector(selector: &str) -> Option<String> {
+    let mut normalized = selector.trim().to_string();
+    let cleaned = normalized
+        .replace(" = ", "=")
+        .replace("= ", "=")
+        .replace(" =", "=");
+    if cleaned.contains('\'') && !cleaned.contains('\"') {
+        normalized = cleaned.replace('\'', "\"");
+    } else {
+        normalized = cleaned;
+    }
+    if normalized == selector {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+fn normalize(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .flat_map(|ch| ch.to_lowercase())
+        .collect()
+}
+
+fn escape_attr_value(value: &str) -> String {
+    value.replace('"', "\\\"")
+}

--- a/services/executor_web/src/telemetry.rs
+++ b/services/executor_web/src/telemetry.rs
@@ -27,6 +27,7 @@ const EXPORT_TIMEOUT_SECS: u64 = 5;
 const METER_NAME: &str = "tyrum-executor-web";
 const DURATION_METRIC_NAME: &str = "tyrum_executor_web_attempt_duration_seconds";
 const COUNT_METRIC_NAME: &str = "tyrum_executor_web_attempt_total";
+const RETRY_COUNT_METRIC_NAME: &str = "executor_web.retry";
 
 #[derive(Clone, Debug)]
 pub struct AttemptContext {
@@ -104,6 +105,13 @@ struct MetricsCache {
 
 static METRICS: OnceCell<Mutex<MetricsCache>> = OnceCell::new();
 
+#[derive(Clone)]
+struct RetryInstruments {
+    count: Counter<u64>,
+}
+
+static RETRIES: OnceCell<Mutex<Option<RetryInstruments>>> = OnceCell::new();
+
 fn record_metrics(context: &AttemptContext, attempt: u32, outcome: &str, duration: Duration) {
     let instruments = metrics_instruments();
     let attributes = [
@@ -117,6 +125,27 @@ fn record_metrics(context: &AttemptContext, attempt: u32, outcome: &str, duratio
         .duration
         .record(duration.as_secs_f64(), &attributes);
     instruments.count.add(1, &attributes);
+}
+
+pub fn record_retry_event(context: &AttemptContext, attempt: u32, selector_count: u32) {
+    let instruments = retry_instruments();
+    let attributes = [
+        KeyValue::new("executor.web.host", context.host().to_string()),
+        KeyValue::new("executor.web.scheme", context.scheme().to_string()),
+        KeyValue::new("attempt", attempt as i64),
+        KeyValue::new("selector_count", selector_count as i64),
+    ];
+
+    instruments.count.add(1, &attributes);
+
+    tracing::info!(
+        target: "executor_web.retry",
+        attempt,
+        selector_count,
+        host = context.host(),
+        scheme = context.scheme(),
+        "selector retry scheduled"
+    );
 }
 
 fn metrics_instruments() -> MetricsInstruments {
@@ -154,6 +183,34 @@ fn metrics_instruments() -> MetricsInstruments {
 
     guard.provider = Some(provider);
     guard.instruments = Some(instruments.clone());
+
+    instruments
+}
+
+fn retry_instruments() -> RetryInstruments {
+    let provider = global::meter_provider();
+    let cache = RETRIES.get_or_init(|| Mutex::new(None));
+    let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("retry metrics cache lock poisoned; continuing");
+            poisoned.into_inner()
+        }
+    };
+
+    if let Some(instruments) = &*guard {
+        return instruments.clone();
+    }
+
+    let meter = provider.meter(METER_NAME);
+    let instruments = RetryInstruments {
+        count: meter
+            .u64_counter(RETRY_COUNT_METRIC_NAME)
+            .with_description("Selector retries scheduled by the web executor")
+            .build(),
+    };
+
+    *guard = Some(instruments.clone());
 
     instruments
 }

--- a/services/executor_web/tests/browser.rs
+++ b/services/executor_web/tests/browser.rs
@@ -11,7 +11,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::task::JoinHandle;
-use tyrum_executor_web::{WebExecutorError, execute_web_action};
+use tyrum_executor_web::{SelectorRole, WebExecutorError, execute_web_action};
 use tyrum_shared::planner::{ActionArguments, ActionPrimitive, ActionPrimitiveKind};
 
 const FORM_HTML: &str = r#"
@@ -27,13 +27,13 @@ const FORM_HTML: &str = r#"
         <form action="/submit" method="post">
             <label>
                 Name
-                <input name="name" type="text" />
+                <input name="name" data-testid="booking-name" type="text" placeholder="Full name" />
             </label>
             <label>
                 Preferred time
-                <input name="slot" type="time" />
+                <input name="slot" data-testid="booking-slot" type="time" aria-label="Preferred time" />
             </label>
-            <button type="submit">Request booking</button>
+            <button type="submit" data-testid="submit-booking">Request booking</button>
         </form>
     </main>
 </body>
@@ -101,6 +101,111 @@ async fn form_action_executes_and_captures_confirmation() -> anyhow::Result<()> 
     assert_eq!(outcome.submitted_fields[1].selector, "input[name='slot']");
     assert_eq!(outcome.submitted_fields[1].value, "15:00");
     assert!(!outcome.submitted_fields[1].redacted);
+
+    handle.abort();
+    let _ = handle.await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn semantic_retry_recovers_from_selector_drift() -> anyhow::Result<()> {
+    if !playwright_runtime_available() {
+        tracing::warn!(
+            "Skipping semantic retry test; Playwright runtime not installed on this runner"
+        );
+        return Ok(());
+    }
+
+    let (addr, handle) = start_fixture_server().await?;
+    let url = format!("http://{addr}");
+
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Web,
+        into_args(json!({
+            "url": url,
+            "executor": "generic-web",
+            "fields": [
+                { "selector": "input[name='full_name']", "value": "Retry Example", "redact": true },
+                { "selector": "input[data-testid='booking_slot']", "value": "10:30" }
+            ],
+            "submit": {
+                "selector": "button[data-testid='submit_request']",
+                "kind": "click",
+                "wait_after_ms": 25
+            },
+            "snapshot_selector": "#confirmation"
+        })),
+    );
+
+    let outcome = execute_web_action(&primitive).await?;
+
+    assert!(outcome.current_url.ends_with("/submit"));
+    assert_eq!(outcome.submitted_fields.len(), 2);
+    assert_eq!(outcome.submitted_fields[0].selector, "input[name=\"name\"]");
+    assert_eq!(outcome.submitted_fields[0].value, "REDACTED");
+    assert_eq!(
+        outcome.submitted_fields[1].selector,
+        "input[data-testid=\"booking-slot\"]"
+    );
+    assert_eq!(outcome.submitted_fields[1].value, "10:30");
+
+    handle.abort();
+    let _ = handle.await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn semantic_retry_reports_history_on_failure() -> anyhow::Result<()> {
+    if !playwright_runtime_available() {
+        tracing::warn!(
+            "Skipping semantic failure test; Playwright runtime not installed on this runner"
+        );
+        return Ok(());
+    }
+
+    let (addr, handle) = start_fixture_server().await?;
+    let url = format!("http://{addr}");
+
+    let primitive = ActionPrimitive::new(
+        ActionPrimitiveKind::Web,
+        into_args(json!({
+            "url": url,
+            "executor": "generic-web",
+            "fields": [
+                { "selector": "input[data-testid='missing_field']", "value": "Donna" }
+            ],
+            "submit": {
+                "selector": "button[data-testid='missing_submit']",
+                "kind": "click"
+            }
+        })),
+    );
+
+    let err = execute_web_action(&primitive)
+        .await
+        .expect_err("selectors should exhaust when no matches");
+
+    match err {
+        WebExecutorError::SelectorsExhausted {
+            attempts,
+            attempted,
+        } => {
+            assert!(attempts >= 1);
+            let field_attempts = attempted
+                .iter()
+                .find(|summary| matches!(summary.role, SelectorRole::Field { .. }))
+                .expect("field attempts present");
+            assert!(
+                field_attempts
+                    .tried
+                    .iter()
+                    .any(|selector| selector.contains("missing_field"))
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
 
     handle.abort();
     let _ = handle.await;


### PR DESCRIPTION
## Summary
- add semantic selector retries and structured errors to the web executor
- add HTTP executor backoff with idempotent-aware retry tracking
- extend executor docs and integration coverage for success/failure retries

## Testing
- cargo test -p tyrum-executor-web
- cargo test -p tyrum-executor-http
- pre-commit run --all-files

Closes #183

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce semantic selector-based retries in the web executor and idempotent-aware exponential backoff retries in the HTTP executor, with new structured errors, telemetry, and tests.
> 
> - **Executors**:
>   - **Web (`services/executor_web/`)**:
>     - Add semantic selector retries with candidate generation (`semantic.rs`) using normalized attributes and similarity scoring.
>     - Introduce structured errors: `SelectorFallback` and `SelectorsExhausted` with attempt history (`SelectorRetryDetail`, `SelectorAttemptSummary`, `SelectorRole`).
>     - Add retry supervisor, per-attempt planning, and telemetry for retries (`executor_web.retry`).
>     - Refactor execution to resolved action plan; enhance DOM snapshot/redaction and selector presence checks.
>     - Tests: add recovery from drift and exhaustion history assertions; update fixture selectors.
>     - Dependency: add `strsim`.
>   - **HTTP (`services/executor_http/`)**:
>     - Implement idempotent-only retries with exponential backoff and classification (`HttpRetryOutcome`), tracked via `HttpRetryRecord` and `RetriesExhausted` error.
>     - Extend telemetry: attempt numbers, retry counter/logs (`executor_http.retry`).
>     - Tests: add flaky-success path and retry exhaustion history assertions.
> - **Docs**:
>   - `docs/executors/web_executor.md`: add Drift Handling & Retries section.
>   - `docs/executors/http_executor.md`: add Retry Semantics section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e49a343531c685299a2f08125ce4a7f51299fe3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->