### PR TITLE
fix: apply blur to docs mobile sidebar

### DIFF
--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -42,7 +42,8 @@
   --docusaurus-highlighted-code-line-bg: rgba(59, 130, 246, 0.1);
 }
 
-.navbar {
+.navbar,
+.navbar-sidebar {
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }


### PR DESCRIPTION
## Summary
- Added `.navbar-sidebar` to the list of elements that receive the backdrop-filter blur.
- This ensures the sidebar on mobile has the correct frosted glass effect, making the menu links readable.

## Test plan
- Open docs on mobile.
- Open the sidebar.
- Verify the background is blurred and text is readable.