### PR TITLE
fix(ci): use npm for docs pages deploy

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
           command: pages deploy docs --project-name=tyrum-docs


### PR DESCRIPTION
Fixes Actions job 64049018465 failing with: Unable to locate executable file: pnpm.

Cloudflare wrangler-action infers pnpm from pnpm lockfiles; explicitly set packageManager=npm for the docs deploy workflow.