### PR TITLE
docs(architecture): messaging/session UX, auth, observability

### DIFF
--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -1,0 +1,86 @@
+# Provider Auth and Onboarding
+
+Tyrum supports multiple model providers and authentication mechanisms while preserving the invariant that raw credentials never enter model context.
+
+## Principles
+
+- **Secrets by handle:** credentials are stored in a secret provider and referenced via secret handles (see [Secrets](./secrets.md)).
+- **Least privilege:** auth profiles are scoped per agent and gated by policy.
+- **Observable and auditable:** auth changes, refreshes, and failovers emit events and are attributable to an operator identity.
+- **Deterministic failover:** when calls fail, Tyrum rotates credentials and models in a predictable order (see [Models](./models.md)).
+
+## Auth profiles
+
+An **auth profile** is a durable record that tells Tyrum how to authenticate to a provider.
+
+Profiles are **metadata + secret handles**:
+
+- `profile_id` (stable; used for routing/pinning)
+- `provider` (for example `openai`, `anthropic`, `openrouter`)
+- `type`:
+  - `api_key`
+  - `oauth` (access + refresh)
+  - `token` (non-refreshing bearer token)
+- `secret_handles` (for example `api_key_handle`, `oauth_refresh_handle`)
+- `expires_at` (when applicable)
+- optional labels (`email`, `account_id`, `workspace`, `notes`)
+
+Profiles are scoped per `agent_id`. Cross-agent sharing is deny-by-default and requires explicit policy.
+
+## OAuth flows (subscription and multi-account)
+
+When a provider supports OAuth, Tyrum supports interactive login and headless login:
+
+- **Interactive (PKCE / local callback):** a local callback endpoint completes the exchange.
+- **Headless (paste / device-code):** the operator pastes a code or redirect URL to complete login.
+
+OAuth tokens are stored via the secret provider; only token **handles** are persisted in Tyrum state. Refresh is automatic:
+
+- access tokens are refreshed under a lock
+- refresh outputs overwrite the prior handles
+- refresh failures are surfaced as structured events and status surfaces
+
+Multiple accounts are represented as multiple auth profiles for the same provider (distinct `profile_id`s).
+
+## Credential selection, pinning, and rotation
+
+For a given provider, Tyrum selects an auth profile using:
+
+1. An explicit configured order (if present).
+2. Stored profiles for the provider (stable, deterministic ordering).
+
+Selections are **pinned per session** to keep provider caches warm and to make behavior repeatable. The pinned profile is reused until:
+
+- the session is reset
+- the profile expires or is revoked
+- the profile enters cooldown due to repeated transient failures
+
+### Cooldowns and disabling
+
+When a request fails, Tyrum classifies the failure and reacts predictably:
+
+- **Rate limit / transient:** rotate to the next profile for the provider and apply a cooldown to the failing profile.
+- **Auth invalid / revoked:** disable the profile until an operator re-authenticates.
+- **Billing / quota exhausted:** disable the profile with a long backoff and rotate to another profile or model fallback.
+
+Cooldown/disable state is durable and visible in the control panel and `/status`.
+
+## Operator UX (CLI + control panel)
+
+Tyrum exposes a small operator surface for auth lifecycle:
+
+- Add/remove profiles (API key and OAuth).
+- List profiles and their status (expiry, cooldown, disabled reason).
+- Select a profile globally or per-session (pin override).
+- Export a redacted auth inventory (no secret material).
+
+All auth mutations require an authenticated operator identity and are audited.
+
+## Integration points
+
+Auth profiles integrate with:
+
+- **Policy:** which providers/profiles can be used for which sessions and lanes.
+- **Approvals:** high-risk auth changes (adding a privileged key, granting a broad OAuth scope) can be approval-gated.
+- **Usage tracking:** provider usage endpoints are queried using the active profile and displayed in `/usage` and UI surfaces (see [Observability](./observability.md)).
+

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -2,6 +2,8 @@
 
 Channels are message transports that connect Tyrum to external chat surfaces. A channel connector normalizes inbound messages into session events and sends outbound messages when the agent replies.
 
+Channel connectors are a high-risk integration boundary. They are responsible for preserving identity, provenance, and auditability while presenting a consistent messaging model to the gateway.
+
 ## Channel types (examples)
 
 - WhatsApp (DM, group)
@@ -18,8 +20,43 @@ Even when APIs differ, Tyrum should normalize "where a conversation lives" into 
 - **DM:** direct message thread
 - **Group:** group chat
 - **Channel:** named channel (server/workspace)
