### PR TITLE
Document approve-always policy overrides

### DIFF
--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -50,6 +50,7 @@ An approval request should be explicit about impact and traceability:
 - `scope` (agent/session/run/step identifiers)
 - `risk` and `estimated_cost` (when applicable)
 - `items_preview` (capped, optional)
+- `suggested_overrides` (optional; bounded list of safe “approve always” patterns for tool-policy approvals)
 - `expires_at`
 - `resume_token` (when the approval gates a paused workflow)
 
@@ -57,12 +58,34 @@ An approval request should be explicit about impact and traceability:
 
 Resolutions are durable records:
 
-- `approved: boolean`
+- `outcome` (`approved`, `denied`, or `expired`)
 - `resolved_at`
 - `resolved_by` (client identity / user identity)
 - optional `reason` (operator-provided)
+- optional `mode` (`once` or `always`, only meaningful when `outcome=approved`)
+- optional `policy_override_id` (when `mode=always` creates a durable policy override)
 
 Expired approvals behave like denial unless explicitly configured otherwise.
+
+## Approve once vs approve always
+
+Approvals should support three operator outcomes:
+
+- **Approve once:** resolve the pending approval and resume/cancel the waiting run as normal. No standing authorization is created.
+- **Approve always:** resolve the pending approval and also create a **durable policy override** that allows *future* matching actions without prompting. “Always” should be offered only when the approval includes `suggested_overrides` (or when a domain-specific durable authorization exists, such as node pairing).
+- **Reject:** deny the pending approval (or let it expire), and cancel/keep paused according to policy.
+
+“Approve always” is **enforcement**, not convenience: the override is a durable, auditable record with explicit scope and revocation. See [Policy overrides](./policy-overrides.md).
+
+## Suggested overrides (pattern suggestions)
+
+For tool-policy approvals, the gateway should include `suggested_overrides` so operator clients can offer an “always” option without free-form rule authoring.
+
+Each suggested override is a *tool-specific wildcard pattern* over a well-defined match target (see [Tools](./tools.md)). Suggestions are conservative:
+
+- narrow scope by default (agent and workspace scoped where applicable)
+- prefer prefix patterns over broad wildcards
+- never suggest a rule that would bypass an explicit `deny`
 
 ## Integration with workflows (pause/resume)
 
@@ -78,6 +101,8 @@ Approvals should be observable via gateway-emitted events:
 
 - `approval.requested`
 - `approval.resolved`
+- `policy_override.created` (when `mode=always` creates an override)
+- `policy_override.revoked` / `policy_override.expired`
 - `run.paused` (with reason: approval)
 - `run.resumed`
 - `run.cancelled` (when denied/expired)
@@ -88,5 +113,7 @@ The control panel should expose:
 
 - An **approval queue** (filterable by agent/run/kind)
 - Approval details (prompt, preview, linked evidence/artifacts)
-- One-tap approve/deny with clear consequences
+- Approve **once** / approve **always** / deny with clear consequences
+- “Always” UI that presents the bounded `suggested_overrides` list (scope + match target + pattern) and requires selecting one or more suggestions
+- A policy override inventory (list/describe/revoke) with links back to the approvals and runs that created each override
 - Deep links from notifications into the approval detail view

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -84,6 +84,7 @@ flowchart LR
 - [Messages and Sessions](./messages-sessions.md)
 - [Playbooks](./playbooks.md)
 - [Approvals](./approvals.md)
+- [Policy overrides (approve-always)](./policy-overrides.md)
 - [Secrets](./secrets.md)
 - [Provider Auth and Onboarding](./auth.md)
 - [Artifacts](./artifacts.md)

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -39,12 +39,13 @@ Usage is scoped to the current session by default, with agent-wide and deploymen
 Tyrum emits typed events for:
 
 - approvals requested/resolved
+- policy overrides created/revoked/expired
 - runs/steps lifecycle and retries
 - policy decisions (allow/deny/require-approval + reasons + snapshot references)
 - artifacts created/attached/fetched
 - model/provider selection, auth rotation, and fallback decisions
 
-Durable logs include stable ids (`run_id`, `step_id`, `attempt_id`, `approval_id`, `artifact_id`, `policy_snapshot_id`) so operators can correlate UI, DB records, and exported bundles.
+Durable logs include stable ids (`run_id`, `step_id`, `attempt_id`, `approval_id`, `policy_override_id`, `artifact_id`, `policy_snapshot_id`) so operators can correlate UI, DB records, and exported bundles.
 
 ## Provider quota polling
 
