### PR TITLE
Implement timed voice calibration flow (#198)

### DIFF
--- a/docs/product_concept_v1.md
+++ b/docs/product_concept_v1.md
@@ -609,6 +609,7 @@ curl -X POST http://localhost:8080/telegram/webhook \
 ### M3 — Persona & Voice
 - PVP editor (tone, verbosity, initiative, consent style) with on‑the‑fly tweaks (#12, Appendix B).
 - 90‑second calibration in onboarding (Telegram) (#12, Appendix E).
+- Portal onboarding start runs the timed calibration flow, persisting persona defaults alongside consent selections for the stubbed review stack.
 - Voice notes + TTS; per‑contact pronunciation dictionary (#12).
 - Explainability in voice: concise rationales tied to audit events (#13).
 

--- a/web/app/api/onboarding/consent/route.test.ts
+++ b/web/app/api/onboarding/consent/route.test.ts
@@ -98,6 +98,73 @@ describe("onboarding consent route", () => {
     expect(secondPayload.auditReference).toBe("CONSENT-STUB-0001-R02");
   });
 
+  it("persists calibration snapshots when provided", async () => {
+    const request = createRequest({
+      selections: {
+        shareCalendarSignals: true,
+        allowPlannerAutonomy: true,
+        retainAuditTrail: true,
+      },
+      calibration: {
+        persona: {
+          tone: "upbeat",
+          verbosity: "balanced",
+          initiative: "act_within_limits",
+          quietHours: "21-07",
+          spending: "50",
+          voice: "warm",
+        },
+        startedAt: "2025-10-12T10:00:00.000Z",
+        completedAt: "2025-10-12T10:01:10.000Z",
+        durationSeconds: 70,
+      },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    const payload = (await response.json()) as {
+      calibration: {
+        persona: Record<string, string>;
+        durationSeconds: number;
+        startedAt: string;
+        completedAt: string;
+      };
+      revision: number;
+    };
+
+    expect(payload.revision).toBe(1);
+    expect(payload.calibration.persona.voice).toBe("warm");
+    expect(payload.calibration.durationSeconds).toBe(70);
+
+    const snapshot = await GET();
+    const snapshotPayload = (await snapshot.json()) as {
+      calibration: { persona: Record<string, string> };
+    };
+    expect(snapshotPayload.calibration?.persona.initiative).toBe("act_within_limits");
+  });
+
+  it("rejects invalid calibration payloads", async () => {
+    const response = await POST(
+      createRequest({
+        selections: {
+          shareCalendarSignals: false,
+          allowPlannerAutonomy: true,
+          retainAuditTrail: true,
+        },
+        calibration: {
+          persona: {},
+          startedAt: "not-a-date",
+          completedAt: "still-not-a-date",
+          durationSeconds: -2,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const payload = (await response.json()) as { error: string };
+    expect(payload.error).toBe("invalid_calibration");
+  });
+
   it("rejects invalid payloads", async () => {
     const request = createRequest({ selections: { foo: "bar" } });
     const response = await POST(request);

--- a/web/app/api/onboarding/consent/route.ts
+++ b/web/app/api/onboarding/consent/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   type ConsentSelections,
+  type CalibrationSnapshot,
   persistConsent,
   snapshotConsent,
 } from "./store";
@@ -17,6 +18,56 @@ function isConsentSelections(payload: unknown): payload is ConsentSelections {
     typeof record.allowPlannerAutonomy === "boolean" &&
     typeof record.retainAuditTrail === "boolean"
   );
+}
+
+function isCalibrationPersona(value: unknown) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const allowedKeys = new Set([
+    "tone",
+    "verbosity",
+    "initiative",
+    "quietHours",
+    "spending",
+    "voice",
+  ]);
+  const record = value as Record<string, unknown>;
+
+  return Object.keys(record).every(
+    (key) => allowedKeys.has(key) && (record[key] === undefined || typeof record[key] === "string"),
+  );
+}
+
+function isIsoDate(value: unknown) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function isCalibrationSnapshot(payload: unknown): payload is CalibrationSnapshot {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  if (!isCalibrationPersona(record.persona)) {
+    return false;
+  }
+
+  if (!isIsoDate(record.startedAt) || !isIsoDate(record.completedAt)) {
+    return false;
+  }
+
+  if (
+    typeof record.durationSeconds !== "number" ||
+    !Number.isFinite(record.durationSeconds) ||
+    record.durationSeconds < 0
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 export async function GET() {
@@ -39,6 +90,7 @@ export async function POST(request: NextRequest) {
   }
 
   const selections = (payload as { selections?: unknown }).selections;
+  const calibrationPayload = (payload as { calibration?: unknown }).calibration;
 
   if (!isConsentSelections(selections)) {
     return NextResponse.json(
@@ -51,7 +103,23 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const record = persistConsent(selections);
+  let calibration: CalibrationSnapshot | undefined;
+  if (typeof calibrationPayload !== "undefined") {
+    if (!isCalibrationSnapshot(calibrationPayload)) {
+      return NextResponse.json(
+        {
+          error: "invalid_calibration",
+          message:
+            "Calibration payload must include persona, startedAt, completedAt, and durationSeconds fields.",
+        },
+        { status: 400 },
+      );
+    }
+
+    calibration = calibrationPayload;
+  }
+
+  const record = persistConsent(selections, calibration);
 
   return NextResponse.json(
     {
@@ -60,6 +128,7 @@ export async function POST(request: NextRequest) {
       revision: record.revision,
       recordedAt: record.recordedAt,
       selections: record.selections,
+      calibration: record.calibration,
       stub: record.stub,
     },
     { status: 201 },

--- a/web/app/api/onboarding/consent/store.ts
+++ b/web/app/api/onboarding/consent/store.ts
@@ -11,10 +11,27 @@ export type ConsentRecord = {
   auditReference: string;
   recordedAt: string;
   selections: ConsentSelections;
+  calibration?: CalibrationSnapshot;
   stub: {
     persistence: "memory";
     note: string;
   };
+};
+
+export type CalibrationPersona = {
+  tone?: string;
+  verbosity?: string;
+  initiative?: string;
+  quietHours?: string;
+  spending?: string;
+  voice?: string;
+};
+
+export type CalibrationSnapshot = {
+  persona: CalibrationPersona;
+  startedAt: string;
+  completedAt: string;
+  durationSeconds: number;
 };
 
 const CONSENT_RECORD_ID = "onboarding-consent-stub";
@@ -51,6 +68,7 @@ export function snapshotConsent() {
       allowPlannerAutonomy: false,
       retainAuditTrail: false,
     },
+    calibration: undefined,
     stub: {
       persistence: "memory" as const,
       note: "Replace with onboarding consent service; stub keeps the most recent selections in memory only.",
@@ -58,7 +76,10 @@ export function snapshotConsent() {
   } satisfies ConsentRecord;
 }
 
-export function persistConsent(selections: ConsentSelections): ConsentRecord {
+export function persistConsent(
+  selections: ConsentSelections,
+  calibration?: CalibrationSnapshot,
+): ConsentRecord {
   const previousRevision = latestRecord?.revision ?? 0;
   const revision = previousRevision + 1;
 
@@ -68,6 +89,7 @@ export function persistConsent(selections: ConsentSelections): ConsentRecord {
     auditReference: buildAuditReference(revision),
     recordedAt: computeRecordedAt(revision),
     selections,
+    calibration,
     stub: {
       persistence: "memory",
       note: "Replace with onboarding consent service; stub keeps the most recent selections in memory only.",

--- a/web/app/portal/onboarding/start/calibration-flow.tsx
+++ b/web/app/portal/onboarding/start/calibration-flow.tsx
@@ -1,0 +1,570 @@
+"use client";
+
+import React, { useEffect, useMemo, useReducer } from "react";
+import Link from "next/link";
+import type { ConsentSelections } from "../../../api/onboarding/consent/store";
+import {
+  CALIBRATION_DURATION_SECONDS,
+  CALIBRATION_STEP_IDS,
+  calibrationReducer,
+  canAdvanceFromCurrentStep,
+  createInitialCalibrationState,
+  hasCompletedAllPersonaFields,
+  isPersonaStep,
+  remainingSeconds,
+} from "./calibration.machine";
+import type {
+  CalibrationStepId,
+  CalibrationState,
+  PersonaSelections,
+  PersonaStepId,
+} from "./calibration.machine";
+
+const CONSENT_TOGGLES: Array<{
+  key: keyof ConsentSelections;
+  title: string;
+  description: string;
+}> = [
+  {
+    key: "shareCalendarSignals",
+    title: "Share scheduling signals",
+    description:
+      "Allow Tyrum to read summaries of your holds, cancellations, and travel windows so we can pre-stage reschedules.",
+  },
+  {
+    key: "allowPlannerAutonomy",
+    title: "Approve autopilot guardrails",
+    description:
+      "Permit Tyrum to act within the limits you confirm here so urgent requests keep moving without manual approval.",
+  },
+  {
+    key: "retainAuditTrail",
+    title: "Retain the audit trail",
+    description:
+      "Store a 180-day record of each consent change to keep compliance reviewers unblocked and exports deterministic.",
+  },
+];
+
+type PersonaOption = {
+  value: string;
+  label: string;
+  helper?: string;
+};
+
+type PersonaPrompt = {
+  id: PersonaStepId;
+  title: string;
+  description: string;
+  options: PersonaOption[];
+};
+
+const PERSONA_PROMPTS: PersonaPrompt[] = [
+  {
+    id: "tone",
+    title: "Tone",
+    description: "Pick the baseline energy Tyrum uses when drafting voice replies.",
+    options: [
+      { value: "upbeat", label: "Upbeat", helper: "Warm, optimistic, and proactive." },
+      { value: "neutral", label: "Neutral", helper: "Even cadence with minimal flourishes." },
+      { value: "formal", label: "Formal", helper: "Structured, precise, and audit-friendly." },
+    ],
+  },
+  {
+    id: "verbosity",
+    title: "Verbosity",
+    description: "Control how much detail Tyrum delivers by default.",
+    options: [
+      { value: "terse", label: "Crisp", helper: "Bulleted highlights only." },
+      { value: "balanced", label: "Balanced", helper: "Summary plus key evidence." },
+      { value: "thorough", label: "Thorough", helper: "Full context with references." },
+    ],
+  },
+  {
+    id: "initiative",
+    title: "Initiative",
+    description: "Decide how quickly Tyrum should act once a plan is ready.",
+    options: [
+      { value: "ask_first", label: "Ask every time", helper: "Always request confirmation." },
+      { value: "ask_once_per_vendor", label: "Ask once per vendor", helper: "Remember approvals by counterpart." },
+      {
+        value: "act_within_limits",
+        label: "Act within limits",
+        helper: "Proceed immediately when spend stays under your caps.",
+      },
+    ],
+  },
+  {
+    id: "quietHours",
+    title: "Quiet hours",
+    description: "Tell Tyrum when to pause non-urgent messages.",
+    options: [
+      { value: "21-07", label: "21:00 – 07:00", helper: "Evening and overnight focus blocks." },
+      { value: "22-06", label: "22:00 – 06:00", helper: "Late night guardrails." },
+      { value: "none", label: "No quiet hours", helper: "Reach out whenever something happens." },
+    ],
+  },
+  {
+    id: "spending",
+    title: "Spending",
+    description: "Set the ceiling for autonomous, everyday approvals.",
+    options: [
+      { value: "25", label: "Up to €25", helper: "Coffee runs, local rides, and takeout." },
+      { value: "50", label: "Up to €50", helper: "Most daily purchases and renewals." },
+      { value: "manual", label: "Always ask", helper: "Keep approvals manual regardless of amount." },
+    ],
+  },
+  {
+    id: "voice",
+    title: "Voice sample",
+    description: "Choose the delivery you prefer for voice notes and TTS.",
+    options: [
+      { value: "bright", label: "Bright", helper: "Higher pace and upbeat cadence." },
+      { value: "warm", label: "Warm", helper: "Measured pace with softer edges." },
+      { value: "precise", label: "Precise", helper: "Neutral timbre prioritising enunciation." },
+    ],
+  },
+];
+
+function formatSeconds(seconds: number) {
+  const safeSeconds = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const clamped = safeSeconds > CALIBRATION_DURATION_SECONDS ? CALIBRATION_DURATION_SECONDS : safeSeconds;
+  const minutes = Math.floor(clamped / 60)
+    .toString()
+    .padStart(2, "0");
+  const remaining = Math.floor(clamped % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${remaining}`;
+}
+
+function getCurrentPrompt(stepId: PersonaStepId | undefined) {
+  if (!stepId) {
+    return null;
+  }
+
+  return PERSONA_PROMPTS.find((prompt) => prompt.id === stepId) ?? null;
+}
+
+function nextStepLabel(step: CalibrationStepId | undefined) {
+  if (!step) {
+    return "Next";
+  }
+
+  if (step === "consent") {
+    return "Review selections";
+  }
+
+  return "Next prompt";
+}
+
+function buildSubmissionPayload(
+  state: CalibrationState,
+  now: number,
+): {
+  selections: ConsentSelections;
+  calibration: {
+    persona: PersonaSelections;
+    startedAt: string;
+    completedAt: string;
+    durationSeconds: number;
+  };
+} {
+  if (!state.startedAt) {
+    throw new Error("Calibration has not started yet.");
+  }
+
+  const durationSeconds = Math.min(
+    CALIBRATION_DURATION_SECONDS,
+    Math.max(0, Math.floor((now - state.startedAt) / 1000)),
+  );
+
+  return {
+    selections: state.consent,
+    calibration: {
+      persona: state.persona,
+      startedAt: new Date(state.startedAt).toISOString(),
+      completedAt: new Date(now).toISOString(),
+      durationSeconds,
+    },
+  };
+}
+
+export default function CalibrationFlow() {
+  const [state, dispatch] = useReducer(calibrationReducer, undefined, () =>
+    createInitialCalibrationState(),
+  );
+
+  useEffect(() => {
+    if (
+      state.status !== "collecting" &&
+      state.status !== "review" &&
+      state.status !== "submitting"
+    ) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      dispatch({ type: "tick", now: Date.now() });
+    }, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [state.status]);
+
+  const currentStepId = useMemo(() => {
+    if (state.status !== "collecting") {
+      return null;
+    }
+
+    return CALIBRATION_STEP_IDS[state.stepIndex] ?? null;
+  }, [state.status, state.stepIndex]);
+
+  const personaPrompt = useMemo(() => {
+    if (!currentStepId || !isPersonaStep(currentStepId)) {
+      return null;
+    }
+
+    return getCurrentPrompt(currentStepId);
+  }, [currentStepId]);
+
+  const countdown = formatSeconds(remainingSeconds(state));
+  const progressLabel = state.status === "collecting"
+    ? `Prompt ${state.stepIndex + 1} of ${CALIBRATION_STEP_IDS.length}`
+    : state.status === "review"
+      ? "Review"
+      : state.status === "success"
+        ? "Completed"
+        : state.status === "expired"
+          ? "Expired"
+          : undefined;
+
+  const showBackButton =
+    (state.status === "collecting" && state.stepIndex > 0) || state.status === "review";
+
+  const personaSummary = useMemo(() => {
+    const entries = PERSONA_PROMPTS.map((prompt) => ({
+      id: prompt.id,
+      label: prompt.title,
+      value: state.persona[prompt.id],
+    }));
+
+    return entries;
+  }, [state.persona]);
+
+  const handleStart = () => {
+    dispatch({ type: "start", now: Date.now() });
+  };
+
+  const handlePersonaSelect = (step: PersonaStepId, value: string) => {
+    dispatch({ type: "update_persona", step, value });
+  };
+
+  const handleConsentToggle = (key: keyof ConsentSelections) => {
+    dispatch({ type: "set_consent", key, value: !state.consent[key] });
+  };
+
+  const handleAdvance = () => {
+    dispatch({ type: "advance" });
+  };
+
+  const handleBack = () => {
+    dispatch({ type: "back" });
+  };
+
+  const handleReset = () => {
+    dispatch({ type: "reset" });
+  };
+
+  const handleSubmit = async () => {
+    if (state.status !== "review") {
+      return;
+    }
+
+    if (!state.startedAt) {
+      dispatch({
+        type: "submit_failure",
+        message: "Calibration start time is missing. Restart and try again.",
+      });
+      return;
+    }
+
+    const now = Date.now();
+    const payload = buildSubmissionPayload(state, now);
+
+    dispatch({ type: "submit" });
+
+    try {
+      const response = await fetch("/api/onboarding/consent", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+        cache: "no-store",
+      });
+
+      const json = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message =
+          typeof (json as { message?: unknown } | null)?.message === "string"
+            ? (json as { message: string }).message
+            : "Unable to store calibration yet. Try again.";
+        dispatch({ type: "submit_failure", message });
+        return;
+      }
+
+      const auditReference = (json as { auditReference?: unknown })?.auditReference;
+      const revision = (json as { revision?: unknown })?.revision;
+
+      if (typeof auditReference !== "string" || typeof revision !== "number") {
+        dispatch({
+          type: "submit_failure",
+          message: "Consent service returned an unexpected response. Try again.",
+        });
+        return;
+      }
+
+      dispatch({
+        type: "submit_success",
+        submission: { auditReference, revision },
+        completedAt: now,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Unable to reach the consent service. Try again.";
+      dispatch({ type: "submit_failure", message });
+    }
+  };
+
+  if (state.status === "idle") {
+    return (
+      <section className="portal-onboarding__content" aria-label="Voice calibration setup">
+        <header className="portal-onboarding__calibration-header">
+          <div>
+            <h2>Voice calibration</h2>
+            <p>
+              Calibration runs for 90 seconds. Answer each prompt once and confirm the consent toggles so Tyrum can honour your voice defaults from the first session.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="portal-onboarding__cta"
+            onClick={handleStart}
+          >
+            Start calibration
+          </button>
+        </header>
+      </section>
+    );
+  }
+
+  if (state.status === "expired") {
+    return (
+      <section className="portal-onboarding__content" aria-label="Calibration expired">
+        <header className="portal-onboarding__calibration-header">
+          <div>
+            <h2>Calibration expired</h2>
+            <p>
+              The 90-second window elapsed before the prompts were confirmed. Restart to capture your persona and consent defaults.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="portal-onboarding__cta"
+            onClick={handleReset}
+          >
+            Restart calibration
+          </button>
+        </header>
+      </section>
+    );
+  }
+
+  if (state.status === "success") {
+    return (
+      <section className="portal-onboarding__content" aria-label="Calibration complete">
+        <header className="portal-onboarding__calibration-header">
+          <div>
+            <h2>Calibration recorded</h2>
+            <p>
+              Persona defaults and consent selections are stored as {state.submission?.auditReference}. Tyrum will carry these guardrails into the next onboarding steps.
+            </p>
+            <p className="portal-onboarding__calibration-meta">
+              Duration: {formatSeconds(state.elapsedSeconds)} · Revision: {state.submission?.revision}
+            </p>
+          </div>
+          <Link className="portal-onboarding__cta" href="/portal/onboarding/consent">
+            Continue to consent checklist
+          </Link>
+        </header>
+      </section>
+    );
+  }
+
+  const isCollecting = state.status === "collecting";
+  const isReview = state.status === "review" || state.status === "submitting";
+  const disableNext =
+    isCollecting && (!currentStepId || !canAdvanceFromCurrentStep(state));
+
+  return (
+    <section
+      className="portal-onboarding__content portal-onboarding__calibration"
+      aria-live="polite"
+      aria-label="Calibration prompts"
+    >
+      <header className="portal-onboarding__calibration-header">
+        <div>
+          <h2>{isReview ? "Review calibration" : "Calibrate Tyrum"}</h2>
+          <p>
+            {isReview
+              ? "Confirm your persona defaults and consent selections before we store them."
+              : "Keep an eye on the countdown—answers lock once the timer expires."}
+          </p>
+          {progressLabel ? (
+            <p className="portal-onboarding__calibration-progress">{progressLabel}</p>
+          ) : null}
+        </div>
+        <div className="portal-onboarding__calibration-timer" aria-live="assertive">
+          <span aria-label="Countdown">{countdown}</span>
+        </div>
+      </header>
+
+      {isCollecting && personaPrompt ? (
+        <article className="portal-onboarding__calibration-card">
+          <header>
+            <h3>{personaPrompt.title}</h3>
+            <p>{personaPrompt.description}</p>
+          </header>
+          <div className="portal-onboarding__calibration-options">
+            {personaPrompt.options.map((option) => {
+              const checked = state.persona[personaPrompt.id] === option.value;
+              const optionId = `${personaPrompt.id}-${option.value}`;
+              return (
+                <label key={option.value} htmlFor={optionId} className="portal-onboarding__option">
+                  <input
+                    id={optionId}
+                    type="radio"
+                    name={personaPrompt.id}
+                    value={option.value}
+                    checked={checked}
+                    onChange={() => handlePersonaSelect(personaPrompt.id, option.value)}
+                  />
+                  <span>
+                    <strong>{option.label}</strong>
+                    {option.helper ? <small>{option.helper}</small> : null}
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </article>
+      ) : null}
+
+      {isCollecting && currentStepId === "consent" ? (
+        <article className="portal-onboarding__calibration-card">
+          <header>
+            <h3>Consent toggles</h3>
+            <p>Select the guardrails Tyrum should enforce from day one.</p>
+          </header>
+          <ul className="portal-onboarding__consent-preview">
+            {CONSENT_TOGGLES.map((toggle) => {
+              const toggleId = `calibration-consent-${toggle.key}`;
+              return (
+                <li key={toggle.key}>
+                  <label htmlFor={toggleId} className="portal-linking__toggle">
+                    <input
+                      id={toggleId}
+                      type="checkbox"
+                      className="portal-linking__checkbox"
+                      checked={state.consent[toggle.key]}
+                      onChange={() => handleConsentToggle(toggle.key)}
+                    />
+                    <span className="portal-linking__toggle-track" aria-hidden="true">
+                      <span className="portal-linking__toggle-thumb" />
+                    </span>
+                    <span className="portal-linking__toggle-text">
+                      <strong>{toggle.title}</strong>
+                      <small>{toggle.description}</small>
+                    </span>
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </article>
+      ) : null}
+
+      {isReview ? (
+        <article className="portal-onboarding__calibration-card">
+          <header>
+            <h3>Summary</h3>
+            <p>Verify persona defaults and ensure at least one consent toggle stays active.</p>
+          </header>
+          <dl className="portal-onboarding__calibration-summary">
+            {personaSummary.map((entry) => (
+              <div key={entry.id}>
+                <dt>{entry.label}</dt>
+                <dd>{entry.value ?? "Not set"}</dd>
+              </div>
+            ))}
+            <div>
+              <dt>Consent toggles</dt>
+              <dd>
+                {Object.entries(state.consent)
+                  .filter(([, enabled]) => enabled)
+                  .map(([key]) => CONSENT_TOGGLES.find((toggle) => toggle.key === key)?.title)
+                  .filter(Boolean)
+                  .join(", ") || "None enabled"}
+              </dd>
+            </div>
+          </dl>
+          {state.error ? (
+            <p className="portal-onboarding__calibration-error" role="alert">
+              {state.error}
+            </p>
+          ) : null}
+        </article>
+      ) : null}
+
+      <footer className="portal-onboarding__calibration-actions">
+        {showBackButton ? (
+          <button type="button" className="portal-onboarding__cta-secondary" onClick={handleBack}>
+            Back
+          </button>
+        ) : null}
+
+        {isCollecting ? (
+          <button
+            type="button"
+            className="portal-onboarding__cta"
+            onClick={handleAdvance}
+            disabled={disableNext}
+          >
+            {nextStepLabel(currentStepId ?? undefined)}
+          </button>
+        ) : null}
+
+        {state.status === "review" ? (
+          <button
+            type="button"
+            className="portal-onboarding__cta"
+            onClick={handleSubmit}
+            disabled={!hasCompletedAllPersonaFields(state)}
+          >
+            Record calibration
+          </button>
+        ) : null}
+
+        {state.status === "submitting" ? (
+          <button type="button" className="portal-onboarding__cta" disabled>
+            Recording…
+          </button>
+        ) : null}
+      </footer>
+    </section>
+  );
+}

--- a/web/app/portal/onboarding/start/calibration.machine.ts
+++ b/web/app/portal/onboarding/start/calibration.machine.ts
@@ -1,0 +1,377 @@
+import type {
+  ConsentSelections,
+  ConsentToggleKey,
+} from "../../../api/onboarding/consent/store";
+
+export const CALIBRATION_DURATION_SECONDS = 90;
+
+export const CALIBRATION_STEP_IDS = [
+  "tone",
+  "verbosity",
+  "initiative",
+  "quietHours",
+  "spending",
+  "voice",
+  "consent",
+] as const;
+
+export type CalibrationStepId = (typeof CALIBRATION_STEP_IDS)[number];
+export type PersonaStepId = Exclude<CalibrationStepId, "consent">;
+
+export type PersonaSelections = {
+  tone?: string;
+  verbosity?: string;
+  initiative?: string;
+  quietHours?: string;
+  spending?: string;
+  voice?: string;
+};
+
+export type CalibrationSubmission = {
+  auditReference: string;
+  revision: number;
+};
+
+export type CalibrationStatus =
+  | "idle"
+  | "collecting"
+  | "review"
+  | "submitting"
+  | "success"
+  | "expired";
+
+export type CalibrationState = {
+  status: CalibrationStatus;
+  stepIndex: number;
+  startedAt: number | null;
+  completedAt: number | null;
+  elapsedSeconds: number;
+  persona: PersonaSelections;
+  consent: ConsentSelections;
+  submission: CalibrationSubmission | null;
+  error: string | null;
+};
+
+export type StartEvent = {
+  type: "start";
+  now: number;
+};
+
+export type TickEvent = {
+  type: "tick";
+  now: number;
+};
+
+export type UpdatePersonaEvent = {
+  type: "update_persona";
+  step: CalibrationStepId;
+  value: string;
+};
+
+export type SetConsentEvent = {
+  type: "set_consent";
+  key: ConsentToggleKey;
+  value: boolean;
+};
+
+export type AdvanceEvent = {
+  type: "advance";
+};
+
+export type BackEvent = {
+  type: "back";
+};
+
+export type SubmitEvent = {
+  type: "submit";
+};
+
+export type SubmitSuccessEvent = {
+  type: "submit_success";
+  submission: CalibrationSubmission;
+  completedAt: number;
+};
+
+export type SubmitFailureEvent = {
+  type: "submit_failure";
+  message: string;
+};
+
+export type ResetEvent = {
+  type: "reset";
+};
+
+export type CalibrationEvent =
+  | StartEvent
+  | TickEvent
+  | UpdatePersonaEvent
+  | SetConsentEvent
+  | AdvanceEvent
+  | BackEvent
+  | SubmitEvent
+  | SubmitSuccessEvent
+  | SubmitFailureEvent
+  | ResetEvent;
+
+const INITIAL_CONSENT: ConsentSelections = {
+  shareCalendarSignals: false,
+  allowPlannerAutonomy: false,
+  retainAuditTrail: false,
+};
+
+const LAST_STEP_INDEX = CALIBRATION_STEP_IDS.length - 1;
+
+export function createInitialCalibrationState(): CalibrationState {
+  return {
+    status: "idle",
+    stepIndex: -1,
+    startedAt: null,
+    completedAt: null,
+    elapsedSeconds: 0,
+    persona: {},
+    consent: { ...INITIAL_CONSENT },
+    submission: null,
+    error: null,
+  };
+}
+
+function clampElapsedSeconds(elapsed: number) {
+  if (elapsed < 0) {
+    return 0;
+  }
+
+  if (elapsed > CALIBRATION_DURATION_SECONDS) {
+    return CALIBRATION_DURATION_SECONDS;
+  }
+
+  return elapsed;
+}
+
+function computeElapsedSeconds(startedAt: number | null, now: number) {
+  if (!startedAt) {
+    return 0;
+  }
+
+  const elapsed = Math.floor((now - startedAt) / 1000);
+  return clampElapsedSeconds(elapsed);
+}
+
+export function calibrationReducer(
+  state: CalibrationState,
+  event: CalibrationEvent,
+): CalibrationState {
+  switch (event.type) {
+    case "start": {
+      if (state.status !== "idle") {
+        return state;
+      }
+
+      return {
+        ...state,
+        status: "collecting",
+        stepIndex: 0,
+        startedAt: event.now,
+        completedAt: null,
+        elapsedSeconds: 0,
+        submission: null,
+        error: null,
+        persona: {},
+        consent: { ...INITIAL_CONSENT },
+      };
+    }
+    case "tick": {
+      if (!state.startedAt) {
+        return state;
+      }
+
+      const status = state.status;
+
+      if (!(status === "collecting" || status === "review" || status === "submitting" || status === "success")) {
+        return state;
+      }
+
+      const elapsedSeconds = computeElapsedSeconds(state.startedAt, event.now);
+
+      if (elapsedSeconds >= CALIBRATION_DURATION_SECONDS) {
+        if (status === "submitting" || status === "success") {
+          return {
+            ...state,
+            elapsedSeconds,
+          };
+        }
+
+        return {
+          ...state,
+          status: "expired",
+          elapsedSeconds,
+          completedAt: state.completedAt ?? event.now,
+          error: null,
+        };
+      }
+
+      return {
+        ...state,
+        elapsedSeconds,
+      };
+    }
+    case "update_persona": {
+      if (state.status !== "collecting" && state.status !== "review") {
+        return state;
+      }
+
+      if (event.step === "consent") {
+        return state;
+      }
+
+      return {
+        ...state,
+        persona: {
+          ...state.persona,
+          [event.step]: event.value,
+        },
+        error: null,
+      };
+    }
+    case "set_consent": {
+      if (state.status !== "collecting" && state.status !== "review") {
+        return state;
+      }
+
+      return {
+        ...state,
+        consent: {
+          ...state.consent,
+          [event.key]: event.value,
+        },
+        error: null,
+      };
+    }
+    case "advance": {
+      if (state.status !== "collecting") {
+        return state;
+      }
+
+      if (state.stepIndex >= LAST_STEP_INDEX) {
+        return {
+          ...state,
+          status: "review",
+          error: null,
+        };
+      }
+
+      return {
+        ...state,
+        stepIndex: state.stepIndex + 1,
+        error: null,
+      };
+    }
+    case "back": {
+      if (state.status === "review") {
+        return {
+          ...state,
+          status: "collecting",
+          stepIndex: LAST_STEP_INDEX,
+          error: null,
+        };
+      }
+
+      if (state.status !== "collecting" || state.stepIndex <= 0) {
+        return state;
+      }
+
+      return {
+        ...state,
+        stepIndex: state.stepIndex - 1,
+        error: null,
+      };
+    }
+    case "submit": {
+      if (state.status !== "review") {
+        return state;
+      }
+
+      return {
+        ...state,
+        status: "submitting",
+        error: null,
+      };
+    }
+    case "submit_success": {
+      if (state.status !== "submitting") {
+        return state;
+      }
+
+      const elapsedSeconds = state.startedAt
+        ? clampElapsedSeconds(Math.floor((event.completedAt - state.startedAt) / 1000))
+        : state.elapsedSeconds;
+
+      return {
+        ...state,
+        status: "success",
+        submission: event.submission,
+        completedAt: event.completedAt,
+        elapsedSeconds,
+        error: null,
+      };
+    }
+    case "submit_failure": {
+      if (state.status !== "submitting") {
+        return state;
+      }
+
+      return {
+        ...state,
+        status: "review",
+        error: event.message,
+      };
+    }
+    case "reset": {
+      return {
+        ...createInitialCalibrationState(),
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export function isPersonaStep(step: CalibrationStepId): step is PersonaStepId {
+  return step !== "consent";
+}
+
+export function isStepComplete(
+  state: CalibrationState,
+  step: CalibrationStepId,
+): boolean {
+  if (step === "consent") {
+    return Object.values(state.consent).some(Boolean);
+  }
+
+  return Boolean(state.persona[step]);
+}
+
+export function canAdvanceFromCurrentStep(state: CalibrationState) {
+  if (state.status !== "collecting") {
+    return false;
+  }
+
+  const currentStep = CALIBRATION_STEP_IDS[state.stepIndex];
+  if (!currentStep) {
+    return false;
+  }
+
+  return isStepComplete(state, currentStep);
+}
+
+export function remainingSeconds(state: CalibrationState) {
+  const remaining = CALIBRATION_DURATION_SECONDS - state.elapsedSeconds;
+  return remaining > 0 ? remaining : 0;
+}
+
+export function isExpired(state: CalibrationState) {
+  return state.status === "expired";
+}
+
+export function hasCompletedAllPersonaFields(state: CalibrationState) {
+  return CALIBRATION_STEP_IDS.every((step) => isStepComplete(state, step));
+}

--- a/web/app/portal/onboarding/start/page.test.tsx
+++ b/web/app/portal/onboarding/start/page.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OnboardingStart from "./page";
 
 const trackAnalytics = vi.fn();
+const originalFetch = global.fetch;
 
 type SearchParamRecord = Record<string, string | string[] | undefined>;
 
@@ -18,10 +19,14 @@ vi.mock("../../../lib/analytics", () => ({
 describe("OnboardingStart", () => {
   beforeEach(() => {
     trackAnalytics.mockReset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-10-12T10:00:00.000Z"));
   });
 
   afterEach(() => {
     trackAnalytics.mockReset();
+    vi.useRealTimers();
+    global.fetch = originalFetch;
   });
 
   it("shows the welcome flash message and tracks analytics when arriving from the waitlist", async () => {
@@ -39,22 +44,108 @@ describe("OnboardingStart", () => {
       screen.getByText("You're on the list. Let's calibrate Tyrum to your voice."),
     ).toBeVisible();
 
-    await waitFor(() =>
-      expect(trackAnalytics).toHaveBeenCalledWith("waitlist_signup", {
-        status: "created",
-        utm_source: "ads",
-      }),
-    );
+    await vi.runOnlyPendingTimersAsync();
+    expect(trackAnalytics).toHaveBeenCalledWith("waitlist_signup", {
+      status: "created",
+      utm_source: "ads",
+    });
   });
 
-  it("renders the onboarding steps", () => {
+  it(
+    "guides the user through calibration and posts the payload to consent stub",
+    async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "recorded",
+          auditReference: "CONSENT-STUB-0001",
+          revision: 1,
+        }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
     render(<OnboardingStart />);
 
+    fireEvent.click(screen.getByRole("button", { name: /start calibration/i }));
+    fireEvent.click(screen.getByLabelText(/upbeat/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/balanced/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/act within limits/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/21:00 – 07:00/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/up to €50/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/warm/i));
+    fireEvent.click(screen.getByRole("button", { name: /next prompt/i }));
+    fireEvent.click(screen.getByLabelText(/share scheduling signals/i));
+    fireEvent.click(screen.getByRole("button", { name: /review selections/i }));
+
+    vi.setSystemTime(new Date("2025-10-12T10:00:24.000Z"));
+
+    fireEvent.click(screen.getByRole("button", { name: /record calibration/i }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(requestInit.method).toBe("POST");
+    const body = JSON.parse(requestInit.body as string) as {
+      selections: Record<string, boolean>;
+      calibration: {
+        persona: Record<string, string>;
+        durationSeconds: number;
+        startedAt: string;
+        completedAt: string;
+      };
+    };
+    expect(body.selections).toMatchObject({
+      shareCalendarSignals: true,
+      allowPlannerAutonomy: false,
+      retainAuditTrail: false,
+    });
+    expect(body.calibration.persona).toMatchObject({
+      tone: "upbeat",
+      verbosity: "balanced",
+      initiative: "act_within_limits",
+      quietHours: "21-07",
+      spending: "50",
+      voice: "warm",
+    });
+    expect(body.calibration.durationSeconds).toBe(24);
+    expect(body.calibration.startedAt).toBe("2025-10-12T10:00:00.000Z");
+    expect(body.calibration.completedAt).toBe("2025-10-12T10:00:24.000Z");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(
-      screen.getByRole("heading", { level: 2, name: "Calibrate voice and consent" }),
+      screen.getByRole("heading", { level: 2, name: /calibration recorded/i }),
     ).toBeVisible();
+    expect(screen.getByText(/CONSENT-STUB-0001/i)).toBeVisible();
+    },
+    10000,
+  );
+
+  it(
+    "expires the flow if the countdown reaches zero",
+    async () => {
+    render(<OnboardingStart />);
+
+    fireEvent.click(screen.getByRole("button", { name: /start calibration/i }));
+    act(() => {
+      vi.advanceTimersByTime(91_000);
+    });
+
     expect(
-      screen.getByRole("heading", { level: 2, name: "What happens next" }),
+      screen.getByRole("heading", { level: 2, name: /calibration expired/i }),
     ).toBeVisible();
-  });
+    expect(screen.getByRole("button", { name: /restart calibration/i })).toBeEnabled();
+    },
+    10000,
+  );
 });

--- a/web/app/portal/onboarding/start/page.tsx
+++ b/web/app/portal/onboarding/start/page.tsx
@@ -5,6 +5,7 @@ import {
   CAMPAIGN_PARAM_KEYS,
   type CampaignParams,
 } from "../../../lib/campaign";
+import CalibrationFlow from "./calibration-flow";
 
 const FLASH_PARAM = "flash";
 const SIGNUP_STATUS_PARAM = "signup_status";
@@ -21,24 +22,6 @@ const FLASH_CONFIG = {
     analyticsStatus: "duplicate",
   },
 };
-
-const STEPS = [
-  {
-    title: "Calibrate voice and consent",
-    copy:
-      "Lock in tone, initiative, and escalation defaults so the planner honours your guardrails from the first automation.",
-  },
-  {
-    title: "Review mandatory watchers",
-    copy:
-      "Enable baseline observers for spend, privacy, and audit coverage. Tyrum will only act inside the limits you approve.",
-  },
-  {
-    title: "Queue first outcomes",
-    copy:
-      "Prioritise the initial tasks you want Tyrum to own—visa renewals, inbox triage, or spend monitoring—to guide the planner preview.",
-  },
-];
 
 type SearchParamRecord = Record<string, string | string[] | undefined>;
 
@@ -123,24 +106,12 @@ export default function OnboardingStart({
           />
         ) : null}
       </header>
-      <section
-        className="portal-onboarding__content"
-        aria-label="Onboarding preparation steps"
-      >
-        <ol className="portal-onboarding__steps">
-          {STEPS.map(({ title, copy }) => (
-            <li className="portal-onboarding__step" key={title}>
-              <h2>{title}</h2>
-              <p>{copy}</p>
-            </li>
-          ))}
-        </ol>
-      </section>
+      <CalibrationFlow />
       <section className="portal-onboarding__next">
         <h2>What happens next</h2>
         <p>
-          We&apos;ll notify you as soon as the consent checklist (ONB-02) is live so you can
-          finalise the session placeholder, unlock planner previews, and start the full audit trail.
+          Once calibration is recorded we&apos;ll surface watcher defaults (ONB-02) so you can review
+          spend, privacy, and escalation observers before the planner issues your first preview.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- replace the onboarding start checklist with a timed 90-second calibration flow that collects persona defaults and consent toggles
- persist calibration payloads through the existing onboarding consent stub and extend the store/tests to snapshot persona metadata
- exercise the new flow with dedicated portal tests, add API coverage, and document the calibration experience in the product concept

## Testing
- npm run test -- run app/portal/onboarding/start/page.test.tsx
- npm run test -- run app/api/onboarding/consent/route.test.ts
- pre-commit run --all-files *(fails: tyrum-planner http server tests expect a Postgres fixture and abort with "expected to read … bytes at EOF")*

Closes #198

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 90‑second onboarding calibration flow that posts persona defaults and consent toggles to the consent API with validation and tests, and updates docs.
> 
> - **Portal (Onboarding Start)**:
>   - **Calibration UI**: Replace checklist with timed 90‑second flow in `web/app/portal/onboarding/start/calibration-flow.tsx` using state machine `calibration.machine.ts` (persona prompts, consent toggles, countdown, review/submit).
>   - **Submission**: Posts combined `selections` + `calibration` payload to `/api/onboarding/consent` and handles success/expiry.
>   - **Page**: `page.tsx` now renders `CalibrationFlow`; “What happens next” copy updated.
> - **API (Consent Stub)**:
>   - **Validation & Types**: Add `CalibrationSnapshot` and persona schema; validate ISO dates and `durationSeconds` in `route.ts`.
>   - **Persistence**: Extend `persistConsent` to store optional `calibration`; include `calibration` in responses and snapshot (`store.ts`).
> - **Tests**:
>   - **API**: New tests for persisting calibration and rejecting invalid payloads in `route.test.ts`.
>   - **Portal**: New e2e-style test driving the flow, mocking `fetch`, timers, and expiry in `page.test.tsx`.
> - **Docs**:
>   - Note in `docs/product_concept_v1.md` that portal onboarding starts the timed calibration and persists persona defaults with consent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0220f10c5a2e79405aa2deeb5f0170bb4cc291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->