### PR TITLE
docs: scalable gateway topology and HA

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -32,6 +32,11 @@ const sidebars: SidebarsConfig = {
           label: "Overview",
         },
         {
+          type: "doc",
+          id: "architecture/scaling-ha",
+          label: "Scaling & HA",
+        },
+        {
           type: "category",
           label: "Runtime Components",
           items: [

--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -23,6 +23,14 @@ Approvals are **enforcement**, not prompt guidance.
 
 Approvals must be safe to process more than once (idempotent resolution handling).
 
+## Cluster notes
+
+Approvals are durable records in the StateStore and should behave correctly when multiple gateway instances (and multiple operator clients) are active:
+
+- **Any gateway edge instance can serve the approval queue** (read from the StateStore) and accept resolution requests.
+- **Atomic resolution:** apply `pending → approved|denied|expired` transitions in a single durable write so double-submission is safe.
+- **At-least-once events:** `approval.requested` / `approval.resolved` events may be delivered more than once; clients should dedupe using event ids.
+
 ## Approval request shape (conceptual)
 
 An approval request should be explicit about impact and traceability:

--- a/docs/architecture/automation.md
+++ b/docs/architecture/automation.md
@@ -21,3 +21,11 @@ Automation lets Tyrum act on schedules and triggers while keeping behavior obser
 - Automation must be idempotent where possible.
 - Emit events for triggers, actions taken, and outcomes.
 - Apply the same policy and approval gates as interactive runs.
+
+## Scheduler safety (DB-leases)
+
+To keep semantics identical between single-host and clustered deployments, automation triggers use DB-leases stored in the StateStore (with one instance this is typically uncontested):
+
+- **Lease acquisition:** one scheduler instance owns a time-bounded lease for a trigger/schedule shard.
+- **Renewal + takeover:** leases are renewed periodically; on expiry, another instance can take over.
+- **Durable dedupe:** each firing should have a durable unique id so downstream enqueue/execution can dedupe under retries.

--- a/docs/architecture/execution-engine.md
+++ b/docs/architecture/execution-engine.md
@@ -25,6 +25,17 @@ LLMs are good at planning, but they are a poor place to host the control plane f
 - **Evidence and verification:** capture artifacts and validate postconditions (required for state-changing steps when feasible).
 - **Auditability:** emit events for run/step lifecycle and persist a run log suitable for troubleshooting and export.
 
+## Distributed execution (workers)
+
+The execution engine can run co-located with the gateway edge (even in the same OS process) or be split into separate processes/hosts. To minimize surprises when scaling up, the same execution semantics apply in all deployments: workers claim/lease work in the StateStore and publish lifecycle events through the backplane abstraction (see [Scaling and High Availability](./scaling-ha.md)).
+
+Cluster-safe execution typically requires:
+
+- **Claim/lease:** workers claim work with a time-bounded lease recorded in the StateStore so only one worker executes a given attempt at a time.
+- **Idempotency:** side-effecting steps define `idempotency_key` semantics so retries are safe under at-least-once execution.
+- **Lane serialization:** workers acquire a distributed lock/lease keyed by `(session_key, lane)` before executing steps that must be serialized.
+- **Durable outcomes:** attempt results, artifacts, and postcondition evaluations are persisted before emitting “completed” events.
+
 ## Non-responsibilities
 
 - The execution engine does not decide *what* to do from a user message (planning is in the agent/planner).
@@ -76,7 +87,7 @@ flowchart TB
 
   Engine --> Evidence["Artifacts + Postconditions"]
   Engine --> Events["Events/AuditLog"]
-  Engine <--> DB["SQLite state"]
+  Engine <--> DB["StateStore (SQLite/Postgres)"]
 ```
 
 ## Data model sketch (conceptual)

--- a/docs/architecture/gaps.md
+++ b/docs/architecture/gaps.md
@@ -64,3 +64,14 @@ This document tracks architecture areas that are still **missing**, **ambiguous*
 - **Tracing/metrics:** what is emitted, where it’s collected, and what SLOs are targeted.
 - **Cost attribution:** how token usage and executor time are attributed per run/step.
 
+## Scaling and high availability
+
+- **StateStore portability:** define the compatibility bar for SQLite vs Postgres (schema features allowed, JSON/array usage, transaction semantics, locking expectations).
+- **Migration story:** how a local SQLite StateStore can be migrated to Postgres (one-time export/import, live dual-write, or “new deployment only”).
+- **Worker claim/lease model:** canonical claim/lease fields, expiry/renewal, poison job handling, and backoff semantics under retries.
+- **Lane serialization mechanism:** how `(session_key, lane)` exclusivity is enforced in multi-instance deployments (advisory locks vs lease rows; failure and takeover behavior).
+- **Event backplane choice:** outbox schema and delivery semantics; how to combine outbox durability with low-latency pub/sub; replay strategy for reconnecting clients.
+- **WebSocket connection routing:** how cross-instance delivery works when a client/node is connected to a different gateway edge instance (connection directory, message routing, and revocation).
+- **Scheduler DB-leases:** how cron/watchers/heartbeat are coordinated to prevent double-fires (sharding, leases, and durable dedupe ids).
+- **Artifact store scaling:** local filesystem vs object store; retention policies; artifact reference formats and export bundles.
+- **HA / failover testing:** define what failures must be tolerated (single instance crash, DB failover, partition) and the expected behavior for in-flight runs and approvals.

--- a/docs/architecture/gateway/index.md
+++ b/docs/architecture/gateway/index.md
@@ -2,7 +2,9 @@
 
 Status:
 
-The gateway is Tyrum's single long-lived daemon. It is the system's authority for connectivity, policy, validation, routing, orchestration, and persistence.
+The gateway is Tyrum's long-lived service component. It is the system's authority for connectivity, policy enforcement, validation, routing, orchestration, and durable state coordination.
+
+Deployments range from a single host (replica count = 1) to multi-instance clusters (replicated gateway edges and workers). The goal is consistent behavior across topologies: the gateway coordinates execution and event delivery via the StateStore and event backplane regardless of deployment size. See [Scaling and High Availability](../scaling-ha.md).
 
 ## Responsibilities
 
@@ -11,8 +13,8 @@ The gateway is Tyrum's single long-lived daemon. It is the system's authority fo
 - Validate inbound/outbound messages against contracts.
 - Route requests to internal modules or to capable nodes.
 - Emit events for lifecycle, actions, and state changes.
-- Persist essential state (sessions, transcripts, memory, audit logs).
-- Host the **execution engine** (queue, retries, idempotency, pause/resume, evidence capture).
+- Persist essential state (sessions, transcripts, memory, audit logs) via the StateStore.
+- Host the **execution engine** (queue, retries, idempotency, pause/resume, evidence capture). Step execution is performed by workers coordinated via the StateStore (workers may be co-located/in-process or run as separate processes/hosts).
 - Host the **approvals** subsystem and enforce policy at tool boundaries.
 - Integrate with a **secret provider** so raw credentials are never exposed to the model.
 - Host automation triggers (hooks, cron, heartbeat) in a controlled way.
@@ -46,7 +48,7 @@ flowchart TB
   ENG --> AUDIT["Audit/event log"]
   ENG <--> SECRETS["Secret provider"]
 
-  DB[("SQLite state")] <--> MEM
+  DB[("StateStore (SQLite/Postgres)")] <--> MEM
   DB <--> AUDIT
   DB <--> AG
   DB <--> ENG

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -39,11 +39,35 @@ A gateway-emitted server-push message that notifies clients of lifecycle, progre
 
 ## Gateway
 
-The single long-lived daemon that owns connectivity, routing, validation, policy, and persistence.
+A long-lived service component that owns edge connectivity, routing, validation, policy enforcement, and durable state coordination. It can be deployed as a single instance or replicated in a cluster.
 
 ## Gateway plugin
 
 An in-process code module loaded by the gateway to extend the system (for example tools, slash commands, and gateway RPC endpoints). Gateway plugins are **trusted** extensions and are not the primary mechanism for per-app/per-vendor integrations (prefer capability providers for that).
+
+## StateStore
+
+The system of record for durable state and logs (sessions, approvals, run/job state, audit). SQLite is the default local backend; HA Postgres (or Postgres-compatible managed databases) are used for scale and availability.
+
+## Backplane
+
+A cross-instance event delivery mechanism used in clustered deployments so workers/schedulers can publish events that the gateway edge instances deliver to their connected clients/nodes.
+
+## Worker
+
+A step execution process that claims work (leases) and performs tool/capability calls. Workers scale horizontally.
+
+## Scheduler
+
+A component that enqueues work from time-based triggers (cron/watchers/heartbeats). In multi-instance deployments, schedulers coordinate using DB-leases to avoid double-fires.
+
+## Lease
+
+A time-bounded claim stored in the StateStore that coordinates ownership of work or schedules across instances.
+
+## Outbox
+
+A durable event log/table used to publish events reliably to the backplane (supporting replay and recovery).
 
 ## Lane
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -13,9 +13,9 @@ flowchart LR
   end
 
   subgraph Runtime["Tyrum runtime"]
-    G["Gateway<br/>(single long-lived daemon)"]
-    DB[("State + logs<br/>SQLite")]
-    EV["Event bus"]
+    G["Gateway<br/>(long-lived service)"]
+    DB[("State + logs<br/>StateStore (SQLite/Postgres)")]
+    EV["Event backplane"]
     ENG["Execution engine"]
     APPR["Approvals"]
     PB["Playbook runtime"]
@@ -48,8 +48,12 @@ flowchart LR
 
 ## Building blocks
 
-- **Gateway:** the long-lived process that owns connections, routing, validation, persistence, and orchestration.
-- **Execution engine:** the job runner that executes workflows with retries, idempotency, pause/resume, and evidence capture.
+- **Gateway:** the long-lived service that owns edge connectivity (WebSocket), routing, and contract validation. See [Gateway](./gateway/index.md).
+- **StateStore:** durable state and logs (SQLite local; Postgres for HA/scale). See [Scaling and high availability](./scaling-ha.md).
+- **Event backplane:** cross-component event delivery (in-process for replica count = 1; shared for clusters). See [Scaling and high availability](./scaling-ha.md) and [Events](./protocol/events.md).
+- **Execution engine:** the durable orchestration runtime (retries, idempotency, pause/resume, evidence). See [Execution engine](./execution-engine.md).
+- **Workers:** step executors that claim work (leases), perform side effects, and publish results/events. See [Execution engine](./execution-engine.md).
+- **Scheduler:** cron/watchers/heartbeat enqueuers coordinated by DB-leases. See [Automation](./automation.md).
 - **Playbooks:** deterministic workflow specs executed by the runtime (approval gates + resume tokens).
 - **Approvals:** durable operator confirmation requests that gate risky actions and pause/resume workflows.
 - **Secrets:** a first-class boundary; raw secrets stay behind a secret provider and are referenced via handles.
@@ -71,6 +75,7 @@ flowchart LR
 
 ## Where to start
 
+- [Scaling and high availability](./scaling-ha.md)
 - [Gateway](./gateway/index.md)
 - [Execution engine](./execution-engine.md)
 - [Playbooks](./playbooks.md)

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -30,5 +30,6 @@ The canonical wire shape lives in `@tyrum/schemas` (`packages/schemas/src/protoc
 
 ## Delivery expectations
 
-- Events should be safe to handle more than once (idempotent consumption).
-- Clients should tolerate reconnect and resubscribe without losing safety invariants.
+- Events are delivered **at-least-once**. Consumers must tolerate duplicates and implement idempotent handling.
+- Deduplicate using `event_id` (and treat `occurred_at` as informational, not a strict ordering guarantee).
+- Clients should tolerate reconnect and resubscribe without losing safety invariants; durable state in the StateStore remains the source of truth.

--- a/docs/architecture/protocol/index.md
+++ b/docs/architecture/protocol/index.md
@@ -22,6 +22,15 @@ The protocol is the primary interface for:
 - Primary transport is WebSocket for low-latency, long-lived connectivity.
 - Heartbeats detect dead connections and enable safe eviction/reconnect.
 
+## Deployment notes (reconnect + dedupe)
+
+The protocol is designed to work across gateway restarts and multi-instance deployments:
+
+- **Reconnect is normal:** clients and nodes should tolerate disconnects and reconnect without violating safety invariants.
+- **Events are at-least-once:** events may be delivered more than once (especially across reconnect). Deduplicate using `event_id`.
+- **Requests can be retried:** when a peer does not observe a response, it may retry by re-sending the request with the same `request_id` (subject to each request type’s idempotency contract).
+- **Durable state is the source of truth:** important state transitions must be backed by the StateStore and can be re-derived after reconnect; do not assume in-memory ordering guarantees across reconnects.
+
 ## Message classes
 
 - **Handshake:** identifies the connecting device and declares capabilities.

--- a/docs/architecture/protocol/requests-responses.md
+++ b/docs/architecture/protocol/requests-responses.md
@@ -51,3 +51,10 @@ Prefer explicit, typed errors over ambiguous strings:
 - `internal`
 
 For operations with side effects, idempotency should be defined up-front so clients can safely retry.
+
+## Retry and idempotency expectations
+
+Distributed systems lose packets and drop connections; retries are expected. Tyrum relies on two related ideas:
+
+- **Transport-level retry (`request_id`):** if a peer does not observe a response, it may retry the same logical request by re-sending it with the same `request_id`. Servers should handle duplicate `request_id` safely according to the request type’s contract.
+- **Side-effect idempotency:** for state-changing operations, the request payload (or the workflow step) may also carry an explicit `idempotency_key` so that retries do not duplicate side effects even under at-least-once execution.

--- a/docs/architecture/scaling-ha.md
+++ b/docs/architecture/scaling-ha.md
@@ -1,0 +1,153 @@
+# Scaling and High Availability
+
+Status:
+
+This document describes how Tyrum scales from a single-machine install (for example a desktop app with an embedded gateway and a local SQLite database) to a horizontally scalable deployment (replicated gateway edge + workers + lease-based schedulers backed by HA Postgres).
+
+The intent is a **single architecture** with a fixed set of logical components that can be co-located or split across processes/hosts as deployment needs grow.
+
+A core goal is that a single-host deployment behaves like “the cluster, but with 1 of each”: the same coordination primitives (leases and the event backplane) exist in all deployments, and the single-host case is simply uncontested and often implemented in-process.
+
+## Hard invariants
+
+Tyrum’s architecture relies on a few invariants that must hold in both small and large deployments:
+
+- **Durable state:** sessions, approvals, runs/jobs/steps, and audit logs must survive process restarts.
+- **Retry safety:** requests and events must be safe under retries and at-least-once delivery.
+- **Lane serialization:** execution is serialized per `(session_key, lane)` (see [Sessions and Lanes](./sessions-lanes.md)).
+- **Secrets by handle:** raw secret values do not enter model context; executors resolve handles at the last responsible moment (see [Secrets](./secrets.md)).
+- **Observable execution:** long-running work emits events and can be inspected/replayed from durable logs (see [Execution engine](./execution-engine.md)).
+
+## Logical components
+
+These are the logical building blocks that appear in all deployments:
+
+- **Gateway edge:** WebSocket server, auth, contract validation, routing, event delivery to connected clients/nodes.
+- **Execution engine:** durable run state machine and orchestration (pause/resume, retries, idempotency, budgets).
+- **Workers:** step executors that claim work and perform side effects via tools/nodes/MCP.
+- **Schedulers:** cron/watchers/heartbeat triggers that enqueue work (must be cluster-safe; see below).
+- **StateStore:** the system of record for durable state and logs (SQLite locally; Postgres for HA/scale).
+- **Event backplane:** a cross-instance delivery mechanism for events/commands in clustered deployments.
+- **Secret provider:** resolves secret handles to raw values in trusted execution contexts.
+
+## StateStore (SQLite → HA Postgres)
+
+Tyrum is local-first by default and can use SQLite for a single-machine install. Horizontal scaling and HA require a shared StateStore with stronger concurrency and durability semantics (typically Postgres).
+
+- **Local default:** SQLite file, single host.
+- **Scalable/HA:** HA Postgres cluster (3-node) or a Postgres-compatible managed database platform.
+
+The most important portability discipline is: **treat persisted schemas as contracts**. If you want SQLite and Postgres to be swappable backends, schema changes must be versioned and tested against both backends.
+
+## WebSocket-first event delivery (the “WS reality”)
+
+Tyrum is **WebSocket-first**: typed requests/responses plus server-push events are the primary operator interface transport (see [Protocol](./protocol/index.md)).
+
+A WebSocket connection is a single long-lived TCP connection. Practically that means:
+
+- **A connection is owned by exactly one gateway edge instance at a time** (trivial when there is only one instance).
+- Durable state can live entirely in the StateStore, but **only the owning instance can write to that socket**.
+
+This is not a Tyrum-specific limitation; it is a property of long-lived connections. To keep behavior consistent when scaling up, deployments route updates through an **event backplane** abstraction: in a single-host deployment this may be in-process, while in multi-instance deployments it becomes a shared backplane.
+
+### Event backplane options (capabilities, not mandates)
+
+The backplane is a logical requirement; it can be implemented in several ways depending on scale:
+
+- **In-process backplane:** local pub/sub when components are co-located (replica count = 1). Lowest operational overhead while keeping the same eventing model.
+- **DB outbox + polling:** write events to an outbox table in the StateStore; gateway edges poll and deliver. Simple, durable, and a good starting point.
+- **Postgres `LISTEN/NOTIFY`:** useful for low/medium scale real-time signaling; still typically paired with an outbox for durability.
+- **External pub/sub (Redis/NATS/Kafka):** higher throughput and lower latency; commonly paired with an outbox for replay/recovery.
+
+## Workers: claim/lease + idempotency + lane locks
+
+To scale execution safely, workers must be able to run concurrently without duplicating side effects or corrupting session state. The standard pattern is:
+
+- **Durable job/run state** in the StateStore.
+- **Atomic claim/lease** of work items so only one worker executes a given step attempt at a time.
+- **Idempotency keys** for side-effecting steps so retries are safe.
+- **Lane serialization** enforced via a distributed lock/lease keyed by `(session_key, lane)`.
+
+The exact mechanism can vary (row-level locks, advisory locks, lease rows), but the observable behavior must match the [Sessions and Lanes](./sessions-lanes.md) guarantee.
+
+## Schedulers/watchers/cron: DB-leases (always)
+
+Schedulers must not double-fire triggers when multiple instances are running. To keep semantics identical between single-host and clustered deployments, schedulers use **DB-leasing** in the StateStore:
+
+- A scheduler instance acquires a lease (owner id + expiry) for a given schedule/trigger shard.
+- The lease is renewed periodically; on expiry another instance can take over.
+- Each firing should have a durable, unique `firing_id` so downstream enqueue/execution can dedupe under retries.
+
+## Deployment topologies
+
+These are examples of deploying the same logical components in different shapes.
+
+### Single host (co-located)
+
+All logical components run on one machine, and may run in a single OS process for simplicity. The backplane and leases still exist; they are simply uncontested and often implemented in-process.
+
+```mermaid
+flowchart TB
+  subgraph singleHost[SingleHostDeployment]
+    GatewayEdge[GatewayEdge]
+    ExecutionEngine[ExecutionEngine]
+    WorkerPool[Workers]
+    Scheduler["Scheduler (DB_lease)"]
+    StateStore["StateStore (SQLite)"]
+    Backplane["EventBackplane (in_process_or_outbox)"]
+
+    GatewayEdge --> ExecutionEngine
+    GatewayEdge <--> StateStore
+    ExecutionEngine <--> StateStore
+    WorkerPool <--> StateStore
+    Scheduler <--> StateStore
+
+    WorkerPool --> Backplane
+    ExecutionEngine --> Backplane
+    Backplane --> GatewayEdge
+  end
+
+  Client[Client] <--> GatewayEdge
+  NodeRuntime[Node] <--> GatewayEdge
+```
+
+### Cluster (replicated edge + replicated workers + leased scheduler)
+
+Gateway edge instances are replicated for connection handling and API capacity. Workers are replicated for throughput. The execution engine can be co-located with each gateway edge instance; coordination via the StateStore (leases/locks) keeps behavior consistent as replica counts change. Schedulers use DB-leases to prevent double-fires. Durable state lives in HA Postgres.
+
+```mermaid
+flowchart TB
+  Client[Client] --> LB[LoadBalancer]
+  NodeRuntime[Node] --> LB
+
+  LB --> EdgeA[GatewayEdge_A]
+  LB --> EdgeB[GatewayEdge_B]
+
+  EdgeA <--> StateStore["StateStore (HA Postgres)"]
+  EdgeB <--> StateStore
+
+  EdgeA --> EngineA[ExecutionEngine_A]
+  EdgeB --> EngineB[ExecutionEngine_B]
+
+  EngineA <--> StateStore
+  EngineB <--> StateStore
+
+  subgraph workerPool[Workers]
+    Worker1[Worker_1]
+    Worker2[Worker_2]
+  end
+
+  Worker1 <--> StateStore
+  Worker2 <--> StateStore
+
+  Scheduler["Scheduler (DB_lease)"] --> StateStore
+
+  Backplane["EventBackplane (outbox_pubsub)"]
+  Worker1 --> Backplane
+  Worker2 --> Backplane
+  EngineA --> Backplane
+  EngineB --> Backplane
+  Backplane --> EdgeA
+  Backplane --> EdgeB
+```
+

--- a/docs/architecture/secrets.md
+++ b/docs/architecture/secrets.md
@@ -33,6 +33,15 @@ An opaque reference to a stored secret. Handles are the only representation of s
 - The gateway (or a trusted executor) resolves the handle at the **last responsible moment** and injects the secret into the execution context.
 - Resolution must be **policy-gated** and **audited** (who requested, why, which scope).
 
+## Cluster notes
+
+In a single-host deployment, secret resolution can be local (for example OS keychain, encrypted local store, or environment variables). In multi-process and clustered deployments, secret handling must still preserve the same invariant: **raw secret values are never exposed to the model and are never persisted to the StateStore**.
+
+That implies one of the following patterns:
+
+- **Shared secret provider:** any process that executes steps (workers, trusted executors) can resolve secret handles via a provider reachable over a trusted channel.
+- **Gateway-mediated resolution:** only the gateway resolves handles and injects secrets into a trusted execution context (for example a paired node) without persisting the raw value.
+
 ## Redaction and logging
 
 - Raw secrets must never be written to the database, artifacts, or logs.

--- a/docs/architecture/sessions-lanes.md
+++ b/docs/architecture/sessions-lanes.md
@@ -57,6 +57,12 @@ The execution engine should associate each run with:
 
 Serialization is enforced per `(key, lane)` so concurrent work does not trample shared state, while still allowing independent lanes to progress.
 
+## Distributed serialization (all deployments)
+
+The `(key, lane)` serialization guarantee must be enforced using coordination backed by the StateStore (for example advisory locks or lease rows with expiry).
+
+With a single host and a single worker, these locks are typically uncontested, but they should still be acquired so the system behaves the same when scaled out: at most one run executes for a given `(key, lane)` at a time.
+
 ## Queue modes (target)
 
 Channels can choose how inbound messages are queued:


### PR DESCRIPTION
## Summary
- Add a WS-first Scaling & HA architecture doc (`docs/architecture/scaling-ha.md`).
- Update architecture docs to treat the database as a `StateStore (SQLite/Postgres)` and to document leases/backplane semantics so single-host behaves like a 1-replica cluster.
- Add protocol deployment notes for reconnect, at-least-once events, and retry/idempotency.
- Add the new doc to the docs sidebar.

## Test plan
- `pnpm -C apps/docs build`