### PR TITLE
Add TTS preview stub and pronunciation dictionary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "redis",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "serial_test",

--- a/config/model_gateway.yml
+++ b/config/model_gateway.yml
@@ -16,4 +16,9 @@ models:
   frontier-mock:
     target: mock
     endpoint: http://mock-llm:8085
-    capabilities: [text]
+    capabilities: [text, audio]
+
+  tyrum-voice-preview:
+    target: mock
+    endpoint: http://mock-llm:8085
+    capabilities: [audio]

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "chrono", "uuid", "macros", "migrate"] }
 thiserror = "2"
 tokio = { version = "1.43", features = ["full"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "registry"] }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, env, net::SocketAddr, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    net::SocketAddr,
+    time::Duration,
+};
 
 use anyhow::{Context, Result, anyhow};
 
@@ -31,7 +36,9 @@ use axum::{
     routing::{get, post, put},
 };
 use chrono::{DateTime, Utc};
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map as JsonMap, Value, json};
 use tyrum_shared::telegram::{TelegramNormalizationError, normalize_update};
 use uuid::Uuid;
 use validator::Validate;
@@ -46,12 +53,19 @@ const TELEGRAM_WEBHOOK_ROUTE: &str = "/telegram/webhook";
 const PROFILES_ROUTE: &str = "/profiles";
 const PROFILE_PAM_ROUTE: &str = "/profiles/pam";
 const PROFILE_PVP_ROUTE: &str = "/profiles/pvp";
+const PROFILE_PVP_PREVIEW_ROUTE: &str = "/profiles/pvp/preview";
 const PORTAL_ACCOUNT_ID: &str = "11111111-2222-3333-4444-555555555555";
 const CAPABILITY_SCHEMA_ROUTE: &str =
     "/capabilities/:subject_id/:capability_type/:capability_identifier/:executor_kind/schema";
 const CAPABILITY_COST_ROUTE: &str =
     "/capabilities/:subject_id/:capability_type/:capability_identifier/:executor_kind/cost";
 const DEFAULT_CAPABILITY_CACHE_TTL: Duration = Duration::from_secs(300);
