### PR TITLE
test: add process-level smoke coverage for gateway and desktop startup

### DIFF
--- a/apps/desktop/scripts/stage-gateway-bin.mjs
+++ b/apps/desktop/scripts/stage-gateway-bin.mjs
@@ -39,11 +39,34 @@ rmSync(targetDir, { recursive: true, force: true });
 mkdirSync(dirname(targetDir), { recursive: true });
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-const deploy = spawnSync(
+const deployArgsBase = ["--filter", "@tyrum/gateway", "deploy", "--prod"];
+
+let deploy = spawnSync(
   pnpmCmd,
-  ["--filter", "@tyrum/gateway", "deploy", "--prod", targetDir],
-  { stdio: "inherit", cwd: repoRoot },
+  [...deployArgsBase, targetDir],
+  { stdio: "pipe", cwd: repoRoot, encoding: "utf8" },
 );
+
+if (deploy.status !== 0) {
+  const stdout = deploy.stdout ?? "";
+  const stderr = deploy.stderr ?? "";
+  const needsLegacy =
+    stdout.includes("ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE") ||
+    stderr.includes("ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE");
+
+  if (needsLegacy) {
+    rmSync(targetDir, { recursive: true, force: true });
+    deploy = spawnSync(
+      pnpmCmd,
+      [...deployArgsBase, "--legacy", targetDir],
+      { stdio: "inherit", cwd: repoRoot },
+    );
+  } else {
+    process.stdout.write(stdout);
+    process.stderr.write(stderr);
+  }
+}
+
 if (deploy.status !== 0) {
   throw new Error(
     `Failed to stage gateway dependencies (pnpm deploy exit code ${String(deploy.status)}).`,


### PR DESCRIPTION
## Summary
- add a gateway integration smoke test that starts the real gateway process and asserts `/healthz` readiness
- add a desktop integration test that starts embedded gateway via `GatewayManager` and validates startup/shutdown
- add a full Electron process smoke test (with headless Linux `xvfb-run` support) that verifies embedded gateway startup and process-tree teardown
- harden `apps/desktop/scripts/stage-gateway-bin.mjs` for pnpm v10 by retrying `pnpm deploy` with `--legacy` and clearing the target dir before retry

## Testing
- `pnpm vitest run packages/gateway/tests/integration/startup-process.test.ts`
- `pnpm vitest run apps/desktop/tests/integration/embedded-gateway-startup.test.ts`
- `pnpm vitest run apps/desktop/tests/integration/electron-process-smoke.test.ts`
- `pnpm typecheck`
- `pnpm lint`
