### PR TITLE
docs(architecture): tighten security guidance

### DIFF
--- a/docs/architecture/automation.md
+++ b/docs/architecture/automation.md
@@ -19,6 +19,10 @@ Automation lets Tyrum act on schedules and triggers while keeping behavior obser
 - Automation must be idempotent where possible.
 - Emit events for triggers, actions taken, and outcomes.
 - Apply the same policy and approval gates as interactive runs.
+- Webhooks must be authenticated and replay-resistant (for example a signature over the request body plus timestamp/nonce), and should be rate-limited.
+- Webhook secrets must be stored behind the secret provider and referenced via handles. Avoid placing secrets in URLs.
+- Prefer running webhook-triggered work in a dedicated lane/session with minimal permissions.
+- Hooks must be explicitly configured/allowlisted and run under the same policy/sandbox constraints as any other execution.
 
 ## Scheduler safety (DB-leases)
 

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -72,6 +72,9 @@ Plugin lifecycle is observable:
 
 ## Safety expectations
 
+- Plugins run **in-process**. Installing/enabling a plugin is equivalent to running trusted code with the gateway’s privileges.
+- Treat plugin install/enable/upgrade as a privileged operation (authenticated operator, auditable events, and approval-gated when appropriate).
+- Prefer allowlisted/curated sources; pin versions and verify package integrity/provenance where feasible.
 - Plugins must declare what they add (tools/commands/endpoints) and what permissions they require.
 - Plugin boundaries should be validated by contracts and guarded by policy.
 - Prefer least-privilege scopes over broad access.

--- a/docs/architecture/presence.md
+++ b/docs/architecture/presence.md
@@ -7,14 +7,16 @@ Presence is Tyrum’s lightweight, best-effort view of:
 
 Presence exists to give operators immediate visibility into “what is connected and healthy” without reading logs.
 
+Presence is a **diagnostic surface**, not a security boundary. The only authoritative identity is the device-derived `instance_id`. Other fields like `host` and `ip` may be self-reported and must not be used for authorization or policy decisions.
+
 ## Presence entries
 
 Presence entries are structured objects with fields like:
 
 - `instance_id`: stable device identity (derived from the device public key; see [Handshake](./protocol/handshake.md)).
 - `role`: `gateway | client | node`.
-- `host`: human-friendly host label.
-- `ip`: best-effort remote address (with tunnel-aware handling).
+- `host`: human-friendly host label (often self-reported).
+- `ip`: best-effort remote address (may include observed and/or self-reported values; see tunnel note below).
 - `version`: client/node version string (when provided).
 - `mode`: `ui | web | cli | node | backend | probe | test` (used for filtering).
 - `last_seen_at`: last update timestamp.
@@ -36,7 +38,7 @@ Short-lived, one-off CLI connections can be excluded from presence by `mode` to 
 
 Presence is keyed by stable device identity (`instance_id`). When a device reconnects, Tyrum updates the existing entry instead of creating duplicates.
 
-Tunnel caveat: when a connection arrives through a local port-forward, the gateway may observe `127.0.0.1` as the remote address. In that case, client-reported IP/host fields from periodic beacons take precedence.
+Tunnel caveat: when a connection arrives through a local port-forward, the gateway may observe `127.0.0.1` as the remote address. Operator clients may optionally report additional host/IP fields via periodic beacons for UI display, but these values are self-reported and must be clearly labeled. Prefer storing both observed and reported values rather than overwriting them.
 
 ## TTL and bounded size
 
@@ -56,4 +58,3 @@ Operator surfaces consume presence as:
 - diagnostics exports for support and debugging
 
 Presence is access-controlled: only authenticated operator clients can view presence entries.
-

--- a/docs/architecture/protocol/handshake.md
+++ b/docs/architecture/protocol/handshake.md
@@ -57,6 +57,8 @@ The gateway validates the gateway access token during the WS upgrade using WebSo
 The gateway selects `tyrum-v1` as the negotiated subprotocol and reads the token from the `tyrum-auth.*` entry.
 The access token should be short-lived, revocable, and scoped to the peer role (`client` vs `node`) and least-privilege permissions. Avoid placing tokens in URLs.
 
+Operational note: some intermediaries log `Sec-WebSocket-Protocol`. Treat it as sensitive (redact in gateway/proxy logs). For peers that can set headers (non-browser clients/nodes), deployments may prefer an `Authorization: Bearer …` header rather than embedding the token in subprotocol metadata.
+
 ## Authorization notes
 
 After a connection is authenticated, the gateway authorizes what the peer can do based on its role and (for operator clients) its granted scopes. The gateway can also issue device-bound tokens to reduce bootstrap-token usage during normal operation.

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -18,3 +18,6 @@ Skills are discoverable and installable from a curated catalog.
 
 - Skills are guidance, not enforcement.
 - Hard enforcement comes from tool policy, approvals, and sandboxing.
+- Skills can still be a social-engineering and supply-chain risk (especially marketplace and workspace-provided skills). Operator clients should surface skill origin (bundled vs user vs workspace) and encourage review before enabling.
+- Workspace skills are supplied by the current workspace contents; treat them as untrusted by default and load them only in trusted workspaces under explicit policy.
+- Skills must not contain raw secret values; use secret handles via the secret provider.

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -35,6 +35,7 @@ MCP servers expose tool catalogs that Tyrum can call through a standardized inte
 - State-changing tools should support **postconditions** and emit **artifacts** suitable for audit.
 - Tools should accept **secret handles**, not raw secret values.
 - Tool outputs should redact secrets and avoid leaking sensitive local data by default.
+- Treat tool outputs (especially from web pages and channels) as untrusted input and rely on provenance tagging plus policy rules to prevent prompt injection and unsafe tool chaining (see [Sandbox and policy](./sandbox-policy.md)).
 
 ## Approval pattern suggestions (approve-always)
 


### PR DESCRIPTION
## Summary
- Clarify presence fields (`host`/`ip`) are diagnostic-only; avoid using them for authorization.
- Add supply-chain/trust warnings for in-process plugins and marketplace/workspace skills.
- Tighten webhook/hook safety expectations (auth, replay resistance, rate limiting, secret handles, least privilege lanes).
- Add operational note to redact WS auth tokens in `Sec-WebSocket-Protocol` logs; prefer `Authorization` header where possible.
- Remind that tool outputs are untrusted; rely on provenance + policy to prevent injection/tool chaining.

## Verification
- `pnpm docs:public-check`
