### PR TITLE
docs(architecture): brain-inspired memory design

### DIFF
--- a/docs/architecture/agent.md
+++ b/docs/architecture/agent.md
@@ -7,7 +7,7 @@ An agent is a configured runtime persona that owns sessions, a workspace, enable
 - Tool allowlist/policy configuration
 - Enabled skills and MCP servers
 - Model configuration and fallback chain
-- Memory configuration (what is stored, retention, forget controls)
+- Memory configuration (agent scope, budgets, consolidation, and forget controls)
 
 ## Agent outputs
 

--- a/docs/architecture/context-compaction.md
+++ b/docs/architecture/context-compaction.md
@@ -33,6 +33,15 @@ Compaction should:
 - Preserve key decisions and unfinished threads.
 - Avoid inventing facts or deleting obligations.
 
+## Compaction vs long-term memory
+
+Session compaction is a **prompt-level** optimization; it is not a long-term memory system.
+
+- The compaction summary exists to keep ongoing work safe and coherent within a bounded context window.
+- Long-term memory lives in the StateStore (agent-scoped) and is retrieved as a budgeted digest for each turn (see [Memory](./memory.md)).
+
+At compaction boundaries, the system MAY trigger consolidation workflows that promote durable lessons (facts/preferences/procedures) out of ephemeral context into long-term memory. These workflows are budget-driven and auditable, and must not silently “remember” sensitive content.
+
 ## Pruning (tool-result trimming)
 
 Pruning reduces context bloat by trimming or clearing older tool results in the prompt for a single run while leaving the durable transcript intact.

--- a/docs/architecture/data-lifecycle.md
+++ b/docs/architecture/data-lifecycle.md
@@ -15,7 +15,7 @@ References:
 
 ## Principles
 
-- **Bounded by default:** every high-volume log or cache has an explicit retention/TTL/limit.
+- **Bounded by default:** every high-volume surface has an explicit retention/TTL/limit/budget.
 - **Durable truth vs derived views:** durable tables are the source of truth; derived views (presence, directories, caches) are TTL-bounded.
 - **Safety first:** sensitive classes (secrets, sensitive artifacts, connector payloads) default to shorter retention and stricter access.
 - **Auditable deletion:** destructive lifecycle actions are observable and attributable (who/when/why).
@@ -27,6 +27,7 @@ References:
 Examples:
 
 - sessions and transcripts
+- durable agent memory (facts, notes/preferences, procedures, tombstones)
 - run/job/step/attempt state
 - approvals and policy overrides
 - audit/event logs and policy decision records
@@ -71,6 +72,15 @@ Lifecycle expectations:
 - Operational recovery (edge restarts, brief partitions) should succeed without manual outbox surgery.
 - When outbox items are deleted by retention, recovery remains possible via durable StateStore-backed reads (events are not the only truth).
 
+## Memory budgets (special case)
+
+Agent memory is durable by design, but must remain bounded for cost and operability. The default lifecycle model is **budget-based**, not time-based:
+
+- Inactivity must not cause forgetting.
+- When budgets are exceeded, the system performs consolidation and eviction until back under budget.
+- Eviction should prefer compressing/re-summarizing high-volume episodic data and dropping derived indexes (embeddings) before deleting canonical memory content.
+- Explicit “forget” actions must be auditable and should produce tombstones that preserve stable ids and deletion proof without retaining content.
+
 ## Redaction and privacy boundaries
 
 Retention is only safe when redaction boundaries are correct:
@@ -91,4 +101,3 @@ If a deployment supports “forget” or data deletion requests, it MUST define:
 - which durable records are deleted vs anonymized vs retained for audit,
 - how linked artifacts are handled (metadata and bytes), and
 - how the system proves deletion occurred (auditable events).
-

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -8,6 +8,26 @@ A configured runtime identity that owns sessions, a workspace, enabled tools/ski
 
 The end-to-end path from an inbound message to model inference, tool execution, streaming output, and persistence.
 
+## Memory
+
+The durable, agent-scoped knowledge system that stores facts, preferences, procedures, and episodic records for later recall. Memory is bounded by **budgets** (not time-based TTL) and supports explicit “forget” with tombstones for auditability.
+
+## Memory item
+
+An addressable long-term memory record (stable id) stored in the StateStore and scoped to an agent. Memory items may be structured (facts) or text (notes) and can have derived indexes (for example embeddings) used for retrieval.
+
+## Memory budget
+
+A per-agent limit on memory volume (for example bytes/items/vectors). When exceeded, the system consolidates and evicts until back under budget. Inactivity must not cause forgetting.
+
+## Consolidation
+
+The process that converts high-volume episodic experience into lower-volume, reusable semantic/procedural memory and prunes redundancy under budget pressure (for example deduplication, summarization, merging facts, dropping derived indexes).
+
+## Tombstone
+
+A minimal durable record indicating a memory item was deleted/forgotten (who/when/why), without retaining the deleted content. Tombstones provide auditability and deletion proof.
+
 ## Capability
 
 A named interface a node can provide (for example `camera.capture`) with typed operations and evidence.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -110,6 +110,7 @@ flowchart LR
 - [Gateway authN/authZ](./gateway-authz.md)
 - [Execution engine](./execution-engine.md)
 - [Messages and Sessions](./messages-sessions.md)
