### PR TITLE
chore: align installer/docs domains and add public docs guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Lint installer script
         run: shellcheck scripts/install.sh
 
+  docs-public-content:
+    name: Docs Public Content Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check docs for internal-only content
+        run: bash scripts/check-public-docs.sh
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,25 @@
+name: docs-pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy Docs to Cloudflare Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Publish docs/
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs --project-name=tyrum-docs

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Self-hosted autonomous worker agent platform with a single-instance, single-user
 | `packages/gateway` | Main gateway process — Hono HTTP + WebSocket + SQLite |
 | `packages/client` | Client SDK for connecting to the gateway |
 | `config/` | Runtime configuration (model gateway YAML) |
-| `docs/` | Architecture and design documentation |
+| `docs/` | Public user documentation (install, guides, advanced topics) |
+
+Docs are deployed to Cloudflare Pages (`tyrum-docs`) by `.github/workflows/docs-pages.yml`.
 
 ## Installation
 
@@ -45,11 +47,11 @@ The gateway can be installed in multiple ways:
 
 1. **One-line installer (recommended):**
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash
+   curl -fsSL https://get.tyrum.ai/install.sh | bash
    ```
    Beta channel:
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- --channel beta
+   curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- --channel beta
    ```
 2. **npm global install:**
    ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Tyrum Documentation
+
+These documents are public and user-facing.
+
+## Getting Started
+
+- [Installation Guide](install.md)
+- [Quick Start](getting-started.md)
+
+## Advanced Guides
+
+- [Remote Gateway](advanced/remote-gateway.md)
+- [Multi-Node Deployments](advanced/multi-node.md)
+
+## Product Reference
+
+- [Policy Service](policy_service.md)
+- [HTTP Executor](executors/http_executor.md)
+- [Web Executor](executors/web_executor.md)

--- a/docs/advanced/multi-node.md
+++ b/docs/advanced/multi-node.md
@@ -1,0 +1,47 @@
+# Multi-Node Guide
+
+This guide explains running more than one Tyrum node.
+
+## Core rule
+
+Run each node with its own state directory and port.
+
+Use a unique `TYRUM_HOME` per node to keep databases and runtime state isolated.
+
+## Example: two local nodes
+
+Node A:
+
+```bash
+TYRUM_HOME=$HOME/.tyrum-a GATEWAY_PORT=8080 tyrum-gateway
+```
+
+Node B:
+
+```bash
+TYRUM_HOME=$HOME/.tyrum-b GATEWAY_PORT=8081 tyrum-gateway
+```
+
+## Recommended structure
+
+- One process manager entry per node.
+- One log stream per node.
+- One health check per node.
+
+## Configuration strategy
+
+- Keep shared defaults in environment templates.
+- Override only per-node values (`TYRUM_HOME`, `GATEWAY_PORT`, host binding).
+- Pin release versions during coordinated upgrades.
+
+## Upgrade pattern
+
+1. Upgrade one node first.
+2. Validate startup and basic workflows.
+3. Roll forward remaining nodes.
+
+## Common mistakes
+
+- Reusing the same `TYRUM_HOME` across nodes.
+- Port collisions between nodes.
+- Upgrading all nodes at once without a canary.

--- a/docs/advanced/remote-gateway.md
+++ b/docs/advanced/remote-gateway.md
@@ -1,0 +1,41 @@
+# Remote Gateway Guide
+
+This guide covers running Tyrum on a remote host you control.
+
+## Who this is for
+
+Use this when Tyrum needs to run on a different machine than your local workstation.
+
+## Baseline setup
+
+1. Install Tyrum on the remote host.
+2. Start Tyrum with an explicit host and port.
+3. Restrict network access using host firewall rules.
+
+Example:
+
+```bash
+GATEWAY_HOST=0.0.0.0 GATEWAY_PORT=8080 tyrum-gateway
+```
+
+## Security expectations
+
+The self-hosted profile is local-first. If you expose a remote endpoint, add network controls and transport protection appropriate for your environment.
+
+Recommended minimum controls:
+
+- Allowlist source IPs.
+- Use TLS termination in front of the gateway.
+- Avoid direct internet exposure without access controls.
+- Rotate API keys used by external model providers.
+
+## Operations checklist
+
+- Persist `TYRUM_HOME` on durable storage.
+- Keep Node.js and Tyrum updated.
+- Monitor process restarts and disk usage.
+
+## Troubleshooting
+
+- Gateway unreachable: verify `GATEWAY_HOST`, firewall, and listening port.
+- Slow responses: validate upstream model latency and local CPU/memory pressure.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,49 @@
+# Quick Start
+
+This guide helps new users go from install to first successful run.
+
+## 1. Install Tyrum
+
+Use the installer script:
+
+```bash
+curl -fsSL https://get.tyrum.ai/install.sh | bash
+```
+
+Or install with npm:
+
+```bash
+npm i -g @tyrum/gateway
+```
+
+## 2. Start the gateway
+
+```bash
+tyrum-gateway
+```
+
+By default, Tyrum runs local-first and binds to `127.0.0.1`.
+
+## 3. Open the web app
+
+Open:
+
+- `http://127.0.0.1:8080/app`
+
+## 4. Enable singleton agent routes (optional)
+
+```bash
+TYRUM_AGENT_ENABLED=1 tyrum-gateway
+```
+
+## 5. Common first-time checks
+
+- Verify Node.js 24.x: `node -v`
+- Verify command install path: `command -v tyrum-gateway`
+- If a port conflict occurs, set `GATEWAY_PORT`.
+
+Example:
+
+```bash
+GATEWAY_PORT=8081 tyrum-gateway
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,19 +18,19 @@ This guide covers end-user installation options for Tyrum gateway.
 Installs a versioned `@tyrum/gateway` release tarball after verifying `SHA256SUMS`.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash
+curl -fsSL https://get.tyrum.ai/install.sh | bash
 ```
 
 Install from a channel:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- --channel beta
+curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- --channel beta
 ```
 
 Install a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- 2026.2.18
+curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- 2026.2.18
 ```
 
 Advanced overrides:
@@ -90,7 +90,7 @@ npm i -g @tyrum/gateway@latest
 If installed with the script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash
+curl -fsSL https://get.tyrum.ai/install.sh | bash
 ```
 
 ## Version Pinning
@@ -104,5 +104,11 @@ npm i -g @tyrum/gateway@2026.2.18
 or:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- 2026.2.18
+curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- 2026.2.18
 ```
+
+## Next Steps
+
+- [Quick Start](getting-started.md)
+- [Remote Gateway Guide](advanced/remote-gateway.md)
+- [Multi-Node Guide](advanced/multi-node.md)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
+    "docs:public-check": "bash scripts/check-public-docs.sh",
     "lint": "oxlint --ignore-pattern '**/dist/**' .",
     "typecheck": "tsc -b"
   },

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCS_DIR="${1:-docs}"
+
+if [[ ! -d "$DOCS_DIR" ]]; then
+  echo "error: docs directory not found: $DOCS_DIR" >&2
+  exit 1
+fi
+
+declare -a BLOCKED_PATTERNS=(
+  "domain routing"
+  "dns record"
+  "cloudflare dashboard"
+  "vercel dashboard"
+  "internal runbook"
+  "ops-only"
+)
+
+violations=0
+
+scan_pattern() {
+  local pattern="$1"
+  if command -v rg >/dev/null 2>&1; then
+    rg -n --ignore-case --glob "*.md" "$pattern" "$DOCS_DIR"
+    return
+  fi
+
+  grep -Rni --include "*.md" -- "$pattern" "$DOCS_DIR"
+}
+
+for pattern in "${BLOCKED_PATTERNS[@]}"; do
+  if scan_pattern "$pattern" >/dev/null; then
+    echo "error: blocked docs phrase found: '$pattern'" >&2
+    scan_pattern "$pattern" >&2 || true
+    violations=1
+  fi
+done
+
+if [[ "$violations" -ne 0 ]]; then
+  echo "error: public docs policy check failed" >&2
+  exit 1
+fi
+
+echo "public docs policy check passed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # Tyrum installer (macOS + Linux)
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- --channel beta
-#   curl -fsSL https://raw.githubusercontent.com/rhernaus/tyrum/main/scripts/install.sh | bash -s -- 2026.2.18
+#   curl -fsSL https://get.tyrum.ai/install.sh | bash
+#   curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- --channel beta
+#   curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- 2026.2.18
 
 REPO="${TYRUM_REPO:-rhernaus/tyrum}"
 CHANNEL="${TYRUM_CHANNEL:-stable}"


### PR DESCRIPTION
## Summary
- switch installer docs/examples to `https://get.tyrum.ai/install.sh`
- add public docs content structure for beginner + advanced topics
- add CI guard to block internal-only docs terms
- add Cloudflare Pages workflow to deploy `docs/` to `docs.tyrum.com`

## Changes
- updated: `README.md`, `docs/install.md`, `scripts/install.sh`
- added: `docs/README.md`, `docs/getting-started.md`
- added: `docs/advanced/remote-gateway.md`, `docs/advanced/multi-node.md`
- added: `scripts/check-public-docs.sh`
- updated CI: `.github/workflows/ci.yml`
- added docs deploy workflow: `.github/workflows/docs-pages.yml`
- added npm script: `docs:public-check`

## Validation
- `bash scripts/check-public-docs.sh`
- `shellcheck scripts/install.sh scripts/check-public-docs.sh`
