### PR TITLE
Show Tyrum name in desktop app

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: net.tyrum.desktop
-productName: Tyrum Desktop
+productName: Tyrum
 directories:
   output: release
 publish:

--- a/apps/desktop/src/main/ipc/update-ipc.ts
+++ b/apps/desktop/src/main/ipc/update-ipc.ts
@@ -67,7 +67,7 @@ function buildReleaseFileFilters(platform: NodeJS.Platform): FileFilter[] {
 
 async function openReleaseFileFromDisk(): Promise<ManualReleaseFileResult> {
   const dialogOptions: OpenDialogOptions = {
-    title: "Select Tyrum Desktop Release File",
+    title: "Select Tyrum Release File",
     buttonLabel: "Open Installer",
     properties: ["openFile"],
     filters: buildReleaseFileFilters(process.platform),
@@ -99,7 +99,7 @@ async function openReleaseFileFromDisk(): Promise<ManualReleaseFileResult> {
   return {
     opened: true,
     path: selectedPath,
-    message: "Installer opened. Complete installation, then relaunch Tyrum Desktop.",
+    message: "Installer opened. Complete installation, then relaunch Tyrum.",
   };
 }
 

--- a/apps/desktop/src/main/platform/permissions.ts
+++ b/apps/desktop/src/main/platform/permissions.ts
@@ -42,13 +42,13 @@ export function checkMacPermissions(): MacPermissions {
     if (!accessibility) {
       instructions.push(
         "Accessibility: Open System Settings > Privacy & Security > Accessibility, " +
-          "then add Tyrum Desktop to the list and enable it.",
+          "then add Tyrum to the list and enable it.",
       );
     }
     if (!screenRecording) {
       instructions.push(
         "Screen Recording: Open System Settings > Privacy & Security > Screen Recording, " +
-          "then add Tyrum Desktop to the list and enable it.",
+          "then add Tyrum to the list and enable it.",
       );
     }
   } catch {
@@ -113,7 +113,7 @@ export async function requestMacPermission(
     return {
       granted: false,
       instructions:
-        "Opened Screen Recording settings. Enable Tyrum Desktop, then restart the app.",
+        "Opened Screen Recording settings. Enable Tyrum, then restart the app.",
     };
   } catch {
     return {

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -54,7 +54,7 @@ function navItemStyle(active: boolean): React.CSSProperties {
 export function Sidebar({ currentPage, onNavigate }: SidebarProps) {
   return (
     <nav style={sidebarStyle}>
-      <div style={titleStyle}>Tyrum Desktop</div>
+      <div style={titleStyle}>Tyrum</div>
       {NAV_ITEMS.map((item) => (
         <div
           key={item.id}

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tyrum Desktop</title>
+  <title>Tyrum</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />

--- a/apps/desktop/tests/update-ipc-handlers.test.ts
+++ b/apps/desktop/tests/update-ipc-handlers.test.ts
@@ -158,7 +158,7 @@ describe("registerUpdateIpc handlers", () => {
       opened: true,
       path: selectedPath,
       message:
-        "Installer opened. Complete installation, then relaunch Tyrum Desktop.",
+        "Installer opened. Complete installation, then relaunch Tyrum.",
     });
   });
 

--- a/packages/gateway/src/routes/web-ui.ts
+++ b/packages/gateway/src/routes/web-ui.ts
@@ -1620,7 +1620,7 @@ export function createWebUiRoutes(deps: WebUiDeps): Hono {
 
       <section class="card">
         <h2>What happens next</h2>
-        <p class="muted">Choose Embedded to continue persona + consent onboarding. Choose Remote to stop onboarding and configure a remote connection in Tyrum Desktop.</p>
+        <p class="muted">Choose Embedded to continue persona + consent onboarding. Choose Remote to stop onboarding and configure a remote connection in Tyrum.</p>
       </section>
 
       <script>
@@ -1672,7 +1672,7 @@ export function createWebUiRoutes(deps: WebUiDeps): Hono {
       redirectWithMessageFromRequest(
         c,
         "/app",
-        "Remote mode selected. Configure remote connection in Tyrum Desktop.",
+        "Remote mode selected. Configure remote connection in Tyrum.",
       ),
     );
   });


### PR DESCRIPTION
Closes #349.

- Rename visible app strings from 'Tyrum Desktop' to 'Tyrum' (packaging + UI copy).