+- **Thread:** optional sub-container (topics/threads) when supported by the provider
+
+Normalized inbound messages follow the envelope rules described in [Messages and Sessions](./messages-sessions.md).
+
+## Inbound reliability (dedupe + debounce)
+
+Connectors make inbound delivery safe and cost-efficient:
+
+- **Dedupe:** prevent redelivery from spawning duplicate runs using a stable `(channel, account_id, container_id, message_id)` key.
+- **Debounce:** batch rapid bursts of text into a single turn per container, while attachments flush immediately.
+
+Both behaviors are observable via events and do not weaken execution guarantees.
+
+## Queueing while running
+
+If a run is already active for the target session/lane, connectors apply an explicit queue mode (`collect`, `followup`, `steer`, `steer_backlog`, `interrupt`). Queueing is lane-aware and bounded (cap + overflow policy). Details: [Messages and Sessions](./messages-sessions.md).
+
+## Outbound delivery (side effects)
+
+Outbound sends are treated as side effects:
+
+- Each send carries an idempotency key so retries do not duplicate messages.
+- Provider receipts (message ids, timestamps, errors) are captured as audit events and can be stored as artifacts.
+- Sending is policy-gated (allowlists, scope rules, and approvals for risky sends).
+
+## Formatting, chunking, and streaming
+
+Connectors render assistant output in a channel-safe way:
+
+- **Markdown → IR → chunk → render** to avoid breaking formatting across chunks.
+- Channel-specific caps are enforced (max chars, max lines, media limits).
+- Block streaming and typing indicators are supported where providers allow it.
+
+Details: [Markdown Formatting](./markdown-formatting.md).
 
 ## Safety expectations
 
 - Connector configuration should be explicit and scoped.
 - Message sending should be auditable (evented) and redact secrets by default.
+- Connectors must not bypass approvals/policy/sandboxing by “helpfully” performing side effects outside the execution engine.

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -25,6 +25,8 @@ The gateway’s web control panel is a client form that connects over WebSocket 
 - **Session:** a session-centric view rendered as a unified timeline that merges chat, runs/steps/attempts, approvals, and artifacts (reconstructible from durable state; live events stream updates). The UI supports lane filters and surfaces queue-mode semantics as pending input items.
 - **Approvals:** an approval queue (approve/deny) with previews and linked evidence.
 - **Nodes/devices:** pairing requests, connected capability providers, revoke controls.
+- **Instances:** a presence view of connected gateway/client/node instances with TTL-based pruning (see [Presence](./presence.md)).
+- **Context/usage:** context breakdown (`/context`) and usage/quota panels (`/usage`) for operational transparency (see [Observability](./observability.md)).
 - **Settings:** policy defaults, tool allowlists, model config, secrets setup, and automation toggles.
 
 ## What a client is not

--- a/docs/architecture/context-compaction.md
+++ b/docs/architecture/context-compaction.md
@@ -1,6 +1,6 @@
-# Context and Compaction
+# Context, Compaction, and Pruning
 
-The context for a run is the message stack provided to the model. Context is bounded by the model's context window (token limit), so long-running sessions need compaction.
+The context for a run is the message stack provided to the model. Context is bounded by the model's context window (token limit), so long-running sessions use compaction and pruning to stay within limits without losing safety-critical information.
 
 ## Context stack
 
@@ -9,6 +9,19 @@ Typical layers:
 - System prompt (rules, tools, skills, runtime, injected files)
 - Conversation history (user + assistant messages)
 - Tool calls/results and attachments (command output, files, images/audio)
+
+Tool schemas (contracts) are also part of what the model receives and therefore count toward the context window even though they are not plain-text history.
+
+## Context reports (inspectability)
+
+For observability, the gateway produces a per-run context report that captures:
+
+- injected workspace files (raw vs injected sizes)
+- system prompt section sizes
+- largest tool schema contributors
+- recent-history and tool-result contributions
+
+Operator clients expose the report via `/context list` and `/context detail` (see [Observability](./observability.md)).
 
 ## Compaction
 
@@ -19,3 +32,13 @@ Compaction should:
 - Keep approvals, constraints, and user preferences intact.
 - Preserve key decisions and unfinished threads.
 - Avoid inventing facts or deleting obligations.
+
+## Pruning (tool-result trimming)
+
+Pruning reduces context bloat by trimming or clearing older tool results in the prompt for a single run while leaving the durable transcript intact.
+
+Pruning:
+
+- applies only to tool-result messages (never to user or assistant turns)
+- is deterministic and policy-controlled
+- is designed to improve cost and cache behavior for providers that support prompt caching

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -81,7 +81,7 @@ A typed operation and typed reply correlated by `request_id`. Either peer may in
 
 ## Session
 
-A durable conversation container with transcript history and queued inbound messages.
+A durable conversation container with transcript history and queue state. Session keys and DM scope rules determine which messages share context.
 
 ## Skill
 
@@ -126,3 +126,43 @@ An out-of-process component responsible for storing and retrieving secrets. It r
 ## Secret handle
 
 An opaque reference to a secret stored in the secret provider. Executors and capability providers use handles to obtain the secret value at the last responsible moment; the model never receives the raw value.
