### PR TITLE
Add voice rationales to planner audit logs

### DIFF
--- a/services/api/src/audit.rs
+++ b/services/api/src/audit.rs
@@ -64,12 +64,15 @@ impl AuditTimelineRepository {
                 has_redactions = true;
             }
 
+            let voice_rationale = extract_voice_rationale(&action);
+
             events.push(PlanAuditEvent {
                 replay_id,
                 step_index,
                 occurred_at,
                 recorded_at,
                 action,
+                voice_rationale,
                 redactions,
             });
         }
@@ -109,6 +112,8 @@ pub struct PlanAuditEvent {
     #[serde(rename = "recorded_at")]
     pub recorded_at: DateTime<Utc>,
     pub action: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub voice_rationale: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redactions: Vec<String>,
 }
@@ -118,6 +123,53 @@ fn collect_redactions(action: &Value) -> Vec<String> {
     let mut segments = vec!["action".to_string()];
     collect_redactions_inner(action, &mut segments, &mut paths);
     paths
+}
+
+fn extract_voice_rationale(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            if let Some(voice) = map.get("voice_rationale").and_then(Value::as_str)
+                && let Some(cleaned) = clean_voice_string(voice)
+            {
+                return Some(cleaned);
+            }
+
+            if let Some(steps) = map.get("steps").and_then(Value::as_array) {
+                let voices: Vec<String> =
+                    steps.iter().filter_map(extract_voice_rationale).collect();
+                if !voices.is_empty() {
+                    return Some(voices.join(" • "));
+                }
+            }
+
+            for (key, nested) in map {
+                if key == "steps" {
+                    continue;
+                }
+                if let Some(voice) = extract_voice_rationale(nested) {
+                    return Some(voice);
+                }
+            }
+        }
+        Value::Array(items) => {
+            let voices: Vec<String> = items.iter().filter_map(extract_voice_rationale).collect();
+            if !voices.is_empty() {
+                return Some(voices.join(" • "));
+            }
+        }
+        _ => {}
+    }
+
+    None
+}
+
+fn clean_voice_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn collect_redactions_inner(value: &Value, path: &mut Vec<String>, acc: &mut Vec<String>) {
@@ -154,4 +206,36 @@ fn format_pointer(segments: &[String]) -> String {
 
 fn escape_pointer_segment(segment: &str) -> String {
     segment.replace('~', "~0").replace('/', "~1")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn extract_voice_rationale_prefers_top_level_field() {
+        let action = json!({ "voice_rationale": "Executor completed successfully." });
+        assert_eq!(
+            super::extract_voice_rationale(&action),
+            Some("Executor completed successfully.".into())
+        );
+    }
+
+    #[test]
+    fn extract_voice_rationale_joins_step_rationales() {
+        let action = json!({
+            "outcome": {
+                "status": "success",
+                "steps": [
+                    { "voice_rationale": "Collected context." },
+                    { "voice_rationale": "Executed capability." }
+                ]
+            }
+        });
+
+        assert_eq!(
+            super::extract_voice_rationale(&action),
+            Some("Collected context. • Executed capability.".into())
+        );
+    }
 }

--- a/services/planner/src/event_log.rs
+++ b/services/planner/src/event_log.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info, instrument, warn};
 use url::Url;
 use uuid::Uuid;
 
+use crate::http::sanitize_detail;
 use crate::{ActionPrimitive, ActionPrimitiveKind};
 
 static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
@@ -230,7 +231,53 @@ fn build_outcome_metadata(primitive: &ActionPrimitive, outcome: &Value) -> Value
         metadata.insert("url".into(), url_metadata);
     }
 
+    if let Some(voice) = primitive_voice_rationale(primitive) {
+        metadata.insert("voice_rationale".into(), Value::String(voice));
+    }
+
     Value::Object(metadata)
