### PR TITLE
Fix live console WS heartbeat ping responses

### DIFF
--- a/packages/gateway/src/routes/web-ui.ts
+++ b/packages/gateway/src/routes/web-ui.ts
@@ -1084,6 +1084,11 @@ export function createWebUiRoutes(deps: WebUiDeps): Hono {
               }
               return;
             }
+
+            if (type === "ping" && msg.request_id) {
+              send({ request_id: msg.request_id, type: "ping", ok: true });
+              return;
+            }
             log("<< request " + type);
           });
 

--- a/packages/gateway/tests/unit/web-ui-live.test.ts
+++ b/packages/gateway/tests/unit/web-ui-live.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { createWebUiRoutes, type WebUiDeps } from "../../src/routes/web-ui.js";
+
+describe("/app/live", () => {
+  function buildDeps(): WebUiDeps {
+    return {
+      approvalDal: {} as WebUiDeps["approvalDal"],
+      memoryDal: {} as WebUiDeps["memoryDal"],
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: {} as WebUiDeps["canvasDal"],
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+    };
+  }
+
+  it("auto-responds to gateway ping heartbeats", async () => {
+    const app = createWebUiRoutes(buildDeps());
+    const res = await app.request("/app/live?token=test-token");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Regression: the live console must reply to gateway heartbeat `ping` requests
+    // or the gateway will evict the connection after the heartbeat timeout.
+    expect(html).toContain('type: "ping"');
+    expect(html).toContain("ok: true");
+    expect(html).toContain("request_id: msg.request_id");
+  });
+});
+


### PR DESCRIPTION
Closes #351.

Root cause: the /app/live WebSocket client logged gateway `ping` requests but did not reply, so the gateway heartbeat evicted the connection after the timeout.

Changes:
- Reply to `ping` requests with an ok response in the /app/live embedded WS client
- Add a unit test ensuring the ping responder is present

How to test:
- pnpm test
- pnpm typecheck
- pnpm lint
- Open /app/live?token=... and verify it stays connected >10s