+- [Memory](./memory.md)
 - [Playbooks](./playbooks.md)
 - [Approvals](./approvals.md)
 - [Policy overrides (approve-always)](./policy-overrides.md)

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -1,23 +1,156 @@
 # Memory
 
-Memory is Tyrum's durable store of facts, lessons learned, and episodic events that should outlive a single model context window.
+Memory is Tyrum’s durable, **agent-scoped** knowledge system. It converts transient run context into reusable knowledge and retrieves that knowledge safely across future sessions — even when the same agent is communicating over multiple channels.
 
-## Kinds of memory
+## Goals
 
-- **Short-term:** recent run context and cached signals (bounded).
-- **Long-term:** durable facts and lessons that survive compaction and restarts.
-- **Episodic events:** structured records of what happened (useful for audit and troubleshooting).
+- **Agent-scoped continuity:** a single agent can learn in channel A and use it later in channel B.
+- **Durable and auditable:** memory survives restarts and supports “why did it know/do that?” investigation.
+- **Bounded by budgets (not time):** inactivity must not cause forgetting; forgetting/compaction happens when budgets are exceeded.
+- **Safe by default:** no secrets; privacy-aware retention; explicit user/operator controls.
+
+## Non-goals
+
+- Memory is **not** a raw transcript store (sessions/transcripts are separate durable surfaces).
+- Memory is **not** a secret manager (secrets stay behind a secret provider and are referenced by handles).
+- Memory is **not** a shared team knowledge base unless explicitly modeled as such (default scope is the agent).
+
+## Scope and identity (hard rule)
+
+All durable memory is partitioned by `agent_id`.
+
+- The agent’s memory is available across all channels and threads that agent participates in.
+- Channels/threads contribute **provenance** (where a memory came from) but do not isolate or “silo” memory.
+- Deployments that require user-level separation MUST model that separately; agent-scoped memory is the default.
 
 ## Automatic pre-compaction flush
 
-When a session is close to auto-compaction, Tyrum can trigger a silent turn that reminds the agent to write durable memory before older context is summarized away. In many cases the correct behavior is to record memory and produce no user-visible reply.
+When a session is close to auto-compaction, Tyrum will trigger a silent turn that reminds the agent to write durable memory before older context is summarized away. In many cases the correct behavior is to record memory and produce no user-visible reply.
 
-## Vector memory search
+## Brain-inspired model (practical mapping)
 
-Tyrum can build a small vector index over markdown memory files so semantic queries can locate relevant notes even when wording differs.
+Tyrum uses the brain as a **metaphor for useful system behaviors**, not as a neuroscience simulation:
 
