### PR TITLE
Add structured API discovery probe (#202)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +215,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-webpki 0.102.8",
  "serde",
@@ -172,6 +232,16 @@ dependencies = [
  "tracing",
  "tryhard",
  "url",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
+dependencies = [
+ "async-lock",
+ "event-listener",
 ]
 
 [[package]]
@@ -383,7 +453,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -586,6 +656,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -847,6 +927,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1493,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.3.1",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1548,6 +1682,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13ea3a316b6847082f6b00f4c49af2f8ec241666d917bdac7b33f8ca398f48d"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-timer",
+ "futures-util",
+ "headers",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "if-addrs",
+ "path-tree",
+ "rcgen",
+ "regex",
+ "rustls 0.23.32",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror 2.0.17",
+ "tls-detect",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,7 +1796,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -1637,7 +1812,9 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
+ "log",
  "rustls 0.23.32",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1863,6 +2040,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2142,6 +2329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,7 +2385,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2222,6 +2415,16 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "signatory",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2334,6 +2537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2557,6 +2769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2785,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2891,6 +3122,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3416,7 @@ version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3180,7 +3435,19 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -3291,7 +3558,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3374,6 +3654,16 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -3578,6 +3868,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -3833,6 +4129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stringmetrics"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,7 +4250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -3959,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -3981,6 +4283,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4134,6 +4445,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-detect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1800cba3e521412d15e88358ddda292fa8f157f06a66a418fed5e1b8ecb166"
+dependencies = [
+ "async-trait",
+]
 
 [[package]]
 name = "tokio"
@@ -4527,11 +4847,14 @@ dependencies = [
 name = "tyrum-discovery"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.22.1",
+ "httpmock",
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
  "redis",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "tokio",
@@ -4701,6 +5024,7 @@ name = "tyrum-planner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "clap",
@@ -4845,6 +5169,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -5522,10 +5852,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/services/discovery/Cargo.toml
+++ b/services/discovery/Cargo.toml
@@ -22,11 +22,14 @@ serde_json = "1.0"
 base64 = "0.22"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 url = "2.5"
-tokio = { version = "1.43", features = ["rt"] }
+tokio = { version = "1.43", features = ["rt", "rt-multi-thread"] }
+async-trait = "0.1"
+reqwest = { version = "0.12.23", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "testing"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
+httpmock = { version = "0.8.1", features = ["https"] }
 
 [lints]
 workspace = true

--- a/services/discovery/src/lib.rs
+++ b/services/discovery/src/lib.rs
@@ -1,6 +1,7 @@
 //! Discovery pipeline interfaces and default stub implementation.
 
 mod cache;
+mod probe;
 mod telemetry;
 
 pub mod pipeline;

--- a/services/discovery/src/pipeline.rs
+++ b/services/discovery/src/pipeline.rs
@@ -1,19 +1,27 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
 use std::net::IpAddr;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use url::Url;
 
 use crate::cache::{CacheError, CachedConnector, ConnectorCache, RedisConnectorCache};
-use crate::telemetry;
+use crate::probe::{ProbeOutcome, ProbeResult, probe_structured_origin};
+use crate::telemetry::{self, ProbeStatus};
 
 fn default_top_k() -> NonZeroUsize {
     NonZeroUsize::new(5).unwrap_or(NonZeroUsize::MIN)
+}
+
+fn default_probe_timeout() -> Duration {
+    Duration::from_secs(2)
 }
 
 /// Request envelope supplied to discovery strategies.
@@ -151,33 +159,42 @@ impl DiscoveryStrategy {
 }
 
 /// Defines the contract for executing discovery strategies in a fixed order.
-pub trait DiscoveryPipeline {
-    fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
+#[async_trait]
+pub trait DiscoveryPipeline: Send + Sync {
+    async fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
 
-    fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
+    async fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
 
-    fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
+    async fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome;
 
     /// Executes the discovery strategies in priority order, short-circuiting on
     /// the first non-`NotFound` outcome.
-    fn discover(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
-        debug!(subject = %request.sanitized_subject(), "Starting discovery");
+    async fn discover(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+        debug!(
+            subject = %request.sanitized_subject(),
+            "Starting discovery"
+        );
 
-        let outcome = execute_step(request, DiscoveryStrategy::Mcp, || self.try_mcp(request));
-        if !outcome.continues() {
-            return outcome;
-        }
-
-        let outcome = execute_step(request, DiscoveryStrategy::StructuredApi, || {
-            self.try_structured_api(request)
-        });
-        if !outcome.continues() {
-            return outcome;
-        }
-
-        execute_step(request, DiscoveryStrategy::GenericHttp, || {
-            self.try_generic_http(request)
+        let outcome = execute_step(request, DiscoveryStrategy::Mcp, || async {
+            self.try_mcp(request).await
         })
+        .await;
+        if !outcome.continues() {
+            return outcome;
+        }
+
+        let outcome = execute_step(request, DiscoveryStrategy::StructuredApi, || async {
+            self.try_structured_api(request).await
+        })
+        .await;
+        if !outcome.continues() {
+            return outcome;
+        }
+
+        execute_step(request, DiscoveryStrategy::GenericHttp, || async {
+            self.try_generic_http(request).await
+        })
+        .await
     }
 }
 
@@ -187,6 +204,8 @@ pub trait DiscoveryPipeline {
 pub struct DefaultDiscoveryPipeline {
     cache: Option<PipelineCache>,
     top_k: NonZeroUsize,
+    probe_client: Client,
+    probe_timeout: Duration,
 }
 
 struct PipelineCache {
@@ -214,6 +233,7 @@ struct CacheContext {
 pub struct DiscoveryPipelineConfig {
     pub cache: Option<DiscoveryCacheSettings>,
     pub top_k: NonZeroUsize,
+    pub probe_timeout: Duration,
 }
 
 impl Default for DiscoveryPipelineConfig {
@@ -221,6 +241,7 @@ impl Default for DiscoveryPipelineConfig {
         Self {
             cache: None,
             top_k: default_top_k(),
+            probe_timeout: default_probe_timeout(),
         }
     }
 }
@@ -256,6 +277,29 @@ impl DefaultDiscoveryPipeline {
         Self {
             cache: None,
             top_k: default_top_k(),
+            probe_client: Client::new(),
+            probe_timeout: default_probe_timeout(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_probe_timeout(timeout: Duration) -> Self {
+        Self {
+            cache: None,
+            top_k: default_top_k(),
+            probe_client: Client::new(),
+            probe_timeout: timeout,
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[must_use]
+    pub fn with_probe_client(client: Client, probe_timeout: Duration) -> Self {
+        Self {
+            cache: None,
+            top_k: default_top_k(),
+            probe_client: client,
+            probe_timeout,
         }
     }
 
@@ -277,6 +321,8 @@ impl DefaultDiscoveryPipeline {
         Ok(Self {
             cache,
             top_k: config.top_k,
+            probe_client: Client::new(),
+            probe_timeout: config.probe_timeout,
         })
     }
 
@@ -345,6 +391,72 @@ impl DefaultDiscoveryPipeline {
         }
 
         None
+    }
+
+    async fn probe_structured_connectors(
+        &self,
+        descriptor: &SubjectDescriptor,
+    ) -> Option<Vec<DiscoveryConnector>> {
+        let url = descriptor.url.as_ref()?;
+        let origin = Self::https_origin(url)?;
+
+        let started = Instant::now();
+        let ProbeResult { outcome, urls } =
+            probe_structured_origin(&self.probe_client, &origin, self.probe_timeout).await;
+        let elapsed = started.elapsed();
+        telemetry::record_probe(Self::map_probe_status(outcome), elapsed);
+
+        let connectors = urls
+            .into_iter()
+            .filter_map(|url| {
+                if !matches!(url.scheme(), "http" | "https") {
+                    return None;
+                }
+                Some(DiscoveryConnector::new(
+                    DiscoveryStrategy::StructuredApi,
+                    Self::canonicalize_http_url(&url),
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        Some(connectors)
+    }
+
+    fn map_probe_status(outcome: ProbeOutcome) -> ProbeStatus {
+        match outcome {
+            ProbeOutcome::Success => ProbeStatus::Success,
+            ProbeOutcome::Miss => ProbeStatus::Miss,
+            ProbeOutcome::Timeout => ProbeStatus::Timeout,
+            ProbeOutcome::Error => ProbeStatus::Error,
+        }
+    }
+
+    fn https_origin(url: &Url) -> Option<Url> {
+        if !url.scheme().eq_ignore_ascii_case("https") {
+            return None;
+        }
+
+        let mut origin = url.clone();
+        origin.set_path("/");
+        origin.set_query(None);
+        origin.set_fragment(None);
+        origin.set_username("").ok()?;
+        origin.set_password(None).ok()?;
+        Some(origin)
+    }
+
+    fn dedupe_connectors(connectors: Vec<DiscoveryConnector>) -> Vec<DiscoveryConnector> {
+        let mut seen = HashSet::new();
+        let mut deduped = Vec::new();
+
+        for connector in connectors {
+            let key = (connector.strategy, connector.locator.clone());
+            if seen.insert(key) {
+                deduped.push(connector);
+            }
+        }
+
+        deduped
     }
 
     fn structured_from_alias(&self, descriptor: &SubjectDescriptor) -> Option<String> {
@@ -454,31 +566,52 @@ impl DefaultDiscoveryPipeline {
         None
     }
 
-    fn collect_connectors(
+    async fn collect_connectors(
         &self,
         request: &DiscoveryRequest,
         now_ms: u64,
     ) -> Result<Vec<CachedConnector>, DiscoveryOutcome> {
         let mut collected = Vec::new();
 
-        for outcome in [
-            execute_step(request, DiscoveryStrategy::Mcp, || self.try_mcp(request)),
-            execute_step(request, DiscoveryStrategy::StructuredApi, || {
-                self.try_structured_api(request)
-            }),
-            execute_step(request, DiscoveryStrategy::GenericHttp, || {
-                self.try_generic_http(request)
-            }),
-        ] {
-            match outcome {
-                DiscoveryOutcome::Found(resolution) => {
-                    collected.extend(self.cache_entries_from_resolution(resolution, now_ms));
-                    break;
-                }
-                DiscoveryOutcome::RetryLater { .. } => return Err(outcome),
-                DiscoveryOutcome::RequiresConsent { .. } => return Err(outcome),
-                DiscoveryOutcome::NotFound => {}
+        let outcome = execute_step(request, DiscoveryStrategy::Mcp, || async {
+            self.try_mcp(request).await
+        })
+        .await;
+        match outcome {
+            DiscoveryOutcome::Found(resolution) => {
+                collected.extend(self.cache_entries_from_resolution(resolution, now_ms));
+                return Ok(collected);
             }
+            DiscoveryOutcome::RetryLater { .. } => return Err(outcome),
+            DiscoveryOutcome::RequiresConsent { .. } => return Err(outcome),
+            DiscoveryOutcome::NotFound => {}
+        }
+
+        let outcome = execute_step(request, DiscoveryStrategy::StructuredApi, || async {
+            self.try_structured_api(request).await
+        })
+        .await;
+        match outcome {
+            DiscoveryOutcome::Found(resolution) => {
+                collected.extend(self.cache_entries_from_resolution(resolution, now_ms));
+                return Ok(collected);
+            }
+            DiscoveryOutcome::RetryLater { .. } => return Err(outcome),
+            DiscoveryOutcome::RequiresConsent { .. } => return Err(outcome),
+            DiscoveryOutcome::NotFound => {}
+        }
+
+        let outcome = execute_step(request, DiscoveryStrategy::GenericHttp, || async {
+            self.try_generic_http(request).await
+        })
+        .await;
+        match outcome {
+            DiscoveryOutcome::Found(resolution) => {
+                collected.extend(self.cache_entries_from_resolution(resolution, now_ms));
+            }
+            DiscoveryOutcome::RetryLater { .. } => return Err(outcome),
+            DiscoveryOutcome::RequiresConsent { .. } => return Err(outcome),
+            DiscoveryOutcome::NotFound => {}
         }
 
         Ok(collected)
@@ -529,6 +662,8 @@ impl DefaultDiscoveryPipeline {
                 namespace: namespace.to_string(),
             }),
             top_k,
+            probe_client: Client::new(),
+            probe_timeout: default_probe_timeout(),
         }
     }
 
@@ -618,8 +753,9 @@ fn clamp_millis(value: u128) -> u64 {
     u64::try_from(value).unwrap_or(u64::MAX)
 }
 
+#[async_trait]
 impl DiscoveryPipeline for DefaultDiscoveryPipeline {
-    fn discover(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn discover(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         debug!(
             subject = %request.sanitized_subject(),
             "Starting discovery"
@@ -633,7 +769,7 @@ impl DiscoveryPipeline for DefaultDiscoveryPipeline {
         }
 
         let now = Self::now_epoch_ms();
-        let connectors = match self.collect_connectors(request, now) {
+        let connectors = match self.collect_connectors(request, now).await {
             Ok(connectors) => connectors,
             Err(outcome) => return outcome,
         };
@@ -652,7 +788,7 @@ impl DiscoveryPipeline for DefaultDiscoveryPipeline {
         DiscoveryOutcome::Found(resolution)
     }
 
-    fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         let descriptor = self.descriptor(request);
         match self.detect_mcp(&descriptor) {
             Some(locator) => DiscoveryOutcome::Found(DiscoveryResolution::single(
@@ -662,17 +798,40 @@ impl DiscoveryPipeline for DefaultDiscoveryPipeline {
         }
     }
 
-    fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         let descriptor = self.descriptor(request);
-        match self.detect_structured_api(&descriptor) {
-            Some(locator) => DiscoveryOutcome::Found(DiscoveryResolution::single(
-                DiscoveryConnector::new(DiscoveryStrategy::StructuredApi, locator),
-            )),
+        let mut connectors = Vec::new();
+
+        if let Some(locator) = self.detect_structured_api(&descriptor) {
+            connectors.push(DiscoveryConnector::new(
+                DiscoveryStrategy::StructuredApi,
+                locator,
+            ));
+        }
+
+        if let Some(mut probed) = self.probe_structured_connectors(&descriptor).await {
+            connectors.append(&mut probed);
+        }
+
+        let connectors = Self::dedupe_connectors(connectors);
+
+        if connectors.is_empty() {
+            return DiscoveryOutcome::NotFound;
+        }
+
+        let ranked = connectors
+            .into_iter()
+            .enumerate()
+            .map(|(index, connector)| connector.with_rank(index + 1))
+            .collect::<Vec<_>>();
+
+        match DiscoveryResolution::from_ranked(ranked) {
+            Some(resolution) => DiscoveryOutcome::Found(resolution),
             None => DiscoveryOutcome::NotFound,
         }
     }
 
-    fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         let descriptor = self.descriptor(request);
         match self.detect_generic_http(&descriptor) {
             Some(locator) => DiscoveryOutcome::Found(DiscoveryResolution::single(
@@ -924,13 +1083,14 @@ fn strip_prefix_case_insensitive<'a>(value: &'a str, prefix: &str) -> Option<&'a
     }
 }
 #[allow(clippy::cognitive_complexity)]
-fn execute_step<F>(
+async fn execute_step<F, Fut>(
     request: &DiscoveryRequest,
     strategy: DiscoveryStrategy,
     attempt: F,
 ) -> DiscoveryOutcome
 where
-    F: FnOnce() -> DiscoveryOutcome,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = DiscoveryOutcome> + Send,
 {
     debug!(
         subject = %request.sanitized_subject(),
@@ -938,7 +1098,7 @@ where
         "Running discovery step",
     );
 
-    let outcome = telemetry::record_step(strategy, request.sanitized_subject(), attempt);
+    let outcome = telemetry::record_step(strategy, request.sanitized_subject(), attempt).await;
 
     if outcome.continues() {
         debug!(strategy = strategy.as_str(), "Strategy returned NotFound");
@@ -953,13 +1113,14 @@ where
 mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used, clippy::len_zero)]
     use super::*;
-    use std::cell::RefCell;
     use std::fmt;
+    use std::future::Future;
     use std::num::NonZeroUsize;
     use std::sync::{Arc, Mutex, MutexGuard};
 
     use crate::cache::InMemoryConnectorCache;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use httpmock::{Method, prelude::*};
     use once_cell::sync::Lazy;
     use opentelemetry::{Value, global};
     use opentelemetry_sdk::metrics::{
@@ -976,6 +1137,14 @@ mod tests {
     };
 
     static TELEMETRY_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    fn block_on_future<F: Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+            .block_on(future)
+    }
 
     fn resolution(strategy: DiscoveryStrategy, locator: &str) -> DiscoveryResolution {
         DiscoveryResolution::single(DiscoveryConnector {
@@ -1006,7 +1175,7 @@ mod tests {
             subject: "mcp://knowledge-base".into(),
         };
 
-        match pipeline.try_mcp(&request) {
+        match block_on_future(pipeline.try_mcp(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::Mcp);
@@ -1023,7 +1192,7 @@ mod tests {
             subject: "Connect calendar automation via MCP".into(),
         };
 
-        match pipeline.try_mcp(&request) {
+        match block_on_future(pipeline.try_mcp(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::Mcp);
@@ -1040,7 +1209,7 @@ mod tests {
             subject: "MCP:Workspace/Tool".into(),
         };
 
-        match pipeline.try_mcp(&request) {
+        match block_on_future(pipeline.try_mcp(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::Mcp);
@@ -1057,7 +1226,7 @@ mod tests {
             subject: "mcp://".into(),
         };
 
-        match pipeline.try_mcp(&request) {
+        match block_on_future(pipeline.try_mcp(&request)) {
             DiscoveryOutcome::NotFound => {}
             other => panic!("expected NotFound, got {other:?}"),
         }
@@ -1070,7 +1239,7 @@ mod tests {
             subject: "https://api.example.com/v1/openapi.json".into(),
         };
 
-        match pipeline.try_structured_api(&request) {
+        match block_on_future(pipeline.try_structured_api(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::StructuredApi);
@@ -1087,7 +1256,7 @@ mod tests {
             subject: "calendar:events:list".into(),
         };
 
-        match pipeline.try_structured_api(&request) {
+        match block_on_future(pipeline.try_structured_api(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::StructuredApi);
@@ -1104,13 +1273,86 @@ mod tests {
             subject: "calendar.example.com/slots".into(),
         };
 
-        match pipeline.try_generic_http(&request) {
+        match block_on_future(pipeline.try_generic_http(&request)) {
             DiscoveryOutcome::Found(resolution) => {
                 let connector = &resolution.primary;
                 assert_eq!(connector.strategy, DiscoveryStrategy::GenericHttp);
                 assert_eq!(connector.locator, "https://calendar.example.com/slots");
             }
             other => panic!("expected generic HTTP connector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_discovers_well_known_openapi() {
+        let server = MockServer::start();
+        let _openapi = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/openapi.json");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .body(r#"{"openapi":"3.0.0"}"#);
+        });
+        let _ai_plugin = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/ai-plugin.json");
+            then.status(404);
+        });
+        let _head = server.mock(|when, then| {
+            when.method(Method::HEAD).path("/");
+            then.status(404);
+        });
+
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("build probe client");
+        let pipeline = DefaultDiscoveryPipeline::with_probe_client(client, Duration::from_secs(1));
+        let request = DiscoveryRequest {
+            subject: server.base_url(),
+        };
+
+        match block_on_future(pipeline.try_structured_api(&request)) {
+            DiscoveryOutcome::Found(resolution) => {
+                let connector = &resolution.primary;
+                assert_eq!(connector.strategy, DiscoveryStrategy::StructuredApi);
+                assert_eq!(connector.locator, server.url("/.well-known/openapi.json"));
+            }
+            other => panic!("expected structured API connector from probe, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_discovers_graphql_from_header() {
+        let server = MockServer::start();
+        let _head = server.mock(|when, then| {
+            when.method(Method::HEAD).path("/");
+            then.status(200)
+                .header("Link", "</graphql>; rel=\"graphql\"");
+        });
+        let _openapi = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/openapi.json");
+            then.status(404);
+        });
+        let _ai_plugin = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/ai-plugin.json");
+            then.status(404);
+        });
+
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("build probe client");
+        let pipeline = DefaultDiscoveryPipeline::with_probe_client(client, Duration::from_secs(1));
+        let request = DiscoveryRequest {
+            subject: server.base_url(),
+        };
+
+        match block_on_future(pipeline.try_structured_api(&request)) {
+            DiscoveryOutcome::Found(resolution) => {
+                let connector = &resolution.primary;
+                assert_eq!(connector.strategy, DiscoveryStrategy::StructuredApi);
+                assert_eq!(connector.locator, server.url("/graphql"));
+            }
+            other => panic!("expected graphql connector from probe, got {other:?}"),
         }
     }
 
@@ -1152,7 +1394,7 @@ mod tests {
             subject: subject.into(),
         };
 
-        let outcome = pipeline.discover(&request);
+        let outcome = block_on_future(pipeline.discover(&request));
 
         match outcome {
             DiscoveryOutcome::Found(resolution) => {
@@ -1197,7 +1439,7 @@ mod tests {
             subject: subject.into(),
         };
 
-        let outcome = pipeline.discover(&request);
+        let outcome = block_on_future(pipeline.discover(&request));
 
         match outcome {
             DiscoveryOutcome::Found(resolution) => {
@@ -1227,7 +1469,7 @@ mod tests {
     }
 
     struct ScriptedPipeline {
-        calls: RefCell<Vec<DiscoveryStrategy>>,
+        calls: Mutex<Vec<DiscoveryStrategy>>,
         mcp_outcome: DiscoveryOutcome,
         structured_outcome: DiscoveryOutcome,
         generic_outcome: DiscoveryOutcome,
@@ -1240,7 +1482,7 @@ mod tests {
             generic_outcome: DiscoveryOutcome,
         ) -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
+                calls: Mutex::new(Vec::new()),
                 mcp_outcome,
                 structured_outcome,
                 generic_outcome,
@@ -1248,25 +1490,33 @@ mod tests {
         }
 
         fn calls(&self) -> Vec<DiscoveryStrategy> {
-            self.calls.borrow().clone()
+            self.calls.lock().expect("lock calls").clone()
         }
     }
 
+    #[async_trait]
     impl DiscoveryPipeline for ScriptedPipeline {
-        fn try_mcp(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
-            self.calls.borrow_mut().push(DiscoveryStrategy::Mcp);
+        async fn try_mcp(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
+            self.calls
+                .lock()
+                .expect("record mcp call")
+                .push(DiscoveryStrategy::Mcp);
             self.mcp_outcome.clone()
         }
 
-        fn try_structured_api(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
+        async fn try_structured_api(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
             self.calls
-                .borrow_mut()
+                .lock()
+                .expect("record structured call")
                 .push(DiscoveryStrategy::StructuredApi);
             self.structured_outcome.clone()
         }
 
-        fn try_generic_http(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
-            self.calls.borrow_mut().push(DiscoveryStrategy::GenericHttp);
+        async fn try_generic_http(&self, _request: &DiscoveryRequest) -> DiscoveryOutcome {
+            self.calls
+                .lock()
+                .expect("record generic call")
+                .push(DiscoveryStrategy::GenericHttp);
             self.generic_outcome.clone()
         }
     }
@@ -1364,7 +1614,7 @@ mod tests {
             DiscoveryOutcome::NotFound,
         );
 
-        let outcome = pipeline.discover(&request());
+        let outcome = block_on_future(pipeline.discover(&request()));
 
         assert_eq!(outcome, DiscoveryOutcome::NotFound);
         assert_eq!(
@@ -1389,7 +1639,7 @@ mod tests {
             found(DiscoveryStrategy::GenericHttp, "https://example.com"),
         );
 
-        let outcome = pipeline.discover(&request());
+        let outcome = block_on_future(pipeline.discover(&request()));
 
         assert_eq!(outcome, DiscoveryOutcome::Found(connector));
         assert_eq!(
@@ -1413,7 +1663,7 @@ mod tests {
         );
 
         with_default(subscriber, || {
-            let _ = pipeline.discover(&request());
+            let _ = block_on_future(pipeline.discover(&request()));
         });
 
         let captured = lock(&spans, "captured spans").clone();
@@ -1460,7 +1710,7 @@ mod tests {
             found(DiscoveryStrategy::GenericHttp, "https://example.com"),
         );
 
-        let outcome = pipeline.discover(&request());
+        let outcome = block_on_future(pipeline.discover(&request()));
         assert_eq!(outcome, DiscoveryOutcome::Found(connector));
 
         if let Err(err) = meter_provider.force_flush() {

--- a/services/discovery/src/probe.rs
+++ b/services/discovery/src/probe.rs
@@ -1,0 +1,535 @@
+use std::collections::HashSet;
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use reqwest::header::{HeaderMap, HeaderValue, LINK};
+use reqwest::{Client, Method, StatusCode, Url};
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeOutcome {
+    Success,
+    Miss,
+    Timeout,
+    Error,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProbeResult {
+    pub outcome: ProbeOutcome,
+    pub urls: Vec<Url>,
+}
+
+#[derive(Default)]
+struct ProbeStatusTracker {
+    saw_timeout: bool,
+    saw_error: bool,
+}
+
+impl ProbeStatusTracker {
+    fn outcome(&self, found: bool) -> ProbeOutcome {
+        if found {
+            ProbeOutcome::Success
+        } else if self.saw_timeout {
+            ProbeOutcome::Timeout
+        } else if self.saw_error {
+            ProbeOutcome::Error
+        } else {
+            ProbeOutcome::Miss
+        }
+    }
+
+    fn register_timeout(&mut self, context: &str) {
+        self.saw_timeout = true;
+        debug!("{context} probe timed out");
+    }
+
+    fn register_transport_error(&mut self, context: &str, error: String) {
+        self.saw_error = true;
+        debug!(error = %error, "{context} probe failed");
+    }
+
+    fn register_error(&mut self, error: ProbeError, context: &str) {
+        match error {
+            ProbeError::Timeout => self.register_timeout(context),
+            ProbeError::Transport { error } => self.register_transport_error(context, error),
+        }
+    }
+}
+
+async fn run_probe_step<F, Fut>(
+    deadline: Instant,
+    tracker: &mut ProbeStatusTracker,
+    context: &str,
+    op: F,
+    collected: &mut Vec<Url>,
+) where
+    F: Fn(Duration) -> Fut,
+    Fut: Future<Output = Result<Vec<Url>, ProbeError>>,
+{
+    if tracker.saw_timeout {
+        return;
+    }
+
+    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+        tracker.register_timeout(context);
+        return;
+    };
+
+    if remaining.is_zero() {
+        tracker.register_timeout(context);
+        return;
+    }
+
+    match op(remaining).await {
+        Ok(mut urls) => collected.append(&mut urls),
+        Err(err) => tracker.register_error(err, context),
+    }
+}
+
+pub(crate) async fn probe_structured_origin(
+    client: &Client,
+    origin: &Url,
+    timeout: Duration,
+) -> ProbeResult {
+    let mut tracker = ProbeStatusTracker::default();
+    let mut collected = Vec::new();
+    let deadline = Instant::now() + timeout;
+
+    run_probe_step(
+        deadline,
+        &mut tracker,
+        "openapi well-known",
+        |step_timeout| async move {
+            match fetch_openapi_well_known(client, origin, step_timeout).await? {
+                Some(url) => Ok(vec![url]),
+                None => Ok(Vec::new()),
+            }
+        },
+        &mut collected,
+    )
+    .await;
+
+    run_probe_step(
+        deadline,
+        &mut tracker,
+        "ai-plugin",
+        |step_timeout| async move { fetch_ai_plugin(client, origin, step_timeout).await },
+        &mut collected,
+    )
+    .await;
+
+    run_probe_step(
+        deadline,
+        &mut tracker,
+        "header",
+        |step_timeout| async move { fetch_header_hints(client, origin, step_timeout).await },
+        &mut collected,
+    )
+    .await;
+
+    let deduped = dedupe_urls(collected);
+    let outcome = tracker.outcome(!deduped.is_empty());
+
+    ProbeResult {
+        outcome,
+        urls: deduped,
+    }
+}
+
+#[derive(Debug)]
+enum ProbeError {
+    Timeout,
+    Transport { error: String },
+}
+
+async fn fetch_openapi_well_known(
+    client: &Client,
+    origin: &Url,
+    timeout: Duration,
+) -> Result<Option<Url>, ProbeError> {
+    let target = match origin.join(".well-known/openapi.json") {
+        Ok(url) => url,
+        Err(error) => {
+            warn!(%error, origin = %origin, "failed to build openapi well-known url");
+            return Ok(None);
+        }
+    };
+
+    let response = client
+        .get(target.clone())
+        .timeout(timeout)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(map_reqwest_error)?;
+
+    if response.status().is_success() {
+        Ok(Some(target))
+    } else {
+        Ok(None)
+    }
+}
+
+async fn fetch_ai_plugin(
+    client: &Client,
+    origin: &Url,
+    timeout: Duration,
+) -> Result<Vec<Url>, ProbeError> {
+    let target = match origin.join(".well-known/ai-plugin.json") {
+        Ok(url) => url,
+        Err(error) => {
+            warn!(%error, origin = %origin, "failed to build ai-plugin url");
+            return Ok(Vec::new());
+        }
+    };
+
+    let response = client
+        .get(target.clone())
+        .timeout(timeout)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(map_reqwest_error)?;
+
+    if !response.status().is_success() {
+        return Ok(Vec::new());
+    }
+
+    let body = response.bytes().await.map_err(map_reqwest_error)?;
+    let document: AiPluginDocument = match serde_json::from_slice(&body) {
+        Ok(doc) => doc,
+        Err(error) => {
+            warn!(%error, url = %target, "failed to parse ai-plugin.json");
+            return Ok(Vec::new());
+        }
+    };
+
+    let Some(api) = document.api else {
+        return Ok(Vec::new());
+    };
+
+    let Some(url) = api.url.and_then(|raw| resolve_url(origin, &raw)) else {
+        return Ok(Vec::new());
+    };
+
+    Ok(vec![url])
+}
+
+async fn fetch_header_hints(
+    client: &Client,
+    origin: &Url,
+    timeout: Duration,
+) -> Result<Vec<Url>, ProbeError> {
+    match request_headers(client, origin, Method::HEAD, timeout).await {
+        Ok(Some(headers)) => return Ok(parse_header_hints(&headers, origin)),
+        Ok(None) => {}
+        Err(HeaderProbeError::Timeout) => return Err(ProbeError::Timeout),
+        Err(HeaderProbeError::Transport { error }) => {
+            return Err(ProbeError::Transport { error });
+        }
+    }
+
+    match request_headers(client, origin, Method::OPTIONS, timeout).await {
+        Ok(Some(headers)) => Ok(parse_header_hints(&headers, origin)),
+        Ok(None) => Ok(Vec::new()),
+        Err(HeaderProbeError::Timeout) => Err(ProbeError::Timeout),
+        Err(HeaderProbeError::Transport { error }) => Err(ProbeError::Transport { error }),
+    }
+}
+
+enum HeaderProbeError {
+    Timeout,
+    Transport { error: String },
+}
+
+async fn request_headers(
+    client: &Client,
+    origin: &Url,
+    method: Method,
+    timeout: Duration,
+) -> Result<Option<HeaderMap>, HeaderProbeError> {
+    let response = client
+        .request(method.clone(), origin.clone())
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(map_header_error)?;
+
+    if response.status() == StatusCode::METHOD_NOT_ALLOWED
+        || response.status() == StatusCode::NOT_IMPLEMENTED
+    {
+        return Ok(None);
+    }
+
+    if response.status().is_success() {
+        Ok(Some(response.headers().clone()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn map_reqwest_error(error: reqwest::Error) -> ProbeError {
+    if error.is_timeout() {
+        ProbeError::Timeout
+    } else {
+        ProbeError::Transport {
+            error: error.to_string(),
+        }
+    }
+}
+
+fn map_header_error(error: reqwest::Error) -> HeaderProbeError {
+    if error.is_timeout() {
+        HeaderProbeError::Timeout
+    } else {
+        HeaderProbeError::Transport {
+            error: error.to_string(),
+        }
+    }
+}
+
+fn parse_header_hints(headers: &HeaderMap, origin: &Url) -> Vec<Url> {
+    let mut urls = Vec::new();
+    urls.extend(parse_link_headers(headers, origin));
+    urls.extend(extract_hint_headers(headers, origin));
+    dedupe_urls(urls)
+}
+
+fn parse_link_headers(headers: &HeaderMap, origin: &Url) -> Vec<Url> {
+    let mut urls = Vec::new();
+    for value in headers.get_all(LINK).iter() {
+        if let Ok(raw) = value.to_str() {
+            for segment in split_link_entries(raw) {
+                if let Some(url) = parse_link_entry(&segment, origin) {
+                    urls.push(url);
+                }
+            }
+        }
+    }
+    urls
+}
+
+fn parse_link_entry(entry: &str, origin: &Url) -> Option<Url> {
+    let mut parts = entry.split(';');
+    let target = parts.next()?.trim();
+    if !target.starts_with('<') || !target.ends_with('>') {
+        return None;
+    }
+
+    let href = &target[1..target.len() - 1];
+    let mut rels = Vec::new();
+    let mut mime = None;
+
+    for part in parts {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let mut kv = trimmed.splitn(2, '=');
+        let key = kv.next()?.trim().to_ascii_lowercase();
+        let value = kv.next()?.trim().trim_matches('"').to_ascii_lowercase();
+        match key.as_str() {
+            "rel" => {
+                rels = value
+                    .split_whitespace()
+                    .map(|segment| segment.to_string())
+                    .collect();
+            }
+            "type" => {
+                mime = Some(value);
+            }
+            _ => {}
+        }
+    }
+
+    if !is_structured_link(&rels, mime.as_deref()) {
+        return None;
+    }
+
+    resolve_url(origin, href)
+}
+
+fn is_structured_link(rels: &[String], mime: Option<&str>) -> bool {
+    let rel_match = rels.iter().any(|rel| {
+        matches!(
+            rel.as_str(),
+            "service-desc"
+                | "service-doc"
+                | "openapi"
+                | "graphql"
+                | "https://spec.openapis.org/oas/3.0/rel/definition"
+                | "https://spec.openapis.org/oas/3.1/rel/definition"
+        )
+    });
+
+    if rel_match {
+        return true;
+    }
+
+    if rels.iter().any(|rel| rel == "alternate")
+        && mime.is_some_and(|value| {
+            value.contains("openapi")
+                || value.contains("json")
+                || value.contains("yaml")
+                || value.contains("graphql")
+        })
+    {
+        return true;
+    }
+
+    mime.is_some_and(|value| value.contains("openapi") || value.contains("graphql"))
+}
+
+fn extract_hint_headers(headers: &HeaderMap, origin: &Url) -> Vec<Url> {
+    let mut collected = Vec::new();
+    for (name, value) in headers.iter() {
+        if let Some(hint) = header_hint_for(name.as_str())
+            && let Some(url) = parse_header_value(origin, value)
+        {
+            debug!(header = %name, url = %url, "discovery header hint {hint}");
+            collected.push(url);
+        }
+    }
+    collected
+}
+
+fn header_hint_for(name: &str) -> Option<&'static str> {
+    let lower = name.to_ascii_lowercase();
+    if HEADER_HINT_OPENAPI.contains(&lower.as_str()) {
+        Some("openapi")
+    } else if HEADER_HINT_GRAPHQL.contains(&lower.as_str()) {
+        Some("graphql")
+    } else {
+        None
+    }
+}
+
+fn parse_header_value(origin: &Url, value: &HeaderValue) -> Option<Url> {
+    let raw = value.to_str().ok()?;
+    resolve_url(origin, raw.trim())
+}
+
+fn resolve_url(origin: &Url, raw: &str) -> Option<Url> {
+    Url::parse(raw).ok().or_else(|| origin.join(raw).ok())
+}
+
+fn dedupe_urls(urls: Vec<Url>) -> Vec<Url> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for url in urls {
+        let key = url.to_string();
+        if seen.insert(key.clone()) {
+            deduped.push(url);
+        }
+    }
+    deduped
+}
+
+fn split_link_entries(value: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in value.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                current.push(ch);
+            }
+            ',' if !in_quotes => {
+                if !current.trim().is_empty() {
+                    parts.push(current.trim().to_string());
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.trim().is_empty() {
+        parts.push(current.trim().to_string());
+    }
+
+    parts
+}
+
+#[derive(Debug, Deserialize)]
+struct AiPluginDocument {
+    api: Option<AiPluginApi>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AiPluginApi {
+    url: Option<String>,
+}
+
+const HEADER_HINT_OPENAPI: &[&str] = &[
+    "x-openapi-endpoint",
+    "x-openapi-spec",
+    "x-openapi-url",
+    "x-openapi-schema",
+    "openapi-endpoint",
+    "openapi-url",
+];
+
+const HEADER_HINT_GRAPHQL: &[&str] = &[
+    "x-graphql-endpoint",
+    "x-graphql-url",
+    "graphql-endpoint",
+    "graphql-url",
+    "apollo-graphql-url",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method, prelude::*};
+    use reqwest::Client;
+
+    fn block_on_future<F: Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap_or_else(|err| panic!("build tokio runtime: {err}"))
+            .block_on(future)
+    }
+
+    #[test]
+    fn probe_respects_total_timeout_budget() {
+        let server = MockServer::start();
+        let _openapi = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/openapi.json");
+            then.status(404);
+        });
+        let _ai_plugin = server.mock(|when, then| {
+            when.method(Method::GET).path("/.well-known/ai-plugin.json");
+            then.status(404);
+        });
+        let _head = server.mock(|when, then| {
+            when.method(Method::HEAD).path("/");
+            then.status(200).delay(Duration::from_millis(500));
+        });
+
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .unwrap_or_else(|err| panic!("build probe client: {err}"));
+
+        let origin =
+            Url::parse(&server.base_url()).unwrap_or_else(|err| panic!("parse origin url: {err}"));
+        let timeout = Duration::from_millis(150);
+
+        let result = block_on_future(async {
+            tokio::time::timeout(
+                Duration::from_millis(220),
+                probe_structured_origin(&client, &origin, timeout),
+            )
+            .await
+        })
+        .unwrap_or_else(|_| panic!("probe exceeded total timeout budget"));
+
+        assert!(matches!(result.outcome, ProbeOutcome::Timeout));
+    }
+}

--- a/services/discovery/src/telemetry.rs
+++ b/services/discovery/src/telemetry.rs
@@ -1,6 +1,6 @@
-use std::convert::TryFrom;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use std::{convert::TryFrom, future::Future};
 
 use once_cell::sync::OnceCell;
 use opentelemetry::{
@@ -15,6 +15,8 @@ const METER_NAME: &str = "tyrum-discovery";
 const DURATION_METRIC_NAME: &str = "tyrum_discovery_attempt_duration_seconds";
 const COUNT_METRIC_NAME: &str = "tyrum_discovery_attempt_total";
 const CACHE_HIT_METRIC_NAME: &str = "discovery.cache.hit";
+const PROBE_DURATION_METRIC_NAME: &str = "tyrum_discovery_probe_duration_seconds";
+const PROBE_COUNT_METRIC_NAME: &str = "tyrum_discovery_probe_total";
 
 #[derive(Clone)]
 struct MetricsInstruments {
@@ -30,6 +32,7 @@ struct MetricsCache {
 
 static METRICS: OnceCell<Mutex<MetricsCache>> = OnceCell::new();
 static CACHE_METRICS: OnceCell<Mutex<CacheMetricCache>> = OnceCell::new();
+static PROBE_METRICS: OnceCell<Mutex<ProbeMetricCache>> = OnceCell::new();
 
 #[derive(Default)]
 struct CacheMetricCache {
@@ -44,6 +47,14 @@ pub(crate) enum CacheEvent {
     Error,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum ProbeStatus {
+    Success,
+    Miss,
+    Timeout,
+    Error,
+}
+
 pub(crate) fn record_cache_event(event: CacheEvent) {
     let counter = cache_counter();
     let (hit, status) = match event {
@@ -55,13 +66,14 @@ pub(crate) fn record_cache_event(event: CacheEvent) {
     counter.add(1, &labels);
 }
 
-pub(crate) fn record_step<F>(
+pub(crate) async fn record_step<F, Fut>(
     strategy: DiscoveryStrategy,
     subject: &str,
     attempt: F,
 ) -> DiscoveryOutcome
 where
-    F: FnOnce() -> DiscoveryOutcome,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = DiscoveryOutcome>,
 {
     let span = info_span!(
         "discovery.step",
@@ -73,7 +85,7 @@ where
     let _guard = span.enter();
     let start = Instant::now();
 
-    let outcome = attempt();
+    let outcome = attempt().await;
     let elapsed = start.elapsed();
 
     let outcome_label = outcome.label();
@@ -93,6 +105,15 @@ where
     record_metrics(strategy, &outcome, elapsed);
 
     outcome
+}
+
+pub(crate) fn record_probe(status: ProbeStatus, duration: Duration) {
+    let instruments = probe_instruments();
+    let attributes = [KeyValue::new("probe.status", status.as_str())];
+    instruments
+        .duration
+        .record(duration.as_secs_f64(), &attributes);
+    instruments.count.add(1, &attributes);
 }
 
 fn record_metrics(strategy: DiscoveryStrategy, outcome: &DiscoveryOutcome, duration: Duration) {
@@ -178,4 +199,66 @@ fn cache_counter() -> Counter<u64> {
     guard.counter = Some(counter.clone());
 
     counter
+}
+
+#[derive(Clone)]
+struct ProbeInstruments {
+    duration: Histogram<f64>,
+    count: Counter<u64>,
+}
+
+#[derive(Default)]
+struct ProbeMetricCache {
+    provider: Option<Arc<dyn opentelemetry::metrics::MeterProvider + Send + Sync>>,
+    instruments: Option<ProbeInstruments>,
+}
+
+fn probe_instruments() -> ProbeInstruments {
+    let provider = global::meter_provider();
+    let cache = PROBE_METRICS.get_or_init(|| Mutex::new(ProbeMetricCache::default()));
+    let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("probe metric lock poisoned; continuing with cached instruments");
+            poisoned.into_inner()
+        }
+    };
+
+    if guard
+        .provider
+        .as_ref()
+        .is_some_and(|current| Arc::ptr_eq(current, &provider))
+        && let Some(instruments) = &guard.instruments
+    {
+        return instruments.clone();
+    }
+
+    let meter = provider.meter(METER_NAME);
+    let instruments = ProbeInstruments {
+        duration: meter
+            .f64_histogram(PROBE_DURATION_METRIC_NAME)
+            .with_unit("s")
+            .with_description("Duration of structured discovery probes by outcome")
+            .build(),
+        count: meter
+            .u64_counter(PROBE_COUNT_METRIC_NAME)
+            .with_description("Count of structured discovery probes by outcome")
+            .build(),
+    };
+
+    guard.provider = Some(provider);
+    guard.instruments = Some(instruments.clone());
+
+    instruments
+}
+
+impl ProbeStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Miss => "miss",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
 }

--- a/services/planner/Cargo.toml
+++ b/services/planner/Cargo.toml
@@ -61,6 +61,7 @@ tower = "0.5"
 http-body-util = "0.1"
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "testing"] }
 tyrum-risk-classifier = { path = "../risk_classifier" }
+async-trait = "0.1"
 
 [[bin]]
 name = "audit_demo"

--- a/services/planner/src/bin/http_server.rs
+++ b/services/planner/src/bin/http_server.rs
@@ -18,6 +18,7 @@ const RISK_CLASSIFIER_CONFIG_ENV: &str = "PLANNER_RISK_CLASSIFIER_CONFIG";
 
 const EVENT_LOG_URL_ENV: &str = "PLANNER_EVENT_LOG_URL";
 const WALLET_GATE_URL_ENV: &str = "WALLET_GATE_URL";
+const DISCOVERY_PROBE_TIMEOUT_MS_ENV: &str = "DISCOVERY_PROBE_TIMEOUT_MS";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
@@ -78,9 +79,15 @@ async fn main() -> Result<()> {
 }
 
 fn build_discovery_pipeline() -> DefaultDiscoveryPipeline {
+    let probe_timeout_ms = env::var(DISCOVERY_PROBE_TIMEOUT_MS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(1_500);
+    let probe_timeout = Duration::from_millis(probe_timeout_ms);
+
     let redis_url = match env::var("REDIS_URL") {
         Ok(url) if !url.trim().is_empty() => url,
-        _ => return DefaultDiscoveryPipeline::new(),
+        _ => return DefaultDiscoveryPipeline::with_probe_timeout(probe_timeout),
     };
 
     let ttl_seconds = env::var("DISCOVERY_CACHE_TTL_SECONDS")
@@ -100,11 +107,12 @@ fn build_discovery_pipeline() -> DefaultDiscoveryPipeline {
     match DefaultDiscoveryPipeline::from_config(DiscoveryPipelineConfig {
         cache: Some(settings),
         top_k,
+        probe_timeout,
     }) {
         Ok(pipeline) => pipeline,
         Err(error) => {
             warn!(%error, "failed to initialize Redis cache for discovery; continuing without caching");
-            DefaultDiscoveryPipeline::new()
+            DefaultDiscoveryPipeline::with_probe_timeout(probe_timeout)
         }
     }
 }

--- a/services/planner/src/http.rs
+++ b/services/planner/src/http.rs
@@ -691,7 +691,7 @@ async fn build_outcome_for_decision(
     match decision.decision {
         PolicyDecisionKind::Approve => {
             let discovery_request = discovery_request_for(request);
-            let initial_outcome = discovery.discover(&discovery_request);
+            let initial_outcome = discovery.discover(&discovery_request).await;
             let gated = match gate_discovery_outcome(policy_client, request, initial_outcome).await
             {
                 Ok(result) => result,

--- a/services/planner/tests/http_server.rs
+++ b/services/planner/tests/http_server.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::{borrow::Cow, collections::VecDeque};
 
+use async_trait::async_trait;
 use axum::{
     Json, Router,
     body::Body,
@@ -193,8 +194,9 @@ impl MockDiscoveryPipeline {
     }
 }
 
+#[async_trait]
 impl DiscoveryPipeline for MockDiscoveryPipeline {
-    fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_mcp(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         assert!(
             !request.sanitized_subject().is_empty(),
             "subject should be sanitized"
@@ -203,7 +205,7 @@ impl DiscoveryPipeline for MockDiscoveryPipeline {
         self.mcp.clone()
     }
 
-    fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_structured_api(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         assert!(
             !request.sanitized_subject().is_empty(),
             "subject should be sanitized"
@@ -212,7 +214,7 @@ impl DiscoveryPipeline for MockDiscoveryPipeline {
         self.structured.clone()
     }
 
-    fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
+    async fn try_generic_http(&self, request: &DiscoveryRequest) -> DiscoveryOutcome {
         assert!(
             !request.sanitized_subject().is_empty(),
             "subject should be sanitized"


### PR DESCRIPTION
## Summary
- add asynchronous discovery probe that fetches .well-known documents and header hints for OpenAPI/GraphQL
- record probe telemetry, wire configurable timeout, and expose async pipeline through planner
- add httpmock-based tests for probe hit/miss scenarios and update dependencies

## Testing
- pre-commit run --all-files

Closes #202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce an async structured API discovery probe (.well-known + header hints) with telemetry and configurable timeout, and update planner to use the async discovery pipeline.
> 
> - **Discovery**:
>   - **Async Pipeline**: Convert `DiscoveryPipeline` and `execute_step` to async (via `async-trait`), updating `DefaultDiscoveryPipeline` methods to `async`.
>   - **Structured Probe**: Add `probe` module to check `/.well-known/openapi.json`, `/.well-known/ai-plugin.json`, and `Link`/hint headers; dedupe/canonicalize URLs; map outcomes; respect a total timeout.
>   - **Config & Client**: Add `reqwest` client and `probe_timeout` (`with_probe_timeout`, `with_probe_client`, `DiscoveryPipelineConfig.probe_timeout`).
>   - **Telemetry**: Add probe metrics (`tyrum_discovery_probe_*`) and make step recording async; record probe outcome/duration.
> - **Planner**:
>   - **Integration**: Update to await async discovery (`discover`), propagate results through policy gating.
>   - **Config**: Add `DISCOVERY_PROBE_TIMEOUT_MS` env var; pass timeout into `DiscoveryPipelineConfig`; enable multi-thread Tokio.
> - **Tests**:
>   - Add `httpmock`-based probe tests; update existing tests to run async discovery; add helpers to block on futures.
> - **Dependencies**:
>   - Add `reqwest`, `httpmock`, `async-trait`; enable `tokio` `rt-multi-thread`; lockfile updates (rustls, headers, parsing crates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f07a9c3ed0e752b0ef2fe814064cf590a9a372d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->