### PR TITLE
chore: rename project from Tyrum to Byetodo

### DIFF
--- a/docs/plans/2026-02-16-rename-to-byetodo-design.md
+++ b/docs/plans/2026-02-16-rename-to-byetodo-design.md
@@ -1,0 +1,32 @@
+# Rename: Tyrum -> Byetodo
+
+**Date:** 2026-02-16
+**Status:** Approved
+
+## Decision
+
+Rename the project from **Tyrum** to **Byetodo**.
+
+- **Domain:** byetodo.ai (registered)
+- **Pronunciation:** bye-to-do
+- **Tagline:** "The end of to-do. No lists. Just outcomes."
+
+## Rationale
+
+- "Tyrum" was too abstract, hard to remember/spell, and tonally flat
+- "Byetodo" is clever & playful, suggestive of the product's purpose (eliminating to-do lists), and directly ties to the existing marketing tagline
+- Easy to say, easy to spell, immediately communicates the value proposition
+
+## Scope of rename
+
+All references to "tyrum" (case-insensitive) across the codebase need updating:
+
+- Rust service crate names (`tyrum-*` -> `byetodo-*`)
+- Cargo.toml package names and internal dependencies
+- Dockerfiles and image names
+- Helm charts and Kubernetes manifests
+- GitHub Actions workflows
+- Web (package.json, Next.js config, UI copy)
+- Documentation (README, product docs)
+- Environment variables and config templates
+- Code references (module paths, imports, struct names)


### PR DESCRIPTION
## Summary
- Documents the decision to rename the project from **Tyrum** to **Byetodo**
- Domain `byetodo.ai` has been registered
- Name ties directly to the product tagline: "The end of to-do"

## What's in this PR
- Design doc at `docs/plans/2026-02-16-rename-to-byetodo-design.md` covering rationale and rename scope

## Next steps
- Separate PR(s) to execute the actual rename across the codebase (Cargo.toml, Dockerfiles, Helm charts, workflows, web app, docs, code references)