-## Safety expectations
+- **Working memory (PFC analogue):** the bounded context stack assembled for a single model call.
+- **Episodic memory (hippocampus analogue):** append-only records of what happened (high-fidelity, high-volume).
+- **Semantic memory (neocortex analogue):** stable facts and “lessons learned” (lower volume, higher reuse).
+- **Procedural memory (basal ganglia/cerebellum analogue):** “what tends to work” (capability/tool strategies).
+- **Consolidation (“sleep”):** background compaction that promotes durable lessons and prunes redundancy under budget pressure.
+
+## Memory primitives (what exists)
+
+Memory is stored in the **StateStore** (SQLite/Postgres) as durable records. Conceptually, memory is made of:
+
+- **Memory items:** addressable records (stable ids) containing either structured data (facts) or text (notes).
+- **Episodic events:** immutable events that capture experience and provenance for audit/consolidation.
+- **Derived indexes:** embeddings/vectors and other indexes used for retrieval. Derived data is never the source of truth.
+- **Tombstones:** minimal “deleted” records that preserve auditability without retaining content.
+
+### Memory item kinds
+
+The architecture supports multiple kinds of memory items, all scoped to `agent_id`:
+
+- **Facts (semantic):** key/value assertions with source and confidence.
+- **Notes (semantic/preferences/lessons):** operator- and user-readable memory (often markdown) used for recall.
+- **Procedures (procedural):** durable strategy records (“this approach works for capability X”) with success/failure signals.
+- **Episodes (episodic):** stored as events plus optional summaries; episodes are the raw material for consolidation.
+
+## Memory tools (agent-facing interface)
+
+Agents interact with durable memory via policy-gated tools that support **search + CRUD**:
+
+- **Search:** retrieve relevant memory items for a query (keyword and/or semantic), returning stable ids and snippets.
+- **Create:** store a new memory item (fact/note/procedure) with provenance, confidence, and sensitivity classification.
+- **Read:** fetch a memory item by id (and optionally list by filters).
+- **Update:** revise an existing memory item (for example increase confidence, refine phrasing, or attach better provenance).
+- **Delete:** delete/forget a memory item by id; deletion produces an auditable tombstone and invalidates derived indexes.
+
+All memory tool operations are implicitly scoped to the active `agent_id` so knowledge learned in one channel is available in another.
+
+## Encoding (write path)
+
+Memory can be written from multiple sources:
+
+- **Explicit user intent:** “remember this”, “always/never”, preferences, durable decisions.
+- **Workflow outcomes:** successful procedures, failures with lessons learned, approvals and policy outcomes.
+- **Operator annotations:** notes that should persist and apply broadly to the agent.
+
+Write-time safety gates (baseline expectations):
+
+- **Secret detection + redaction:** refuse or redact secret-like content.
+- **Classification:** tag sensitivity (public/private/sensitive) to drive access control and retention budgets.
+- **Provenance capture:** keep references to where this came from (session id, channel, tool evidence, approvals).
+
+## Retrieval (read path)
+
+Retrieval is cue-based and **budgeted**: the system assembles a small, high-signal set of memories for the current turn.
+
+Typical retrieval strategies (combined and ranked):
+
+- **Structured lookup:** exact keys, tags, and pinned preferences (high precision).
+- **Keyword search:** over note text and selected episodic summaries (fast baseline).
+- **Semantic search:** embeddings over eligible memory items (high recall).
+- **Procedural search:** rank “procedures” by success signals and relevance to the current intent.
+- **Association expansion (optional):** a small “spreading activation” step that pulls a few strongly connected items.
+
+Retrieval output MUST be:
+
+- **bounded** (token/char/item budget for injection),
+- **attributed** (stable ids + provenance),
+- **safe** (treated as information, not as instructions that bypass policy/approvals).
+
+## Consolidation (budget-triggered)
+
+Consolidation converts episodic records into reusable semantic/procedural memory and keeps the whole system bounded.
+
+Key properties:
+
+- Consolidation runs when **budgets are exceeded** (and may also run at task boundaries like “plan completed” or “context compaction happened”).
+- Consolidation prefers **compression over deletion**: summarize episodes into notes, merge duplicate facts, and keep “canonical” items.
+- Derived indexes (embeddings) are rebuilt or dropped as needed; they are expendable compared to canonical memory content.
+
+## Budgets and enforcement (no time-based forgetting)
+
+Forgetting is driven by **budgets**, not by wall-clock time:
+
+- Inactivity does not cause forgetting.
+- When new memories push the agent over budget, the system performs consolidation/eviction until it returns under budget.
+
+Budgets are per agent and may be expressed as:
+
+- maximum bytes/chars of note text,
+- maximum number of items per kind,
+- maximum embedding/vector count and/or total vector bytes,
+- maximum episodic “detail” retained before summaries replace raw payloads,
+- maximum association edge count (if enabled).
+
+### Eviction order (recommended)
+
+When over budget, apply the least-destructive steps first:
+
+1. **Deduplicate and merge** (same facts/notes).
+2. **Summarize/compress** high-volume episodic material into semantic notes.
+3. **Drop or downsample derived indexes** (embeddings/edges) while keeping canonical content.
+4. **Evict low-utility items** (low importance, low access, low confidence), preserving tombstones.
+
+Timestamps may be used as tie-breakers (“least recently activated”) but MUST NOT be used as TTL triggers.
+
+## Forgetting and tombstones
+
+Agents must support explicit, targeted forgetting:
+
+- Forget by stable id (preferred), or by selectors (kind/key/tag/provenance).
+- Forgetting deletes canonical content and invalidates derived indexes.
+
+For auditability, forgetting produces **tombstones**:
+
+- Tombstones preserve stable ids and minimal metadata (who/when/why), without retaining the deleted content.
+- Tombstones are queryable for “deletion proof” and compliance workflows.
+- Tombstones themselves are small and can have their own budget, but should be retained long enough to meet audit policy.
+
+## Safety expectations (hard requirements)
 
 - Do not store secrets in memory.