@@ -55,4 +56,3 @@ When enabled, Tyrum queries provider usage endpoints using the active auth profi
 - results are never treated as authoritative billing records; they are operator guidance
 
 Provider polling respects policy: usage endpoints are only queried for allowed providers/profiles and never with raw secret values in model context.
-

--- a/docs/architecture/policy-overrides.md
+++ b/docs/architecture/policy-overrides.md
@@ -1,0 +1,95 @@
+# Policy overrides (approve-always)
+
+Policy overrides are durable, operator-created enforcement rules that reduce repeated prompts without weakening Tyrum’s auditability or safety model.
+
+They are most commonly created when an operator resolves an approval with **approve always** (see [Approvals](./approvals.md)).
+
+## What a policy override is (and is not)
+
+- **Is:** a durable, auditable rule that can turn a future `require_approval` decision into an `allow` decision for *matching* tool actions.
+- **Is not:** prompt text, a “hint”, or an implicit trust signal. Overrides are evaluated by the policy engine and recorded in the audit log.
+
+## Scope and safety invariants
+
+Policy overrides are scoped and conservative by default:
+
+- scoped at least to `agent_id` (and typically also `workspace_id` for workspace-backed tools)
+- **cannot** override an explicit `deny` by default
+- intended to relax only `require_approval → allow`
+
+If a deployment needs “deny overrides”, it must be an explicit, audited, policy-gated exception and should be avoided.
+
+## Relationship to PolicyBundle
+
+The baseline enforcement configuration is the merged `PolicyBundle` (deployment + agent + playbook). Policy overrides form an additional, operator-controlled layer applied during policy evaluation. See [Sandbox and policy](./sandbox-policy.md).
+
+## Matching and pattern language
+
+Overrides use **tool-specific wildcard patterns** matched against a well-defined per-tool “match target”.
+
+Wildcard grammar:
+
+- `*` matches zero or more characters
+- `?` matches exactly one character
+
+No regex by default.
+
+Each override stores:
+
+- `tool_id` (the tool the pattern applies to)
+- `pattern` (wildcard pattern over that tool’s match target)
+
+Tools must define their match targets unambiguously (examples live in [Tools](./tools.md)).
+
+## Evaluation semantics
+
+Policy evaluation remains deterministic and conservative:
+
+1. Evaluate merged `PolicyBundle` layers (deployment → agent → playbook) to produce `allow | deny | require_approval`.
+2. If the result is `deny`, return `deny` (overrides do not apply).
+3. If the result is `allow`, return `allow`.
+4. If the result is `require_approval`, check for a matching **active** policy override:
+   - if a match exists, return `allow` and include the applied `policy_override_id`(s) in the decision record
+   - otherwise return `require_approval` as normal
+
+## Data model (durable records)
+
+Policy overrides are durable records separate from approvals. A minimal record shape:
+
+- `policy_override_id`
+- `status` (`active`, `revoked`, `expired`)
+- `created_at`, `created_by` (user identity + client identity)
+- `agent_id`
+- optional `workspace_id` (recommended for workspace-backed tools)
+- `tool_id`
+- `pattern`
+- `created_from_approval_id` (link back to the originating approval)
+- `created_from_policy_snapshot_id` (link back to the policy snapshot in effect when the approval was requested)
+- optional `expires_at`
+- optional `revoked_at`, `revoked_by`, `revoked_reason`
+
+## Audit, events, and export
+
+Overrides are first-class audit objects:
+
+- Creation emits `policy_override.created` with the durable `policy_override_id` and linkage fields.
+- Revocation emits `policy_override.revoked`.
+- Expiry emits `policy_override.expired`.
+
+Policy decision records (and run logs) should include which override ids were applied so operators can answer “why was this allowed?” after the fact.
+
+Snapshot exports should include:
+
+- approval records (requested/resolved)
+- policy override records (active + historical with status)
+- audit/event logs linking `approval_id`, `policy_snapshot_id`, and `policy_override_id`
+
+## Operator UX expectations
+
+Operator clients should provide:
+
+- Override inventory (filter by agent/tool/status)
+- Override detail view (match target description, pattern, scope, created-from approval/run)
+- One-tap revoke with an operator-provided reason (revocation is audited)
+
+Suggested control-plane commands: see [Slash commands](./slash-commands.md).