+}
+
+fn primitive_voice_rationale(primitive: &ActionPrimitive) -> Option<String> {
+    const VOICE_KEYS: &[&str] = &[
+        "voice_rationale",
+        "notes",
+        "body",
+        "prompt",
+        "summary",
+        "reason",
+        "message",
+    ];
+
+    for key in VOICE_KEYS {
+        if let Some(value) = primitive.args.get(*key).and_then(Value::as_str)
+            && let Some(rationale) = sanitize_voice_for_log(value)
+        {
+            return Some(rationale);
+        }
+    }
+
+    if let Some(intent) = primitive.args.get("intent").and_then(Value::as_str) {
+        let friendly = intent.replace('_', " ");
+        if let Some(rationale) = sanitize_voice_for_log(&friendly) {
+            return Some(rationale);
+        }
+    }
+
+    None
+}
+
+fn sanitize_voice_for_log(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if looks_sensitive(trimmed) {
+        return Some("[redacted]".into());
+    }
+
+    Some(sanitize_detail(trimmed))
 }
 
 fn build_result_summary(

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -974,6 +974,7 @@ impl PlannerDecisionAudit {
         outcome: &PlanOutcome,
         risk: Option<&RiskVerdict>,
     ) -> Self {
+        let wallet_voice = wallet.voice_rationale().and_then(sanitize_voice_text);
         Self {
             plan_id: plan_id.to_owned(),
             plan_uuid,
@@ -981,7 +982,7 @@ impl PlannerDecisionAudit {
             policy,
             discovery,
             wallet,
-            outcome: PlanOutcomeAudit::from(outcome, risk),
+            outcome: PlanOutcomeAudit::from(outcome, risk, wallet_voice.as_deref()),
         }
     }
 }
@@ -1170,6 +1171,14 @@ impl WalletAudit {
             error: (!error.is_empty()).then_some(error),
         }
     }
