### PR TITLE
Add planner replay sandbox for stored traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "clap",
  "http-body-util",
  "opentelemetry",
  "opentelemetry_sdk",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Follow these steps to provision the Telegram channel safely across local and sta
 - On success the run writes `artifacts/audit-demo/trace.json` (full payloads) and `artifacts/audit-demo/trace.md` (table view) so reviewers can inspect the trace without rerunning the demo.
 - The script exits non-zero if any assertion fails (missing events, postcondition mismatch, replay drift) to keep CI-friendly behaviour. Docker must be available locally.
 
+## Planner Replay Sandbox
+- Use `cargo run -p tyrum-planner --bin replay_sandbox -- --plan-id <UUID> --database-url <postgres-url> [--subject-id <UUID>] [--output-dir <dir>]` to replay stored planner traces. The CLI also exposes `--help` for full flag descriptions.
+- The sandbox rehydrates plan steps from `planner_events`, replays them with stub executors, and repopulates Tyrum memory (facts + episodic events) when a `--subject-id` is supplied.
+- OpenTelemetry counters `replay.steps_total` and `replay.failures_total` emit for each invocation when a global meter provider is configured.
+- Divergences cause a non-zero exit code and a markdown diff at `artifacts/replay/<plan-id>.md` summarising executor drift and JSON pointer mismatches.
+
 ## Memory Tooling
 - `tyrum-memory` crate exposes a Postgres-backed data access layer for facts, episodic events, and vector embeddings.
 - Seed sample data for manual smoke tests with `cargo run -p tyrum-memory -- insert-sample --subject <uuid>` (subject optional).

--- a/docs/planner_event_log.md
+++ b/docs/planner_event_log.md
@@ -83,6 +83,18 @@ replay.
 2. Provides `append` to insert entries with idempotent handling.
 3. Exposes `events_for_plan` to stream traces back when deriving audit or replay artefacts.
 
+## Replay Sandbox Workflow
+- The binary `replay_sandbox` replays recorded planner steps to detect executor drift and postcondition regressions.
+- Usage (also printed by `cargo run -p tyrum-planner --bin replay_sandbox -- --help`):
+
+  ```
+  replay_sandbox --plan-id <UUID> --database-url <postgres-url> [--subject-id <UUID>] [--output-dir <dir>]
+  ```
+
+- `--subject-id` is optional but recommended so the sandbox can repopulate Tyrum memory with episodic events and capability facts during replay.
+- Metrics `replay.steps_total` and `replay.failures_total` are emitted via OpenTelemetry for each run when instrumentation is enabled.
+- On divergence the command exits non-zero and writes a markdown summary to `artifacts/replay/<plan-id>.md`, detailing executors, expected vs actual results, and JSON pointer diffs.
+
 ## Capability Memory Hydration
 - Before dispatching any mutating primitive, the planner consults the capability memory store using a
   connection shared with the event log (via `CapabilityMemoryService`).

--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -38,6 +38,8 @@ reqwest = { version = "0.12.23", default-features = false, features = ["json", "
 url = "2"
 tyrum-discovery = { path = "../discovery", features = ["test-support"] }
 tyrum-wallet = { path = "../tyrum-wallet" }
+clap = { version = "4.5", features = ["derive", "env"] }
+opentelemetry = { version = "0.31", features = ["metrics"] }
 
 [dev-dependencies]
 anyhow = "1"
@@ -56,7 +58,6 @@ tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread", "time
 tyrum-memory = { path = "../memory" }
 tower = "0.5"
 http-body-util = "0.1"
-opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "testing"] }
 
 [[bin]]
@@ -67,6 +68,10 @@ required-features = ["audit-demo"]
 [[bin]]
 name = "planner_http"
 path = "src/bin/http_server.rs"
+
+[[bin]]
+name = "replay_sandbox"
+path = "src/bin/replay_sandbox.rs"
 
 [lints]
 workspace = true