+const DEFAULT_MODEL_GATEWAY_URL: &str = "http://model-gateway:8001";
+const VOICE_PREVIEW_MODEL: &str = "tyrum-voice-preview";
+const VOICE_PREVIEW_SAMPLE: &str =
+    "Hi, this is Tyrum. Thanks for calibrating your pronunciation preferences.";
+const MAX_PRONUNCIATION_ENTRIES: usize = 32;
+const MAX_PRONUNCIATION_FIELD_LENGTH: usize = 128;
 
 #[derive(Clone, Copy)]
 struct IntegrationDefinition {
@@ -90,6 +104,190 @@ struct AppState {
     capabilities: CapabilityRepository,
     cache: CapabilityCache,
     portal_subject_id: Uuid,
+    model_gateway: ModelGatewayClient,
+}
+
+#[derive(Clone)]
+struct ModelGatewayClient {
+    client: reqwest::Client,
+    audio_url: Url,
+    preview_model: String,
+}
+
+impl ModelGatewayClient {
+    fn new(base_url: Url, preview_model: impl Into<String>) -> Result<Self> {
+        let audio_url = base_url
+            .join("/v1/audio/speech")
+            .context("resolving /v1/audio/speech on MODEL_GATEWAY_URL")?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .context("building model gateway HTTP client")?;
+        Ok(Self {
+            client,
+            audio_url,
+            preview_model: preview_model.into(),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_client(
+        client: reqwest::Client,
+        base_url: Url,
+        preview_model: impl Into<String>,
+    ) -> Result<Self> {
+        let audio_url = base_url
+            .join("/v1/audio/speech")
+            .context("resolving /v1/audio/speech on MODEL_GATEWAY_URL")?;
+        Ok(Self {
+            client,
+            audio_url,
+            preview_model: preview_model.into(),
+        })
+    }
+
+    async fn request_preview(
+        &self,
+        mut payload: JsonMap<String, Value>,
+    ) -> Result<ModelGatewaySpeechResponse> {
+        payload.insert(
+            "model".to_string(),
+            Value::String(self.preview_model.clone()),
+        );
+        payload.insert("stream".to_string(), Value::Bool(false));
+
+        let response = self
+            .client
+            .post(self.audio_url.clone())
+            .json(&payload)
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "sending preview request to model gateway at {}",
+                    self.audio_url
+                )
+            })?;
+
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .context("reading model gateway preview response body")?;
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&bytes);
+            return Err(anyhow!(
+                "model gateway returned {} for preview request: {}",
+                status,
+                body
+            ));
+        }
+
+        let preview: ModelGatewaySpeechResponse = serde_json::from_slice(&bytes)
+            .context("deserializing model gateway preview response")?;
+        Ok(preview)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ModelGatewaySpeechResponse {
+    audio_base64: String,
+    #[serde(default = "default_preview_format")]
+    format: String,
+}
+
+fn default_preview_format() -> String {
+    "wav".to_string()
+}
+
+fn sanitize_pvp_profile(profile: Value) -> Result<Value, String> {
+    let Value::Object(mut object) = profile else {
+        return Err("profile must be a JSON object".to_string());
+    };
+
+    if let Some(voice_value) = object.get_mut("voice") {
+        let voice_object = voice_value
+            .as_object_mut()
+            .ok_or_else(|| "voice must be an object".to_string())?;
+
+        if let Some(raw_dict) = voice_object.remove("pronunciation_dict") {
+            let sanitized = sanitize_pronunciation_dict(raw_dict)?;
+            if let Some(entries) = sanitized {
+                voice_object.insert("pronunciation_dict".to_string(), entries);
+            }
+        }
+    }
+
+    Ok(Value::Object(object))
+}
+
+fn sanitize_pronunciation_dict(raw: Value) -> Result<Option<Value>, String> {
+    let entries = raw
+        .as_array()
+        .ok_or_else(|| "pronunciation_dict must be an array".to_string())?;
+    if entries.len() > MAX_PRONUNCIATION_ENTRIES {
+        return Err(format!(
+            "pronunciation_dict cannot exceed {MAX_PRONUNCIATION_ENTRIES} entries"
+        ));
+    }
+
+    let mut sanitized = Vec::with_capacity(entries.len());
+    let mut seen_tokens = HashSet::new();
+
+    for (index, entry) in entries.iter().enumerate() {
+        let object = entry
+            .as_object()
+            .ok_or_else(|| format!("pronunciation_dict[{index}] must be an object"))?;
+        let token = object
+            .get("token")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pronunciation_dict[{index}] is missing a token"))?;
+        let pronounce = object
+            .get("pronounce")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pronunciation_dict[{index}] is missing a pronounce value"))?;
+
+        let token_trimmed = token.trim();
+        if token_trimmed.is_empty() {
+            return Err(format!("pronunciation_dict[{index}].token cannot be empty"));
+        }
+        if token_trimmed.len() > MAX_PRONUNCIATION_FIELD_LENGTH {
+            return Err(format!(
+                "pronunciation_dict[{index}].token must be at most {MAX_PRONUNCIATION_FIELD_LENGTH} characters"
+            ));
+        }
+
+        let pronounce_trimmed = pronounce.trim();
+        if pronounce_trimmed.is_empty() {
+            return Err(format!(
+                "pronunciation_dict[{index}].pronounce cannot be empty"
+            ));
+        }
+        if pronounce_trimmed.len() > MAX_PRONUNCIATION_FIELD_LENGTH {
+            return Err(format!(
+                "pronunciation_dict[{index}].pronounce must be at most {MAX_PRONUNCIATION_FIELD_LENGTH} characters"
+            ));
+        }
+
+        let normalized_token = token_trimmed.to_lowercase();
+        if !seen_tokens.insert(normalized_token) {
+            return Err(format!(
+                "pronunciation_dict contains a duplicate entry for '{}'",
+                token_trimmed
+            ));
+        }
+
+        sanitized.push(json!({
+            "token": token_trimmed,
+            "pronounce": pronounce_trimmed,
+        }));
+    }
+
+    if sanitized.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Value::Array(sanitized)))
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -206,6 +404,7 @@ fn build_router(state: AppState) -> Router {
         .route(PROFILES_ROUTE, get(get_profiles))
         .route(PROFILE_PAM_ROUTE, put(update_pam_profile))
         .route(PROFILE_PVP_ROUTE, put(update_pvp_profile))
+        .route(PROFILE_PVP_PREVIEW_ROUTE, post(preview_pvp_voice))
         .route(WATCHERS_ROUTE, post(register_watcher))
         .route(CAPABILITY_SCHEMA_ROUTE, get(get_capability_schema))
         .route(CAPABILITY_COST_ROUTE, get(get_capability_cost))
@@ -222,6 +421,171 @@ async fn index() -> Response {
 
     metrics::record_http_request("GET", "/", response.status().as_u16());
 
+    response
+}
+
+#[tracing::instrument(name = "api.profiles.preview_pvp_voice", skip_all)]
+async fn preview_pvp_voice(State(state): State<AppState>) -> Response {
+    let stored_profiles = match state.profiles.fetch_profiles(state.portal_subject_id).await {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            tracing::error!(reason = %error, "failed to load profiles before preview");
+            let response = (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "profiles_unavailable",
+                    message: "Unable to load persona profile for preview.".into(),
+                }),
+            )
+                .into_response();
+            metrics::record_http_request(
+                "POST",
+                PROFILE_PVP_PREVIEW_ROUTE,
+                response.status().as_u16(),
+            );
+            return response;
+        }
+    };
+
+    let Some(pvp_profile) = stored_profiles.pvp else {
+        let response = (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "voice_not_configured",
+                message: "Save persona voice settings before requesting a preview.".into(),
+            }),
+        )
+            .into_response();
+        metrics::record_http_request(
+            "POST",
+            PROFILE_PVP_PREVIEW_ROUTE,
+            response.status().as_u16(),
+        );
+        return response;
+    };
+
+    let profile_object = match pvp_profile.profile.as_object() {
+        Some(profile) => profile,
+        None => {
+            let response = (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "voice_not_configured",
+                    message: "Stored persona profile is not a JSON object.".into(),
+                }),
+            )
+                .into_response();
+            metrics::record_http_request(
+                "POST",
+                PROFILE_PVP_PREVIEW_ROUTE,
+                response.status().as_u16(),
+            );
+            return response;
+        }
+    };
+
+    let voice_object = match profile_object
+        .get("voice")
+        .and_then(|value| value.as_object())
+    {
+        Some(voice) => voice,
+        None => {
+            let response = (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "voice_not_configured",
+                    message: "Save a voice configuration before requesting a preview.".into(),
+                }),
+            )
+                .into_response();
+            metrics::record_http_request(
+                "POST",
+                PROFILE_PVP_PREVIEW_ROUTE,
+                response.status().as_u16(),
+            );
+            return response;
+        }
+    };
+
+    let voice_id = match voice_object
+        .get("voice_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(id) => id.to_string(),
+        None => {
+            let response = (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "voice_not_configured",
+                    message: "Set a voice identifier before requesting a preview.".into(),
+                }),
+            )
+                .into_response();
+            metrics::record_http_request(
+                "POST",
+                PROFILE_PVP_PREVIEW_ROUTE,
+                response.status().as_u16(),
+            );
+            return response;
+        }
+    };
+
+    let mut request_payload = JsonMap::new();
+    request_payload.insert(
+        "input".to_string(),
+        Value::String(VOICE_PREVIEW_SAMPLE.to_string()),
+    );
+    request_payload.insert("voice".to_string(), Value::String(voice_id));
+
+    if let Some(pace) = voice_object.get("pace").and_then(Value::as_f64) {
+        request_payload.insert("pace".to_string(), Value::from(pace));
+    }
+    if let Some(pitch) = voice_object.get("pitch").and_then(Value::as_f64) {
+        request_payload.insert("pitch".to_string(), Value::from(pitch));
+    }
+    if let Some(warmth) = voice_object.get("warmth").and_then(Value::as_f64) {
+        request_payload.insert("warmth".to_string(), Value::from(warmth));
+    }
+    if let Some(pronunciations) = voice_object
+        .get("pronunciation_dict")
+        .and_then(|value| value.as_array())
+        .filter(|array| !array.is_empty())
+    {
+        request_payload.insert(
+            "pronunciation_dict".to_string(),
+            Value::Array(pronunciations.clone()),
+        );
+    }
+
+    let preview = match state.model_gateway.request_preview(request_payload).await {
+        Ok(preview) => preview,
+        Err(error) => {
+            tracing::error!(reason = %error, "model gateway preview failed");
+            let response = (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse {
+                    error: "preview_unavailable",
+                    message: "Voice preview is temporarily unavailable.".into(),
+                }),
+            )
+                .into_response();
+            metrics::record_http_request(
+                "POST",
+                PROFILE_PVP_PREVIEW_ROUTE,
+                response.status().as_u16(),
+            );
+            return response;
+        }
+    };
+
+    let response = Json(preview).into_response();
+    metrics::record_http_request(
+        "POST",
+        PROFILE_PVP_PREVIEW_ROUTE,
+        response.status().as_u16(),
+    );
     response
 }
 
