### PR TITLE
Change default gateway default port to 8788

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pnpm --filter @tyrum/schemas build \
 
 ENV NODE_ENV=production
 
-EXPOSE 8080
+EXPOSE 8788
 
 RUN groupadd --system --gid 10001 tyrum \
   && useradd --system --uid 10001 --gid 10001 --create-home --home-dir /home/tyrum --shell /usr/sbin/nologin tyrum \

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ See `docs/install.md` for full details, version pinning, and update commands.
 5. **Run checks:** `pnpm typecheck && pnpm test && pnpm lint`
 6. **Start the gateway:** `pnpm --filter @tyrum/gateway start`
    - To enable singleton agent routes (`/agent/status`, `/agent/turn`), set `TYRUM_AGENT_ENABLED=1`.
-7. **Open the integrated web app:** `http://127.0.0.1:8080/app`
+7. **Open the integrated web app:** `http://127.0.0.1:8788/app`
 
 ### Localhost Safety Defaults
 
 - `GATEWAY_HOST` defaults to `127.0.0.1`.
-- `GATEWAY_PORT` defaults to `8080`.
+- `GATEWAY_PORT` defaults to `8788`.
 - Gateway auth token is required on localhost and non-local interfaces (`GATEWAY_TOKEN` env or `${TYRUM_HOME}/.admin-token`, auto-generated if missing).
 - The gateway serves the web UI directly at `/app` and supports WebSocket upgrades on `/ws`.
 
@@ -99,7 +99,7 @@ See `docs/install.md` for full details, version pinning, and update commands.
 | Build all packages | `pnpm build` |
 | Start gateway | `pnpm --filter @tyrum/gateway start` |
 | Start gateway + agent runtime | `TYRUM_AGENT_ENABLED=1 pnpm --filter @tyrum/gateway start` |
-| Open integrated app | `http://127.0.0.1:8080/app` |
+| Open integrated app | `http://127.0.0.1:8788/app` |
 
 ## Telegram Bot Setup
 

