### PR TITLE
Fix docs deploy pipeline

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -46,10 +46,14 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          workingDirectory: apps/docs
           command: pages project create tyrum-docs --production-branch=main
       - name: Publish docs site
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/docs/build --project-name=tyrum-docs --commit-dirty=true
+          packageManager: pnpm
+          workingDirectory: apps/docs
+          command: pages deploy build --project-name=tyrum-docs --commit-dirty=true


### PR DESCRIPTION
Fixes the `docs-pages` workflow failing during the `cloudflare/wrangler-action@v3` install step.

The workflow ran `pnpm install` and then asked the wrangler action to use `packageManager: npm`, which made it run `npm i wrangler@...` against a pnpm-managed `node_modules` tree.

This change removes the explicit packageManager so the action infers `pnpm` from `pnpm-lock.yaml`.

Verification:
- `pnpm --filter @tyrum/docs build`