@@ -542,12 +906,28 @@ async fn update_pvp_profile(
         return response;
     }
 
+    let sanitized_profile = match sanitize_pvp_profile(payload.profile) {
+        Ok(profile) => profile,
+        Err(message) => {
+            let response = (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "invalid_profile",
+                    message,
+                }),
+            )
+                .into_response();
+            metrics::record_http_request("PUT", PROFILE_PVP_ROUTE, response.status().as_u16());
+            return response;
+        }
+    };
+
     let response = match state
         .profiles
         .upsert_pvp_profile(
             state.portal_subject_id,
             DEFAULT_PVP_PROFILE_ID,
-            payload.profile,
+            sanitized_profile,
         )
         .await
     {
@@ -989,6 +1369,13 @@ async fn main() -> Result<()> {
     let telegram = telegram::TelegramWebhookVerifier::new(telegram_secret)
         .context("invalid telegram webhook secret")?;
 
+    let model_gateway_base =
+        env::var("MODEL_GATEWAY_URL").unwrap_or_else(|_| DEFAULT_MODEL_GATEWAY_URL.to_string());
+    let model_gateway_url =
+        Url::parse(&model_gateway_base).context("MODEL_GATEWAY_URL must be a valid URL")?;
+    let model_gateway = ModelGatewayClient::new(model_gateway_url, VOICE_PREVIEW_MODEL)
+        .context("initializing model gateway client")?;
+
     let app = build_router(AppState {
         waitlist,
         account_linking,
@@ -1000,6 +1387,7 @@ async fn main() -> Result<()> {
         capabilities,
         cache,
         portal_subject_id,
+        model_gateway,
     });
 
     tracing::info!("listening on {}", bind_addr);
@@ -1019,25 +1407,33 @@ mod tests {
 
     use super::{
         ACCOUNT_LINKING_ROUTE, AppState, AuditTimelineRepository, DEFAULT_CAPABILITY_CACHE_TTL,
-        PLACEHOLDER_INTEGRATIONS, PORTAL_ACCOUNT_ID, PROFILE_PAM_ROUTE, PROFILE_PVP_ROUTE,
-        PROFILES_ROUTE, TELEGRAM_WEBHOOK_ROUTE, WAITLIST_ROUTE, build_router, sanitize_opt,
+        ModelGatewayClient, PLACEHOLDER_INTEGRATIONS, PORTAL_ACCOUNT_ID, PROFILE_PAM_ROUTE,
+        PROFILE_PVP_PREVIEW_ROUTE, PROFILE_PVP_ROUTE, PROFILES_ROUTE, TELEGRAM_WEBHOOK_ROUTE,
+        VOICE_PREVIEW_MODEL, VOICE_PREVIEW_SAMPLE, WAITLIST_ROUTE, build_router, sanitize_opt,
     };
     use crate::metrics;
     use axum::{
+        Json, Router,
         body::Body,
         http::{Request, StatusCode},
+        routing::post,
     };
     use chrono::{DateTime, Utc};
     use http_body_util::BodyExt;
+    use reqwest::Url;
     use serde_json::{Value, json};
     use serial_test::serial;
     use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+    use std::sync::Arc;
     use std::{path::Path, time::Duration};
     use testcontainers::{
         ContainerAsync, GenericImage, ImageExt,
         core::{IntoContainerPort, WaitFor},
         runners::AsyncRunner,
     };
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+    use tokio::task::JoinHandle;
     use tokio::time::sleep;
     use tower::ServiceExt;
     use tyrum_api::{
@@ -1133,6 +1529,8 @@ mod tests {
 
     const TELEGRAM_SECRET: &str = "test-telegram-secret";
 
+    const TEST_PREVIEW_AUDIO: &str = "UklGRmQGAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YUAGAAAAAAENeRgNIbcl7SWmIWQZIg40ASP0eOiV34fa6NnK3bflwPCX/bYKkRbCHzElOia+IiYbWRCdA3T2a+rw4CHbrtnD3APkku4w+2AIkxRXHoQkYSazI80cfxIBBs/4dexq4uDbmtng22ridezP+AEGfxLNHLMjYSaEJFcekxRgCDD7ku4D5MPcrtkh2/Dga+p09p0DWRAmG74iOiYxJcIfkRa2Cpf9wPC35crd6NmH2pXfeOgj9DQBIg5kGaYh7SW3JQ0heRgBDQAA//KH5/PeSdoT2lrenObe8cz+3QuIF2sgeSUYJjYiSRpAD2kCSvVv6T7gz9rG2ULd2uSn72P8jAmVFRAf3yRSJj0j/RtuEdAEoPdt66nhfNuf2U3cM+OB7f/5MQeLE5YdICRmJiAklh2LEzEH//mB7TPjTdyf2XzbqeFt66D30ARuEf0bPSNSJt8kEB+VFYwJY/yn79rkQt3G2c/aPuBv6Ur1aQJAD0kaNiIYJnklayCIF90LzP7e8ZzmWt4T2kna896H5//yAAA";
+
     struct TestContext {
         #[allow(dead_code)]
         container: ContainerAsync<GenericImage>,
@@ -1146,6 +1544,9 @@ mod tests {
         #[allow(dead_code)]
         cache: CapabilityCache,
         telegram: TelegramWebhookVerifier,
+        #[allow(dead_code)]
+        model_gateway_handle: JoinHandle<()>,
+        tts_requests: Arc<Mutex<Vec<Value>>>,
     }
 
     impl TestContext {
@@ -1191,6 +1592,43 @@ mod tests {
             let telegram =
                 TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
 
+            let tts_requests: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+            let tts_store = tts_requests.clone();
+            let tts_app = Router::new().route(
+                "/v1/audio/speech",
+                post(move |Json(payload): Json<Value>| {
+                    let tts_store = tts_store.clone();
+                    async move {
+                        tts_store.lock().await.push(payload);
+                        (
+                            StatusCode::OK,
+                            Json(json!({
+                                "audio_base64": TEST_PREVIEW_AUDIO,
+                                "format": "wav",
+                            })),
+                        )
+                    }
+                }),
+            );
+
+            let listener = TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind preview stub listener");
+            let addr = listener.local_addr().expect("preview stub addr");
+            let gateway_handle = tokio::spawn(async move {
+                if let Err(error) = axum::serve(listener, tts_app).await {
+                    eprintln!("model gateway preview stub terminated unexpectedly: {error}");
+                }
+            });
+
+            let gateway_url = Url::parse(&format!("http://{}", addr)).expect("preview stub url");
+            let model_gateway = ModelGatewayClient::with_client(
+                reqwest::Client::new(),
+                gateway_url,
+                VOICE_PREVIEW_MODEL,
+            )
+            .expect("construct model gateway client");
+
             let router = build_router(AppState {
                 waitlist: waitlist.clone(),
                 account_linking: account_linking.clone(),
@@ -1202,6 +1640,7 @@ mod tests {
                 capabilities: capabilities.clone(),
                 cache: cache.clone(),
                 portal_subject_id,
+                model_gateway,
             });
 
             Self {
@@ -1214,7 +1653,15 @@ mod tests {
                 capabilities,
                 cache,
                 telegram,
+                model_gateway_handle: gateway_handle,
+                tts_requests,
             }
+        }
+    }
+
+    impl Drop for TestContext {
+        fn drop(&mut self) {
+            self.model_gateway_handle.abort();
         }
     }
 
@@ -1359,6 +1806,12 @@ mod tests {
             TelegramWebhookVerifier::new(TELEGRAM_SECRET).expect("construct telegram verifier");
         let portal_subject_id =
             Uuid::parse_str(PORTAL_ACCOUNT_ID).expect("valid portal subject uuid");
+        let model_gateway = ModelGatewayClient::with_client(
+            reqwest::Client::new(),
+            Url::parse("http://localhost:65535").expect("parse fallback gateway url"),
+            VOICE_PREVIEW_MODEL,
+        )
+        .expect("construct model gateway client");
         let state = AppState {
             waitlist,
             account_linking,
@@ -1370,6 +1823,7 @@ mod tests {
             capabilities,
             cache,
             portal_subject_id,
+            model_gateway,
         };
         let app = build_router(state);
 
@@ -1940,7 +2394,11 @@ mod tests {
                 "verbosity": "balanced",
                 "voice": {
                     "voice_id": "voice_test",
-                    "pace": 0.4
+                    "pace": 0.4,
+                    "pronunciation_dict": [
+                        { "token": " Tyrum ", "pronounce": "Tie-rum" },
+                        { "token": "AI", "pronounce": "Aye Eye" }
+                    ]
                 }
             }
         });
@@ -1990,6 +2448,124 @@ mod tests {
             payload["pvp"]["profile"]["voice"]["voice_id"],
             json!("voice_test")
         );
+        assert_eq!(
+            payload["pvp"]["profile"]["voice"]["pronunciation_dict"],
+            json!([
+                { "token": "Tyrum", "pronounce": "Tie-rum" },
+                { "token": "AI", "pronounce": "Aye Eye" }
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn pvp_update_rejects_invalid_pronunciation_dictionary() {
+        if !docker_available() {
+            return;
+        }
+
+        let ctx = TestContext::new().await;
+        let app = ctx.router.clone();
+
+        let payload = json!({
+            "profile": {
+                "voice": {
+                    "voice_id": "voice_test",
+                    "pronunciation_dict": [
+                        { "token": "Tyrum", "pronounce": "Tie-rum" },
+                        { "token": "tyrum", "pronounce": "Different" }
+                    ]
+                }
+            }
+        });
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(PROFILE_PVP_ROUTE)
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["error"], "invalid_profile");
+        assert!(
+            payload["message"]
+                .as_str()
+                .expect("error message")
+                .contains("duplicate entry")
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_voice_returns_audio_clip_and_forwards_voice_settings() {
+        if !docker_available() {
+            return;
+        }
+
+        let ctx = TestContext::new().await;
+        let app = ctx.router.clone();
+
+        let pvp_payload = json!({
+            "profile": {
+                "voice": {
+                    "voice_id": "tyrum-preview",
+                    "pace": 0.7,
+                    "pronunciation_dict": [
+                        { "token": "Tyrum", "pronounce": "Tie-rum" }
+                    ]
+                }
+            }
+        });
+
+        let store_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(PROFILE_PVP_ROUTE)
+                    .header("content-type", "application/json")
+                    .body(Body::from(pvp_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(store_response.status(), StatusCode::OK);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(PROFILE_PVP_PREVIEW_ROUTE)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["format"], json!("wav"));
+        assert_eq!(payload["audio_base64"], json!(TEST_PREVIEW_AUDIO));
+
+        let recordings = ctx.tts_requests.lock().await;
+        assert_eq!(recordings.len(), 1);
+        let forwarded = recordings[0].clone();
+        assert_eq!(forwarded["model"], json!(VOICE_PREVIEW_MODEL));
+        assert_eq!(forwarded["stream"], json!(false));
+        assert_eq!(forwarded["input"], json!(VOICE_PREVIEW_SAMPLE));
+        assert_eq!(forwarded["voice"], json!("tyrum-preview"));
+        assert_eq!(
+            forwarded["pronunciation_dict"],
+            json!([{ "token": "Tyrum", "pronounce": "Tie-rum" }])
+        );
+        assert_eq!(forwarded["pace"], json!(0.7));
     }
 
     #[tokio::test]
@@ -2091,6 +2667,13 @@ mod tests {
             .expect("load capability")
             .expect("capability stored");
 
+        let model_gateway = ModelGatewayClient::with_client(
+            reqwest::Client::new(),
+            Url::parse("http://localhost:65535").expect("parse fallback gateway url"),
+            VOICE_PREVIEW_MODEL,
+        )
+        .expect("construct model gateway client");
+
         let router = build_router(AppState {
             waitlist,
             account_linking,
@@ -2102,6 +2685,7 @@ mod tests {
             capabilities,
             cache,
             portal_subject_id,
+            model_gateway,
         });
 
         let schema_route = format!(
@@ -2254,6 +2838,13 @@ mod tests {
             .expect("load capability")
             .expect("capability stored");
 
+        let model_gateway = ModelGatewayClient::with_client(
+            reqwest::Client::new(),
+            Url::parse("http://localhost:65535").expect("parse fallback gateway url"),
+            VOICE_PREVIEW_MODEL,
+        )
+        .expect("construct model gateway client");
+
         let router = build_router(AppState {
             waitlist,
             account_linking,
@@ -2265,6 +2856,7 @@ mod tests {
             capabilities,
             cache,
             portal_subject_id,
+            model_gateway,
         });
 
         let cost_route = format!(
@@ -2387,6 +2979,13 @@ mod tests {
             .expect("load capability")
             .expect("capability stored");
 
+        let model_gateway = ModelGatewayClient::with_client(
+            reqwest::Client::new(),
+            Url::parse("http://localhost:65535").expect("parse fallback gateway url"),
+            VOICE_PREVIEW_MODEL,
+        )
+        .expect("construct model gateway client");
+
         let router = build_router(AppState {
             waitlist,
             account_linking,
@@ -2398,6 +2997,7 @@ mod tests {
             capabilities,
             cache,
             portal_subject_id,
+            model_gateway,
         });
 
         let cost_route = format!(

--- a/services/mock_llm/app.py
+++ b/services/mock_llm/app.py
@@ -1,10 +1,15 @@
 from datetime import datetime
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+import base64
+import io
 import json
+import math
+import struct
+import wave
 
 app = FastAPI(title="Tyrum Mock LLM", version="0.1.0")
 
@@ -26,6 +31,28 @@ class CompletionResponse(BaseModel):
     model: str
     choices: List[CompletionChoice]
     usage: Dict[str, Any]
+
+
+class PronunciationEntry(BaseModel):
+    token: str
+    pronounce: str
+
+
+class SpeechRequest(BaseModel):
+    model: str
+    input: str
+    voice: str
+    format: str = Field(default="wav", pattern="^(wav|mp3)$")
+    stream: bool = False
+    pace: Optional[float] = None
+    pitch: Optional[float] = None
+    warmth: Optional[float] = None
+    pronunciation_dict: List[PronunciationEntry] = Field(default_factory=list)
+
+
+class SpeechResponse(BaseModel):
+    audio_base64: str
+    format: str
 
 
 @app.get("/healthz")
@@ -64,3 +91,27 @@ def create_completion(request: CompletionRequest):
         choices=[CompletionChoice(index=0, text=f"Echo: {request.prompt}")],
         usage={"prompt_tokens": len(request.prompt.split()), "completion_tokens": 3},
     )
+
+
+@app.post("/v1/audio/speech")
+def create_speech(request: SpeechRequest):
+    buffer = io.BytesIO()
+    sample_rate = 8000
+    frequency = 660.0
+    duration = 0.1
+    amplitude = 0.3
+
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        for n in range(int(sample_rate * duration)):
+            value = int(
+                amplitude
+                * 32767
+                * math.sin(2 * math.pi * frequency * n / sample_rate)
+            )
+            wav_file.writeframes(struct.pack("<h", value))
+
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return SpeechResponse(audio_base64=encoded, format=request.format)

--- a/services/model_gateway/src/main.rs
+++ b/services/model_gateway/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/healthz", get(health))
         .route("/v1/completions", post(proxy))
         .route("/v1/chat/completions", post(proxy))
+        .route("/v1/audio/speech", post(proxy))
         .route("/v1/embeddings", post(proxy))
         .with_state(app_state)
         .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()));

--- a/web/app/api/profiles/pvp/preview/route.ts
+++ b/web/app/api/profiles/pvp/preview/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { parseUpstreamResponse, resolveApiBaseUrl } from "../../../shared";
+
+export async function POST() {
+  const baseUrl = resolveApiBaseUrl();
+  if (!baseUrl) {
+    return NextResponse.json(
+      {
+        error: "configuration",
+        message: "API_BASE_URL is not configured.",
+      },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const upstreamResponse = await fetch(`${baseUrl}/profiles/pvp/preview`, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+      },
+      cache: "no-store",
+    });
+
+    const payload = await parseUpstreamResponse(upstreamResponse);
+    return NextResponse.json(payload, { status: upstreamResponse.status });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: "upstream_unavailable",
+        message: "Unable to fetch voice preview from the API.",
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -832,6 +832,35 @@ main.consent-container {
   box-shadow: none;
 }
 
+.portal-settings__button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.portal-settings__button--secondary {
+  background: transparent;
+  border: 1px dashed rgba(147, 197, 253, 0.6);
+  color: #bfdbfe;
+  box-shadow: none;
+}
+
+.portal-settings__button--secondary:hover {
+  transform: none;
+  box-shadow: 0 0 0 1px rgba(147, 197, 253, 0.4);
+}
+
+.portal-settings__button--ghost {
+  background: rgba(37, 99, 235, 0.18);
+  color: #bfdbfe;
+  box-shadow: none;
+}
+
+.portal-settings__button--ghost:hover {
+  transform: none;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.25);
+}
+
 .portal-settings__form {
   display: flex;
   flex-direction: column;
@@ -870,6 +899,77 @@ main.consent-container {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.portal-settings__dictionary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px dashed rgba(88, 114, 181, 0.6);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.portal-settings__dictionary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.portal-settings__dictionary-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(224, 242, 254, 0.95);
+}
+
+.portal-settings__dictionary-header p {
+  margin: 0;
+  color: rgba(204, 219, 252, 0.72);
+  font-size: 0.9rem;
+}
+
+.portal-settings__dictionary-empty {
+  margin: 0;
+  color: rgba(209, 213, 219, 0.7);
+  font-size: 0.9rem;
+}
+
+.portal-settings__dictionary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.portal-settings__dictionary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.portal-settings__dictionary-remove {
+  align-self: center;
+  background: transparent;
+  border: none;
+  color: #fda4af;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.4rem 0.6rem;
+}
+
+.portal-settings__dictionary-remove:hover {
+  text-decoration: underline;
+}
+
+.portal-settings__dictionary-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  text-decoration: none;
 }
 
 .portal-settings__meta {

--- a/web/app/portal/settings/page.test.tsx
+++ b/web/app/portal/settings/page.test.tsx
@@ -7,13 +7,30 @@ import AccountSettingsPage from "./page";
 declare global {
   // eslint-disable-next-line no-var
   var fetch: typeof fetch;
+  // eslint-disable-next-line no-var
+  var Audio: typeof Audio;
 }
 
 describe("AccountSettingsPage", () => {
   const emptyProfilesResponse = { pam: null, pvp: null };
+  let audioPlayMock: ReturnType<typeof vi.fn>;
+  let audioPauseMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.resetAllMocks();
+    audioPlayMock = vi.fn().mockResolvedValue(undefined);
+    audioPauseMock = vi.fn();
+    global.Audio = vi
+      .fn()
+      .mockImplementation(
+        () =>
+          ({
+            src: "",
+            currentTime: 0,
+            play: audioPlayMock,
+            pause: audioPauseMock,
+          }) as unknown as HTMLAudioElement,
+      ) as unknown as typeof Audio;
     global.fetch = vi
       .fn()
       .mockResolvedValue(mockFetch(emptyProfilesResponse)) as unknown as typeof fetch;
@@ -136,6 +153,10 @@ describe("AccountSettingsPage", () => {
             pace: 0.7,
             pitch: 0.2,
             warmth: 0.5,
+            pronunciation_dict: [
+              { token: "Tyrum", pronounce: "Tie-rum" },
+              { token: "AI", pronounce: "A I" },
+            ],
           },
         },
       },
@@ -164,7 +185,159 @@ describe("AccountSettingsPage", () => {
     expect(screen.getByLabelText("Voice pace")).toHaveValue(0.7);
     expect(screen.getByLabelText("Voice pitch")).toHaveValue(0.2);
     expect(screen.getByLabelText("Voice warmth")).toHaveValue(0.5);
+    const tokenFields = screen.getAllByLabelText("Token");
+    expect(tokenFields).toHaveLength(2);
+    expect(tokenFields[0]).toHaveValue("Tyrum");
+    expect(tokenFields[1]).toHaveValue("AI");
+    const pronounceFields = screen.getAllByLabelText("Pronounce as");
+    expect(pronounceFields).toHaveLength(2);
+    expect(pronounceFields[0]).toHaveValue("Tie-rum");
+    expect(pronounceFields[1]).toHaveValue("A I");
     expect(screen.getByText("Current version: pvp-version-456")).toBeInTheDocument();
+  });
+
+  it("allows adding and removing pronunciation overrides", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockFetch(emptyProfilesResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const user = userEvent.setup();
+    render(<AccountSettingsPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/profiles", expect.any(Object));
+    });
+
+    await user.click(screen.getByRole("button", { name: "Add pronunciation" }));
+    const tokenFields = screen.getAllByLabelText("Token");
+    const pronounceFields = screen.getAllByLabelText("Pronounce as");
+    expect(tokenFields).toHaveLength(1);
+    expect(pronounceFields).toHaveLength(1);
+
+    await user.type(tokenFields[0], "Tyrum");
+    await user.type(pronounceFields[0], "Tie-rum");
+    expect(tokenFields[0]).toHaveValue("Tyrum");
+    expect(pronounceFields[0]).toHaveValue("Tie-rum");
+
+    await user.click(screen.getByRole("button", { name: /Remove pronunciation override/ }));
+    expect(screen.queryAllByLabelText("Token")).toHaveLength(0);
+  });
+
+  it("surfaces an error when a pronunciation entry is incomplete", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockFetch(emptyProfilesResponse));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const user = userEvent.setup();
+    render(<AccountSettingsPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/profiles", expect.any(Object));
+    });
+
+    await user.click(screen.getByRole("button", { name: "Add pronunciation" }));
+    await user.type(screen.getByLabelText("Token"), "Tyrum");
+
+    await user.click(screen.getByRole("button", { name: "Save persona profile" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Pronunciation entries must include both the token and the pronunciation.",
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/profiles/pvp",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  it("plays a voice preview when the API returns audio", async () => {
+    const previewAudio = "ZmFrZS1hdWRpby1kYXRh";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockFetch({
+          pam: null,
+          pvp: {
+            profile_id: "pvp-default",
+            version: "pvp-version-200",
+            profile: {
+              voice: {
+                voice_id: "nova",
+              },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockFetch({
+          audio_base64: previewAudio,
+          format: "wav",
+        }),
+      );
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const user = userEvent.setup();
+    render(<AccountSettingsPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/profiles", expect.any(Object));
+    });
+
+    await user.click(screen.getByRole("button", { name: "Preview voice" }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/profiles/pvp/preview",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(audioPlayMock).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText("Playing voice preview.")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces an error when the voice preview fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockFetch({
+          pam: null,
+          pvp: {
+            profile_id: "pvp-default",
+            version: "pvp-version-201",
+            profile: {
+              voice: {
+                voice_id: "nova",
+              },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockFetch(
+          {
+            message: "Preview unavailable.",
+          },
+          { ok: false, status: 502 },
+        ),
+      );
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const user = userEvent.setup();
+    render(<AccountSettingsPage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/profiles", expect.any(Object));
+    });
+
+    await user.click(screen.getByRole("button", { name: "Preview voice" }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/profiles/pvp/preview",
+      expect.objectContaining({ method: "POST" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Preview unavailable.");
+    });
+    expect(audioPlayMock).not.toHaveBeenCalled();
   });
 
   it("submits autonomy preferences and surfaces success feedback", async () => {
@@ -267,6 +440,7 @@ describe("AccountSettingsPage", () => {
               pace: 0.6,
               pitch: 0.3,
               warmth: 0.4,
+              pronunciation_dict: [{ token: "Tyrum", pronounce: "Tie-rum" }],
             },
           },
           version: "pvp-version-321",
@@ -296,6 +470,9 @@ describe("AccountSettingsPage", () => {
     await user.type(screen.getByLabelText("Voice pitch"), "0.3");
     await user.clear(screen.getByLabelText("Voice warmth"));
     await user.type(screen.getByLabelText("Voice warmth"), "0.4");
+    await user.click(screen.getByRole("button", { name: "Add pronunciation" }));
+    await user.type(screen.getByLabelText("Token"), "Tyrum");
+    await user.type(screen.getByLabelText("Pronounce as"), "Tie-rum");
 
     await user.click(screen.getByRole("button", { name: "Save persona profile" }));
 
@@ -305,6 +482,11 @@ describe("AccountSettingsPage", () => {
         method: "PUT",
       }),
     );
+    const [, requestInit] = fetchMock.mock.calls.at(-1) ?? [];
+    const body = requestInit && requestInit.body ? JSON.parse(requestInit.body as string) : {};
+    expect(body.profile.voice.pronunciation_dict).toEqual([
+      { token: "Tyrum", pronounce: "Tie-rum" },
+    ]);
 
     await waitFor(() => {
       expect(screen.getByText("Persona preferences saved.")).toBeInTheDocument();

--- a/web/app/portal/settings/page.tsx
+++ b/web/app/portal/settings/page.tsx
@@ -31,6 +31,12 @@ type PamFormState = {
   currency: string;
 };
 
+type PronunciationFormEntry = {
+  id: number;
+  token: string;
+  pronounce: string;
+};
+
 type PvpFormState = {
   tone: string;
   verbosity: string;
@@ -42,6 +48,7 @@ type PvpFormState = {
   pace: string;
   pitch: string;
   warmth: string;
+  pronunciationDict: PronunciationFormEntry[];
 };
 
 type ProfilesEnvelope = {
@@ -74,6 +81,7 @@ const DEFAULT_PVP_FORM: PvpFormState = {
   pace: "",
   pitch: "",
   warmth: "",
+  pronunciationDict: [],
 };
 
 const PAM_ESCALATION_OPTIONS = [
@@ -91,6 +99,8 @@ const PVP_CONSENT_OPTIONS = [
   "act_within_limits",
 ];
 const PVP_EMOJI_OPTIONS = ["never", "sometimes", "often"];
+const PRONUNCIATION_MAX_ENTRIES = 32;
+const PRONUNCIATION_MAX_LENGTH = 128;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -165,6 +175,9 @@ export default function AccountSettingsPage() {
   const [pamVersion, setPamVersion] = useState<string | null>(null);
   const [pvpForm, setPvpForm] = useState<PvpFormState>(DEFAULT_PVP_FORM);
   const [pvpVersion, setPvpVersion] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const pronunciationIdRef = useRef(0);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -183,6 +196,14 @@ export default function AccountSettingsPage() {
     return () => window.clearTimeout(timeout);
   }, [toast]);
 
+  useEffect(() => {
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+      }
+    };
+  }, []);
+
   const raiseToast = useCallback((tone: ToastTone, message: string) => {
     if (!isMountedRef.current) {
       return;
@@ -198,6 +219,71 @@ export default function AccountSettingsPage() {
       return next;
     });
   }, []);
+
+  const extractPronunciationDict = useCallback(
+    (value: unknown): PronunciationFormEntry[] => {
+      if (!Array.isArray(value)) {
+        pronunciationIdRef.current = 0;
+        return [];
+      }
+
+      let counter = 0;
+      const entries: PronunciationFormEntry[] = [];
+      for (const item of value) {
+        if (!isRecord(item)) {
+          continue;
+        }
+        const token = typeof item.token === "string" ? item.token : "";
+        const pronounce = typeof item.pronounce === "string" ? item.pronounce : "";
+        counter += 1;
+        entries.push({ id: counter, token, pronounce });
+      }
+      pronunciationIdRef.current = counter;
+      return entries;
+    },
+    [],
+  );
+
+  const handlePronunciationChange = useCallback(
+    (id: number, field: "token" | "pronounce", value: string) => {
+      setPvpForm((current) => ({
+        ...current,
+        pronunciationDict: current.pronunciationDict.map((entry) =>
+          entry.id === id ? { ...entry, [field]: value } : entry,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const handleRemovePronunciation = useCallback((id: number) => {
+    setPvpForm((current) => ({
+      ...current,
+      pronunciationDict: current.pronunciationDict.filter((entry) => entry.id !== id),
+    }));
+  }, []);
+
+  const handleAddPronunciation = useCallback(() => {
+    setPvpForm((current) => {
+      if (current.pronunciationDict.length >= PRONUNCIATION_MAX_ENTRIES) {
+        raiseToast(
+          "error",
+          `You can only store up to ${PRONUNCIATION_MAX_ENTRIES} pronunciation overrides.`,
+        );
+        return current;
+      }
+      const nextId = pronunciationIdRef.current + 1;
+      pronunciationIdRef.current = nextId;
+
+      return {
+        ...current,
+        pronunciationDict: [
+          ...current.pronunciationDict,
+          { id: nextId, token: "", pronounce: "" },
+        ],
+      };
+    });
+  }, [raiseToast]);
 
   const triggerAction = async (action: AccountAction) => {
     if (pendingAction) {
@@ -385,6 +471,55 @@ export default function AccountSettingsPage() {
       profile.voice = voice;
     }
 
+    const pronunciationEntries: Array<{ token: string; pronounce: string }> = [];
+    const seenTokens = new Set<string>();
+
+    for (const entry of pvpForm.pronunciationDict) {
+      const token = entry.token.trim();
+      const pronounce = entry.pronounce.trim();
+
+      if (!token && !pronounce) {
+        continue;
+      }
+
+      if (!token || !pronounce) {
+        raiseToast(
+          "error",
+          "Pronunciation entries must include both the token and the pronunciation.",
+        );
+        return;
+      }
+
+      if (token.length > PRONUNCIATION_MAX_LENGTH || pronounce.length > PRONUNCIATION_MAX_LENGTH) {
+        raiseToast(
+          "error",
+          `Pronunciation entries must be ${PRONUNCIATION_MAX_LENGTH} characters or fewer.`,
+        );
+        return;
+      }
+
+      const normalizedToken = token.toLowerCase();
+      if (seenTokens.has(normalizedToken)) {
+        raiseToast("error", `Duplicate pronunciation override for "${token}".`);
+        return;
+      }
+      seenTokens.add(normalizedToken);
+      pronunciationEntries.push({ token, pronounce });
+    }
+
+    if (pronunciationEntries.length > PRONUNCIATION_MAX_ENTRIES) {
+      raiseToast(
+        "error",
+        `You can only store up to ${PRONUNCIATION_MAX_ENTRIES} pronunciation overrides.`,
+      );
+      return;
+    }
+
+    if (pronunciationEntries.length > 0) {
+      voice.pronunciation_dict = pronunciationEntries;
+      profile.voice = voice;
+    }
+
     try {
       const response = await fetch("/api/profiles/pvp", {
         method: "PUT",
@@ -422,6 +557,9 @@ export default function AccountSettingsPage() {
         : undefined;
       const numericToString = (value: unknown) =>
         typeof value === "number" ? value.toString() : "";
+      const savedPronunciations = extractPronunciationDict(
+        updatedVoice?.pronunciation_dict,
+      );
 
       setPvpForm({
         tone: typeof pvpProfile?.tone === "string" ? pvpProfile.tone : "",
@@ -441,6 +579,7 @@ export default function AccountSettingsPage() {
         pace: numericToString(updatedVoice?.pace),
         pitch: numericToString(updatedVoice?.pitch),
         warmth: numericToString(updatedVoice?.warmth),
+        pronunciationDict: savedPronunciations,
       });
       setPvpVersion(payload.version ?? null);
       raiseToast("success", "Persona preferences saved.");
@@ -454,6 +593,82 @@ export default function AccountSettingsPage() {
       }
     }
   };
+
+  const handleVoicePreview = useCallback(async () => {
+    if (previewLoading) {
+      return;
+    }
+
+    if (!pvpVersion) {
+      raiseToast("error", "Save your persona profile before requesting a preview.");
+      return;
+    }
+
+    if (!pvpForm.voiceId.trim()) {
+      raiseToast("error", "Set a voice ID before requesting a preview.");
+      return;
+    }
+
+    setPreviewLoading(true);
+    try {
+      const response = await fetch("/api/profiles/pvp/preview", {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+        },
+        cache: "no-store",
+      });
+
+      const payload = (await parseJsonResponse(response)) as {
+        audio_base64?: unknown;
+        audioBase64?: unknown;
+        format?: unknown;
+        message?: string;
+      };
+
+      if (!response.ok) {
+        const message =
+          typeof payload?.message === "string"
+            ? payload.message
+            : "Unable to load voice preview.";
+        throw new Error(message);
+      }
+
+      const base64 =
+        typeof payload?.audio_base64 === "string"
+          ? payload.audio_base64
+          : typeof payload?.audioBase64 === "string"
+            ? payload.audioBase64
+            : "";
+      if (!base64) {
+        throw new Error("Voice preview response did not include audio data.");
+      }
+
+      const format =
+        typeof payload?.format === "string" && payload.format.trim()
+          ? payload.format
+          : "wav";
+      const dataUrl = `data:audio/${format};base64,${base64}`;
+
+      if (!audioRef.current) {
+        audioRef.current = new Audio();
+      } else {
+        audioRef.current.pause();
+        audioRef.current.currentTime = 0;
+      }
+      audioRef.current.src = dataUrl;
+      await audioRef.current.play();
+      raiseToast("success", "Playing voice preview.");
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : "Unable to play voice preview.";
+      raiseToast("error", message);
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [pvpForm.voiceId, pvpVersion, previewLoading, raiseToast]);
 
   useEffect(() => {
     const loadProfiles = async () => {
@@ -519,6 +734,9 @@ export default function AccountSettingsPage() {
 
         const numericToString = (value: unknown) =>
           typeof value === "number" ? value.toString() : "";
+        const savedPronunciations = extractPronunciationDict(
+          voice?.pronunciation_dict,
+        );
 
         setPvpForm({
           tone: typeof pvpProfile?.tone === "string" ? pvpProfile.tone : "",
@@ -538,6 +756,7 @@ export default function AccountSettingsPage() {
           pace: numericToString(voice?.pace),
           pitch: numericToString(voice?.pitch),
           warmth: numericToString(voice?.warmth),
+          pronunciationDict: savedPronunciations,
         });
         setPvpVersion(payload?.pvp?.version ?? null);
       } catch (error) {
@@ -872,14 +1091,85 @@ export default function AccountSettingsPage() {
                 />
               </div>
             </div>
-            <footer className="portal-settings__card-footer">
+            <div className="portal-settings__dictionary">
+              <div className="portal-settings__dictionary-header">
+                <h3>Pronunciation dictionary</h3>
+                <p>Teach Tyrum how to pronounce important names or phrases.</p>
+              </div>
+              {pvpForm.pronunciationDict.length === 0 ? (
+                <p className="portal-settings__dictionary-empty">
+                  No pronunciation overrides saved yet.
+                </p>
+              ) : (
+                <ul className="portal-settings__dictionary-list">
+                  {pvpForm.pronunciationDict.map((entry) => (
+                    <li key={entry.id} className="portal-settings__dictionary-row">
+                      <div className="portal-settings__field">
+                        <label htmlFor={`pvp-pronunciation-token-${entry.id}`}>Token</label>
+                        <input
+                          id={`pvp-pronunciation-token-${entry.id}`}
+                          type="text"
+                          value={entry.token}
+                          onChange={(event) =>
+                            handlePronunciationChange(entry.id, "token", event.target.value)
+                          }
+                          disabled={profilesLoading}
+                        />
+                      </div>
+                      <div className="portal-settings__field">
+                        <label htmlFor={`pvp-pronunciation-value-${entry.id}`}>Pronounce as</label>
+                        <input
+                          id={`pvp-pronunciation-value-${entry.id}`}
+                          type="text"
+                          value={entry.pronounce}
+                          onChange={(event) =>
+                            handlePronunciationChange(entry.id, "pronounce", event.target.value)
+                          }
+                          disabled={profilesLoading}
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        className="portal-settings__dictionary-remove"
+                        onClick={() => handleRemovePronunciation(entry.id)}
+                        disabled={profilesLoading}
+                        aria-label={`Remove pronunciation override ${entry.token || entry.id}`}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
               <button
-                type="submit"
-                className="portal-settings__button"
-                disabled={profilesLoading}
+                type="button"
+                className="portal-settings__button portal-settings__button--secondary"
+                onClick={handleAddPronunciation}
+                disabled={
+                  profilesLoading || pvpForm.pronunciationDict.length >= PRONUNCIATION_MAX_ENTRIES
+                }
               >
-                Save persona profile
+                Add pronunciation
               </button>
+            </div>
+            <footer className="portal-settings__card-footer">
+              <div className="portal-settings__button-group">
+                <button
+                  type="submit"
+                  className="portal-settings__button"
+                  disabled={profilesLoading}
+                >
+                  Save persona profile
+                </button>
+                <button
+                  type="button"
+                  className="portal-settings__button portal-settings__button--ghost"
+                  onClick={handleVoicePreview}
+                  disabled={profilesLoading || previewLoading}
+                >
+                  {previewLoading ? "Previewing…" : "Preview voice"}
+                </button>
+              </div>
             </footer>
             <p className="portal-settings__meta" aria-live="polite">
               {pvpVersion ? `Current version: ${pvpVersion}` : "No persona profile saved yet."}


### PR DESCRIPTION
## Summary
- add model-gateway preview endpoint backed by reqwest and sanitize pronunciation dictionaries
- extend mock LLM and configuration to serve stubbed TTS audio for previews
- surface pronunciation dictionary UI and voice preview button in portal settings with full test coverage

## Testing
- cargo test -p tyrum-api
- npm run test -- --watch=false
- pre-commit run --all-files

Closes #199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces voice preview via model-gateway and adds a sanitized pronunciation dictionary with frontend UI, mock TTS, and tests.
> 
> - **Backend (API)**:
>   - Add `POST /profiles/pvp/preview` to return TTS preview audio via `ModelGatewayClient` (configurable `MODEL_GATEWAY_URL`).
>   - Sanitize `profile.voice.pronunciation_dict` (limits, de-duplication, trimming) before storing PVP profiles.
>   - Wire new client in `AppState`; add `reqwest` dep; constants for preview model and defaults.
> - **Model Gateway**:
>   - Proxy new route `POST /v1/audio/speech` alongside existing completions/embeddings.
>   - Config updates to include audio capabilities and `tyrum-voice-preview`.
> - **Mock LLM**:
>   - Implement `POST /v1/audio/speech` generating short WAV; accept `pace`, `pitch`, `warmth`, and `pronunciation_dict`.
> - **Web**:
>   - API route `web/app/api/profiles/pvp/preview` to fetch preview.
>   - Portal settings: add pronunciation dictionary UI (add/remove, validation, de-dup), and "Preview voice" button that plays returned audio; new styles.
> - **Tests**:
>   - Extensive API tests for pronunciation validation and preview forwarding; web tests for pronunciation UI, persistence, and preview success/failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf5373711f319be314b68796cefbbe60a2701ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->