--- a/services/planner/src/bin/replay_sandbox.rs
+++ b/services/planner/src/bin/replay_sandbox.rs
@@ -1,0 +1,177 @@
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::Parser;
+use serde_json::to_string_pretty;
+use tracing::{info, warn};
+use tracing_subscriber::{EnvFilter, fmt};
+use uuid::Uuid;
+
+use tyrum_memory::MemoryDal;
+use tyrum_planner::{
+    EventLog, EventLogSettings,
+    replay::{ReplayMetrics, ReplayReport, ReplaySandbox},
+};
+
+/// CLI surface for the replay sandbox binary.
+#[derive(Debug, Parser)]
+#[command(
+    name = "replay_sandbox",
+    about = "Replay stored planner traces against stub executors to detect capability drift."
+)]
+struct Args {
+    /// Planner plan identifier to replay.
+    #[arg(long)]
+    plan_id: Uuid,
+
+    /// Postgres URL hosting the planner event log.
+    #[arg(long, env = "PLANNER_EVENT_LOG_URL")]
+    database_url: String,
+
+    /// Subject identifier used to hydrate Tyrum memory artifacts (optional).
+    #[arg(long, env = "REPLAY_SUBJECT_ID")]
+    subject_id: Option<Uuid>,
+
+    /// Directory for drift artifacts on replay failure.
+    #[arg(long, default_value = "artifacts/replay")]
+    output_dir: PathBuf,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<()> {
+    init_tracing()?;
+    let args = Args::parse();
+
+    let event_log = EventLog::connect(EventLogSettings::new(&args.database_url))
+        .await
+        .context("connect planner event log")?;
+    let memory = MemoryDal::new(event_log.pool().clone());
+
+    let sandbox = ReplaySandbox::new(event_log, memory, ReplayMetrics::global());
+    let report = sandbox
+        .replay_plan(args.plan_id, args.subject_id)
+        .await
+        .context("replay plan trace")?;
+
+    if report.succeeded() {
+        info!(
+            plan_id = %args.plan_id,
+            steps = report.steps_replayed,
+            "replay completed successfully"
+        );
+        return Ok(());
+    }
+
+    let artifact =
+        write_diff_markdown(&report, &args.output_dir).context("write replay diff artifact")?;
+    warn!(
+        plan_id = %args.plan_id,
+        steps = report.steps_replayed,
+        mismatches = report.mismatches.len(),
+        artifact = %artifact.display(),
+        "replay detected drift"
+    );
+    bail!(
+        "detected drift while replaying plan {} — see {}",
+        args.plan_id,
+        artifact.display()
+    );
+}
+
+fn init_tracing() -> Result<()> {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,tyrum_planner=info,replay_sandbox=info"));
+
+    fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .compact()
+        .try_init()
+        .map_err(|err| anyhow!("install tracing subscriber: {err}"))?;
+    Ok(())
+}
+
+fn write_diff_markdown(report: &ReplayReport, output_dir: &Path) -> Result<PathBuf> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("create replay artifact directory {}", output_dir.display()))?;
+
+    let file_path = output_dir.join(format!("{}.md", report.plan_id));
+    let mut file = File::create(&file_path)
+        .with_context(|| format!("create replay artifact {}", file_path.display()))?;
+
+    writeln!(file, "# Planner Replay Drift")?;
+    writeln!(file)?;
+    writeln!(file, "- Plan ID: {}", report.plan_id)?;
+    writeln!(file, "- Steps replayed: {}", report.steps_replayed)?;
+    writeln!(file, "- Mismatches: {}", report.mismatches.len())?;
+    writeln!(file)?;
+
+    for mismatch in &report.mismatches {
+        writeln!(
+            file,
+            "## Step {} – {:?}",
+            mismatch.step_index, mismatch.primitive.kind
+        )?;
+        writeln!(file, "- Expected executor: {}", mismatch.expected_executor)?;
+        writeln!(file, "- Actual executor: {}", mismatch.actual_executor)?;
+        writeln!(file)?;
+
+        writeln!(file, "### Primitive")?;
+        writeln!(
+            file,
+            "```json\n{}\n```",
+            to_string_pretty(&mismatch.primitive)
+                .unwrap_or_else(|_| "<primitive serialization failed>".into())
+        )?;
+
+        writeln!(file, "### Expected Result")?;
+        writeln!(
+            file,
+            "```json\n{}\n```",
+            to_string_pretty(&mismatch.expected_result)
+                .unwrap_or_else(|_| "<expected serialization failed>".into())
+        )?;
+
+        writeln!(file, "### Actual Result")?;
+        writeln!(
+            file,
+            "```json\n{}\n```",
+            to_string_pretty(&mismatch.actual_result)
+                .unwrap_or_else(|_| "<actual serialization failed>".into())
+        )?;
+
+        if mismatch.diffs.is_empty() {
+            writeln!(file, "_No structured diffs available._")?;
+        } else {
+            writeln!(file, "### Differences")?;
+            for diff in &mismatch.diffs {
+                let expected = to_string_pretty(&diff.expected)
+                    .unwrap_or_else(|_| "<expected serialization failed>".into());
+                let actual = to_string_pretty(&diff.actual)
+                    .unwrap_or_else(|_| "<actual serialization failed>".into());
+                let path = if diff.path.is_empty() {
+                    "/"
+                } else {
+                    diff.path.as_str()
+                };
+                writeln!(file, "- `{path}`: expected `{expected}` got `{actual}`")?;
+            }
+        }
+
+        writeln!(file)?;
+    }
+
+    if report.mismatches.is_empty() {
+        writeln!(
+            file,
+            "_Replay succeeded; no drift detected for plan {}._",
+            report.plan_id
+        )?;
+    }
+
+    Ok(file_path)
+}