+
+    fn voice_rationale(&self) -> Option<&str> {
+        match self {
+            Self::Evaluated { reason, .. } => reason.as_deref(),
+            Self::Errored { error } => error.as_deref(),
+            Self::Skipped => None,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -1188,6 +1197,8 @@ enum PlanOutcomeAudit {
         arg_keys: Vec<String>,
         rationale_present: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
+        voice_rationale: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         risk: Option<RiskVerdictAudit>,
     },
     Failure {
@@ -1195,46 +1206,76 @@ enum PlanOutcomeAudit {
         retryable: bool,
         detail: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        voice_rationale: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         risk: Option<RiskVerdictAudit>,
     },
 }
 
 impl PlanOutcomeAudit {
-    fn from(outcome: &PlanOutcome, risk: Option<&RiskVerdict>) -> Self {
+    fn from(outcome: &PlanOutcome, risk: Option<&RiskVerdict>, wallet_voice: Option<&str>) -> Self {
         match outcome {
-            PlanOutcome::Success { steps, summary } => Self::Success {
-                step_count: steps.len(),
-                steps: steps
+            PlanOutcome::Success { steps, summary } => {
+                let wallet_override = wallet_voice.and_then(|voice| {
+                    first_spend_request(steps).map(|spend| (spend.step_index, voice.to_string()))
+                });
+
+                let logged_steps: Vec<LoggedStep> = steps
                     .iter()
                     .enumerate()
-                    .map(|(idx, step)| LoggedStep::from_step(idx, step))
-                    .collect(),
-                summary_present: summary
-                    .synopsis
-                    .as_ref()
-                    .is_some_and(|synopsis| !synopsis.is_empty()),
-                risk: map_risk_verdict(risk),
-            },
-            PlanOutcome::Escalate { escalation } => Self::Escalate {
-                step_index: escalation.step_index,
-                action_kind: escalation.action.kind,
-                arg_keys: escalation.action.args.keys().cloned().collect(),
-                rationale_present: escalation
+                    .map(|(idx, step)| {
+                        let from_wallet =
+                            wallet_override.as_ref().and_then(|(wallet_idx, message)| {
+                                (*wallet_idx == idx).then(|| message.clone())
+                            });
+                        let fallback = default_voice_rationale(step);
+                        LoggedStep::from_step(idx, step, from_wallet.or(fallback))
+                    })
+                    .collect();
+
+                Self::Success {
+                    step_count: logged_steps.len(),
+                    steps: logged_steps,
+                    summary_present: summary
+                        .synopsis
+                        .as_ref()
+                        .is_some_and(|synopsis| !synopsis.is_empty()),
+                    risk: map_risk_verdict(risk),
+                }
+            }
+            PlanOutcome::Escalate { escalation } => {
+                let voice_rationale = escalation
                     .rationale
-                    .as_ref()
-                    .is_some_and(|value| !value.is_empty()),
-                risk: map_risk_verdict(risk),
-            },
-            PlanOutcome::Failure { error } => Self::Failure {
-                code: error.code,
-                retryable: error.retryable,
-                detail: error
-                    .detail
-                    .as_ref()
-                    .map(|value| sanitize_detail(value))
-                    .filter(|value| !value.is_empty()),
-                risk: map_risk_verdict(risk),
-            },
+                    .as_deref()
+                    .and_then(sanitize_voice_text);
+                Self::Escalate {
+                    step_index: escalation.step_index,
+                    action_kind: escalation.action.kind,
+                    arg_keys: escalation.action.args.keys().cloned().collect(),
+                    rationale_present: escalation
+                        .rationale
+                        .as_ref()
+                        .is_some_and(|value| !value.is_empty()),
+                    voice_rationale,
+                    risk: map_risk_verdict(risk),
+                }
+            }
+            PlanOutcome::Failure { error } => {
+                let detail = error.detail.as_deref().and_then(sanitize_voice_text);
+                let voice_rationale = detail.or_else(|| sanitize_voice_text(&error.message));
+
+                Self::Failure {
+                    code: error.code,
+                    retryable: error.retryable,
+                    detail: error
+                        .detail
+                        .as_ref()
+                        .map(|value| sanitize_detail(value))
+                        .filter(|value| !value.is_empty()),
+                    voice_rationale,
+                    risk: map_risk_verdict(risk),
+                }
+            }
         }
     }
 }
@@ -1275,21 +1316,83 @@ struct LoggedStep {
     arg_keys: Vec<String>,
     has_postcondition: bool,
     has_idempotency_key: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    voice_rationale: Option<String>,
 }
 
 impl LoggedStep {
-    fn from_step(index: usize, step: &ActionPrimitive) -> Self {
+    fn from_step(index: usize, step: &ActionPrimitive, voice_rationale: Option<String>) -> Self {
         Self {
             step_index: index,
             kind: step.kind,
             arg_keys: step.args.keys().cloned().collect(),
             has_postcondition: step.postcondition.is_some(),
             has_idempotency_key: step.idempotency_key.is_some(),
+            voice_rationale,
         }
     }
 }
 
-fn sanitize_detail(detail: &str) -> String {
+fn default_voice_rationale(step: &ActionPrimitive) -> Option<String> {
+    const VOICE_KEYS: &[&str] = &[
+        "voice_rationale",
+        "notes",
+        "body",
+        "prompt",
+        "summary",
+        "reason",
+        "message",
+    ];
+
+    for key in VOICE_KEYS {
+        if let Some(value) = step.args.get(*key).and_then(Value::as_str)
+            && let Some(text) = sanitize_voice_text(value)
+        {
+            return Some(text);
+        }
+    }
+
+    if let Some(intent) = step.args.get("intent").and_then(Value::as_str) {
+        let friendly = intent.replace('_', " ");
+        if let Some(text) = sanitize_voice_text(&friendly) {
+            return Some(text);
+        }
+    }
+
+    None
+}
+
+fn sanitize_voice_text(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if voice_text_looks_sensitive(trimmed) {
+        return Some("[redacted]".into());
+    }
+
+    Some(sanitize_detail(trimmed))
+}
+
+fn voice_text_looks_sensitive(value: &str) -> bool {
+    if value.len() > 128 {
+        return true;
+    }
+
+    if value.contains('@') {
+        return true;
+    }
+
+    if value.chars().all(|character| character.is_ascii_digit()) && value.len() >= 6 {
+        return true;
+    }
+
+    let lowercase = value.to_ascii_lowercase();
+    lowercase.starts_with("bearer ") || lowercase.starts_with("basic ")
+}
+
+pub(crate) fn sanitize_detail(detail: &str) -> String {
     // Replace numeric characters to avoid leaking precise spend thresholds in audit logs.
     detail
         .chars()
@@ -1390,6 +1493,105 @@ high_minor_units = 40000
                 .any(|reason| reason.contains("exceeds high threshold")),
             "expected reasons to include threshold notice, got: {:?}",
             verdict.reasons
+        );
+    }
+
+    #[test]
+    fn plan_outcome_audit_includes_step_voice_rationales() {
+        let mut research_args = JsonMap::new();
+        research_args.insert(
+            "notes".to_string(),
+            Value::String("Review memory and prior commitments".into()),
+        );
+        let research_step = ActionPrimitive::new(ActionPrimitiveKind::Research, research_args);
+
+        let mut pay_args = JsonMap::new();
+        pay_args.insert("amount_minor_units".to_string(), json!(10_000u64));
+        pay_args.insert("currency".to_string(), Value::String("USD".into()));
+        pay_args.insert(
+            "merchant".to_string(),
+            Value::String("Test Merchant".into()),
+        );
+        let pay_step = ActionPrimitive::new(ActionPrimitiveKind::Pay, pay_args);
+
+        let outcome = PlanOutcome::Success {
+            steps: vec![research_step, pay_step],
+            summary: PlanSummary {
+                synopsis: Some("Demo summary".into()),
+            },
+        };
+
+        let wallet_voice = match sanitize_voice_text("Spend approved within configured limits.") {
+            Some(value) => value,
+            None => panic!("wallet rationale sanitized"),
+        };
+
+        let audit = PlanOutcomeAudit::from(&outcome, None, Some(wallet_voice.as_str()));
+
+        let PlanOutcomeAudit::Success { steps, .. } = audit else {
+            panic!("expected success audit payload");
+        };
+
+        assert_eq!(steps.len(), 2);
+        assert_eq!(
+            steps[0].voice_rationale.as_deref(),
+            Some("Review memory and prior commitments")
+        );
+        assert_eq!(
+            steps[1].voice_rationale.as_deref(),
+            Some(wallet_voice.as_str())
+        );
+    }
+
+    #[test]
+    fn plan_outcome_audit_sets_escalation_voice_rationale() {
+        let escalation = PlanEscalation {
+            step_index: 2,
+            action: ActionPrimitive::new(ActionPrimitiveKind::Confirm, JsonMap::new()),
+            rationale: Some("Spend exceeded guardrail; confirm before proceeding.".into()),
+            expires_at: None,
+        };
+
+        let audit = PlanOutcomeAudit::from(&PlanOutcome::Escalate { escalation }, None, None);
+
+        let PlanOutcomeAudit::Escalate {
+            voice_rationale, ..
+        } = audit
+        else {
+            panic!("expected escalation audit payload");
+        };
+
+        assert_eq!(
+            voice_rationale.as_deref(),
+            Some("Spend exceeded guardrail; confirm before proceeding.")
+        );
+    }
+
+    #[test]
+    fn plan_outcome_audit_sets_failure_voice_rationale() {
+        let audit = PlanOutcomeAudit::from(
+            &PlanOutcome::Failure {
+                error: PlanError {
+                    code: PlanErrorCode::PolicyDenied,
+                    message: "Policy denied the request".into(),
+                    detail: Some("Escalate to human reviewer.".into()),
+                    retryable: false,
+                },
+            },
+            None,
+            None,
+        );
+
+        let PlanOutcomeAudit::Failure {
+            voice_rationale, ..
+        } = audit
+        else {
+            panic!("expected failure audit payload");
+        };
+
+        assert_eq!(
+            voice_rationale.as_deref(),
+            Some("Escalate to human reviewer.")
         );
     }
 }

--- a/services/planner/tests/capability_memory.rs
+++ b/services/planner/tests/capability_memory.rs
@@ -330,7 +330,8 @@ async fn capability_memory_hydration_hit_populates_primitive() -> Result<()> {
                     "appointment": {
                         "status": "booked"
                     }
-                }
+                },
+                "voice_rationale": "fallback automation"
             }),
             result_summary: Some("generic-web satisfied intent book_call".into()),
             success_count: 3,