--- a/docs/architecture/sandbox-policy.md
+++ b/docs/architecture/sandbox-policy.md
@@ -40,11 +40,13 @@ Effective policy is the merged result of:
 1. **Deployment policy** (global defaults)
 2. **Agent policy** (agent-scoped overrides)
 3. **Playbook policy** (workflow-scoped overrides)
+4. **Operator policy overrides** (durable “approve always” edits created via approvals; see [Policy overrides](./policy-overrides.md))
 
 Conflict resolution is conservative:
 
 - `deny` wins over `require_approval` wins over `allow`.
-- Narrower scopes may tighten constraints; widening constraints requires an explicit, auditable mechanism (for example an approval-gated override rule).
+- Narrower scopes may tighten constraints.
+- Widening constraints must be explicit and auditable. Operator policy overrides are the standard mechanism for turning `require_approval → allow` for a narrow, tool-scoped pattern. Overrides must not bypass explicit `deny` by default.
 
 ## Policy snapshots
 
@@ -52,6 +54,7 @@ Every execution run carries the effective policy as a snapshot reference:
 
 - The gateway persists a `policy_snapshot_id` and a content hash for the merged policy used to create the run.
 - Exports and audits reference the snapshot so policy decisions remain explainable and replayable.
+- Policy decisions may also record applied `policy_override_id` values when an operator override turns `require_approval → allow`. This keeps “why was this allowed?” answerable without weakening the conservative `deny` precedence.
 
 ## Minimum policy domains
 

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -39,6 +39,12 @@ Commands are handled by the gateway (not by the model). This keeps control-plane
 - `/queue <collect|followup|steer|steer_backlog|interrupt>` — set the inbound queue mode for the session.
 - `/send <on|off|inherit>` — set or clear a per-session send policy override (operator-scoped).
 
+### Policy overrides
+
+- `/policy overrides list` — list active and historical policy overrides (filterable by agent/tool/status).
+- `/policy overrides describe <policy_override_id>` — show override scope, pattern, and audit linkage.
+- `/policy overrides revoke <policy_override_id>` — revoke an override (audited, optionally with a reason).
+
 ## Design guidelines
 
 - Prefer unambiguous names (`/context list` over `/ctx`).

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -35,3 +35,28 @@ MCP servers expose tool catalogs that Tyrum can call through a standardized inte
 - State-changing tools should support **postconditions** and emit **artifacts** suitable for audit.
 - Tools should accept **secret handles**, not raw secret values.
 - Tool outputs should redact secrets and avoid leaking sensitive local data by default.
+
+## Approval pattern suggestions (approve-always)
+
+When a tool call is policy-gated with `require_approval`, the gateway should provide a bounded set of **suggested overrides** that operator clients can present as “approve always” options.
+
+Guidelines:
+
+- Suggestions are **tool-specific** and conservative (narrow scope, minimal wildcards).
+- Suggestions must never propose bypassing an explicit `deny`.
+- Suggestions must match a well-defined per-tool **match target** so operators can understand what “always” means.
+
+### Pattern grammar
+
+Suggested override patterns use a simple wildcard language:
+
+- `*` matches zero or more characters
+- `?` matches exactly one character
+
+### Match targets (examples)
+
+Tools define what their override patterns match. Common examples:
+
+- **`bash`**: a normalized command string (for example `git status --porcelain`). Suggested patterns should typically be safe prefixes like `git status*`.
+- **`fs`**: an operation + workspace-relative path (for example `write:src/generated/types.ts`). Suggested patterns should be narrow like `write:src/generated/**`.
+- **MCP tools**: a stable tool identifier (server + tool) and optionally selected low-risk arguments. Suggested patterns should prefer tool-name prefixes (for example `mcp.github.*`) over broad argument matches.


### PR DESCRIPTION
## Summary
- Document operator outcomes: approve once / approve always / reject.
- Add durable policy override concept (audit/events, evaluation semantics, revocation).
- Specify suggested override patterns and tool match-target examples.
- Document slash commands for listing/describing/revoking overrides.

## Testing
- `bash scripts/check-public-docs.sh docs`
- `pnpm --filter @tyrum/docs build`

## Issue
- No issue linked (docs-only change).}