### PR TITLE
fix(client): keep reconnect enabled on stale handshake errors

### DIFF
--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -423,6 +423,15 @@ export class TyrumClient {
     this.sendLegacyConnect();
   }
 
+  private disconnectIfHandshakeSocketActive(handshakeWs: WebSocket): void {
+    // Avoid disabling reconnect due to stale async handshake work that outlives
+    // the socket it started on.
+    if (this.ws !== handshakeWs || handshakeWs.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.disconnect();
+  }
+
   private sendLegacyConnect(): void {
     const requestId = crypto.randomUUID();
 
@@ -456,6 +465,9 @@ export class TyrumClient {
   }
 
   private async sendConnectWithDeviceProof(): Promise<void> {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
     try {
       const device = this.opts.device;
       if (!device) {
@@ -465,12 +477,15 @@ export class TyrumClient {
       const pubkey = device.publicKey.trim();
       const privkey = device.privateKey.trim();
       if (!pubkey || !privkey) {
-        this.disconnect();
+        this.disconnectIfHandshakeSocketActive(ws);
         return;
       }
 
       const pubkeyDer = fromBase64Url(pubkey);
       const deviceId = device.deviceId?.trim() || (await computeDeviceId(pubkeyDer));
+      if (this.ws !== ws || ws.readyState !== WebSocket.OPEN) {
+        return;
+      }
       const role = this.opts.role;
       const protocolRev = this.opts.protocolRev;
 
@@ -495,33 +510,38 @@ export class TyrumClient {
 
       this.pending.set(requestId, {
         resolve: (msg) => {
-          void this.handleConnectInitResponse(msg, {
-            deviceId,
-            role,
-            protocolRev,
-            privateKey: privkey,
-          });
+          void this.handleConnectInitResponse(
+            msg,
+            {
+              deviceId,
+              role,
+              protocolRev,
+              privateKey: privkey,
+            },
+            ws,
+          );
         },
         reject: () => {},
       });
 
       this.send(request);
     } catch {
-      this.disconnect();
+      this.disconnectIfHandshakeSocketActive(ws);
     }
   }
 
   private async handleConnectInitResponse(
     msg: WsResponseEnvelope,
     ctx: { deviceId: string; role: WsPeerRole; protocolRev: number; privateKey: string },
+    handshakeWs: WebSocket,
   ): Promise<void> {
     if (!msg.ok) {
-      this.disconnect();
+      this.disconnectIfHandshakeSocketActive(handshakeWs);
       return;
     }
     const parsed = WsConnectInitResult.safeParse(msg.result ?? {});
     if (!parsed.success) {
-      this.disconnect();
+      this.disconnectIfHandshakeSocketActive(handshakeWs);
       return;
     }
 
@@ -534,6 +554,9 @@ export class TyrumClient {
         challenge: parsed.data.challenge,
       });
       const signature = await signEd25519Pkcs8(fromBase64Url(ctx.privateKey), transcript);
+      if (this.ws !== handshakeWs || handshakeWs.readyState !== WebSocket.OPEN) {
+        return;
+      }
       const proof = toBase64UrlBytes(signature);
 
       const requestId = crypto.randomUUID();
@@ -545,13 +568,14 @@ export class TyrumClient {
 
       this.pending.set(requestId, {
         resolve: (msg2) => {
+          if (this.ws !== handshakeWs) return;
           if (!msg2.ok) {
-            this.disconnect();
+            this.disconnectIfHandshakeSocketActive(handshakeWs);
             return;
           }
           const parsed2 = WsConnectProofResult.safeParse(msg2.result ?? {});
           if (!parsed2.success) {
-            this.disconnect();
+            this.disconnectIfHandshakeSocketActive(handshakeWs);
             return;
           }
           this.ready = true;
@@ -563,7 +587,7 @@ export class TyrumClient {
 
       this.send(request);
     } catch {
-      this.disconnect();
+      this.disconnectIfHandshakeSocketActive(handshakeWs);
     }
   }
 

--- a/packages/client/tests/ws-client.test.ts
+++ b/packages/client/tests/ws-client.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { WebSocket as WsWebSocket } from "ws";
+import { generateKeyPairSync } from "node:crypto";
 import { TyrumClient } from "../src/ws-client.js";
 
 // ---------------------------------------------------------------------------
@@ -100,6 +101,15 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return await Promise.race([
+    p,
+    delay(ms).then(() => {
+      throw new Error(`${label} timeout after ${ms}ms`);
+    }),
+  ]);
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -115,6 +125,7 @@ describe("TyrumClient", () => {
       await server.close();
       server = undefined;
     }
+    vi.restoreAllMocks();
   });
 
   it("connects and sends hello with capabilities", async () => {
@@ -660,6 +671,106 @@ describe("TyrumClient", () => {
         result: { client_id: "client-2" },
       }),
     );
+  });
+
+  it("reconnects when socket closes mid device-proof handshake", async () => {
+    server = createTestServer();
+
+    const keyPair = generateKeyPairSync("ed25519");
+    const publicKeyDer = keyPair.publicKey.export({ format: "der", type: "spki" }) as Uint8Array;
+    const privateKeyDer = keyPair.privateKey.export({ format: "der", type: "pkcs8" }) as Uint8Array;
+
+    client = new TyrumClient({
+      url: server.url,
+      token: "t",
+      capabilities: [],
+      reconnect: true,
+      maxReconnectDelay: 25,
+      useDeviceProof: true,
+      role: "node",
+      device: {
+        publicKey: Buffer.from(publicKeyDer).toString("base64url"),
+        privateKey: Buffer.from(privateKeyDer).toString("base64url"),
+      },
+    });
+
+    const connectedP = new Promise<void>((resolve) => {
+      client!.on("connected", () => resolve());
+    });
+
+    if (!globalThis.crypto?.subtle) {
+      throw new Error("WebCrypto subtle API not available");
+    }
+
+    const originalSign = globalThis.crypto.subtle.sign.bind(globalThis.crypto.subtle);
+    let didReject = false;
+    const signRejectedP = new Promise<void>((resolve) => {
+      vi.spyOn(globalThis.crypto.subtle!, "sign").mockImplementation(async (...args) => {
+        if (!didReject) {
+          didReject = true;
+          await delay(50);
+          resolve();
+          throw new Error("test sign failure");
+        }
+        return await originalSign(...(args as Parameters<typeof originalSign>));
+      });
+    });
+
+    client.connect();
+
+    // First connection: server responds to connect.init then closes immediately.
+    const ws1 = await withTimeout(server.waitForClient(), 2_000, "ws1 connection");
+    const init1 = (await withTimeout(waitForMessage(ws1), 2_000, "ws1 connect.init")) as Record<
+      string,
+      unknown
+    >;
+    expect(init1["type"]).toBe("connect.init");
+    ws1.send(
+      JSON.stringify({
+        request_id: String(init1["request_id"]),
+        type: "connect.init",
+        ok: true,
+        result: { connection_id: "conn-1", challenge: "nonce-1" },
+      }),
+    );
+    ws1.terminate();
+
+    // Second connection: wait for the reconnect, then complete the handshake.
+    const ws2 = await withTimeout(server.waitForClient(), 2_000, "ws2 reconnect");
+    const init2 = (await withTimeout(waitForMessage(ws2), 2_000, "ws2 connect.init")) as Record<
+      string,
+      unknown
+    >;
+    expect(init2["type"]).toBe("connect.init");
+    ws2.send(
+      JSON.stringify({
+        request_id: String(init2["request_id"]),
+        type: "connect.init",
+        ok: true,
+        result: { connection_id: "conn-2", challenge: "nonce-2" },
+      }),
+    );
+
+    const proof2 = (await withTimeout(waitForMessage(ws2), 2_000, "ws2 connect.proof")) as Record<
+      string,
+      unknown
+    >;
+    expect(proof2["type"]).toBe("connect.proof");
+
+    // Ensure stale handshake work has a chance to fail while the new socket is alive.
+    await withTimeout(signRejectedP, 2_000, "sign rejection");
+
+    ws2.send(
+      JSON.stringify({
+        request_id: String(proof2["request_id"]),
+        type: "connect.proof",
+        ok: true,
+        result: { client_id: "client-2", device_id: "dev-2", role: "node" },
+      }),
+    );
+
+    await withTimeout(connectedP, 2_000, "connected");
+    expect(client.connected).toBe(true);
   });
 
   it("sends token in websocket subprotocol metadata", async () => {


### PR DESCRIPTION
Context
- PR #344 is merge-conflicting and largely superseded by PR #346; this ports only the WS client reconnect/handshake hardening idea.

What
- Harden the device-proof (connect.init/connect.proof) handshake so stale async failures don't call disconnect() after the socket has already closed/reconnected (which would set intentionalClose and cancel auto-reconnect).
- Add a regression test covering close/reconnect mid-handshake + a one-time WebCrypto sign failure.

Why
- Async handshake work can outlive the WebSocket instance it started on. If the first socket closes and a new one is opened, error handling from the first handshake must not disable reconnect or close the new socket.

How
- Capture the current ws at the start of the async device-proof handshake path and gate disconnect() calls behind: this.ws === capturedWs && capturedWs.readyState === OPEN.

Test
- pnpm exec vitest run packages/client/tests/ws-client.test.ts
- pnpm typecheck
- pnpm lint

Scope
- Only packages/client/src/ws-client.ts and packages/client/tests/ws-client.test.ts. No gateway/auth semantics changes.