### PR TITLE
fix(ci): increase macOS notarization step timeout to 90 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
 
       - name: Build desktop release files (macOS signed + notarized)
         if: ${{ matrix.os == 'macos-latest' }}
-        timeout-minutes: 45
+        timeout-minutes: 90
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}


### PR DESCRIPTION
## Summary

- Increases `timeout-minutes` for the macOS signed+notarized build step from 45 → 90 minutes

## Root cause

`xcrun notarytool submit --wait` (invoked via `@electron/notarize`) produces zero output until it completes and has no inner timeout. The build+sign phase takes ~2 minutes, leaving only ~43 minutes for notarization. Large Electron app bundles can cause Apple's notarization service to take 20–40+ minutes, exceeding the previous budget and killing the job.

See run [22154718225](https://github.com/rhernaus/tyrum/actions/runs/22154718225/job/64055382660) — signing succeeded at 19:39:46, notarization was invoked, then silence for 43 minutes until the step timeout at 20:23:05.

## Test plan

- [ ] Trigger a release and confirm the macOS notarization step completes within the new 90-minute window