+
+## Auth profile
+
+A durable record describing how Tyrum authenticates to a provider (API key or OAuth), represented as metadata plus secret handles. Auth profiles are scoped per agent and participate in deterministic rotation and model failover.
+
+## Context report
+
+A gateway-generated breakdown of what was included in a model call (system prompt sections, injected files, tool schema overhead, and history/tool-result contributions). Context reports are persisted with runs for audit and debugging.
+
+## Debounce
+
+A per-container batching mechanism that coalesces rapid bursts of inbound text messages into a single agent turn within a time window.
+
+## Dedupe
+
+A reliability mechanism that detects and drops duplicate inbound deliveries (for example channel redelivery after reconnect) so they do not start duplicate runs.
+
+## DM scope
+
+A policy that determines how direct messages map to session keys (`shared`, `per_peer`, `per_channel_peer`, `per_account_channel_peer`) to prevent cross-sender context leakage in multi-user inboxes.
+
+## Queue mode
+
+The policy used when a run is already active for a session/lane, controlling whether inbound messages are collected, enqueued for follow-up, steered into the in-flight run, or interrupt the run.
+
+## Markdown IR
+
+An intermediate representation of Markdown used for channel-safe chunking and rendering: plain text plus structured spans for styles, links, and blocks.
+
+## Presence
+
+A best-effort, TTL-bounded view of the gateway, connected clients, and connected nodes, used for operator visibility (“Instances”).
+
+## Typing indicator
+
+A channel-side UX signal sent while a run is active to indicate the system is working. Typing behavior is connector-specific and policy-controlled.
+
+## Usage tracking
+
+Operator-visible accounting of tokens/time/cost per run and provider-reported usage/quota windows when available, exposed via `/usage` and UI panels.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -58,6 +58,7 @@ flowchart LR
 - **Playbooks:** deterministic workflow specs executed by the runtime (approval gates + resume tokens).
 - **Approvals:** durable operator confirmation requests that gate risky actions and pause/resume workflows.
 - **Secrets:** a first-class boundary; raw secrets stay behind a secret provider and are referenced via handles.
+- **Auth profiles:** provider credentials (API keys/OAuth) expressed as metadata + secret handles for deterministic selection and rotation. See [Provider Auth and Onboarding](./auth.md).
 - **Artifacts:** evidence objects stored outside the StateStore with policy-gated access. See [Artifacts](./artifacts.md).
 - **Client:** an operator interface connected to the gateway (desktop/mobile/CLI/web).
 - **Node:** a capability provider connected to the gateway (desktop/mobile/headless).
@@ -80,11 +81,15 @@ flowchart LR
 - [Scaling and high availability](./scaling-ha.md)
 - [Gateway](./gateway/index.md)
 - [Execution engine](./execution-engine.md)
+- [Messages and Sessions](./messages-sessions.md)
 - [Playbooks](./playbooks.md)
 - [Approvals](./approvals.md)
 - [Secrets](./secrets.md)
+- [Provider Auth and Onboarding](./auth.md)
 - [Artifacts](./artifacts.md)
 - [Sandbox and policy](./sandbox-policy.md)
+- [Observability](./observability.md)
+- [Presence](./presence.md)
 - [Client](./client.md)
 - [Node](./node.md)
 - [Protocol](./protocol/index.md)

--- a/docs/architecture/markdown-formatting.md
+++ b/docs/architecture/markdown-formatting.md
@@ -1,0 +1,64 @@
+# Markdown Formatting
+
+Tyrum formats assistant output for outbound channels by converting Markdown into a neutral intermediate representation (IR) before chunking and rendering.
+
+## Goals
+
+- **Consistency:** one parse step, many channel renderers.
+- **Safe chunking:** split before rendering so inline formatting and code fences stay valid.
+- **Channel fit:** map the same IR to Slack/Telegram/Discord/etc. without re-parsing.
+- **Security:** escape/encode channel markup correctly and avoid link/HTML injection.
+
+## Pipeline
+
+1. **Parse Markdown → IR**
+   - IR is plain text plus structured spans:
+     - styles: bold/italic/strike/inline-code/spoiler (where supported)
+     - links: `{start,end,href}`
+     - blocks: paragraphs, lists, blockquotes, code blocks/fences
+   - Parsing is deterministic and does not execute embedded HTML/JS.
+
+2. **Chunk IR (format-first)**
+   - Chunking happens on the IR text, not on channel markup.
+   - Rules:
+     - never split inside inline styles
+     - never split inside fenced code blocks; when forced, close + reopen the fence
+     - prefer chunk breaks at paragraph boundaries, then newlines, then whitespace
+   - Chunk sizes are clamped by each channel’s text limits.
+
+3. **Render per channel**
+   - Each channel adapter renders from IR into the channel’s native format:
+     - Slack: mrkdwn tokens + safe link rendering
+     - Telegram: HTML parse mode with strict escaping
+     - Discord: Markdown with length/line caps
+     - WhatsApp/Signal/iMessage: conservative formatting subset
+
+## Tables
+
+Markdown tables are normalized using a channel policy:
+
+- `code`: render as a fenced code block (portable default)
+- `bullets`: convert rows into bullet points (mobile-friendly)
+- `off`: pass through as plain text
+
+## Link policy
+
+Links are rendered with channel-safe rules:
+
+- preserve label vs href when the channel supports it
+- when the channel cannot represent labeled links, render as `label (url)`
+- normalize and validate URL schemes; disallowed schemes are rendered as plain text
+
+## Fallbacks (never fail closed)
+
+If parsing or rendering fails for a chunk:
+
+- fall back to plain text for that chunk
+- emit an event indicating a formatting fallback occurred
+
+This keeps delivery robust under channel-specific formatting quirks without losing the underlying content.
+
+## Interaction with streaming
+
+Block streaming uses the same IR chunker. This guarantees that streamed partial replies and final replies share identical chunk boundaries and formatting rules.
+