--- a/services/planner/src/lib.rs
+++ b/services/planner/src/lib.rs
@@ -5,6 +5,7 @@ pub mod event_log;
 pub mod http;
 pub mod policy;
 pub mod profiles;
+pub mod replay;
 pub mod state_machine;
 pub mod wallet;
 

--- a/services/planner/src/replay.rs
+++ b/services/planner/src/replay.rs
@@ -1,0 +1,610 @@
+use std::collections::BTreeSet;
+
+use chrono::Utc;
+use opentelemetry::{global, metrics::Counter};
+use serde::Serialize;
+use serde_json::{Value, json};
+use thiserror::Error;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::state_machine::PlanTransitionError;
+use crate::{
+    ActionPrimitive, ActionPrimitiveKind, EventLog, EventLogError, PlanEvent, PlanStateMachine,
+};
+use tyrum_memory::{MemoryDal, MemoryError, NewEpisodicEvent, NewFact};
+
+/// Encapsulates OpenTelemetry counters emitted by the replay sandbox.
+#[derive(Clone)]
+pub struct ReplayMetrics {
+    steps_total: Counter<u64>,
+    failures_total: Counter<u64>,
+}
+
+impl ReplayMetrics {
+    /// Construct metrics using the process-wide OpenTelemetry meter.
+    #[must_use]
+    pub fn global() -> Self {
+        let meter = global::meter("tyrum-planner.replay");
+        Self {
+            steps_total: meter
+                .u64_counter("replay.steps_total")
+                .with_description("Count of planner steps replayed by the sandbox")
+                .build(),
+            failures_total: meter
+                .u64_counter("replay.failures_total")
+                .with_description("Count of replayed steps whose outcomes diverged")
+                .build(),
+        }
+    }
+
+    fn record_step(&self) {
+        self.steps_total.add(1, &[]);
+    }
+
+    fn record_failure(&self) {
+        self.failures_total.add(1, &[]);
+    }
+}
+
+impl Default for ReplayMetrics {
+    fn default() -> Self {
+        Self::global()
+    }
+}
+
+/// Outcome of replaying an individual plan step.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ReplayMismatch {
+    pub step_index: usize,
+    pub primitive: ActionPrimitive,
+    pub expected_executor: String,
+    pub actual_executor: String,
+    pub expected_result: Value,
+    pub actual_result: Value,
+    pub diffs: Vec<ValueDiff>,
+}
+
+/// JSON pointer diff entry describing divergence between two values.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ValueDiff {
+    pub path: String,
+    pub expected: Value,
+    pub actual: Value,
+}
+
+/// Aggregated report containing replay outcomes.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ReplayReport {
+    pub plan_id: Uuid,
+    pub steps_replayed: usize,
+    pub mismatches: Vec<ReplayMismatch>,
+}
+
+impl ReplayReport {
+    /// Returns `true` when no divergences were detected.
+    #[must_use]
+    pub fn succeeded(&self) -> bool {
+        self.mismatches.is_empty()
+    }
+}
+
+/// Domain error produced while loading or replaying plan traces.
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    #[error("plan {plan_id} has no recorded steps")]
+    EmptyTrace { plan_id: Uuid },
+    #[error("negative step index {step_index} in trace")]
+    NegativeStepIndex { step_index: i32 },
+    #[error("trace step {step_index} missing {field}")]
+    MissingField {
+        step_index: usize,
+        field: &'static str,
+    },
+    #[error("invalid primitive payload for step {step_index}: {source}")]
+    Decode {
+        step_index: usize,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("unsupported primitive {kind:?} at step {step_index}")]
+    UnsupportedPrimitive {
+        kind: ActionPrimitiveKind,
+        step_index: usize,
+    },
+    #[error(transparent)]
+    EventLog(#[from] EventLogError),
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+    #[error("plan state machine rejected transition: {0}")]
+    StateTransition(#[from] PlanTransitionError),
+}
+
+/// Orchestrates plan replay using stored planner traces.
+pub struct ReplaySandbox {
+    event_log: EventLog,
+    memory: MemoryDal,
+    metrics: ReplayMetrics,
+}
+
+impl ReplaySandbox {
+    /// Construct a new replay sandbox that shares the planner event log and memory data stores.
+    #[must_use]
+    pub fn new(event_log: EventLog, memory: MemoryDal, metrics: ReplayMetrics) -> Self {
+        Self {
+            event_log,
+            memory,
+            metrics,
+        }
+    }
+
+    /// Replay recorded planner steps and surface divergences between expected and stubbed outcomes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReplayError::EmptyTrace`] when no steps were found for the plan.
+    /// Returns [`ReplayError::MissingField`] if required audit payload keys are absent.
+    /// Propagates [`ReplayError::UnsupportedPrimitive`] when a primitive kind lacks a stub executor.
+    /// Propagates storage errors from the event log or memory layers.
+    pub async fn replay_plan(
+        &self,
+        plan_id: Uuid,
+        subject_id: Option<Uuid>,
+    ) -> Result<ReplayReport, ReplayError> {
+        let mut events = self.event_log.events_for_plan(plan_id).await?;
+        if events.is_empty() {
+            return Err(ReplayError::EmptyTrace { plan_id });
+        }
+
+        // discard plan-level audit payloads (step index sentinel)
+        events.retain(|event| event.step_index != i32::MAX);
+
+        if events.is_empty() {
+            return Err(ReplayError::EmptyTrace { plan_id });
+        }
+
+        let mut steps = Vec::with_capacity(events.len());
+        for event in events {
+            if event.step_index < 0 {
+                return Err(ReplayError::NegativeStepIndex {
+                    step_index: event.step_index,
+                });
+            }
+            let step_index = usize::try_from(event.step_index).unwrap_or_default();
+            let primitive_value =
+                event
+                    .action
+                    .get("primitive")
+                    .cloned()
+                    .ok_or(ReplayError::MissingField {
+                        step_index,
+                        field: "primitive",
+                    })?;
+            let primitive = serde_json::from_value::<ActionPrimitive>(primitive_value)
+                .map_err(|source| ReplayError::Decode { step_index, source })?;
+
+            let expected_executor = event
+                .action
+                .get("executor")
+                .and_then(Value::as_str)
+                .ok_or(ReplayError::MissingField {
+                    step_index,
+                    field: "executor",
+                })?
+                .to_string();
+
+            let expected_result =
+                event
+                    .action
+                    .get("result")
+                    .cloned()
+                    .ok_or(ReplayError::MissingField {
+                        step_index,
+                        field: "result",
+                    })?;
+
+            steps.push(ReplayStep {
+                step_index,
+                primitive,
+                expected_executor,
+                expected_result,
+            });
+        }
+
+        let mut machine = PlanStateMachine::new(steps.len());
+        machine.apply(PlanEvent::SubmittedForPolicy)?;
+        machine.apply(PlanEvent::PolicyApproved)?;
+
+        let mut report = ReplayReport {
+            plan_id,
+            steps_replayed: 0,
+            mismatches: Vec::new(),
+        };
+        if subject_id.is_none() {
+            warn!(
+                "subject id not provided; replay will skip memory hydration for capability facts"
+            );
+        }
+        let executors = StubExecutors::new(self.memory.clone(), subject_id);
+
+        for step in steps {
+            self.metrics.record_step();
+            report.steps_replayed += 1;
+
+            if let Some(mismatch) = self.execute_step(&mut machine, &executors, &step).await? {
+                self.metrics.record_failure();
+                report.mismatches.push(mismatch);
+                break;
+            }
+        }
+
+        Ok(report)
+    }
+
+    async fn execute_step(
+        &self,
+        machine: &mut PlanStateMachine,
+        executors: &StubExecutors,
+        step: &ReplayStep,
+    ) -> Result<Option<ReplayMismatch>, ReplayError> {
+        match step.primitive.kind {
+            ActionPrimitiveKind::Confirm => {
+                machine.apply(PlanEvent::RequiresHumanConfirmation {
+                    step_index: step.step_index,
+                })?
+            }
+            _ => machine.apply(PlanEvent::StepDispatched {
+                step_index: step.step_index,
+            })?,
+        };
+
+        let outcome = executors.execute(step.step_index, &step.primitive).await?;
+
+        let mut diffs = diff_values(&step.expected_result, &outcome.result);
+        if step.expected_executor != outcome.executor {
+            diffs.push(ValueDiff {
+                path: "/executor".into(),
+                expected: Value::String(step.expected_executor.clone()),
+                actual: Value::String(outcome.executor.clone()),
+            });
+        }
+
+        if diffs.is_empty() {
+            match step.primitive.kind {
+                ActionPrimitiveKind::Confirm => machine.apply(PlanEvent::HumanApproved {
+                    step_index: step.step_index,
+                })?,
+                _ => machine.apply(PlanEvent::PostconditionSatisfied {
+                    step_index: step.step_index,
+                })?,
+            };
+            return Ok(None);
+        }
+
+        let detail = describe_diffs(&diffs);
+        match step.primitive.kind {
+            ActionPrimitiveKind::Confirm => machine.apply(PlanEvent::HumanRejected {
+                step_index: step.step_index,
+                detail: Some(detail.clone()),
+            })?,
+            _ => machine.apply(PlanEvent::PostconditionFailed {
+                step_index: step.step_index,
+                detail: detail.clone(),
+            })?,
+        };
+
+        let mismatch = ReplayMismatch {
+            step_index: step.step_index,
+            primitive: step.primitive.clone(),
+            expected_executor: step.expected_executor.clone(),
+            actual_executor: outcome.executor,
+            expected_result: step.expected_result.clone(),
+            actual_result: outcome.result,
+            diffs,
+        };
+
+        Ok(Some(mismatch))
+    }
+}
+
+struct ReplayStep {
+    step_index: usize,
+    primitive: ActionPrimitive,
+    expected_executor: String,
+    expected_result: Value,
+}
+
+struct StubExecutors {
+    memory: MemoryDal,
+    subject_id: Option<Uuid>,
+}
+
+impl StubExecutors {
+    fn new(memory: MemoryDal, subject_id: Option<Uuid>) -> Self {
+        Self { memory, subject_id }
+    }
+
+    async fn execute(
+        &self,
+        step_index: usize,
+        primitive: &ActionPrimitive,
+    ) -> Result<StubOutcome, ReplayError> {
+        match primitive.kind {
+            ActionPrimitiveKind::Confirm => self.handle_confirm(primitive).await,
+            ActionPrimitiveKind::Web => self.handle_web(primitive).await,
+            ActionPrimitiveKind::Message => self.handle_message(primitive).await,
+            other => Err(ReplayError::UnsupportedPrimitive {
+                kind: other,
+                step_index,
+            }),
+        }
+    }
+
+    async fn handle_confirm(
+        &self,
+        _primitive: &ActionPrimitive,
+    ) -> Result<StubOutcome, ReplayError> {
+        let decision = json!({ "decision": "approved" });
+
+        if let Some(subject_id) = self.subject_id {
+            self.record_confirmation_event(subject_id, decision.clone())
+                .await;
+        }
+
+        Ok(StubOutcome {
+            executor: "human".into(),
+            result: decision,
+        })
+    }
+
+    async fn handle_web(&self, primitive: &ActionPrimitive) -> Result<StubOutcome, ReplayError> {
+        let slot = primitive
+            .args
+            .get("slot")
+            .cloned()
+            .unwrap_or_else(|| json!({ "status": "unknown" }));
+
+        if let Some(subject_id) = self.subject_id {
+            self.record_web_fact(subject_id, &slot).await;
+            self.record_web_event(subject_id, primitive, &slot).await;
+        }
+
+        let executor = primitive
+            .args
+            .get("executor")
+            .and_then(Value::as_str)
+            .unwrap_or("generic-web")
+            .to_string();
+
+        let result = match primitive.postcondition.clone() {
+            Some(value) => value,
+            None => json!({
+                "assertions": [],
+                "metadata": {
+                    "slot": slot,
+                    "status": "booked",
+                }
+            }),
+        };
+
+        Ok(StubOutcome { executor, result })
+    }
+
+    async fn handle_message(
+        &self,
+        primitive: &ActionPrimitive,
+    ) -> Result<StubOutcome, ReplayError> {
+        let channel = primitive
+            .args
+            .get("channel")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let recipient = primitive
+            .args
+            .get("recipient")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let body = primitive
+            .args
+            .get("body")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+
+        if let Some(subject_id) = self.subject_id {
+            self.record_message_event(subject_id, &channel, &recipient, body)
+                .await;
+        }
+
+        let result = primitive
+            .postcondition
+            .clone()
+            .unwrap_or_else(|| json!({ "status": "delivered", "channel": channel }));
+
+        Ok(StubOutcome {
+            executor: "generic-message".into(),
+            result,
+        })
+    }
+
+    async fn record_confirmation_event(&self, subject_id: Uuid, payload: Value) {
+        let result = self
+            .memory
+            .create_episodic_event(NewEpisodicEvent {
+                subject_id,
+                event_id: Uuid::new_v4(),
+                occurred_at: Utc::now(),
+                channel: "human".into(),
+                event_type: "confirmation.response".into(),
+                payload,
+            })
+            .await;
+        if let Err(error) = result {
+            warn!(%error, "failed to record confirmation episodic event");
+        }
+    }
+
+    async fn record_web_fact(&self, subject_id: Uuid, slot: &Value) {
+        let result = self
+            .memory
+            .create_fact(NewFact {
+                subject_id,
+                fact_key: "last_scheduled_call".into(),
+                fact_value: json!({
+                    "status": "booked",
+                    "slot": slot.clone(),
+                }),
+                source: "replay-sandbox".into(),
+                observed_at: Utc::now(),
+                confidence: 1.0,
+            })
+            .await;
+        if let Err(error) = result {
+            warn!(%error, "failed to record capability memory fact");
+        }
+    }
+
+    async fn record_web_event(&self, subject_id: Uuid, primitive: &ActionPrimitive, slot: &Value) {
+        let payload = json!({
+            "action": primitive.args.get("intent").cloned().unwrap_or(Value::Null),
+            "slot": slot.clone(),
+        });
+        let result = self
+            .memory
+            .create_episodic_event(NewEpisodicEvent {
+                subject_id,
+                event_id: Uuid::new_v4(),
+                occurred_at: Utc::now(),
+                channel: "executor".into(),
+                event_type: "executor.web".into(),
+                payload,
+            })
+            .await;
+        if let Err(error) = result {
+            warn!(%error, "failed to record web executor episodic event");
+        }
+    }
+
+    async fn record_message_event(
+        &self,
+        subject_id: Uuid,
+        channel: &str,
+        recipient: &str,
+        body: &str,
+    ) {
+        let payload = json!({
+            "to": recipient,
+            "body": body,
+        });
+        let result = self
+            .memory
+            .create_episodic_event(NewEpisodicEvent {
+                subject_id,
+                event_id: Uuid::new_v4(),
+                occurred_at: Utc::now(),
+                channel: channel.into(),
+                event_type: "message.sent".into(),
+                payload,
+            })
+            .await;
+        if let Err(error) = result {
+            warn!(%error, "failed to record message episodic event");
+        }
+    }
+}
+
+struct StubOutcome {
+    executor: String,
+    result: Value,
+}
+
+fn diff_values(expected: &Value, actual: &Value) -> Vec<ValueDiff> {
+    let mut diffs = Vec::new();
+    collect_diffs(expected, actual, "".to_string(), &mut diffs);
+    diffs
+}
+
+fn describe_diffs(diffs: &[ValueDiff]) -> String {
+    if diffs.is_empty() {
+        return "no diff".into();
+    }
+
+    diffs
+        .iter()
+        .map(|diff| {
+            let expected = serde_json::to_string(&diff.expected).unwrap_or_else(|_| "<?>".into());
+            let actual = serde_json::to_string(&diff.actual).unwrap_or_else(|_| "<?>".into());
+            let path = if diff.path.is_empty() {
+                "/".to_string()
+            } else {
+                diff.path.clone()
+            };
+            format!("{path}: expected {expected}, got {actual}")
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn collect_diffs(expected: &Value, actual: &Value, path: String, diffs: &mut Vec<ValueDiff>) {
+    if expected == actual {
+        return;
+    }
+
+    match (expected, actual) {
+        (Value::Object(exp), Value::Object(act)) => {
+            let keys: BTreeSet<_> = exp.keys().chain(act.keys()).cloned().collect();
+            for key in keys {
+                let child_path = join_path(&path, &key);
+                match (exp.get(&key), act.get(&key)) {
+                    (Some(e), Some(a)) => collect_diffs(e, a, child_path, diffs),
+                    (Some(e), None) => diffs.push(ValueDiff {
+                        path: child_path,
+                        expected: e.clone(),
+                        actual: Value::Null,
+                    }),
+                    (None, Some(a)) => diffs.push(ValueDiff {
+                        path: child_path,
+                        expected: Value::Null,
+                        actual: a.clone(),
+                    }),
+                    (None, None) => {}
+                }
+            }
+        }
+        (Value::Array(exp), Value::Array(act)) => {
+            let max_len = exp.len().max(act.len());
+            for index in 0..max_len {
+                let child_path = join_path(&path, &index.to_string());
+                match (exp.get(index), act.get(index)) {
+                    (Some(e), Some(a)) => collect_diffs(e, a, child_path, diffs),
+                    (Some(e), None) => diffs.push(ValueDiff {
+                        path: child_path,
+                        expected: e.clone(),
+                        actual: Value::Null,
+                    }),
+                    (None, Some(a)) => diffs.push(ValueDiff {
+                        path: child_path,
+                        expected: Value::Null,
+                        actual: a.clone(),
+                    }),
+                    (None, None) => {}
+                }
+            }
+        }
+        _ => diffs.push(ValueDiff {
+            path,
+            expected: expected.clone(),
+            actual: actual.clone(),
+        }),
+    }
+}
+
+fn join_path(parent: &str, segment: &str) -> String {
+    let escaped = segment.replace('~', "~0").replace('/', "~1");
+    if parent.is_empty() {
+        format!("/{}", escaped)
+    } else {
+        format!("{}/{}", parent, escaped)
+    }
+}

--- a/services/planner/tests/replay_sandbox.rs
+++ b/services/planner/tests/replay_sandbox.rs
@@ -1,0 +1,240 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use chrono::Utc;
+use common::postgres::{TestPostgres, docker_available};
+use serde_json::{Map as JsonMap, Value, json};
+use tyrum_memory::MemoryDal;
+use tyrum_planner::{
+    AppendOutcome, EventLog, NewPlannerEvent,
+    replay::{ReplayMetrics, ReplaySandbox},
+};
+use tyrum_shared::{ActionArguments, ActionPrimitive, ActionPrimitiveKind};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn replay_succeeds_for_matching_trace() {
+    if !docker_available() {
+        eprintln!("skipping replay_succeeds_for_matching_trace: docker unavailable");
+        return;
+    }
+
+    let postgres = TestPostgres::start().await.expect("start postgres fixture");
+    let pool = postgres.pool().clone();
+
+    let event_log = EventLog::from_pool(pool.clone());
+    event_log.migrate().await.expect("run planner migrations");
+    let memory = MemoryDal::new(pool.clone());
+
+    let plan_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    seed_plan_trace(&event_log, plan_id, |primitive, _| match primitive.kind {
+        ActionPrimitiveKind::Confirm => json!({ "decision": "approved" }),
+        ActionPrimitiveKind::Web => primitive
+            .postcondition
+            .as_ref()
+            .cloned()
+            .expect("web primitive requires postcondition"),
+        ActionPrimitiveKind::Message => json!({
+            "status": "delivered",
+            "channel": primitive
+                .args
+                .get("channel")
+                .and_then(Value::as_str)
+                .unwrap_or("email"),
+        }),
+        _ => Value::Null,
+    })
+    .await;
+
+    let sandbox = ReplaySandbox::new(event_log, memory.clone(), ReplayMetrics::default());
+    let report = sandbox
+        .replay_plan(plan_id, Some(subject_id))
+        .await
+        .expect("replay plan");
+
+    assert!(report.succeeded());
+    assert_eq!(report.steps_replayed, 3);
+
+    let episodic = memory
+        .list_episodic_events_for_subject(subject_id)
+        .await
+        .expect("list episodic events");
+    assert_eq!(
+        episodic.len(),
+        3,
+        "stub executors should emit episodic events"
+    );
+
+    let facts = memory
+        .list_facts_for_subject(subject_id)
+        .await
+        .expect("list capability facts");
+    assert_eq!(facts.len(), 1);
+}
+
+#[tokio::test]
+async fn replay_detects_mismatch_and_reports_diff() {
+    if !docker_available() {
+        eprintln!("skipping replay_detects_mismatch_and_reports_diff: docker unavailable");
+        return;
+    }
+
+    let postgres = TestPostgres::start().await.expect("start postgres fixture");
+    let pool = postgres.pool().clone();
+
+    let event_log = EventLog::from_pool(pool.clone());
+    event_log.migrate().await.expect("run planner migrations");
+    let memory = MemoryDal::new(pool.clone());
+
+    let plan_id = Uuid::new_v4();
+    let subject_id = Uuid::new_v4();
+    seed_plan_trace(&event_log, plan_id, |primitive, step_index| {
+        if primitive.kind == ActionPrimitiveKind::Message && step_index == 2 {
+            json!({
+                "status": "failed",
+                "channel": primitive
+                    .args
+                    .get("channel")
+                    .and_then(Value::as_str)
+                    .unwrap_or("email"),
+            })
+        } else {
+            match primitive.kind {
+                ActionPrimitiveKind::Confirm => json!({ "decision": "approved" }),
+                ActionPrimitiveKind::Web => primitive
+                    .postcondition
+                    .as_ref()
+                    .cloned()
+                    .expect("web primitive requires postcondition"),
+                ActionPrimitiveKind::Message => json!({
+                    "status": "delivered",
+                    "channel": primitive
+                        .args
+                        .get("channel")
+                        .and_then(Value::as_str)
+                        .unwrap_or("email"),
+                }),
+                _ => Value::Null,
+            }
+        }
+    })
+    .await;
+
+    let sandbox = ReplaySandbox::new(event_log, memory, ReplayMetrics::default());
+    let report = sandbox
+        .replay_plan(plan_id, Some(subject_id))
+        .await
+        .expect("replay plan");
+
+    assert!(!report.succeeded());
+    assert_eq!(report.steps_replayed, 3);
+    assert_eq!(report.mismatches.len(), 1);
+    let mismatch = &report.mismatches[0];
+    assert_eq!(mismatch.step_index, 2);
+    assert_eq!(mismatch.primitive.kind, ActionPrimitiveKind::Message);
+    assert!(
+        mismatch.diffs.iter().any(|diff| diff.path == "/status"),
+        "diff should include message status change"
+    );
+}
+
+async fn seed_plan_trace<F>(event_log: &EventLog, plan_id: Uuid, mut result_fn: F)
+where
+    F: FnMut(&ActionPrimitive, usize) -> Value,
+{
+    let steps = build_sample_plan();
+    for (index, primitive) in steps.iter().enumerate() {
+        let executor = match primitive.kind {
+            ActionPrimitiveKind::Confirm => "human",
+            ActionPrimitiveKind::Web => primitive
+                .args
+                .get("executor")
+                .and_then(Value::as_str)
+                .unwrap_or("generic-web"),
+            ActionPrimitiveKind::Message => "generic-message",
+            _ => "unknown",
+        };
+        let payload = json!({
+            "primitive": primitive,
+            "executor": executor,
+            "result": result_fn(primitive, index),
+        });
+        let step_index =
+            i32::try_from(index).expect("plan steps must fit within 32-bit signed indices");
+        let event = NewPlannerEvent::from_payload(
+            Uuid::new_v4(),
+            plan_id,
+            step_index,
+            Utc::now(),
+            &payload,
+        )
+        .expect("encode planner event");
+        match event_log.append(event).await.expect("append planner event") {
+            AppendOutcome::Inserted(_) => {}
+            AppendOutcome::Duplicate => panic!("unexpected duplicate step {index}"),
+        }
+    }
+}
+
+fn build_sample_plan() -> Vec<ActionPrimitive> {
+    let slot = json!({
+        "start": "2025-10-18T15:00:00Z",
+        "end": "2025-10-18T15:30:00Z",
+        "with": "Alex Doe",
+    });
+
+    vec![
+        ActionPrimitive::new(
+            ActionPrimitiveKind::Confirm,
+            into_args(json!({
+                "prompt": "Book call with Alex on Oct 18 at 15:00 UTC?",
+                "context": { "slot": slot.clone() },
+            })),
+        ),
+        ActionPrimitive::new(
+            ActionPrimitiveKind::Web,
+            into_args(json!({
+                "executor": "generic-web",
+                "intent": "book_call",
+                "url": "https://calendar.example.com/slots",
+                "slot": slot.clone(),
+            })),
+        )
+        .with_postcondition(json!({
+            "assertions": [
+                { "type": "dom_contains", "text": "booked", "case_insensitive": true }
+            ],
+            "metadata": {
+                "appointment": {
+                    "status": "booked",
+                    "slot": slot.clone(),
+                }
+            }
+        })),
+        ActionPrimitive::new(
+            ActionPrimitiveKind::Message,
+            into_args(json!({
+                "channel": "email",
+                "recipient": "alex@example.com",
+                "body": "Confirmed call for Oct 18 at 15:00 UTC.",
+            })),
+        )
+        .with_postcondition(json!({
+            "status": "delivered",
+            "channel": "email",
+        })),
+    ]
+}
+
+fn into_args(value: Value) -> ActionArguments {
+    match value {
+        Value::Object(map) => map,
+        other => {
+            let mut map = JsonMap::new();
+            map.insert("value".into(), other);
+            map
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `replay_sandbox` CLI to replay stored planner traces with stub executors, diffing, and OTEL metrics
- expose `ReplaySandbox` in the planner crate plus telemetry helpers and markdown artifact generation
- add integration coverage for replay success/failure paths and document the workflow in README + planner event log

Fixes #185

## Testing
- cargo run -p tyrum-planner --bin replay_sandbox -- --help
- cargo test -p tyrum-planner --tests
- pre-commit run --all-files
