### PR TITLE
fix(ci): stabilize macOS release signing in release workflow

### DIFF
--- a/.github/scripts/decode-base64.sh
+++ b/.github/scripts/decode-base64.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Portable base64 decode helper.
+# Tries GNU (--decode / -d) then BSD (-D) flags in order, writing to a file.
+# Usage: decode_base64 <value> <output-file>
+# Returns 0 on success, 1 if all variants fail.
+decode_base64() {
+  local value="$1"
+  local output="$2"
+
+  printf '%s' "${value}" | base64 --decode > "${output}" 2>/dev/null && return 0
+  printf '%s' "${value}" | base64 -d > "${output}" 2>/dev/null && return 0
+  printf '%s' "${value}" | base64 -D > "${output}" 2>/dev/null && return 0
+
+  return 1
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,16 +209,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          decode_base64() {
-            local value="$1"
-            local output="$2"
-
-            printf '%s' "${value}" | base64 --decode > "${output}" 2>/dev/null && return 0
-            printf '%s' "${value}" | base64 -d > "${output}" 2>/dev/null && return 0
-            printf '%s' "${value}" | base64 -D > "${output}" 2>/dev/null && return 0
-
-            return 1
-          }
+          source "${GITHUB_WORKSPACE}/.github/scripts/decode-base64.sh"
 
           if [[ -z "${APPLE_API_KEY:-}" ]]; then
             exit 0
@@ -305,16 +296,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          decode_base64() {
-            local value="$1"
-            local output="$2"
-
-            printf '%s' "${value}" | base64 --decode > "${output}" 2>/dev/null && return 0
-            printf '%s' "${value}" | base64 -d > "${output}" 2>/dev/null && return 0
-            printf '%s' "${value}" | base64 -D > "${output}" 2>/dev/null && return 0
-
-            return 1
-          }
+          source "${GITHUB_WORKSPACE}/.github/scripts/decode-base64.sh"
 
           keychain_path="${RUNNER_TEMP}/ci-signing.keychain-db"
           cert_file="${RUNNER_TEMP}/codesign-cert.p12"


### PR DESCRIPTION
## Summary
- add a dedicated macOS keychain setup step before Electron packaging on `macos-latest`
- import the Developer ID certificate from `CSC_LINK` (supports URL, `file://`, local path, or base64 secret) and configure key partition access for non-interactive `codesign`
- require `KEYCHAIN_PASSWORD` in credential validation
- add `timeout-minutes: 45` and electron signing/notarization debug logging on the macOS build step

## Why
The release job was hanging for over an hour at `Build desktop release files (macOS signed + notarized)` on first Apple signing runs. This change makes signing key access explicit in CI and prevents indefinite hangs.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test`

## Ops note
- repository secret `KEYCHAIN_PASSWORD` is now required for macOS release jobs
