### PR TITLE
Desktop: set app name to Tyrum

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,8 @@ import type { GatewayManager } from "./gateway-manager.js";
 import { MAIN_WINDOW_OPTIONS } from "./window-options.js";
 import { configExists, loadConfig } from "./config/store.js";
 
+app.setName?.("Tyrum");
+
 let mainWindow: BrowserWindow | null = null;
 let gatewayManager: GatewayManager | null = null;
 let isQuitting = false;


### PR DESCRIPTION
Sets the Electron app name to "Tyrum" so the macOS menu bar/window title doesn't show "Tyrum Desktop" in dev.

- Change: apps/desktop/src/main/index.ts uses app.setName?.("Tyrum").
- Verified: pnpm typecheck, pnpm test, pnpm lint.