--- a/docs/architecture/messages-sessions.md
+++ b/docs/architecture/messages-sessions.md
@@ -1,0 +1,165 @@
+# Messages and Sessions
+
+This document defines how Tyrum turns inbound messages into durable sessions and serialized execution, while keeping chat UX responsive and safe across channels.
+
+## Message flow (end-to-end)
+
+```mermaid
+flowchart TB
+  IN["Inbound message<br/>(channel / client)"] --> NORM["Normalize + tag provenance<br/>(container, sender, ids, timestamps)"]
+  NORM --> ROUTE["Route to agent_id + session key"]
+  ROUTE --> Q["Queue policy<br/>(collect/followup/steer/steer_backlog/interrupt)"]
+  Q --> LOOP["Agent loop<br/>(context assembly + planning)"]
+  LOOP --> ENG["Execution engine<br/>(durable run/steps + approvals + evidence)"]
+  ENG --> OUT["Outbound delivery<br/>(channel send + client streams)"]
+  OUT --> PERSIST["Persist<br/>(transcript + run log + events + artifacts)"]
+```
+
+Key invariants:
+
+- **Durable truth:** the StateStore is the source of truth for transcripts and run state.
+- **Serialization:** at most one run executes per `(session_key, lane)` at a time (see [Sessions and Lanes](./sessions-lanes.md)).
+- **Side effects are controlled:** outbound sends, filesystem, shell, and secret resolution are governed by policy/approvals/sandboxing, and produce audit evidence when feasible.
+
+## Normalization (what every connector produces)
+
+Channel connectors normalize inbound payloads into a small, typed envelope:
+
+- **Container:** `dm | group | channel` plus provider-native ids (conversation/thread identifiers).
+- **Sender identity:** stable sender id (and display labels where available).
+- **Delivery identity:** connector/account identity (so multiple accounts on the same channel are distinct).
+- **Message identity:** provider message id (or a derived stable id when missing), plus a receive timestamp.
+- **Content:** text + attachments, with attachment metadata (type, size, hashes when available).
+- **Provenance tags:** whether content is user-supplied, connector-supplied, tool-supplied, or system-supplied.
+
+Connectors treat inbound content as **data**, not instructions. Provenance is preserved so policy can enforce rules such as “require approval before acting on web-derived content” or “deny outbound sends derived from untrusted sources without operator confirmation”.
+
+## Sessions (durable conversation containers)
+
+Sessions are durable conversation containers with stored transcripts and metadata. Session keys are stable and chosen by Tyrum, not by the model.
+
+### DM isolation (secure by default for multi-user inboxes)
+
+Tyrum isolates direct-message context by default when more than one distinct sender can reach an agent via DMs. This prevents cross-user context leakage.
+
+Session key selection follows a **DM scope** policy:
+
+- `shared` (single-user continuity): all DMs for an agent/channel collapse into a shared key.
+- `per_peer` (secure DM mode): each sender gets an isolated DM session.
+- `per_channel_peer`: isolate by `(channel, sender)`.
+- `per_account_channel_peer`: isolate by `(account, channel, sender)` for multi-account inboxes.
+
+Identity linking can optionally map multiple provider sender ids to a canonical identity so the same person shares a DM session across channels when using the per-peer modes.
+
+The exact key formats are defined in [Sessions and Lanes](./sessions-lanes.md).
+
+## Inbound dedupe (don’t run twice)
+
+Channels can redeliver the same inbound message after reconnects and retries. Tyrum prevents duplicate runs by deduping inbound deliveries before they enqueue work.
+
+Dedupe is keyed by stable identifiers, typically:
+
+- `(channel, account_id, container_id, message_id)`
+
+Dedupe entries are time-bounded (TTL) and stored in a way that remains correct under clustered gateway edges. When a duplicate delivery is detected, Tyrum records an audit event and drops the duplicate without starting another run.
+
+## Inbound debouncing (batch rapid bursts)
+
+Rapid consecutive messages from the same sender/container are batched into a single agent turn using a per-container debounce window:
+
+- Text-only messages arriving within the window are appended to a single “batched input”.
+- Attachments flush immediately (no batching) to preserve ordering and evidence.
+- Standalone control commands bypass debouncing so operator actions stay responsive.
+
+Debouncing reduces unnecessary model calls while preserving the visible ordering of user intent.
+
+## Queueing semantics (when a run is already active)
+
+When a run is active for a `(session_key, lane)`, inbound messages are handled by an explicit queue mode. Queueing is lane-aware so automation lanes do not trample interactive lanes.
+
+### Queue modes
+
+- **`collect` (default):** coalesce queued messages into a single follow-up turn after the active run ends.
+- **`followup`:** enqueue each message as its own follow-up turn (preserves turn-by-turn granularity).
+- **`steer`:** inject the new message into the in-flight run at the next tool boundary and cancel pending tool calls for the current assistant message.
+- **`steer_backlog`:** steer now and also preserve the message for a follow-up turn.
+- **`interrupt`:** abort the active run (at the next safe boundary) and run the newest message.
+
+### Queue limits and overflow policy
+
+Queueing is bounded to keep the system predictable:
+
+- `cap`: maximum queued items per `(session_key, lane)`.
+- `debounce_ms`: quiet-time window used by `collect` to batch bursts into one follow-up.
+- `overflow`: what happens when `cap` is exceeded:
+  - `drop_oldest`
+  - `drop_newest`
+  - `summarize_dropped` (creates a synthetic follow-up message that summarizes the dropped items)
+
+Overflow handling is observable via events so operators can see when messages were dropped or summarized.
+
+### Interaction with execution guarantees
+
+Queued follow-ups are represented as durable jobs/runs in the execution engine. Side-effecting operations inside the active run remain governed by:
+
+- per-step idempotency keys
+- approvals (pause/resume)
+- sandbox/policy enforcement
+- evidence capture and postconditions (when feasible)
+
+`steer` and `interrupt` are conservative: they only take effect at safe boundaries and never violate the “one run per `(session_key, lane)`” invariant.
+
+## Outbound delivery (clients vs channels)
+
+Tyrum delivers outputs to two audiences:
+
+### Operator clients (WebSocket streams)
+
+Operator clients receive server-push events for:
+
+- run/step lifecycle (queued/running/paused/resumed/completed)
+- tool execution progress
+- approvals requested/resolved
+- artifacts created/attached/fetched
+- assistant output deltas and final replies (when streaming is enabled)
+
+These streams are typed, at-least-once, and deduplicated by ids.
+
+### Channels (chat surfaces)
+
+Outbound channel sends are treated as **side effects**:
+
+- They carry explicit idempotency keys so retries do not duplicate messages.
+- They are eligible for approval gates (for example “message new recipient”, “message derived from untrusted content”, or “high-cost broadcast”).
+- They produce audit events and, when applicable, evidence artifacts (provider receipts, message ids, rendered payloads).
+
+## Streaming, typing, and pacing
+
+Tyrum supports user-facing responsiveness without sacrificing determinism:
+
+- **Block streaming (channels):** long replies can be emitted in coarse, completed blocks instead of waiting for the final message.
+- **Typing indicators:** connectors can send “typing…” signals while a run is active, with configurable start modes and refresh cadence.
+- **Human pacing:** optional small delays between streamed blocks to reduce “spammy” multi-message bursts.
+
+Streaming and typing never override safety: policy/approvals still gate side effects, and streaming output is subject to redaction and size limits.
+
+### Typing modes
+
+Typing start behavior is explicit and policy-driven:
+
+- `never` — do not emit typing indicators.
+- `message` — start typing when the first non-silent assistant text is produced.
+- `thinking` — start typing when reasoning/thinking output begins (when supported).
+- `instant` — start typing as soon as a run is accepted for the session/lane.
+
+Typing refresh cadence is bounded and disabled for non-interactive automation lanes unless explicitly enabled.
+
+## Markdown formatting and chunking (channel-safe)
+
+Tyrum preserves consistent formatting across channels by chunking **before** rendering into channel-specific markup:
+
+1. Parse assistant Markdown into a neutral IR (text + spans for styles/links).
+2. Chunk the IR into channel-sized blocks without breaking inline formatting or code fences.
+3. Render each chunk into the channel’s supported format (or fall back to plain text).
+
+Details: [Markdown Formatting](./markdown-formatting.md).

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -20,3 +20,25 @@ When a model call fails, Tyrum attempts recovery in a predictable order:
 2. **Model fallback** to the next model in an explicit fallback chain.
 
 Failures should be surfaced as structured events so clients can show what happened and why.
