### PR TITLE
fix(desktop): recover from corrupted embedded gateway tokens

### DIFF
--- a/apps/desktop/src/main/ipc/gateway-ipc.ts
+++ b/apps/desktop/src/main/ipc/gateway-ipc.ts
@@ -26,16 +26,25 @@ interface EmbeddedGatewayUiUrlOptions {
 
 let startPromise: Promise<void> | null = null;
 
-export function ensureEmbeddedGatewayToken(config: DesktopNodeConfig): string {
-  const existingTokenRef = config.embedded.tokenRef;
-  if (existingTokenRef) {
-    return decryptToken(existingTokenRef);
-  }
-
+function createAndStoreEmbeddedGatewayToken(config: DesktopNodeConfig): string {
   const token = generateToken();
   config.embedded.tokenRef = encryptToken(token);
   saveConfig(config);
   return token;
+}
+
+export function ensureEmbeddedGatewayToken(config: DesktopNodeConfig): string {
+  const existingTokenRef = config.embedded.tokenRef;
+  if (existingTokenRef) {
+    try {
+      return decryptToken(existingTokenRef);
+    } catch (error) {
+      console.warn("Failed to decrypt embedded gateway token; rotating token.", error);
+      return createAndStoreEmbeddedGatewayToken(config);
+    }
+  }
+
+  return createAndStoreEmbeddedGatewayToken(config);
 }
 
 function toHttpAppUrlFromWsUrl(rawUrl: string): string | null {

--- a/apps/desktop/tests/gateway-ipc-handlers.test.ts
+++ b/apps/desktop/tests/gateway-ipc-handlers.test.ts
@@ -2,10 +2,21 @@ import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserWindow } from "electron";
 
-const { ipcMainHandleMock, registeredHandlers, testState, saveConfigMock } = vi.hoisted(() => ({
+const {
+  ipcMainHandleMock,
+  registeredHandlers,
+  testState,
+  saveConfigMock,
+  decryptTokenMock,
+  generateTokenMock,
+  encryptTokenMock,
+} = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
   registeredHandlers: new Map<string, (...args: unknown[]) => unknown>(),
   saveConfigMock: vi.fn(),
+  decryptTokenMock: vi.fn(() => "token"),
+  generateTokenMock: vi.fn(() => "generated-token"),
+  encryptTokenMock: vi.fn((token: string) => `enc:${token}`),
   testState: {
     port: 8080,
     mode: "embedded" as "embedded" | "remote",
@@ -54,9 +65,9 @@ vi.mock("../src/main/config/store.js", () => ({
 }));
 
 vi.mock("../src/main/config/token-store.js", () => ({
-  decryptToken: vi.fn(() => "token"),
-  generateToken: vi.fn(() => "generated-token"),
-  encryptToken: vi.fn((token: string) => `enc:${token}`),
+  decryptToken: decryptTokenMock,
+  generateToken: generateTokenMock,
+  encryptToken: encryptTokenMock,
 }));
 
 vi.mock("../src/main/gateway-bin-path.js", () => ({
@@ -70,6 +81,12 @@ describe("registerGatewayIpc handlers", () => {
     testState.mode = "embedded";
     testState.remoteWsUrl = "ws://127.0.0.1:8080/ws";
     saveConfigMock.mockReset();
+    decryptTokenMock.mockReset();
+    decryptTokenMock.mockImplementation(() => "token");
+    generateTokenMock.mockReset();
+    generateTokenMock.mockImplementation(() => "generated-token");
+    encryptTokenMock.mockReset();
+    encryptTokenMock.mockImplementation((token: string) => `enc:${token}`);
     registeredHandlers.clear();
     ipcMainHandleMock.mockReset();
     ipcMainHandleMock.mockImplementation((channel: string, handler: (...args: unknown[]) => unknown) => {
@@ -140,6 +157,43 @@ describe("registerGatewayIpc handlers", () => {
       displayUrl: "http://127.0.0.1:8080/app",
       externalUrl: "http://127.0.0.1:8080/app/auth?token=token&next=%2Fapp",
     });
+  });
+
+  it("rotates embedded token when persisted token cannot be decrypted", async () => {
+    decryptTokenMock.mockImplementationOnce(() => {
+      throw new Error("Error while decrypting the ciphertext provided to safeStorage.decryptString.");
+    });
+
+    const { registerGatewayIpc } = await import("../src/main/ipc/gateway-ipc.js");
+
+    const windowStub = {
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        send: vi.fn(),
+      },
+    } as unknown as BrowserWindow;
+
+    registerGatewayIpc(windowStub);
+
+    const uiUrlsHandler = registeredHandlers.get("gateway:ui-urls");
+    expect(uiUrlsHandler).toBeDefined();
+
+    const urls = await uiUrlsHandler!({} as never);
+    expect(urls).toEqual({
+      embedUrl: "http://127.0.0.1:8080/app/auth?token=generated-token&next=%2Fapp",
+      displayUrl: "http://127.0.0.1:8080/app",
+      externalUrl: "http://127.0.0.1:8080/app/auth?token=generated-token&next=%2Fapp",
+    });
+    expect(generateTokenMock).toHaveBeenCalledTimes(1);
+    expect(encryptTokenMock).toHaveBeenCalledWith("generated-token");
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embedded: expect.objectContaining({
+          tokenRef: "enc:generated-token",
+        }),
+      }),
+    );
   });
 
   it("returns onboarding URL targets when requested", async () => {


### PR DESCRIPTION
## Summary
- recover embedded gateway startup when persisted `embedded.tokenRef` cannot be decrypted
- rotate and persist a new token instead of throwing from `ensureEmbeddedGatewayToken`
- add a regression test that simulates decrypt failure and verifies token regeneration + save

## Validation
- `pnpm vitest run apps/desktop/tests/gateway-ipc-handlers.test.ts`