--- a/apps/desktop/src/main/config/schema.ts
+++ b/apps/desktop/src/main/config/schema.ts
@@ -12,17 +12,17 @@ export const DesktopNodeConfig = z.object({
   mode: z.enum(["embedded", "remote"]).default("embedded"),
   remote: z
     .object({
-      wsUrl: z.string().default("ws://127.0.0.1:8080/ws"),
+      wsUrl: z.string().default("ws://127.0.0.1:8788/ws"),
       tokenRef: z.string().default(""),
     })
-    .default({ wsUrl: "ws://127.0.0.1:8080/ws", tokenRef: "" }),
+    .default({ wsUrl: "ws://127.0.0.1:8788/ws", tokenRef: "" }),
   embedded: z
     .object({
-      port: z.number().int().min(1024).max(65535).default(8080),
+      port: z.number().int().min(1024).max(65535).default(8788),
       tokenRef: z.string().default(""),
       dbPath: z.string().default(""),
     })
-    .default({ port: 8080, tokenRef: "", dbPath: "" }),
+    .default({ port: 8788, tokenRef: "", dbPath: "" }),
   permissions: z
     .object({
       profile: PermissionProfile.default("balanced"),

--- a/apps/desktop/src/renderer/pages/Connection.tsx
+++ b/apps/desktop/src/renderer/pages/Connection.tsx
@@ -89,9 +89,9 @@ const infoStyle: React.CSSProperties = {
 export function Connection() {
   const [tab, setTab] = useState<Tab>("embedded");
   const [mode, setMode] = useState<string>("embedded");
-  const [port, setPort] = useState(8080);
+  const [port, setPort] = useState(8788);
   const [gatewayStatus, setGatewayStatus] = useState("stopped");
-  const [remoteUrl, setRemoteUrl] = useState("ws://127.0.0.1:8080/ws");
+  const [remoteUrl, setRemoteUrl] = useState("ws://127.0.0.1:8788/ws");
   const [remoteToken, setRemoteToken] = useState("");
   const [hasSavedRemoteToken, setHasSavedRemoteToken] = useState(false);
   const [nodeStatus, setNodeStatus] = useState("disconnected");

--- a/apps/desktop/src/renderer/pages/Gateway.tsx
+++ b/apps/desktop/src/renderer/pages/Gateway.tsx
@@ -118,8 +118,8 @@ export function Gateway({
 }: GatewayProps) {
   const [config, setConfig] = useState<GatewayConfigShape>({
     mode: "embedded",
-    embedded: { port: 8080 },
-    remote: { wsUrl: "ws://127.0.0.1:8080/ws" },
+    embedded: { port: 8788 },
+    remote: { wsUrl: "ws://127.0.0.1:8788/ws" },
   });
   const [gatewayStatus, setGatewayStatus] = useState("stopped");
   const [busy, setBusy] = useState(false);
@@ -170,11 +170,11 @@ export function Gateway({
             : {};
 
         const embeddedPort =
-          typeof embeddedRaw["port"] === "number" ? embeddedRaw["port"] : 8080;
+          typeof embeddedRaw["port"] === "number" ? embeddedRaw["port"] : 8788;
         const remoteWsUrl =
           typeof remoteRaw["wsUrl"] === "string"
             ? remoteRaw["wsUrl"]
-            : "ws://127.0.0.1:8080/ws";
+            : "ws://127.0.0.1:8788/ws";
 
         if (disposed) return;
         setConfig({

--- a/apps/desktop/src/renderer/pages/Overview.tsx
+++ b/apps/desktop/src/renderer/pages/Overview.tsx
@@ -118,7 +118,7 @@ export function Overview() {
       const mode = (c?.["mode"] as string) ?? "embedded";
       const embedded = c?.["embedded"] as Record<string, unknown> | undefined;
       const port =
-        typeof embedded?.["port"] === "number" ? (embedded["port"] as number) : 8080;
+        typeof embedded?.["port"] === "number" ? (embedded["port"] as number) : 8788;
       const capabilities: string[] = [];
       const caps = c?.["capabilities"] as Record<string, boolean> | undefined;
       if (caps) {
@@ -165,7 +165,7 @@ export function Overview() {
     if (!api || busy) return;
     setBusy(true);
     setGatewayError(null);
-    const port = status.port > 0 ? status.port : 8080;
+    const port = status.port > 0 ? status.port : 8788;
     try {
       await api.setConfig({
         mode: "embedded",

--- a/apps/desktop/tests/error-utils.test.ts
+++ b/apps/desktop/tests/error-utils.test.ts
@@ -5,11 +5,11 @@ describe("toErrorMessage", () => {
   it("strips Electron IPC wrapper prefixes", () => {
     const message = toErrorMessage(
       new Error(
-        "Error invoking remote method 'gateway:start': Error: listen EADDRINUSE: address already in use 127.0.0.1:8080",
+        "Error invoking remote method 'gateway:start': Error: listen EADDRINUSE: address already in use 127.0.0.1:8788",
       ),
     );
     expect(message).toBe(
-      "listen EADDRINUSE: address already in use 127.0.0.1:8080",
+      "listen EADDRINUSE: address already in use 127.0.0.1:8788",
     );
   });
 

--- a/apps/desktop/tests/gateway-ipc-handlers.test.ts
+++ b/apps/desktop/tests/gateway-ipc-handlers.test.ts
@@ -18,9 +18,9 @@ const {
   generateTokenMock: vi.fn(() => "generated-token"),
   encryptTokenMock: vi.fn((token: string) => `enc:${token}`),
   testState: {
-    port: 8080,
+    port: 8788,
     mode: "embedded" as "embedded" | "remote",
-    remoteWsUrl: "ws://127.0.0.1:8080/ws",
+    remoteWsUrl: "ws://127.0.0.1:8788/ws",
   },
 }));
 
@@ -77,9 +77,9 @@ vi.mock("../src/main/gateway-bin-path.js", () => ({
 describe("registerGatewayIpc handlers", () => {
   beforeEach(() => {
     vi.resetModules();
-    testState.port = 8080;
+    testState.port = 8788;
     testState.mode = "embedded";
-    testState.remoteWsUrl = "ws://127.0.0.1:8080/ws";
+    testState.remoteWsUrl = "ws://127.0.0.1:8788/ws";
     saveConfigMock.mockReset();
     decryptTokenMock.mockReset();
     decryptTokenMock.mockImplementation(() => "token");
@@ -118,7 +118,7 @@ describe("registerGatewayIpc handlers", () => {
     const startResult = await startHandler!({} as never);
     expect(startResult).toEqual({
       status: "running",
-      port: 8080,
+      port: 8788,
     });
 
     // Simulate elapsed time + tab remount where the renderer asks for a fresh status snapshot.
@@ -153,9 +153,9 @@ describe("registerGatewayIpc handlers", () => {
 
     const urls = await uiUrlsHandler!({} as never);
     expect(urls).toEqual({
-      embedUrl: "http://127.0.0.1:8080/app/auth?token=token&next=%2Fapp",
-      displayUrl: "http://127.0.0.1:8080/app",
-      externalUrl: "http://127.0.0.1:8080/app/auth?token=token&next=%2Fapp",
+      embedUrl: "http://127.0.0.1:8788/app/auth?token=token&next=%2Fapp",
+      displayUrl: "http://127.0.0.1:8788/app",
+      externalUrl: "http://127.0.0.1:8788/app/auth?token=token&next=%2Fapp",
     });
   });
 
@@ -181,9 +181,9 @@ describe("registerGatewayIpc handlers", () => {
 
     const urls = await uiUrlsHandler!({} as never);
     expect(urls).toEqual({
-      embedUrl: "http://127.0.0.1:8080/app/auth?token=generated-token&next=%2Fapp",
-      displayUrl: "http://127.0.0.1:8080/app",
-      externalUrl: "http://127.0.0.1:8080/app/auth?token=generated-token&next=%2Fapp",
+      embedUrl: "http://127.0.0.1:8788/app/auth?token=generated-token&next=%2Fapp",
+      displayUrl: "http://127.0.0.1:8788/app",
+      externalUrl: "http://127.0.0.1:8788/app/auth?token=generated-token&next=%2Fapp",
     });
     expect(generateTokenMock).toHaveBeenCalledTimes(1);
     expect(encryptTokenMock).toHaveBeenCalledWith("generated-token");
@@ -215,10 +215,10 @@ describe("registerGatewayIpc handlers", () => {
     const urls = await uiUrlsHandler!({} as never, { startOnboarding: true });
     expect(urls).toEqual({
       embedUrl:
-        "http://127.0.0.1:8080/app/auth?token=token&next=%2Fapp%2Fonboarding%2Fstart",
-      displayUrl: "http://127.0.0.1:8080/app/onboarding/start",
+        "http://127.0.0.1:8788/app/auth?token=token&next=%2Fapp%2Fonboarding%2Fstart",
+      displayUrl: "http://127.0.0.1:8788/app/onboarding/start",
       externalUrl:
-        "http://127.0.0.1:8080/app/auth?token=token&next=%2Fapp%2Fonboarding%2Fstart",
+        "http://127.0.0.1:8788/app/auth?token=token&next=%2Fapp%2Fonboarding%2Fstart",
     });
   });
 

--- a/apps/desktop/tests/gateway-ipc.test.ts
+++ b/apps/desktop/tests/gateway-ipc.test.ts
@@ -3,20 +3,20 @@ import { getGatewayStatusSnapshot } from "../src/main/ipc/gateway-status.js";
 
 describe("getGatewayStatusSnapshot", () => {
   it("returns running status so newly mounted tabs reflect live gateway state", () => {
-    const snapshot = getGatewayStatusSnapshot("running", 8080);
+    const snapshot = getGatewayStatusSnapshot("running", 8788);
 
     expect(snapshot).toEqual({
       status: "running",
-      port: 8080,
+      port: 8788,
     });
   });
 
   it("defaults to stopped when no manager status is available", () => {
-    const snapshot = getGatewayStatusSnapshot(undefined, 8080);
+    const snapshot = getGatewayStatusSnapshot(undefined, 8788);
 
     expect(snapshot).toEqual({
       status: "stopped",
-      port: 8080,
+      port: 8788,
     });
   });
 });

--- a/apps/desktop/tests/gateway-manager.test.ts
+++ b/apps/desktop/tests/gateway-manager.test.ts
@@ -58,11 +58,11 @@ describe("GatewayManager", () => {
   it("summarizes startup logs with highest-priority bind errors", () => {
     const reason = summarizeGatewayStartupFailure([
       "Watcher processor and scheduler started",
-      "Error: listen EADDRINUSE: address already in use 127.0.0.1:8080",
+      "Error: listen EADDRINUSE: address already in use 127.0.0.1:8788",
       "at Server.setupListenHandle (node:net:1940:16)",
     ]);
     expect(reason).toBe(
-      "Error: listen EADDRINUSE: address already in use 127.0.0.1:8080",
+      "Error: listen EADDRINUSE: address already in use 127.0.0.1:8788",
     );
   });
 

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -215,7 +215,7 @@ function writeDesktopConfig(tyrumHome: string, port: number, dbPath: string): vo
     version: 1,
     mode: "embedded",
     remote: {
-      wsUrl: "ws://127.0.0.1:8080/ws",
+      wsUrl: "ws://127.0.0.1:8788/ws",
       tokenRef: "",
     },
     embedded: {

--- a/apps/desktop/tests/main-lifecycle.test.ts
+++ b/apps/desktop/tests/main-lifecycle.test.ts
@@ -29,7 +29,7 @@ const {
   const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
   const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
     status: "running",
-    port: 8080,
+    port: 8788,
   }));
   const configExistsMock = vi.fn(() => true);
   const loadConfigMock = vi.fn(() => ({ mode: "embedded" }));

--- a/apps/desktop/tests/token-ref-normalizer.test.ts
+++ b/apps/desktop/tests/token-ref-normalizer.test.ts
@@ -39,7 +39,7 @@ describe("normalizeConfigPartialForSave", () => {
   it("encrypts embedded.tokenRef while preserving other embedded fields", () => {
     const normalized = normalizeConfigPartialForSave({
       embedded: {
-        port: 8080,
+        port: 8788,
         tokenRef: "embedded-secret-token",
       },
     });
@@ -49,6 +49,6 @@ describe("normalizeConfigPartialForSave", () => {
 
     expect(tokenRef).not.toBe("embedded-secret-token");
     expect(decryptToken(tokenRef)).toBe("embedded-secret-token");
-    expect(embedded["port"]).toBe(8080);
+    expect(embedded["port"]).toBe(8788);
   });
 });

--- a/charts/tyrum/values.yaml
+++ b/charts/tyrum/values.yaml
@@ -7,7 +7,7 @@ image:
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 8788
 
 gatewayToken:
   # If set, use this secret (key: token). Otherwise create one from value.
@@ -17,7 +17,7 @@ gatewayToken:
 env:
   TYRUM_HOME: /var/lib/tyrum
   GATEWAY_HOST: 0.0.0.0
-  GATEWAY_PORT: "8080"
+  GATEWAY_PORT: "8788"
   GATEWAY_DB_PATH: /var/lib/tyrum/gateway.db
   # Enterprise default per ADR-0007. Values: env|file|keychain
   TYRUM_SECRET_PROVIDER: env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       TYRUM_HOME: /var/lib/tyrum
       GATEWAY_HOST: 0.0.0.0
-      GATEWAY_PORT: "8080"
+      GATEWAY_PORT: "8788"
       GATEWAY_DB_PATH: /var/lib/tyrum/gateway.db
       # Artifact storage: default to filesystem; set TYRUM_ARTIFACT_STORE=s3 and
       # enable the "minio" profile to use object storage.
@@ -22,7 +22,7 @@ services:
       TYRUM_ARTIFACTS_S3_ACCESS_KEY_ID: ${TYRUM_ARTIFACTS_S3_ACCESS_KEY_ID:-}
       TYRUM_ARTIFACTS_S3_SECRET_ACCESS_KEY: ${TYRUM_ARTIFACTS_S3_SECRET_ACCESS_KEY:-}
     ports:
-      - "8080:8080"
+      - "8788:8788"
     volumes:
       - tyrum-data:/var/lib/tyrum
     restart: unless-stopped
@@ -39,7 +39,7 @@ services:
     environment:
       TYRUM_HOME: /var/lib/tyrum
       GATEWAY_HOST: 0.0.0.0
-      GATEWAY_PORT: "8080"
+      GATEWAY_PORT: "8788"
       GATEWAY_DB_PATH: ${GATEWAY_DB_PATH:-postgres://${POSTGRES_USER:-tyrum}:${POSTGRES_PASSWORD:-tyrum}@postgres:5432/${POSTGRES_DB:-tyrum}}
       # In split mode, ensure all services share the same admin token.
       GATEWAY_TOKEN: ${GATEWAY_TOKEN:-tyrum-dev-token}
@@ -58,7 +58,7 @@ services:
     depends_on:
       - postgres
     ports:
-      - "8080:8080"
+      - "8788:8788"
     restart: unless-stopped
 
   tyrum-worker:

--- a/docs/advanced/multi-node.md
+++ b/docs/advanced/multi-node.md
@@ -13,13 +13,13 @@ Use a unique `TYRUM_HOME` per node to keep databases and runtime state isolated.
 Node A:
 
 ```bash
-TYRUM_HOME=$HOME/.tyrum-a GATEWAY_PORT=8080 tyrum-gateway
+TYRUM_HOME=$HOME/.tyrum-a GATEWAY_PORT=8788 tyrum-gateway
 ```
 
 Node B:
 
 ```bash
-TYRUM_HOME=$HOME/.tyrum-b GATEWAY_PORT=8081 tyrum-gateway
+TYRUM_HOME=$HOME/.tyrum-b GATEWAY_PORT=8789 tyrum-gateway
 ```
 
 ## Recommended structure

--- a/docs/advanced/remote-gateway.md
+++ b/docs/advanced/remote-gateway.md
@@ -15,7 +15,7 @@ Use this when Tyrum needs to run on a different machine than your local workstat
 Example:
 
 ```bash
-GATEWAY_HOST=0.0.0.0 GATEWAY_PORT=8080 tyrum-gateway
+GATEWAY_HOST=0.0.0.0 GATEWAY_PORT=8788 tyrum-gateway
 ```
 
 ## Security expectations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ By default, Tyrum runs local-first and binds to `127.0.0.1`.
 
 Open:
 
-- `http://127.0.0.1:8080/app`
+- `http://127.0.0.1:8788/app`
 
 ## 4. Enable singleton agent routes (optional)
 
@@ -45,5 +45,5 @@ TYRUM_AGENT_ENABLED=1 tyrum-gateway
 Example:
 
 ```bash
-GATEWAY_PORT=8081 tyrum-gateway
+GATEWAY_PORT=8789 tyrum-gateway
 ```

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -297,7 +297,7 @@ export async function runShutdownCleanup(
 }
 
 export async function main(role: GatewayRole = "all"): Promise<void> {
-  const port = parseInt(process.env["GATEWAY_PORT"] ?? "8080", 10);
+  const port = parseInt(process.env["GATEWAY_PORT"] ?? "8788", 10);
   const host = process.env["GATEWAY_HOST"]?.trim() || "127.0.0.1";
   const dbPath = process.env["GATEWAY_DB_PATH"] ?? "gateway.db";
   assertSplitRoleUsesPostgres(role, dbPath);

--- a/packages/gateway/src/modules/agent/runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime.ts
@@ -227,7 +227,7 @@ function resolveModelBaseUrl(config: AgentConfigT): string {
   const port =
     process.env["GATEWAY_PORT"]?.trim() ||
     process.env["PORT"]?.trim() ||
-    "8080";
+    "8788";
 
   // Binding addresses like 0.0.0.0 / :: are not connectable as clients.
   const connectHost =

--- a/scripts/smoke-postgres-split.sh
+++ b/scripts/smoke-postgres-split.sh
@@ -10,7 +10,7 @@ docker compose --profile split up -d --build
 
 echo "[smoke] waiting for edge /healthz"
 for _ in $(seq 1 60); do
-  if curl -fsS "http://localhost:8080/healthz" >/dev/null; then
+  if curl -fsS "http://localhost:8788/healthz" >/dev/null; then
     echo "[smoke] healthz ok"
     break
   fi
@@ -78,4 +78,3 @@ await client.end();
 '
 
 echo "[smoke] ok"
-


### PR DESCRIPTION
Reduces collisions with common dev servers by moving the implicit default from 8080 to 8788.

- Gateway fallback port: 8788 (when GATEWAY_PORT is unset)
- Updated docker-compose, Helm values, docs, and Desktop defaults
- Override anytime via GATEWAY_PORT (e.g. 8080)