+
+## Auth profile selection (within a provider)
+
+Providers can have multiple **auth profiles** (API keys and/or OAuth profiles). Profiles are scoped per agent, reference secrets by handle, and can represent multiple accounts.
+
+Selection behavior is deterministic:
+
+- a profile can be explicitly pinned (globally or per-session)
+- otherwise Tyrum chooses a stable default order and pins the chosen profile per session
+- on rate limits and transient failures, Tyrum rotates to the next eligible profile and applies cooldowns
+
+Details: [Provider Auth and Onboarding](./auth.md) and [Secrets](./secrets.md).
+
+## Observability
+
+Model selection emits events that include:
+
+- chosen `provider/model`
+- chosen auth profile id (redacted)
+- rotations, cooldowns, and fallback decisions
+
+Operator surfaces (`/status`, `/usage`, UI settings) expose the active model/provider, auth profile state, and provider usage where available (see [Observability](./observability.md)).

--- a/docs/architecture/multi-agent-routing.md
+++ b/docs/architecture/multi-agent-routing.md
@@ -21,8 +21,9 @@ Inbound events are mapped to an agent via explicit, auditable bindings.
 
 Routing uses the session key conventions described in [Sessions and lanes](./sessions-lanes.md).
 
-- `channel` identifies a connector/account instance (for example `telegram-main`, `whatsapp-family`).
-- Provider-native thread/container identifiers are preserved and stored in the key’s `<id>` portion.
+- `channel` and `account` identify the connector/account instance (`channel=telegram`, `account=work`).
+- Provider-native thread/container identifiers are preserved and stored in the key’s `<id>` portion for groups/channels.
+- Direct-message session keys are chosen using `dm_scope` so multi-user inboxes default to per-sender isolation.
 
 This supports multiple accounts on one gateway while keeping session ids stable.
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,58 @@
+# Observability (Context, Usage, and Audit)
+
+Tyrum is designed so operators can answer: “what happened, why, and what did it cost?” without guessing.
+
+## Core surfaces
+
+### Status
+
+`/status` (and equivalent UI panels) show:
+
+- active model/provider and selected auth profile
+- session key + lane, run state, and queue depth
+- context window utilization (estimated + last-run measured)
+- sandbox/policy mode and whether elevated execution is available
+
+### Context inspection
+
+`/context list` and `/context detail` expose a “context report” for the last run:
+
+- system prompt sections and sizes
+- injected workspace files (raw vs injected, truncation markers)
+- skills list overhead
+- **tool schema overhead** (largest tool contracts and their sizes)
+- recent conversation history size and tool-result contributions
+
+Context reports are generated deterministically by the gateway and persisted alongside the run so “what the model saw” is inspectable after the fact.
+
+### Usage and cost
+
+`/usage` surfaces two complementary views:
+
+- **Local accounting:** tokens/time attributed to runs/steps/attempts (source of truth for budgets and approvals).
+- **Provider usage:** provider-reported quota/usage windows when a provider exposes a usage endpoint and credentials allow access.
+
+Usage is scoped to the current session by default, with agent-wide and deployment-wide rollups available in the control panel.
+
+## Events, logs, and evidence
+
+Tyrum emits typed events for:
+
+- approvals requested/resolved
+- runs/steps lifecycle and retries
+- policy decisions (allow/deny/require-approval + reasons + snapshot references)
+- artifacts created/attached/fetched
+- model/provider selection, auth rotation, and fallback decisions
+
+Durable logs include stable ids (`run_id`, `step_id`, `attempt_id`, `approval_id`, `artifact_id`, `policy_snapshot_id`) so operators can correlate UI, DB records, and exported bundles.
+
+## Provider quota polling
+
+When enabled, Tyrum queries provider usage endpoints using the active auth profile:
+
+- polling is rate-limited and cached
+- failures are non-fatal and reported as structured status fields
+- results are never treated as authoritative billing records; they are operator guidance
+
+Provider polling respects policy: usage endpoints are only queried for allowed providers/profiles and never with raw secret values in model context.
+

