### PR TITLE
Implement Redis-backed capability cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "async-nats"
 version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +271,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -538,7 +553,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -789,6 +808,19 @@ dependencies = [
  "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1320,6 +1352,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2858,13 +2896,22 @@ version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
 dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "cfg-if",
  "combine",
+ "futures-channel",
+ "futures-util",
  "itoa",
  "num-bigint",
  "percent-encoding",
+ "pin-project-lite",
  "ryu",
  "sha1_smol",
  "socket2 0.6.0",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -3416,6 +3463,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4396,8 +4468,10 @@ dependencies = [
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "redis",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sqlx",
  "testcontainers",

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Follow these steps to provision the Telegram channel safely across local and sta
 | `LLM_RATE_LIMIT_PER_SECOND` | `5` | Max planner requests accepted per second. |
 | `LLM_LOG_TRUNCATE` | `256` | Character limit for prompt/response previews in logs. |
 
+### API Environment
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `REDIS_URL` | `redis://redis:6379/0` | Redis connection string for capability schema and cost caches (5 minute TTL). Leave unset to disable caching (requests log `cache_unavailable` and fall back to Postgres). |
+
 Planner containers resolve the gateway via the `LLM_GATEWAY_URL` environment variable, set to `http://llm-gateway:8086/completions` in Docker Compose. The compose file also overrides `LLM_VLLM_URL` to `http://mock-llm:8085/v1/completions` so the stack works without the optional vLLM profile; point this back at `http://vllm-gateway:8000/v1/completions` when running with GPU-backed inference.
 
 The Docker Compose definition lives in `infra/docker-compose.yml` and mirrors how the future GitHub Actions container smoke tests will exercise the stack.

--- a/docs/telemetry_pipeline.md
+++ b/docs/telemetry_pipeline.md
@@ -29,6 +29,7 @@ All other application services automatically depend on the collector and export 
    - **Explore → Tempo** to view spans `api.index`, `api.health`, and `policy.check` grouped by `service.name`.
    - **Explore → Loki** to see structured logs from the `tyrum-api` and `tyrum-policy` services.
    - **Explore → Prometheus** or the Prometheus UI to query `tyrum_api_http_requests_total`, `tyrum_policy_decisions_total`, `tyrum_discovery_attempt_duration_seconds`, and `tyrum_discovery_attempt_total` metrics.
+   - **Explore → Prometheus** to inspect `tyrum_api_cache_hits_total` and `tyrum_api_cache_misses_total`. Filter by the `cache.kind` label (`schema`, `cost`) to verify Redis effectiveness and miss fallbacks.
    - **Explore → Tempo** to inspect the `discovery.step` spans emitted per capability probe; each span records the `strategy`, `subject`, and `outcome` attributes so retry chains are easy to trace.
 
 ## Notes

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -28,6 +28,7 @@ sha2 = "0.10"
 anyhow = "1"
 tyrum-shared = { path = "../../shared/tyrum-shared" }
 uuid = { version = "1", features = ["serde", "v4"] }
+redis = { version = "0.32", features = ["tokio-comp", "connection-manager"] }
 
 [dev-dependencies]
 axum = { version = "0.7", features = ["json"] }
@@ -36,3 +37,4 @@ serde_json = "1"
 testcontainers = "0.18"
 tower = "0.5"
 tyrum-planner = { path = "../planner" }
+serial_test = "2"

--- a/services/api/src/cache.rs
+++ b/services/api/src/cache.rs
@@ -1,0 +1,245 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use redis::{RedisError, aio::ConnectionManager};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Error as SerdeError;
+use thiserror::Error;
+use tracing::warn;
+
+use crate::{
+    capabilities::{CapabilityCacheKey, ToolCostResponse, ToolSchemaResponse},
+    metrics::CacheKind,
+};
+
+const CACHE_NAMESPACE: &str = "tyrum:api";
+
+/// Result of consulting the cache for a specific entry.
+#[derive(Debug)]
+pub enum CacheLookup<T> {
+    Hit(T),
+    Miss,
+    Unavailable,
+}
+
+#[derive(Clone)]
+pub struct CapabilityCache {
+    backend: Option<Arc<RedisBackend>>,
+    disabled_warned: Arc<AtomicBool>,
+    disabled_reason: Arc<Option<String>>,
+}
+
+impl CapabilityCache {
+    pub async fn connect(redis_url: Option<String>, ttl: Duration) -> Self {
+        match redis_url {
+            Some(url) => match RedisBackend::connect(&url, ttl).await {
+                Ok(backend) => Self {
+                    backend: Some(Arc::new(backend)),
+                    disabled_warned: Arc::new(AtomicBool::new(false)),
+                    disabled_reason: Arc::new(None),
+                },
+                Err(error) => {
+                    warn!(
+                        target = "tyrum_api::cache",
+                        reason = %error,
+                        "cache_unavailable: failed to initialize redis backend"
+                    );
+                    Self {
+                        backend: None,
+                        disabled_warned: Arc::new(AtomicBool::new(false)),
+                        disabled_reason: Arc::new(Some(error.to_string())),
+                    }
+                }
+            },
+            None => Self {
+                backend: None,
+                disabled_warned: Arc::new(AtomicBool::new(false)),
+                disabled_reason: Arc::new(Some("REDIS_URL not configured".into())),
+            },
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            backend: None,
+            disabled_warned: Arc::new(AtomicBool::new(false)),
+            disabled_reason: Arc::new(Some("cache explicitly disabled".into())),
+        }
+    }
+
+    pub async fn schema_lookup(&self, key: &CapabilityCacheKey) -> CacheLookup<ToolSchemaResponse> {
+        self.lookup(key, CacheKind::Schema).await
+    }
+
+    pub async fn cost_lookup(&self, key: &CapabilityCacheKey) -> CacheLookup<ToolCostResponse> {
+        self.lookup(key, CacheKind::Cost).await
+    }
+
+    pub async fn cache_schema(&self, key: &CapabilityCacheKey, value: &ToolSchemaResponse) {
+        self.store(key, CacheKind::Schema, value).await;
+    }
+
+    pub async fn cache_cost(&self, key: &CapabilityCacheKey, value: &ToolCostResponse) {
+        self.store(key, CacheKind::Cost, value).await;
+    }
+
+    async fn lookup<T>(&self, key: &CapabilityCacheKey, kind: CacheKind) -> CacheLookup<T>
+    where
+        T: DeserializeOwned,
+    {
+        if let Some(backend) = &self.backend {
+            match backend.get::<T>(key, kind).await {
+                Ok(Some(value)) => CacheLookup::Hit(value),
+                Ok(None) => CacheLookup::Miss,
+                Err(error) => {
+                    backend.warn_unavailable(&error);
+                    CacheLookup::Unavailable
+                }
+            }
+        } else {
+            self.warn_disabled();
+            CacheLookup::Unavailable
+        }
+    }
+
+    async fn store<T>(&self, key: &CapabilityCacheKey, kind: CacheKind, value: &T)
+    where
+        T: Serialize,
+    {
+        if let Some(backend) = &self.backend {
+            if let Err(error) = backend.set(key, kind, value).await {
+                backend.warn_unavailable(&error);
+            }
+        } else {
+            self.warn_disabled();
+        }
+    }
+
+    fn warn_disabled(&self) {
+        if !self.mark_disabled_warned() {
+            return;
+        }
+
+        Self::emit_disabled_warning(self.disabled_reason());
+    }
+
+    fn mark_disabled_warned(&self) -> bool {
+        self.disabled_warned
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    fn disabled_reason(&self) -> Option<&str> {
+        self.disabled_reason.as_ref().as_deref()
+    }
+
+    fn emit_disabled_warning(reason: Option<&str>) {
+        match reason {
+            Some(reason) => Self::emit_disabled_warning_with_reason(reason),
+            None => Self::emit_disabled_warning_without_reason(),
+        }
+    }
+
+    fn emit_disabled_warning_with_reason(reason: &str) {
+        warn!(
+            target = "tyrum_api::cache",
+            reason = %reason,
+            "cache_unavailable: redis cache disabled"
+        );
+    }
+
+    fn emit_disabled_warning_without_reason() {
+        warn!(
+            target = "tyrum_api::cache",
+            "cache_unavailable: redis cache disabled"
+        );
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CacheBackendError {
+    #[error("redis error: {0}")]
+    Redis(#[from] RedisError),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] SerdeError),
+}
+
+struct RedisBackend {
+    manager: ConnectionManager,
+    ttl: Duration,
+}
+
+impl RedisBackend {
+    async fn connect(url: &str, ttl: Duration) -> Result<Self, CacheBackendError> {
+        let client = redis::Client::open(url)?;
+        let manager = ConnectionManager::new(client).await?;
+        Ok(Self { manager, ttl })
+    }
+
+    async fn get<T>(
+        &self,
+        key: &CapabilityCacheKey,
+        kind: CacheKind,
+    ) -> Result<Option<T>, CacheBackendError>
+    where
+        T: DeserializeOwned,
+    {
+        let mut connection = self.manager.clone();
+        let redis_key = key.redis_key(CACHE_NAMESPACE, kind);
+        let payload: Option<String> = redis::cmd("GET")
+            .arg(redis_key)
+            .query_async(&mut connection)
+            .await?;
+
+        match payload {
+            Some(serialized) => {
+                let value = serde_json::from_str(&serialized)?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn set<T>(
+        &self,
+        key: &CapabilityCacheKey,
+        kind: CacheKind,
+        value: &T,
+    ) -> Result<(), CacheBackendError>
+    where
+        T: Serialize,
+    {
+        let mut connection = self.manager.clone();
+        let redis_key = key.redis_key(CACHE_NAMESPACE, kind);
+        let serialized = serde_json::to_string(value)?;
+        let ttl_seconds = self.ttl.as_secs();
+
+        if ttl_seconds == 0 {
+            let _: () = redis::cmd("SET")
+                .arg(redis_key)
+                .arg(serialized)
+                .query_async(&mut connection)
+                .await?;
+        } else {
+            let _: () = redis::cmd("SETEX")
+                .arg(redis_key)
+                .arg(ttl_seconds as usize)
+                .arg(serialized)
+                .query_async(&mut connection)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    fn warn_unavailable(&self, error: &CacheBackendError) {
+        warn!(
+            target = "tyrum_api::cache",
+            reason = %error,
+            "cache_unavailable: redis operation failed"
+        );
+    }
+}

--- a/services/api/src/capabilities.rs
+++ b/services/api/src/capabilities.rs
@@ -1,0 +1,199 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::{FromRow, PgPool};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::metrics::CacheKind;
+
+#[derive(Debug, Error)]
+pub enum CapabilityError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+#[derive(Clone)]
+pub struct CapabilityRepository {
+    pool: PgPool,
+}
+
+impl CapabilityRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    pub async fn fetch(
+        &self,
+        key: &CapabilityCacheKey,
+    ) -> Result<Option<CapabilityRecord>, CapabilityError> {
+        let record = sqlx::query_as::<_, CapabilityRecord>(
+            r#"
+            SELECT
+                subject_id,
+                capability_type,
+                capability_identifier,
+                executor_kind,
+                selectors,
+                outcome_metadata,
+                result_summary,
+                success_count,
+                last_success_at,
+                updated_at
+            FROM capability_memories
+            WHERE subject_id = $1
+              AND capability_type = $2
+              AND capability_identifier = $3
+              AND executor_kind = $4
+            "#,
+        )
+        .bind(key.subject_id)
+        .bind(&key.capability_type)
+        .bind(&key.capability_identifier)
+        .bind(&key.executor_kind)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(record)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSchemaResponse {
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selectors: Option<Value>,
+    pub outcome_metadata: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_summary: Option<String>,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCostResponse {
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+    pub cost: CostBreakdown,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CostBreakdown {
+    pub amount_minor_units: i64,
+    pub currency: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapabilityCacheKey {
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+}
+
+impl CapabilityCacheKey {
+    pub fn redis_key(&self, namespace: &str, kind: CacheKind) -> String {
+        format!(
+            "{namespace}:capability:{}:{}:{}:{}:{}",
+            kind.as_str(),
+            self.subject_id,
+            sanitize_segment(&self.capability_type),
+            sanitize_segment(&self.capability_identifier),
+            sanitize_segment(&self.executor_kind),
+        )
+    }
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct CapabilityRecord {
+    pub subject_id: Uuid,
+    pub capability_type: String,
+    pub capability_identifier: String,
+    pub executor_kind: String,
+    pub selectors: Option<Value>,
+    pub outcome_metadata: Value,
+    pub result_summary: Option<String>,
+    pub success_count: i32,
+    pub last_success_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl CapabilityRecord {
+    pub fn into_schema_response(self) -> ToolSchemaResponse {
+        ToolSchemaResponse {
+            subject_id: self.subject_id,
+            capability_type: self.capability_type,
+            capability_identifier: self.capability_identifier,
+            executor_kind: self.executor_kind,
+            selectors: self.selectors,
+            outcome_metadata: self.outcome_metadata,
+            result_summary: self.result_summary,
+            success_count: self.success_count,
+            last_success_at: self.last_success_at,
+            updated_at: self.updated_at,
+        }
+    }
+
+    pub fn into_cost_response(self) -> Option<ToolCostResponse> {
+        let cost = extract_cost(&self.outcome_metadata)?;
+        Some(ToolCostResponse {
+            subject_id: self.subject_id,
+            capability_type: self.capability_type,
+            capability_identifier: self.capability_identifier,
+            executor_kind: self.executor_kind,
+            cost,
+            success_count: self.success_count,
+            last_success_at: self.last_success_at,
+        })
+    }
+}
+
+fn extract_cost(outcome: &Value) -> Option<CostBreakdown> {
+    let cost = outcome.get("cost")?;
+    let currency = cost.get("currency")?.as_str()?.to_string();
+    let amount_minor_units = cost
+        .get("amount_minor_units")
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            cost.get("amount_minor_units")
+                .and_then(Value::as_u64)
+                .and_then(|value| i64::try_from(value).ok())
+        })?;
+
+    let observed_at = cost
+        .get("observed_at")
+        .and_then(Value::as_str)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|dt| dt.with_timezone(&Utc));
+
+    Some(CostBreakdown {
+        amount_minor_units,
+        currency,
+        observed_at,
+    })
+}
+
+fn sanitize_segment(segment: &str) -> String {
+    segment
+        .chars()
+        .map(|ch| match ch {
+            ' ' | '\n' | '\r' | '\t' => '_',
+            ':' | '|' => '-',
+            other => other,
+        })
+        .collect()
+}

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod account_linking;
 pub mod audit;
+pub mod cache;
+pub mod capabilities;
 pub mod ingress;
 pub mod metrics;
 pub mod profiles;

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,10 +1,12 @@
-use std::{collections::HashMap, env, net::SocketAddr};
+use std::{collections::HashMap, env, net::SocketAddr, time::Duration};
 
 use anyhow::{Context, Result, anyhow};
 
 use tyrum_api::{
     account_linking::AccountLinkingRepository,
     audit::{AuditTimelineError, AuditTimelineRepository},
+    cache::{CacheLookup, CapabilityCache},
+    capabilities::{CapabilityCacheKey, CapabilityRepository},
     ingress::{IngressRepository, IngressRepositoryError},
     metrics,
     profiles::{
@@ -45,6 +47,11 @@ const PROFILES_ROUTE: &str = "/profiles";
 const PROFILE_PAM_ROUTE: &str = "/profiles/pam";
 const PROFILE_PVP_ROUTE: &str = "/profiles/pvp";
 const PORTAL_ACCOUNT_ID: &str = "11111111-2222-3333-4444-555555555555";
+const CAPABILITY_SCHEMA_ROUTE: &str =
+    "/capabilities/:subject_id/:capability_type/:capability_identifier/:executor_kind/schema";
+const CAPABILITY_COST_ROUTE: &str =
+    "/capabilities/:subject_id/:capability_type/:capability_identifier/:executor_kind/cost";
+const DEFAULT_CAPABILITY_CACHE_TTL: Duration = Duration::from_secs(300);
 
 #[derive(Clone, Copy)]
 struct IntegrationDefinition {
@@ -80,6 +87,8 @@ struct AppState {
     watchers: WatcherRepository,
     telegram: telegram::TelegramWebhookVerifier,
     profiles: ProfilesRepository,
+    capabilities: CapabilityRepository,
+    cache: CapabilityCache,
     portal_subject_id: Uuid,
 }
 
@@ -116,6 +125,14 @@ struct UpdatePreferenceRequest {
 struct UpdatePreferenceResponse {
     status: &'static str,
     integration: IntegrationPreferenceResponse,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityPathParams {
+    subject_id: Uuid,
+    capability_type: String,
+    capability_identifier: String,
+    executor_kind: String,
 }
 
 fn normalize_integration_slug(raw: &str) -> String {
@@ -190,6 +207,8 @@ fn build_router(state: AppState) -> Router {
         .route(PROFILE_PAM_ROUTE, put(update_pam_profile))
         .route(PROFILE_PVP_ROUTE, put(update_pvp_profile))
         .route(WATCHERS_ROUTE, post(register_watcher))
+        .route(CAPABILITY_SCHEMA_ROUTE, get(get_capability_schema))
+        .route(CAPABILITY_COST_ROUTE, get(get_capability_cost))
         .route(TELEGRAM_WEBHOOK_ROUTE, post(telegram_webhook))
         .with_state(state)
 }
@@ -243,6 +262,183 @@ async fn get_plan_timeline(State(state): State<AppState>, Path(plan_id): Path<Uu
     metrics::record_http_request("GET", AUDIT_PLAN_TIMELINE_ROUTE, response.status().as_u16());
 
     response
+}
+
+#[tracing::instrument(
+    name = "api.capabilities.schema",
+    skip_all,
+    fields(
+        subject_id = %params.subject_id,
+        capability_type = %params.capability_type,
+        capability_identifier = %params.capability_identifier,
+        executor_kind = %params.executor_kind
+    )
+)]
+async fn get_capability_schema(
+    State(state): State<AppState>,
+    Path(params): Path<CapabilityPathParams>,
+) -> Response {
+    let CapabilityPathParams {
+        subject_id,
+        capability_type,
+        capability_identifier,
+        executor_kind,
+    } = params;
+
+    let cache_key = CapabilityCacheKey {
+        subject_id,
+        capability_type: capability_type.clone(),
+        capability_identifier: capability_identifier.clone(),
+        executor_kind: executor_kind.clone(),
+    };
+
+    let lookup = state.cache.schema_lookup(&cache_key).await;
+    match lookup {
+        CacheLookup::Hit(schema) => {
+            metrics::record_cache_hit(metrics::CacheKind::Schema);
+            let response = Json(schema).into_response();
+            metrics::record_http_request(
+                "GET",
+                CAPABILITY_SCHEMA_ROUTE,
+                response.status().as_u16(),
+            );
+            response
+        }
+        _ => {
+            let status = match lookup {
+                CacheLookup::Miss => metrics::CacheMissStatus::Miss,
+                CacheLookup::Unavailable => metrics::CacheMissStatus::Unavailable,
+                CacheLookup::Hit(_) => unreachable!("handled above"),
+            };
+            metrics::record_cache_miss(metrics::CacheKind::Schema, status);
+
+            let response = match state.capabilities.fetch(&cache_key).await {
+                Ok(Some(record)) => {
+                    let schema = record.into_schema_response();
+                    state.cache.cache_schema(&cache_key, &schema).await;
+                    Json(schema).into_response()
+                }
+                Ok(None) => (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: "capability_not_found",
+                        message: format!(
+                            "Capability {capability_type} / {capability_identifier} for executor {executor_kind} was not found."
+                        ),
+                    }),
+                )
+                    .into_response(),
+                Err(error) => {
+                    tracing::error!(reason = %error, "failed to load capability schema");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: "capability_lookup_failed",
+                            message: "Unable to load capability metadata".into(),
+                        }),
+                    )
+                        .into_response()
+                }
+            };
+
+            metrics::record_http_request(
+                "GET",
+                CAPABILITY_SCHEMA_ROUTE,
+                response.status().as_u16(),
+            );
+            response
+        }
+    }
+}
+
+#[tracing::instrument(
+    name = "api.capabilities.cost",
+    skip_all,
+    fields(
+        subject_id = %params.subject_id,
+        capability_type = %params.capability_type,
+        capability_identifier = %params.capability_identifier,
+        executor_kind = %params.executor_kind
+    )
+)]
+async fn get_capability_cost(
+    State(state): State<AppState>,
+    Path(params): Path<CapabilityPathParams>,
+) -> Response {
+    let CapabilityPathParams {
+        subject_id,
+        capability_type,
+        capability_identifier,
+        executor_kind,
+    } = params;
+
+    let cache_key = CapabilityCacheKey {
+        subject_id,
+        capability_type: capability_type.clone(),
+        capability_identifier: capability_identifier.clone(),
+        executor_kind: executor_kind.clone(),
+    };
+
+    let lookup = state.cache.cost_lookup(&cache_key).await;
+    match lookup {
+        CacheLookup::Hit(cost) => {
+            metrics::record_cache_hit(metrics::CacheKind::Cost);
+            let response = Json(cost).into_response();
+            metrics::record_http_request("GET", CAPABILITY_COST_ROUTE, response.status().as_u16());
+            response
+        }
+        _ => {
+            let status = match lookup {
+                CacheLookup::Miss => metrics::CacheMissStatus::Miss,
+                CacheLookup::Unavailable => metrics::CacheMissStatus::Unavailable,
+                CacheLookup::Hit(_) => unreachable!("handled above"),
+            };
+            metrics::record_cache_miss(metrics::CacheKind::Cost, status);
+
+            let response = match state.capabilities.fetch(&cache_key).await {
+                Ok(Some(record)) => match record.into_cost_response() {
+                    Some(cost) => {
+                        state.cache.cache_cost(&cache_key, &cost).await;
+                        Json(cost).into_response()
+                    }
+                    None => (
+                        StatusCode::NOT_FOUND,
+                        Json(ErrorResponse {
+                            error: "cost_not_recorded",
+                            message: format!(
+                                "No cost metadata recorded for capability {capability_type} / {capability_identifier} ({executor_kind})."
+                            ),
+                        }),
+                    )
+                        .into_response(),
+                },
+                Ok(None) => (
+                    StatusCode::NOT_FOUND,
+                    Json(ErrorResponse {
+                        error: "capability_not_found",
+                        message: format!(
+                            "Capability {capability_type} / {capability_identifier} for executor {executor_kind} was not found."
+                        ),
+                    }),
+                )
+                    .into_response(),
+                Err(error) => {
+                    tracing::error!(reason = %error, "failed to load capability cost data");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: "capability_lookup_failed",
+                            message: "Unable to load capability cost metadata".into(),
+                        }),
+                    )
+                        .into_response()
+                }
+            };
+
+            metrics::record_http_request("GET", CAPABILITY_COST_ROUTE, response.status().as_u16());
+            response
+        }
+    }
 }
 
 #[tracing::instrument(name = "api.profiles.get", skip_all)]
@@ -779,6 +975,12 @@ async fn main() -> Result<()> {
     let audit = AuditTimelineRepository::new(waitlist.pool().clone());
     let watchers = WatcherRepository::new(waitlist.pool().clone());
     let profiles = ProfilesRepository::new(waitlist.pool().clone());
+    let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+    let redis_url = env::var("REDIS_URL")
+        .ok()
+        .map(|raw| raw.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let cache = CapabilityCache::connect(redis_url, DEFAULT_CAPABILITY_CACHE_TTL).await;
     let portal_subject_id =
         Uuid::parse_str(PORTAL_ACCOUNT_ID).context("PORTAL_ACCOUNT_ID must be a valid UUID")?;
 
@@ -795,6 +997,8 @@ async fn main() -> Result<()> {
         watchers,
         telegram,
         profiles,
+        capabilities,
+        cache,
         portal_subject_id,
     });
 
@@ -814,17 +1018,19 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::{
-        ACCOUNT_LINKING_ROUTE, AppState, AuditTimelineRepository, PLACEHOLDER_INTEGRATIONS,
-        PORTAL_ACCOUNT_ID, PROFILE_PAM_ROUTE, PROFILE_PVP_ROUTE, PROFILES_ROUTE,
-        TELEGRAM_WEBHOOK_ROUTE, WAITLIST_ROUTE, build_router, sanitize_opt,
+        ACCOUNT_LINKING_ROUTE, AppState, AuditTimelineRepository, DEFAULT_CAPABILITY_CACHE_TTL,
+        PLACEHOLDER_INTEGRATIONS, PORTAL_ACCOUNT_ID, PROFILE_PAM_ROUTE, PROFILE_PVP_ROUTE,
+        PROFILES_ROUTE, TELEGRAM_WEBHOOK_ROUTE, WAITLIST_ROUTE, build_router, sanitize_opt,
     };
+    use crate::metrics;
     use axum::{
         body::Body,
         http::{Request, StatusCode},
     };
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
     use http_body_util::BodyExt;
     use serde_json::{Value, json};
+    use serial_test::serial;
     use sqlx::{PgPool, Row, postgres::PgPoolOptions};
     use std::{path::Path, time::Duration};
     use testcontainers::{
@@ -836,6 +1042,8 @@ mod tests {
     use tower::ServiceExt;
     use tyrum_api::{
         account_linking::AccountLinkingRepository,
+        cache::CapabilityCache,
+        capabilities::{CapabilityCacheKey, CapabilityRepository},
         ingress::IngressRepository,
         profiles::ProfilesRepository,
         telegram::TelegramWebhookVerifier,
@@ -850,6 +1058,8 @@ mod tests {
     const POSTGRES_USER: &str = "tyrum";
     const POSTGRES_PASSWORD: &str = "tyrum_dev_password";
     const POSTGRES_DB: &str = "tyrum_dev";
+    const REDIS_IMAGE: &str = "redis";
+    const REDIS_TAG: &str = "7-alpine";
 
     async fn ensure_planner_event_log_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
         sqlx::query(
@@ -931,6 +1141,10 @@ mod tests {
         account_linking: AccountLinkingRepository,
         ingress: IngressRepository,
         profiles: ProfilesRepository,
+        #[allow(dead_code)]
+        capabilities: CapabilityRepository,
+        #[allow(dead_code)]
+        cache: CapabilityCache,
         telegram: TelegramWebhookVerifier,
     }
 
@@ -967,6 +1181,8 @@ mod tests {
             let ingress = IngressRepository::new(waitlist.pool().clone());
             let watchers = WatcherRepository::new(waitlist.pool().clone());
             let profiles = ProfilesRepository::new(waitlist.pool().clone());
+            let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+            let cache = CapabilityCache::disabled();
             let portal_subject_id =
                 Uuid::parse_str(PORTAL_ACCOUNT_ID).expect("valid portal subject uuid");
             ensure_planner_event_log_schema(waitlist.pool())
@@ -983,6 +1199,8 @@ mod tests {
                 watchers: watchers.clone(),
                 telegram: telegram.clone(),
                 profiles: profiles.clone(),
+                capabilities: capabilities.clone(),
+                cache: cache.clone(),
                 portal_subject_id,
             });
 
@@ -993,6 +1211,8 @@ mod tests {
                 account_linking,
                 ingress,
                 profiles,
+                capabilities,
+                cache,
                 telegram,
             }
         }
@@ -1026,6 +1246,99 @@ mod tests {
         panic!("postgres never became ready");
     }
 
+    async fn ensure_capability_memory_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS capability_memories (
+                id BIGSERIAL PRIMARY KEY,
+                subject_id UUID NOT NULL,
+                capability_type TEXT NOT NULL,
+                capability_identifier TEXT NOT NULL,
+                executor_kind TEXT NOT NULL,
+                selectors JSONB,
+                outcome_metadata JSONB NOT NULL,
+                result_summary TEXT,
+                success_count INTEGER NOT NULL DEFAULT 1 CHECK (success_count > 0),
+                last_success_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE(subject_id, capability_type, capability_identifier, executor_kind)
+            )
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS capability_memories_subject_type_idx
+            ON capability_memories (subject_id, capability_type)
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE INDEX IF NOT EXISTS capability_memories_last_success_idx
+            ON capability_memories (subject_id, last_success_at DESC)
+            "#,
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn insert_capability_memory(
+        pool: &PgPool,
+        key: &CapabilityCacheKey,
+        selectors: Option<Value>,
+        outcome_metadata: Value,
+        result_summary: Option<&str>,
+        success_count: i32,
+        last_success_at: DateTime<Utc>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO capability_memories (
+                subject_id,
+                capability_type,
+                capability_identifier,
+                executor_kind,
+                selectors,
+                outcome_metadata,
+                result_summary,
+                success_count,
+                last_success_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+            ON CONFLICT (subject_id, capability_type, capability_identifier, executor_kind)
+            DO UPDATE SET
+                selectors = EXCLUDED.selectors,
+                outcome_metadata = EXCLUDED.outcome_metadata,
+                result_summary = EXCLUDED.result_summary,
+                success_count = EXCLUDED.success_count,
+                last_success_at = EXCLUDED.last_success_at,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(key.subject_id)
+        .bind(&key.capability_type)
+        .bind(&key.capability_identifier)
+        .bind(&key.executor_kind)
+        .bind(selectors)
+        .bind(outcome_metadata)
+        .bind(result_summary)
+        .bind(success_count)
+        .bind(last_success_at)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn health_endpoint_returns_ok() {
         let pool = PgPoolOptions::new()
@@ -1040,6 +1353,8 @@ mod tests {
         }
         let audit = AuditTimelineRepository::new(waitlist.pool().clone());
         let profiles = ProfilesRepository::new(waitlist.pool().clone());
+        let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+        let cache = CapabilityCache::disabled();
         let telegram =
             TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
         let portal_subject_id =
@@ -1052,6 +1367,8 @@ mod tests {
             watchers,
             telegram,
             profiles,
+            capabilities,
+            cache,
             portal_subject_id,
         };
         let app = build_router(state);
@@ -1673,6 +1990,447 @@ mod tests {
             payload["pvp"]["profile"]["voice"]["voice_id"],
             json!("voice_test")
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn capability_schema_cache_emits_hit_and_miss_metrics() {
+        if !docker_available() {
+            eprintln!(
+                "skipping capability_schema_cache_emits_hit_and_miss_metrics: docker unavailable"
+            );
+            return;
+        }
+
+        metrics::test::reset();
+
+        let postgres_image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+            .with_exposed_port(5432.tcp())
+            .with_wait_for(WaitFor::message_on_stdout(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_USER", POSTGRES_USER)
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", POSTGRES_DB);
+        let redis_image = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+            .with_exposed_port(6379.tcp())
+            .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+
+        let postgres = postgres_image.start().await.expect("start postgres");
+        let redis = redis_image.start().await.expect("start redis");
+
+        wait_for_postgres_ready(&postgres).await;
+
+        let pg_port = postgres
+            .get_host_port_ipv4(5432.tcp())
+            .await
+            .expect("postgres port");
+        let redis_port = redis
+            .get_host_port_ipv4(6379.tcp())
+            .await
+            .expect("redis port");
+
+        let database_url = format!(
+            "postgres://{}:{}@127.0.0.1:{}/{}",
+            POSTGRES_USER, POSTGRES_PASSWORD, pg_port, POSTGRES_DB
+        );
+        let redis_url = format!("redis://127.0.0.1:{redis_port}/0");
+
+        let waitlist = connect_with_retry(&database_url).await;
+        waitlist.migrate().await.expect("run migrations");
+        ensure_capability_memory_schema(waitlist.pool())
+            .await
+            .expect("create capability memories schema");
+
+        let subject_id = Uuid::new_v4();
+        let key = CapabilityCacheKey {
+            subject_id,
+            capability_type: "web".into(),
+            capability_identifier: "calendar.example.com".into(),
+            executor_kind: "generic-web".into(),
+        };
+        insert_capability_memory(
+            waitlist.pool(),
+            &key,
+            Some(json!({
+                "login_button": "#login",
+                "otp_field": "[data-test\"otp\"]"
+            })),
+            json!({
+                "postcondition": {
+                    "status": "booked"
+                },
+                "cost": {
+                    "amount_minor_units": 2599,
+                    "currency": "USD"
+                }
+            }),
+            Some("generic-web satisfied intent book_call"),
+            3,
+            Utc::now(),
+        )
+        .await
+        .expect("seed capability memory");
+
+        let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
+        let ingress = IngressRepository::new(waitlist.pool().clone());
+        let audit = AuditTimelineRepository::new(waitlist.pool().clone());
+        let watchers = WatcherRepository::new(waitlist.pool().clone());
+        let profiles = ProfilesRepository::new(waitlist.pool().clone());
+        let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+        let cache = CapabilityCache::connect(Some(redis_url), DEFAULT_CAPABILITY_CACHE_TTL).await;
+        let portal_subject_id =
+            Uuid::parse_str(PORTAL_ACCOUNT_ID).expect("valid portal subject uuid");
+        let telegram =
+            TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
+
+        capabilities
+            .clone()
+            .fetch(&key)
+            .await
+            .expect("load capability")
+            .expect("capability stored");
+
+        let router = build_router(AppState {
+            waitlist,
+            account_linking,
+            ingress,
+            audit,
+            watchers,
+            telegram,
+            profiles,
+            capabilities,
+            cache,
+            portal_subject_id,
+        });
+
+        let schema_route = format!(
+            "/capabilities/{}/{}/{}/{}/schema",
+            subject_id, "web", "calendar.example.com", "generic-web"
+        );
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&schema_route)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "schema lookup failed: {}",
+            String::from_utf8_lossy(&body_bytes)
+        );
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(&schema_route)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "schema lookup failed: {}",
+            String::from_utf8_lossy(&body_bytes)
+        );
+
+        let snapshot = metrics::test::snapshot();
+        assert_eq!(snapshot.schema_hits, 1);
+        assert_eq!(snapshot.schema_miss, 1);
+        assert_eq!(snapshot.schema_unavailable, 0);
+        assert_eq!(snapshot.cost_hits, 0);
+        assert_eq!(snapshot.cost_miss, 0);
+        assert_eq!(snapshot.cost_unavailable, 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn capability_cost_cache_emits_hit_and_miss_metrics() {
+        if !docker_available() {
+            eprintln!(
+                "skipping capability_cost_cache_emits_hit_and_miss_metrics: docker unavailable"
+            );
+            return;
+        }
+
+        metrics::test::reset();
+
+        let postgres_image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+            .with_exposed_port(5432.tcp())
+            .with_wait_for(WaitFor::message_on_stdout(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_USER", POSTGRES_USER)
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", POSTGRES_DB);
+        let redis_image = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+            .with_exposed_port(6379.tcp())
+            .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+
+        let postgres = postgres_image.start().await.expect("start postgres");
+        let redis = redis_image.start().await.expect("start redis");
+
+        wait_for_postgres_ready(&postgres).await;
+
+        let pg_port = postgres
+            .get_host_port_ipv4(5432.tcp())
+            .await
+            .expect("postgres port");
+        let redis_port = redis
+            .get_host_port_ipv4(6379.tcp())
+            .await
+            .expect("redis port");
+
+        let database_url = format!(
+            "postgres://{}:{}@127.0.0.1:{}/{}",
+            POSTGRES_USER, POSTGRES_PASSWORD, pg_port, POSTGRES_DB
+        );
+        let redis_url = format!("redis://127.0.0.1:{redis_port}/0");
+
+        let waitlist = connect_with_retry(&database_url).await;
+        waitlist.migrate().await.expect("run migrations");
+        ensure_capability_memory_schema(waitlist.pool())
+            .await
+            .expect("create capability memories schema");
+
+        let subject_id = Uuid::new_v4();
+        let key = CapabilityCacheKey {
+            subject_id,
+            capability_type: "web".into(),
+            capability_identifier: "travel.example.com".into(),
+            executor_kind: "generic-web".into(),
+        };
+        insert_capability_memory(
+            waitlist.pool(),
+            &key,
+            None,
+            json!({
+                "postcondition": {
+                    "status": "completed"
+                },
+                "cost": {
+                    "amount_minor_units": 1899,
+                    "currency": "EUR"
+                }
+            }),
+            None,
+            2,
+            Utc::now(),
+        )
+        .await
+        .expect("seed capability memory");
+
+        let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
+        let ingress = IngressRepository::new(waitlist.pool().clone());
+        let audit = AuditTimelineRepository::new(waitlist.pool().clone());
+        let watchers = WatcherRepository::new(waitlist.pool().clone());
+        let profiles = ProfilesRepository::new(waitlist.pool().clone());
+        let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+        let cache = CapabilityCache::connect(Some(redis_url), DEFAULT_CAPABILITY_CACHE_TTL).await;
+        let portal_subject_id =
+            Uuid::parse_str(PORTAL_ACCOUNT_ID).expect("valid portal subject uuid");
+        let telegram =
+            TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
+
+        capabilities
+            .clone()
+            .fetch(&key)
+            .await
+            .expect("load capability")
+            .expect("capability stored");
+
+        let router = build_router(AppState {
+            waitlist,
+            account_linking,
+            ingress,
+            audit,
+            watchers,
+            telegram,
+            profiles,
+            capabilities,
+            cache,
+            portal_subject_id,
+        });
+
+        let cost_route = format!(
+            "/capabilities/{}/{}/{}/{}/cost",
+            subject_id, "web", "travel.example.com", "generic-web"
+        );
+
+        for _ in 0..2 {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(&cost_route)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let status = response.status();
+            let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "cost lookup failed: {}",
+                String::from_utf8_lossy(&body_bytes)
+            );
+        }
+
+        let snapshot = metrics::test::snapshot();
+        assert_eq!(snapshot.cost_hits, 1);
+        assert_eq!(snapshot.cost_miss, 1);
+        assert_eq!(snapshot.cost_unavailable, 0);
+        assert_eq!(snapshot.schema_hits, 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn capability_cache_gracefully_handles_unavailable_backend() {
+        if !docker_available() {
+            eprintln!(
+                "skipping capability_cache_gracefully_handles_unavailable_backend: docker unavailable"
+            );
+            return;
+        }
+
+        metrics::test::reset();
+
+        let postgres_image = GenericImage::new(POSTGRES_IMAGE, POSTGRES_TAG)
+            .with_exposed_port(5432.tcp())
+            .with_wait_for(WaitFor::message_on_stdout(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_USER", POSTGRES_USER)
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", POSTGRES_DB);
+
+        let postgres = postgres_image.start().await.expect("start postgres");
+        wait_for_postgres_ready(&postgres).await;
+
+        let pg_port = postgres
+            .get_host_port_ipv4(5432.tcp())
+            .await
+            .expect("postgres port");
+
+        let database_url = format!(
+            "postgres://{}:{}@127.0.0.1:{}/{}",
+            POSTGRES_USER, POSTGRES_PASSWORD, pg_port, POSTGRES_DB
+        );
+
+        let waitlist = connect_with_retry(&database_url).await;
+        waitlist.migrate().await.expect("run migrations");
+        ensure_capability_memory_schema(waitlist.pool())
+            .await
+            .expect("create capability memories schema");
+
+        let subject_id = Uuid::new_v4();
+        let key = CapabilityCacheKey {
+            subject_id,
+            capability_type: "web".into(),
+            capability_identifier: "unavailable.example.com".into(),
+            executor_kind: "generic-web".into(),
+        };
+        insert_capability_memory(
+            waitlist.pool(),
+            &key,
+            None,
+            json!({
+                "postcondition": {
+                    "status": "completed"
+                },
+                "cost": {
+                    "amount_minor_units": 990,
+                    "currency": "GBP"
+                }
+            }),
+            None,
+            1,
+            Utc::now(),
+        )
+        .await
+        .expect("seed capability memory");
+
+        let account_linking = AccountLinkingRepository::new(waitlist.pool().clone());
+        let ingress = IngressRepository::new(waitlist.pool().clone());
+        let audit = AuditTimelineRepository::new(waitlist.pool().clone());
+        let watchers = WatcherRepository::new(waitlist.pool().clone());
+        let profiles = ProfilesRepository::new(waitlist.pool().clone());
+        let capabilities = CapabilityRepository::new(waitlist.pool().clone());
+        let cache = CapabilityCache::disabled();
+        let portal_subject_id =
+            Uuid::parse_str(PORTAL_ACCOUNT_ID).expect("valid portal subject uuid");
+        let telegram =
+            TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
+
+        capabilities
+            .clone()
+            .fetch(&key)
+            .await
+            .expect("load capability")
+            .expect("capability stored");
+
+        let router = build_router(AppState {
+            waitlist,
+            account_linking,
+            ingress,
+            audit,
+            watchers,
+            telegram,
+            profiles,
+            capabilities,
+            cache,
+            portal_subject_id,
+        });
+
+        let cost_route = format!(
+            "/capabilities/{}/{}/{}/{}/cost",
+            subject_id, "web", "unavailable.example.com", "generic-web"
+        );
+
+        for _ in 0..2 {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri(&cost_route)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let status = response.status();
+            let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "cost lookup failed: {}",
+                String::from_utf8_lossy(&body_bytes)
+            );
+        }
+
+        let snapshot = metrics::test::snapshot();
+        assert_eq!(snapshot.cost_hits, 0);
+        assert_eq!(snapshot.cost_miss, 0);
+        assert_eq!(snapshot.cost_unavailable, 2);
     }
 
     #[test]

--- a/services/api/src/metrics.rs
+++ b/services/api/src/metrics.rs
@@ -8,6 +8,20 @@ static REQUEST_COUNTER: Lazy<Counter<u64>> = Lazy::new(|| {
         .build()
 });
 
+static CACHE_HIT_COUNTER: Lazy<Counter<u64>> = Lazy::new(|| {
+    global::meter("tyrum-api")
+        .u64_counter("tyrum_api_cache_hits_total")
+        .with_description("Number of cache hits for Tyrum API capability lookups")
+        .build()
+});
+
+static CACHE_MISS_COUNTER: Lazy<Counter<u64>> = Lazy::new(|| {
+    global::meter("tyrum-api")
+        .u64_counter("tyrum_api_cache_misses_total")
+        .with_description("Number of cache misses for Tyrum API capability lookups")
+        .build()
+});
+
 pub fn record_http_request(method: &'static str, route: &'static str, status: u16) {
     REQUEST_COUNTER.add(
         1,
@@ -17,4 +31,130 @@ pub fn record_http_request(method: &'static str, route: &'static str, status: u1
             KeyValue::new("http.status_code", status as i64),
         ],
     );
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CacheKind {
+    Schema,
+    Cost,
+}
+
+impl CacheKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Schema => "schema",
+            Self::Cost => "cost",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CacheMissStatus {
+    Miss,
+    Unavailable,
+}
+
+impl CacheMissStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Miss => "miss",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+pub fn record_cache_hit(kind: CacheKind) {
+    CACHE_HIT_COUNTER.add(1, &[KeyValue::new("cache.kind", kind.as_str())]);
+    test::increment_hit(kind);
+}
+
+pub fn record_cache_miss(kind: CacheKind, status: CacheMissStatus) {
+    CACHE_MISS_COUNTER.add(
+        1,
+        &[
+            KeyValue::new("cache.kind", kind.as_str()),
+            KeyValue::new("status", status.as_str()),
+        ],
+    );
+    test::increment_miss(kind, status);
+}
+
+pub mod test {
+    use super::{CacheKind, CacheMissStatus};
+    use once_cell::sync::Lazy;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[derive(Default)]
+    struct CacheCounters {
+        schema_hits: AtomicU64,
+        cost_hits: AtomicU64,
+        schema_miss: AtomicU64,
+        schema_unavailable: AtomicU64,
+        cost_miss: AtomicU64,
+        cost_unavailable: AtomicU64,
+    }
+
+    static COUNTERS: Lazy<CacheCounters> = Lazy::new(CacheCounters::default);
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    pub struct Snapshot {
+        pub schema_hits: u64,
+        pub schema_miss: u64,
+        pub schema_unavailable: u64,
+        pub cost_hits: u64,
+        pub cost_miss: u64,
+        pub cost_unavailable: u64,
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn reset() {
+        COUNTERS.schema_hits.store(0, Ordering::Relaxed);
+        COUNTERS.cost_hits.store(0, Ordering::Relaxed);
+        COUNTERS.schema_miss.store(0, Ordering::Relaxed);
+        COUNTERS.schema_unavailable.store(0, Ordering::Relaxed);
+        COUNTERS.cost_miss.store(0, Ordering::Relaxed);
+        COUNTERS.cost_unavailable.store(0, Ordering::Relaxed);
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn snapshot() -> Snapshot {
+        Snapshot {
+            schema_hits: COUNTERS.schema_hits.load(Ordering::Relaxed),
+            schema_miss: COUNTERS.schema_miss.load(Ordering::Relaxed),
+            schema_unavailable: COUNTERS.schema_unavailable.load(Ordering::Relaxed),
+            cost_hits: COUNTERS.cost_hits.load(Ordering::Relaxed),
+            cost_miss: COUNTERS.cost_miss.load(Ordering::Relaxed),
+            cost_unavailable: COUNTERS.cost_unavailable.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(super) fn increment_hit(kind: CacheKind) {
+        match kind {
+            CacheKind::Schema => {
+                COUNTERS.schema_hits.fetch_add(1, Ordering::Relaxed);
+            }
+            CacheKind::Cost => {
+                COUNTERS.cost_hits.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    pub(super) fn increment_miss(kind: CacheKind, status: CacheMissStatus) {
+        match (kind, status) {
+            (CacheKind::Schema, CacheMissStatus::Miss) => {
+                COUNTERS.schema_miss.fetch_add(1, Ordering::Relaxed);
+            }
+            (CacheKind::Schema, CacheMissStatus::Unavailable) => {
+                COUNTERS.schema_unavailable.fetch_add(1, Ordering::Relaxed);
+            }
+            (CacheKind::Cost, CacheMissStatus::Miss) => {
+                COUNTERS.cost_miss.fetch_add(1, Ordering::Relaxed);
+            }
+            (CacheKind::Cost, CacheMissStatus::Unavailable) => {
+                COUNTERS.cost_unavailable.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 }

--- a/services/tyrum-watchers/tests/common.rs
+++ b/services/tyrum-watchers/tests/common.rs
@@ -8,6 +8,7 @@ use testcontainers::{
 pub const NATS_IMAGE: &str = "nats";
 pub const NATS_TAG: &str = "2.10-alpine";
 pub const NATS_PORT: u16 = 4222;
+pub const NATS_MONITORING_PORT: u16 = 8222;
 
 pub struct NatsFixture {
     #[allow(dead_code)]
@@ -24,9 +25,10 @@ impl NatsFixture {
     pub async fn start() -> Result<Self> {
         let image = GenericImage::new(NATS_IMAGE, NATS_TAG)
             .with_exposed_port(NATS_PORT.tcp())
+            .with_exposed_port(NATS_MONITORING_PORT.tcp())
             .with_wait_for(WaitFor::http(
                 HttpWaitStrategy::new("/healthz?js-enabled=true")
-                    .with_port(8222.tcp())
+                    .with_port(NATS_MONITORING_PORT.tcp())
                     .with_expected_status_code(200u16),
             ))
             .with_cmd(["-js", "-m", "8222"]);


### PR DESCRIPTION
## Summary
- implement Redis-backed capability schema & cost caching with Redis fallback handling
- add capability repository, cache service, AppState wiring, and metrics plus integration coverage
- document new metrics/config settings and expose NATS monitoring port for watcher tests

## Testing
- cargo test -p tyrum-api
- pre-commit run --all-files

Closes #186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Redis-backed capability cache with new capability schema/cost endpoints, cache hit/miss metrics, integration tests, and docs updates.
> 
> - **API**:
>   - Add Redis-backed capability cache (`services/api/src/cache.rs`) and capability repository/models (`services/api/src/capabilities.rs`).
>   - Expose GET `capabilities/.../schema` and `capabilities/.../cost` routes with cache lookup, DB fallback, and structured errors; wire into `AppState`.
> - **Metrics**:
>   - Add counters `tyrum_api_cache_hits_total` and `tyrum_api_cache_misses_total` with labels (`cache.kind`, `status`); test helpers for snapshots.
> - **Tests**:
>   - Integration tests using Testcontainers for Postgres/Redis validating cache hit/miss/unavailable paths; add `serial_test`.
> - **Docs/Config**:
>   - README: add `REDIS_URL` env var description and caching behavior.
>   - Telemetry docs: note new cache metrics to inspect in Prometheus/Grafana.
> - **Watchers**:
>   - Expose NATS monitoring port `8222` in test fixture.
> - **Deps**:
>   - Add Redis and related crates; enable tokio connection manager.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b3f85531b10c1473893b888a6c73bfda4a5dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->