### PR TITLE
Group Dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,47 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-major:
+        update-types:
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "daily"
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        update-types:
+          - "major"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: "helm"
     directory: "/infra/helm/tyrum-core"
     schedule:
       interval: "daily"
+    groups:
+      helm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add grouping configuration to all Dependabot ecosystems
- Cargo and npm: split into minor/patch (one PR) and major (separate PR for breaking changes)
- GitHub Actions, Docker, Helm: group all updates into a single PR each

## Test plan
- [ ] Verify Dependabot picks up the new config and creates grouped PRs on next run