--- a/docs/architecture/presence.md
+++ b/docs/architecture/presence.md
@@ -1,0 +1,59 @@
+# Presence and Instances
+
+Presence is Tyrum’s lightweight, best-effort view of:
+
+- the gateway service itself, and
+- operator clients and nodes connected to the gateway.
+
+Presence exists to give operators immediate visibility into “what is connected and healthy” without reading logs.
+
+## Presence entries
+
+Presence entries are structured objects with fields like:
+
+- `instance_id`: stable device identity (derived from the device public key; see [Handshake](./protocol/handshake.md)).
+- `role`: `gateway | client | node`.
+- `host`: human-friendly host label.
+- `ip`: best-effort remote address (with tunnel-aware handling).
+- `version`: client/node version string (when provided).
+- `mode`: `ui | web | cli | node | backend | probe | test` (used for filtering).
+- `last_seen_at`: last update timestamp.
+- `last_input_seconds`: optional “seconds since last user input” (when clients report it).
+- `reason`: `self | connect | periodic | node-connected`.
+
+## Producers (where presence comes from)
+
+Presence entries are produced by multiple sources and merged:
+
+1. **Gateway self entry:** the gateway always seeds a `role=gateway` entry at startup.
+2. **WebSocket connect:** successful `connect.init/connect.proof` upserts a presence entry for the connecting device.
+3. **Periodic beacons:** clients can send periodic “system presence” beacons with richer fields (host name, last input, etc.).
+4. **Node heartbeats:** nodes periodically refresh their presence while connected.
+
+Short-lived, one-off CLI connections can be excluded from presence by `mode` to avoid spamming operator UIs.
+
+## Merge and dedupe rules
+
+Presence is keyed by stable device identity (`instance_id`). When a device reconnects, Tyrum updates the existing entry instead of creating duplicates.
+
+Tunnel caveat: when a connection arrives through a local port-forward, the gateway may observe `127.0.0.1` as the remote address. In that case, client-reported IP/host fields from periodic beacons take precedence.
+
+## TTL and bounded size
+
+Presence is intentionally ephemeral:
+
+- entries older than a configured TTL are pruned
+- total entries are capped (oldest dropped first)
+
+Prunes emit events so UIs can remove stale rows.
+
+## Consumers
+
+Operator surfaces consume presence as:
+
+- an “Instances” panel in the gateway control UI
+- `/presence` and `/status` command output
+- diagnostics exports for support and debugging
+
+Presence is access-controlled: only authenticated operator clients can view presence entries.
+

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -15,12 +15,15 @@ The canonical wire shape lives in `@tyrum/schemas` (`packages/schemas/src/protoc
 ## Common event categories
 
 - **Connection lifecycle:** connected/disconnected, heartbeat timeouts.
+- **Presence:** gateway/client/node presence upserts, prunes, and snapshots (see [Presence](../presence.md)).
 - **Pairing:** node requested/approved/denied/revoked.
 - **Approvals:** requests/resolutions, expiry.
 - **Execution engine:** run queued/started/paused/resumed/completed/failed; step started/completed; retries and budget events.
 - **Evidence:** artifacts captured/attached; postconditions passed/failed.
 - **Agent runtime:** plan/workflow selection and high-level intent updates.
 - **Memory:** facts/events written, compaction, snapshots.
+- **Messaging UX:** typing indicators, outbound delivery receipts, and formatting fallbacks.
+- **Observability:** context reports, usage snapshots, and provider quota polling status.
 
 ## Notes
 

--- a/docs/architecture/secrets.md
+++ b/docs/architecture/secrets.md
@@ -74,6 +74,17 @@ Redaction is enforced at persistence and egress boundaries:
 - Web session cookies (stored with explicit expiry metadata)
 - Payment instruments (only if explicitly enabled by the operator and supported by policy)
 
+## Provider credentials and auth profiles
+
+Model-provider credentials (API keys and OAuth tokens) are represented as:
+
+- secret handles stored in the secret provider, and
+- auth profile metadata scoped to an agent (profile id, provider, expiry, labels)
+
+Auth profiles are used for deterministic credential selection, rotation, and multi-account routing without exposing raw secrets to the model.
+
+Details: [Provider Auth and Onboarding](./auth.md).
+
 ## Workflow and approval integration
 
 - Workflows may reference secret handles as parameters.

--- a/docs/architecture/sessions-lanes.md
+++ b/docs/architecture/sessions-lanes.md
@@ -4,7 +4,9 @@ A session is a durable conversation container. A lane is an execution stream wit
 
 ## Sessions
 
-- One primary direct-chat session per agent.
+- Direct messages are scoped to prevent cross-user context leakage.
+- Single-user deployments use a shared direct-chat session for continuity.
+- Multi-user inbox deployments isolate direct chats per sender by default.
 - Session transcripts are stored and can be replayed for troubleshooting.
 - Session identifiers are stable and chosen by Tyrum (not by the model).
 
@@ -16,12 +18,28 @@ The gateway uses stable keys to:
 - serialize execution per lane
 - make audit and replay reliable
 
+## Direct-message scope (secure DM mode)
+
+Tyrum chooses a direct-message scope (`dm_scope`) per agent/channel surface:
+
+- `shared` — all DMs share one session (single-user continuity).
+- `per_peer` — isolate by sender identity (secure DM mode).
+- `per_channel_peer` — isolate by `(channel, sender)`.
+- `per_account_channel_peer` — isolate by `(channel, account, sender)`.
+
+When more than one distinct sender can DM an agent (for example a DM allowlist with multiple entries or an “open DM” policy), Tyrum uses `per_account_channel_peer` by default.
+
+Identity linking can map multiple provider sender ids to a canonical identity so the same person shares a DM session across channels when `dm_scope` is `per_peer`.
+
 ### Key scheme
 
 - **Agent sessions**
-  - `agent:<agentId>:<channel>:main`
-  - `agent:<agentId>:<channel>:group:<id>`
-  - `agent:<agentId>:<channel>:channel:<id>`
+  - Direct (shared): `agent:<agentId>:main`
+  - Direct (per peer): `agent:<agentId>:dm:<peerId>`
+  - Direct (per channel + peer): `agent:<agentId>:<channel>:dm:<peerId>`
+  - Direct (per account + channel + peer): `agent:<agentId>:<channel>:<account>:dm:<peerId>`
+  - Group: `agent:<agentId>:<channel>:<account>:group:<id>`
+  - Channel: `agent:<agentId>:<channel>:<account>:channel:<id>`
 - **Cron**
   - `cron:<jobId>`
 - **Hook**
@@ -32,7 +50,9 @@ The gateway uses stable keys to:
 ### Notes
 
 - `<agentId>` is the gateway’s internal agent identifier.
-- `<channel>` should identify a specific connector/account instance (not just a channel type) so multiple accounts can coexist.
+- `<channel>` is the channel type (for example `telegram`, `whatsapp`, `discord`).
+- `<account>` identifies a configured account/connector instance (for example `default`, `family`, `work`) so multiple accounts can coexist safely.
+- `<peerId>` is the sender identity for DMs (provider-native or canonical identity when identity linking is enabled).
 - `<id>` is the provider-native thread/container identifier (for example a Telegram chat id).
 
 ## Lanes
@@ -61,11 +81,15 @@ With a single host and a single worker, these locks are typically uncontested, b
 
 ## Queue modes
 
-Channels can choose how inbound messages are queued:
+When a run is already active for a `(session_key, lane)`, inbound messages are handled by an explicit queue mode:
 
-- **collect:** coalesce queued messages into a single follow-up turn (default)
-- **followup:** enqueue for the next turn after the active run ends
-- **steer:** inject into the in-flight run at the next tool boundary (cancels pending tool calls after that boundary)
+- **`collect` (default):** coalesce queued messages into a single follow-up turn after the active run ends.
+- **`followup`:** enqueue each message as its own follow-up turn.
+- **`steer`:** inject the new message into the in-flight run at the next tool boundary and cancel pending tool calls for the current assistant message.
+- **`steer_backlog`:** steer now and also preserve the message for a follow-up turn.
+- **`interrupt`:** abort the active run at the next safe boundary and run the newest message.
+
+Queueing is bounded (`cap`, `debounce_ms`, `overflow`) and lane-aware so automation lanes do not trample interactive lanes. Details: [Messages and Sessions](./messages-sessions.md).
 
 ## Command queue
 

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -2,14 +2,42 @@
 
 Slash commands are a client-facing command surface for common actions. Clients translate commands into typed requests to the gateway.
 
-## Example commands
+Commands are handled by the gateway (not by the model). This keeps control-plane actions deterministic, policy-enforced, and auditable.
 
-- `/new` — start a new session or reset context (depending on configuration)
-- `/status` — show agent/runtime status
-- `/context list` — list available context sources
-- `/context detail` — show details for a specific context source
-- `/usage tokens` — show token usage and cost telemetry (when available)
-- `/compact` — request context compaction
+## Command classes
+
+- **Standalone commands:** a message that is only `/...` runs as a command.
+- **Directives:** certain commands persist per-session settings and are stripped before model inference.
+- **Side-effecting commands:** commands that change state or send messages are subject to policy and may require approvals.
+
+## Common commands (examples)
+
+### Session and execution
+
+- `/new` — start a new session (fresh context and new session id).
+- `/reset` — reset the current session state (policy-defined).
+- `/stop` — cancel the active run and clear queued followups for the current session.
+- `/compact` — request compaction of older history into a summary.
+
+### Context and usage
+
+- `/status` — show runtime + session status (model, lane, queue, policy mode).
+- `/context list` — show a context breakdown summary for the last run.
+- `/context detail` — show a detailed breakdown including tool schema overhead.
+- `/usage` — show current session usage summary (tokens/time/cost).
+- `/usage provider` — show provider-reported usage/quota when available.
+- `/presence` — show connected gateway/client/node presence entries.
+
+### Models and auth
+
+- `/model` — show the current model and available options.
+- `/model <provider/model>` — set the model for the current session.
+- `/model <provider/model>@<profile>` — pin an auth profile for the session.
+
+### Messaging behavior
+
+- `/queue <collect|followup|steer|steer_backlog|interrupt>` — set the inbound queue mode for the session.
+- `/send <on|off|inherit>` — set or clear a per-session send policy override (operator-scoped).
 
 ## Design guidelines
 

--- a/docs/architecture/system-prompt.md
+++ b/docs/architecture/system-prompt.md
@@ -5,6 +5,7 @@ For each agent run, Tyrum assembles a custom system prompt. The purpose is to pr
 ## Typical sections
 
 - Tooling: tool list with short descriptions
+- Tool schemas: machine-readable contracts for tool invocation (counts toward context)
 - Safety: short guardrail reminder to avoid bypassing oversight
 - Skills (when available): how to load skill instructions on demand
 - Self-update: how to apply config updates and run updates
@@ -17,6 +18,17 @@ For each agent run, Tyrum assembles a custom system prompt. The purpose is to pr
 - Heartbeats: periodic prompt and acknowledgement behavior
 - Runtime: host/OS/node/model/runtime summary
 - Reasoning visibility: visibility level and how it can be toggled (when supported)
+
+## Context report (what the model saw)
+
+For observability, the gateway produces a per-run **context report** that captures:
+
+- injected workspace files (raw vs injected sizes and truncation)
+- system prompt section sizes
+- skill list overhead
+- the largest tool schema contributors
+
+Operator clients expose this via `/context list` and `/context detail` (see [Observability](./observability.md) and [Slash Commands](./slash-commands.md)).
 
 ## Advisory vs enforcement
 

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -9,12 +9,14 @@ Tools are the gateway's invocable operations used by the agent runtime. Tools ca
 - **runtime:** process and environment information
 - **fs:** read/write/edit/apply-patch operations within a workspace boundary
 - **session:** session list/history/send/spawn/status operations
+- **observability:** status/context/usage inspection and diagnostics
 - **memory:** search/get/write operations over durable memory
 - **web:** search/fetch for browsing and extraction (when enabled)
 - **ui:** browser/canvas style surfaces (when enabled)
 - **workflow:** run/resume deterministic workflows (playbooks) with approvals and resume tokens
 - **automation:** cron/heartbeat/hooks/webhooks
 - **messaging:** sending messages to channels
+- **presence:** connected clients/nodes inventory and instance health (when enabled)
 - **nodes:** node discovery, pairing, and capability routing
 - **model:** model selection, fallback, and telemetry
 


### PR DESCRIPTION
Defines target-state architecture docs for message/session handling (dedupe, debounce, queue modes, typing/streaming), markdown IR formatting, provider auth profiles (API key + OAuth via secret handles), observability (/status, /context, /usage), and presence/instances.

Also aligns session key taxonomy with channel+account and secure DM scoping, and updates client/channel/protocol docs to reference these surfaces.

Validation: pnpm build