### PR TITLE
fix(gateway): heartbeat via WS ping/pong

### DIFF
--- a/packages/gateway/src/ws/connection-manager.ts
+++ b/packages/gateway/src/ws/connection-manager.ts
@@ -66,6 +66,9 @@ export class ConnectionManager {
       capabilities,
       lastPong: Date.now(),
     };
+    ws.on("pong", () => {
+      client.lastPong = Date.now();
+    });
     this.clients.set(id, client);
     return id;
   }
@@ -101,23 +104,37 @@ export class ConnectionManager {
   }
 
   /**
-   * Heartbeat tick: send a `ping` frame to all clients and evict those that
-   * have not responded with a `pong` within {@link HEARTBEAT_TIMEOUT_MS}.
+   * Heartbeat tick: send a WebSocket-level ping control frame to all clients
+   * and evict those that have not responded with a pong within
+   * {@link HEARTBEAT_TIMEOUT_MS}.
    */
   heartbeat(): void {
     const now = Date.now();
-    const pingPayload = JSON.stringify({
-      request_id: `ping-${crypto.randomUUID()}`,
-      type: "ping",
-      payload: {},
-    } satisfies WsRequestEnvelope);
 
     for (const [id, client] of this.clients) {
+      // Drop sockets that are no longer open (close event cleanup is best-effort).
+      if (client.ws.readyState !== 1) {
+        this.clients.delete(id);
+        continue;
+      }
       if (now - client.lastPong > HEARTBEAT_TIMEOUT_MS) {
-        client.ws.close();
+        try {
+          client.ws.terminate();
+        } catch {
+          // ignore
+        }
         this.clients.delete(id);
       } else {
-        client.ws.send(pingPayload);
+        try {
+          client.ws.ping();
+        } catch {
+          try {
+            client.ws.terminate();
+          } catch {
+            // ignore
+          }
+          this.clients.delete(id);
+        }
       }
     }
   }

--- a/packages/gateway/tests/unit/connection-manager.test.ts
+++ b/packages/gateway/tests/unit/connection-manager.test.ts
@@ -12,15 +12,29 @@ import { ConnectionManager } from "../../src/ws/connection-manager.js";
 
 interface MockWebSocket {
   send: ReturnType<typeof vi.fn>;
+  ping: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
   readyState: number;
 }
 
-function createMockWs(): MockWebSocket {
+function createMockWs(): MockWebSocket & { emitPong: () => void } {
+  const pongListeners: Array<() => void> = [];
+
   return {
     send: vi.fn(),
+    ping: vi.fn(),
     close: vi.fn(),
+    terminate: vi.fn(),
+    on: vi.fn((event: string, listener: () => void) => {
+      if (event === "pong") pongListeners.push(listener);
+      return undefined as never;
+    }),
     readyState: 1, // OPEN
+    emitPong: () => {
+      for (const listener of pongListeners) listener();
+    },
   };
 }
 
@@ -112,7 +126,7 @@ describe("ConnectionManager", () => {
   });
 
   describe("heartbeat", () => {
-    it("sends ping to all connected clients", () => {
+    it("sends WebSocket ping control frames to all connected clients", () => {
       const cm = new ConnectionManager();
       const ws1 = createMockWs();
       const ws2 = createMockWs();
@@ -122,16 +136,8 @@ describe("ConnectionManager", () => {
 
       cm.heartbeat();
 
-      expect(ws1.send).toHaveBeenCalledOnce();
-      expect(ws2.send).toHaveBeenCalledOnce();
-
-      const ping = JSON.parse(ws1.send.mock.calls[0]![0] as string) as Record<
-        string,
-        unknown
-      >;
-      expect(ping["type"]).toBe("ping");
-      expect(typeof ping["request_id"]).toBe("string");
-      expect(ping["payload"]).toEqual({});
+      expect(ws1.ping).toHaveBeenCalledOnce();
+      expect(ws2.ping).toHaveBeenCalledOnce();
     });
 
     it("evicts clients that have not ponged within timeout", () => {
@@ -146,7 +152,7 @@ describe("ConnectionManager", () => {
 
       cm.heartbeat();
 
-      expect(ws.close).toHaveBeenCalledOnce();
+      expect(ws.terminate).toHaveBeenCalledOnce();
       expect(cm.getClient(id)).toBeUndefined();
       expect(cm.getStats().totalClients).toBe(0);
     });
@@ -163,9 +169,25 @@ describe("ConnectionManager", () => {
 
       cm.heartbeat();
 
-      expect(ws.close).not.toHaveBeenCalled();
-      expect(ws.send).toHaveBeenCalledOnce(); // ping sent
+      expect(ws.terminate).not.toHaveBeenCalled();
+      expect(ws.ping).toHaveBeenCalledOnce();
       expect(cm.getClient(id)).toBeDefined();
+    });
+
+    it("updates lastPong on websocket pong frames", () => {
+      const cm = new ConnectionManager();
+      const ws = createMockWs();
+      const id = cm.addClient(ws as never, ["playwright"]);
+      const client = cm.getClient(id);
+      expect(client).toBeDefined();
+
+      client!.lastPong = 1000;
+      const before = Date.now();
+      ws.emitPong();
+      const after = Date.now();
+
+      expect(client!.lastPong).toBeGreaterThanOrEqual(before);
+      expect(client!.lastPong).toBeLessThanOrEqual(after);
     });
   });
 

--- a/packages/gateway/tests/unit/outbox-poller.test.ts
+++ b/packages/gateway/tests/unit/outbox-poller.test.ts
@@ -5,6 +5,7 @@ import { ConnectionManager } from "../../src/ws/connection-manager.js";
 interface MockWebSocket {
   send: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
   readyState: number;
 }
 
@@ -12,6 +13,7 @@ function createMockWs(): MockWebSocket {
   return {
     send: vi.fn(),
     close: vi.fn(),
+    on: vi.fn(() => undefined as never),
     readyState: 1,
   };
 }
@@ -76,4 +78,3 @@ describe("OutboxPoller", () => {
     expect(ws.send).toHaveBeenCalledTimes(1);
   });
 });
-

--- a/packages/gateway/tests/unit/ws-protocol.test.ts
+++ b/packages/gateway/tests/unit/ws-protocol.test.ts
@@ -22,6 +22,7 @@ import type { ProtocolDeps } from "../../src/ws/protocol.js";
 interface MockWebSocket {
   send: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
   readyState: number;
 }
 
@@ -29,6 +30,7 @@ function createMockWs(): MockWebSocket {
   return {
     send: vi.fn(),
     close: vi.fn(),
+    on: vi.fn(() => undefined as never),
     readyState: 1,
   };
 }


### PR DESCRIPTION
Follow-up to #351 / PR #352.

**Root cause**
The gateway heartbeat was implemented as *application-level* JSON `{type:"ping"}` requests. Browser clients (including the desktop iframe UI) were not reliably replying with `{ok:true}`, so `ConnectionManager` evicted the connection after the heartbeat timeout (observed as `code=1005`).

**Fix**
Use WebSocket control frames for heartbeats:
- `ConnectionManager.heartbeat()` sends `ws.ping()`.
- Liveness updates on `ws.on("pong")`.
- Stale/broken sockets are removed and terminated.

**Tests**
- Updated `ConnectionManager` heartbeat unit tests to assert `ws.ping()` and pong-driven `lastPong` updates.