@@ -399,15 +400,23 @@ async fn capability_memory_hydration_hit_populates_primitive() -> Result<()> {
         capability.get("result_summary").and_then(Value::as_str),
         Some("generic-web satisfied intent book_call")
     );
+    let outcome_metadata = capability
+        .get("outcome_metadata")
+        .and_then(Value::as_object)
+        .expect("outcome_metadata populated");
     assert_eq!(
-        capability.get("outcome_metadata"),
+        outcome_metadata.get("postcondition"),
         Some(&json!({
-            "postcondition": {
-                "appointment": {
-                    "status": "booked"
-                }
+            "appointment": {
+                "status": "booked"
             }
         }))
+    );
+    assert_eq!(
+        outcome_metadata
+            .get("voice_rationale")
+            .and_then(Value::as_str),
+        Some("fallback automation")
     );
     let selector_hints = enriched
         .args

--- a/web/app/portal/plans/[planId]/timeline/PortalTimelinePage.test.tsx
+++ b/web/app/portal/plans/[planId]/timeline/PortalTimelinePage.test.tsx
@@ -45,6 +45,9 @@ describe("PortalTimelinePage", () => {
     expect(
       await screen.findByText("Hidden for privacy (redacted)."),
     ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Planner compiled summary for playback."),
+    ).toBeInTheDocument();
     expect(screen.queryByText("[redacted]")).not.toBeInTheDocument();
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/web/app/portal/plans/[planId]/timeline/__snapshots__/PortalTimelinePage.test.tsx.snap
+++ b/web/app/portal/plans/[planId]/timeline/__snapshots__/PortalTimelinePage.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`PortalTimelinePage > renders the timeline and matches the snapshot 1`] 
                 Reason
               </span>
               <span>
-                Postconditions satisfied for all steps.
+                Planner compiled summary for playback.
               </span>
             </p>
             <p

--- a/web/app/portal/plans/[planId]/timeline/page.tsx
+++ b/web/app/portal/plans/[planId]/timeline/page.tsx
@@ -11,6 +11,7 @@ type TimelineEvent = {
   occurred_at?: string;
   recorded_at?: string;
   action?: TimelineAction;
+  voice_rationale?: string;
   redactions?: string[];
 };
 
@@ -356,8 +357,10 @@ export default function PlanTimelinePage() {
                   const variant = statusVariant(status);
                   const executor =
                     extractExecutor(event.action) ?? "Unknown executor";
-                  const reason = extractReason(event.action);
-                  const reasonRedacted = isRedacted(reason);
+                  const fallbackReason = extractReason(event.action);
+                  const voiceRationale = ensureString(event.voice_rationale);
+                  const chosenReason = voiceRationale ?? fallbackReason;
+                  const reasonRedacted = isRedacted(chosenReason);
                   const redactions = event.redactions ?? [];
                   const stepNumber =
                     typeof event.step_index === "number"
@@ -366,7 +369,7 @@ export default function PlanTimelinePage() {
 
                   const displayReason = reasonRedacted
                     ? "Hidden for privacy (redacted)."
-                    : reason ?? "No reason provided.";
+                    : chosenReason ?? "No reason provided.";
 
                   return (
                     <li key={event.replay_id ?? `event-${event.step_index}`} className="portal-timeline__event">

--- a/web/app/portal/plans/__fixtures__/plan-timeline.ts
+++ b/web/app/portal/plans/__fixtures__/plan-timeline.ts
@@ -17,6 +17,7 @@ export const planTimelineFixture = {
           detail: "[redacted]",
         },
       },
+      voice_rationale: "[redacted]",
       redactions: ["/action/result/detail"],
     },
     {
@@ -32,8 +33,8 @@ export const planTimelineFixture = {
           notes: "Postconditions satisfied for all steps.",
         },
       },
+      voice_rationale: "Planner compiled summary for playback.",
       redactions: [],
     },
   ],
 };
