### PR TITLE
Fix agent used_tools reporting

### DIFF
--- a/packages/gateway/src/modules/agent/runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime.ts
@@ -428,7 +428,6 @@ export class AgentRuntime {
     return AgentTurnResponse.parse({
       reply,
       session_id: session.session_id,
-      used_tools: tools.map((tool) => tool.id),
       memory_written: memoryWritten,
     });
   }

--- a/packages/gateway/src/modules/agent/workspace.ts
+++ b/packages/gateway/src/modules/agent/workspace.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import {
@@ -108,24 +108,4 @@ export async function loadEnabledMcpServers(
   }
 
   return loaded;
-}
-
-export async function listInstalledSkillIds(home: string): Promise<string[]> {
-  const skillsDir = resolveSkillsDir(home);
-  try {
-    const entries = await readdir(skillsDir, { withFileTypes: true });
-    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
-  } catch {
-    return [];
-  }
-}
-
-export async function listInstalledMcpServerIds(home: string): Promise<string[]> {
-  const mcpDir = resolveMcpDir(home);
-  try {
-    const entries = await readdir(mcpDir, { withFileTypes: true });
-    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
-  } catch {
-    return [];
-  }
 }

--- a/packages/gateway/tests/unit/agent-runtime.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { createContainer, type GatewayContainer } from "../../src/container.js";
+import { AgentRuntime } from "../../src/modules/agent/runtime.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, "../../migrations");
+
+function createFetchStub(reply: string): typeof fetch {
+  return (async () => {
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ choices: [{ message: { content: reply } }] }),
+    } as unknown as Response;
+  }) as typeof fetch;
+}
+
+describe("AgentRuntime", () => {
+  let homeDir: string | undefined;
+  let container: GatewayContainer | undefined;
+
+  afterEach(async () => {
+    container?.db.close();
+    container = undefined;
+
+    if (homeDir) {
+      await rm(homeDir, { recursive: true, force: true });
+      homeDir = undefined;
+    }
+  });
+
+  it("does not report context-available tools as used_tools", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-"));
+    container = createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      fetchImpl: createFetchStub("hello"),
+    });
+
+    const result = await runtime.turn({
+      channel: "test",
+      thread_id: "thread-1",
+      message: "read a file",
+    });
+
+    expect(result.reply).toBe("hello");
+    expect(result.used_tools).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
Fixes incorrect AgentTurnResponse.used_tools reporting (it previously echoed context-available tools even though no tool execution occurs).

Changes:
- Stop populating used_tools from the tool directory
- Add regression unit test
- Remove dead exports in workspace.ts

How to test:
- pnpm lint
- pnpm typecheck
- pnpm test packages/gateway/tests/unit/agent-runtime.test.ts

Risk:
- If any consumer treated used_tools as “available tools”, behavior changes (now empty unless tools are actually executed).