-- Redact sensitive fields where possible.
-- Provide clear user controls for viewing and forgetting memory.
+- Memory must be inspectable and user-controllable (view, export, forget).
+- Retrieval must never bypass policy/approvals; memory is supportive context, not an authority to perform risky actions.
+- All memory operations are policy-gated and observable (events + audit logs).

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -21,7 +21,7 @@ The canonical wire shape lives in `@tyrum/schemas` (`packages/schemas/src/protoc
 - **Execution engine:** run queued/started/paused/resumed/completed/failed; step started/completed; retries and budget events.
 - **Evidence:** artifacts captured/attached; postconditions passed/failed.
 - **Agent runtime:** plan/workflow selection and high-level intent updates.
-- **Memory:** facts/events written, compaction, snapshots.
+- **Memory:** items written/accessed/tombstoned, consolidation runs, and budget GC outcomes.
 - **Messaging UX:** typing indicators, outbound delivery receipts, and formatting fallbacks.
 - **Observability:** context reports, usage snapshots, and provider quota polling status.
 

--- a/docs/architecture/scaling-ha.md
+++ b/docs/architecture/scaling-ha.md
@@ -124,6 +124,8 @@ To keep the single-host and cluster behaviors aligned while avoiding RWX require
 - **Only ToolRunner mounts the workspace filesystem.**
 - Gateway edge, schedulers, and control-plane workers are otherwise **stateless with respect to workspace POSIX volumes**.
 
+Long-term memory does not depend on the workspace filesystem: it is stored in the **StateStore** and is scoped to the agent, making it available across channels and across gateway replicas without requiring shared POSIX mounts.
+
 ToolRunner runs as a **local subprocess** in single-host deployments and as a **sandboxed job/pod** in clustered deployments. Both forms mount the workspace at `TYRUM_HOME`, execute workspace-backed tools, persist outcomes/artifacts to the StateStore, and exit.
 
 ## Deployment topologies

--- a/docs/architecture/system-prompt.md
+++ b/docs/architecture/system-prompt.md
@@ -12,6 +12,7 @@ For each agent run, Tyrum assembles a custom system prompt. The purpose is to pr
 - Workspace: the working directory boundary for tools and file operations
 - Documentation: where local docs live and when to read them
 - Injected workspace files: bootstrap context included without explicit reads
+- Memory digest: budgeted long-term memory recall (from the StateStore), scoped to the agent
 - Sandbox: runtime constraints and whether elevated execution is available
 - Date and time: user-local time and formatting
 - Reply tags: optional provider-specific reply tags
@@ -50,4 +51,5 @@ These files (or equivalents) can be injected as "project context" so the model h
 - `USER.md`
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (only for brand-new workspaces)
-- `MEMORY.md`
+
+Long-term memory is not represented as a workspace file. It lives in the StateStore and is injected as a **budgeted memory digest** (agent-scoped recall) during context assembly.

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -10,7 +10,7 @@ Tools are the gateway's invocable operations used by the agent runtime. Tools ca
 - **fs:** read/write/edit/apply-patch operations within a workspace boundary
 - **session:** session list/history/send/spawn/status operations
 - **observability:** status/context/usage inspection and diagnostics
-- **memory:** search/get/write operations over durable memory
+- **memory:** agent-scoped durable memory tools for search + CRUD (create/read/update/delete), with budget enforcement and tombstones for auditability
 - **web:** search/fetch for browsing and extraction (when enabled)
 - **ui:** browser/canvas style surfaces (when enabled)
 - **workflow:** run/resume deterministic workflows (playbooks) with approvals and resume tokens

--- a/docs/architecture/workspace.md
+++ b/docs/architecture/workspace.md
@@ -7,6 +7,7 @@ A workspace is the agent's working directory boundary for tools that read and wr
 - Each agent has a single workspace directory (identified by a `WorkspaceId`).
 - Tools operate relative to that workspace by default.
 - The gateway can inject selected workspace files into context to reduce tool calls.
+- The workspace filesystem is an operator-visible surface for files and artifacts; **long-term memory is stored in the StateStore** (see [Memory](./memory.md)).
 
 ## Durability (hard requirement)
 


### PR DESCRIPTION
Updates architecture docs to a DB/StateStore-backed, agent-scoped memory system with budget-triggered consolidation/eviction and tombstoned forgetting.

Key points:
- Memory is always scoped to agent_id and shared across channels/threads for that agent.
- Forgetting is budget-driven (not time-based/TTL).
- Explicit forget produces tombstones for auditability.
- Documents agent-facing memory tools: search + CRUD.

Test plan:
- Docs-only change.