### PR TITLE
fix(ci): create docs Pages project before deploying (idempotent)

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -17,10 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Create Pages project (idempotent)
+        uses: cloudflare/wrangler-action@v3
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
+          command: pages project create tyrum-docs --production-branch=main
       - name: Publish docs/
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          command: pages deploy docs --project-name=tyrum-docs
+          command: pages deploy docs --project-name=tyrum-docs --commit-dirty=true


### PR DESCRIPTION
## Summary
- Add idempotent `pages project create tyrum-docs` step before the deploy step, matching the pattern used in the marketing-page workflow
- Add `--commit-dirty=true` to silence the git dirty warning

## Root cause
The docs-pages deploy was failing with `Project not found [code: 8000007]` because the Cloudflare Pages project `tyrum-docs` had never been created. The `pages deploy` command requires the project to already exist.

## Fix
Mirror the marketing page approach: run `pages project create` with `continue-on-error: true` so it succeeds on first run (creates the project) and is a no-op on subsequent runs (project already exists).

## Test plan
- [ ] Merge and confirm the Actions job passes end-to-end