-


### PR DESCRIPTION
## Summary
- add voice rationale fields to planner audit payloads and capability metadata
- expose rationale strings via the audit API and surface them in the portal timeline UI
- extend regression coverage across planner, API, and portal components

## Testing
- cargo fmt --all
- cargo test -p tyrum-planner
- cargo test -p tyrum-api
- npm run test -- --watch=false
- pre-commit run --all-files

Closes #200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extraction/sanitization of voice rationales to planner/audit events and displays them in the portal timeline, with expanded tests.
> 
> - **Backend/API**:
>   - **Audit Events**: `services/api/src/audit.rs` now extracts and returns optional `voice_rationale` for each event (`PlanAuditEvent`), including helpers and tests.
>   - **Planner Audit Payloads**: `services/planner/src/http.rs` augments `PlanOutcomeAudit` and `LoggedStep` with optional `voice_rationale`; propagates wallet/policy/error rationales; introduces `sanitize_voice_text` and sensitivity checks.
>   - **Capability Memory**: `services/planner/src/event_log.rs` captures `voice_rationale` in `outcome_metadata` and step primitives via `primitive_voice_rationale`; adds sanitization/redaction (`sanitize_voice_for_log`) and re-exports `sanitize_detail`.
> - **Frontend**:
>   - **Portal Timeline**: `web/.../timeline/page.tsx` reads `voice_rationale` from events, preferring it over derived reasons; types updated.
>   - **Tests/Fixtures**: Fixtures include `voice_rationale`; timeline tests and snapshots updated to assert new reason strings; planner and API tests added/updated for rationale extraction and sanitization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 150c720479f897d3122943bd8e475381b2254d43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->