### PR TITLE
docs(architecture): tenancy model and scoping

### DIFF
--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -38,7 +38,7 @@ Approvals are exposed over:
 
 ## Scoping
 
-Approvals are scoped to durable identifiers, including `approval_id` and execution scope (`run_id`, `step_id`, `attempt_id`) plus agent/session identifiers where applicable.
+Approvals are scoped to durable identifiers, including `tenant_id`, `approval_id`, and execution scope (`run_id`, `step_id`, `attempt_id`) plus agent/session identifiers where applicable.
 
 ## Approval request shape
 
@@ -60,7 +60,7 @@ Resolutions are durable records:
 
 - `outcome` (`approved`, `denied`, or `expired`)
 - `resolved_at`
-- `resolved_by` (client identity / user identity)
+- `resolved_by` (tenant membership / user identity / client device identity)
 - optional `reason` (operator-provided)
 - optional `mode` (`once` or `always`, only meaningful when `outcome=approved`)
 - optional `policy_override_id` (when `mode=always` creates a durable policy override)

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -11,6 +11,7 @@ Artifacts are referenced using `ArtifactRef` (for example `artifact://…` URIs)
 Artifact metadata includes:
 
 - `artifact_id` / `ArtifactRef`
+- `tenant_id`
 - `agent_id`, `workspace_id`
 - execution scope (`run_id`, `step_id`, `attempt_id`)
 - `labels[]` (for example `screenshot`, `diff`, `log`, `http_trace`)
@@ -41,7 +42,7 @@ Artifact access is mediated by the gateway. Clients do not access artifact stora
 Authorization depends on:
 
 - authenticated operator identity (user + client device identity)
-- agent/workspace scope
+- tenant/agent/workspace scope
 - artifact `labels` and `sensitivity`
 - the policy snapshot reference attached to the artifact/run
 

--- a/docs/architecture/backplane.md
+++ b/docs/architecture/backplane.md
@@ -39,6 +39,13 @@ The backplane does **not** provide a global total order:
 
 If an operator view depends on ordering, it MUST be reconstructible from durable StateStore state (events are an incremental *signal*, not the only source of truth).
 
+### Tenant isolation
+
+In multi-tenant deployments, backplane routing is tenant-scoped:
+
+- outbox items are associated with exactly one `tenant_id`
+- consumers deliver items only to connections authenticated within that same tenant
+
 ### Durable append
 
 Publishing is durable:
@@ -110,4 +117,3 @@ If a peer is offline beyond the outbox retention window, it may miss incremental
 - Outbox payloads SHOULD avoid embedding raw secret values (prefer secret handles and redaction).
 - Treat the outbox and any backplane transport as sensitive data: apply access controls and avoid logging payloads by default.
 - Ensure tooling and infra do not leak auth tokens in WebSocket upgrade headers (see [Handshake](./protocol/handshake.md)).
-

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -7,21 +7,23 @@ A client is an operator interface that connects to the gateway and participates 
 - Desktop app (Windows/Linux/macOS)
 - Mobile app (iOS/Android)
 - CLI/TUI
-- Web interface served by the gateway
+- Web app (SPA)
 
 ## Responsibilities
 
 - Establish a single WebSocket connection per client device identity (`role: client`).
+- Authenticate a user and bind activity to a tenant membership (see [Tenancy](./tenancy.md) and [Gateway authN/authZ](./gateway-authz.md)).
 - Send requests (commands, session interactions, configuration changes).
 - Subscribe to events (status updates, audit evidence, approvals, pairing requests).
 - Provide human approvals and explanations when the gateway escalates.
 - Resume or cancel paused workflow runs (via resume tokens) when approvals are resolved.
 - Initiate and manage node pairing (approve/deny, label devices, revoke access).
 - Provide onboarding and diagnostics surfaces so hardened configuration is easy to reach (see [Operations and onboarding](./operations.md)).
+- Support **Admin Mode** (time-bounded step-up) for tenant administration actions.
 
-## Gateway control panel (web client)
+## Operator UI expectations
 
-The gateway’s web control panel is a client form that connects over WebSocket and provides operator oversight. At minimum it should expose:
+Operator clients provide oversight and administration. At minimum they should expose:
 
 - **Session:** a session-centric view rendered as a unified timeline that merges chat, runs/steps/attempts, approvals, and artifacts (reconstructible from durable state; live events stream updates). The UI supports lane filters and surfaces queue-mode semantics as pending input items.
 - **Approvals:** an approval queue (approve/deny) with previews and linked evidence.

--- a/docs/architecture/gateway-authz.md
+++ b/docs/architecture/gateway-authz.md
@@ -1,9 +1,8 @@
 # Gateway authN/authZ
 
-This document describes Tyrum’s **gateway authentication (authN)** and **authorization (authZ)** model. It supports both:
+This document describes Tyrum’s **gateway authentication (authN)** and **authorization (authZ)** model.
 
-- **Personal assistant mode** (single operator, local-first).
-- **Remote coworker / team mode** (multiple operators, remote access, explicit access control).
+Tyrum is multi-tenant: every authenticated request and connection is bound to exactly one `tenant_id` (see [Tenancy](./tenancy.md)).
 
 The gateway is the authority for identity, scopes, and audit trails. “Safety by prompt” is not a security boundary.
 
@@ -11,19 +10,39 @@ The gateway is the authority for identity, scopes, and audit trails. “Safety b
 
 - **Secure-by-default access:** expose nothing without explicit configuration, and require auth for all privileged interfaces.
 - **Least privilege:** clients and nodes get only the scopes/commands they need.
+- **Tenant-scoped access:** credentials are issued within a tenant and cannot cross tenant boundaries.
 - **Device-bound access:** credentials are issued to device identities, not “whoever has the URL”.
 - **Auditable change control:** auth and authZ decisions produce durable, inspectable evidence.
 
 ## Authentication (authN)
 
-### Bootstrap token
+### Human authentication (users)
 
-The gateway requires an operator bootstrap token (for example `GATEWAY_TOKEN`) for initial access over both:
+Human users authenticate through a tenant-configured auth provider. Tyrum supports both:
 
-- HTTP APIs (Authorization header), and
-- WebSocket upgrade (subprotocol token transport).
+- **Built-in auth** (self-contained user accounts for self-hosted and offline-friendly deployments), and
+- **OIDC auth** (SSO/enterprise deployments).
 
-Bootstrap tokens are treated as **admin-level** credentials and should be used only to enroll devices or recover access.
+The gateway maps provider identities into a canonical `user_id` and creates/updates tenant membership records that drive authorization.
+
+### Bootstrap and recovery
+
+The gateway exposes an explicit bootstrap/recovery mechanism that can be used to:
+
+- create the first tenant and owner membership in a fresh deployment
+- recover access if all admin memberships or devices are lost
+
+Bootstrap credentials are **admin-level** by definition and must be treated as break-glass secrets: used rarely, rotated, and audited.
+
+### Local bootstrap channel (first-device and remote enrollment)
+
+Tyrum provides a local operator channel (for example a CLI/TUI on the gateway host) that can perform tenant administration tasks, including:
+
+- approving/enrolling the first operator device
+- approving/enrolling additional non-local operator devices
+- approving/revoking nodes
+
+When the gateway is configured for loopback-only access, local operator devices can be auto-approved so a single-user desktop installation is frictionless.
 
 ### Device identity + proof
 
@@ -31,16 +50,33 @@ Every WebSocket peer has a **device identity** derived from a long-lived signing
 
 See [Handshake](./protocol/handshake.md) and [Identity](./identity.md).
 
+### Session and access tokens
+
+After a user authenticates, the gateway issues short-lived access tokens scoped to:
+
+- `tenant_id`
+- `user_id` (or service principal id for nodes)
+- peer `role` (`client` or `node`)
+- effective scopes / permissions
+- optional `device_id` binding
+
+Tokens are presented to the gateway on HTTP requests and WebSocket upgrades (see [Handshake](./protocol/handshake.md)).
+
 ## Authorization (authZ)
 
-### Roles and scopes
+### Roles, scopes, and surfaces
 
 Peers connect as one of:
 
 - `client` (operator surface)
 - `node` (capability provider)
 
-Operator clients present an explicit list of scopes (examples):
+Authorization is based on tenant membership plus explicit scopes. Scopes separate two surfaces:
+
+- **Core product surface:** day-to-day operation (sessions, runs, approvals, artifacts, nodes).
+- **Tenant administration surface:** tenant configuration and security operations (users, devices, pairing policy, secrets, exports, enforcement defaults).
+
+Example operator scopes:
 
 - `operator.read` (read-only status/session views)
 - `operator.write` (send messages, start runs)
@@ -50,7 +86,13 @@ Operator clients present an explicit list of scopes (examples):
 
 **Per-method authorization:** every HTTP route and WS request type declares the scopes required to call it. Deny-by-default is the baseline.
 
-### Device tokens
+### Admin mode (step-up)
+
+Operator clients support an **Admin Mode** that grants elevated scopes for a short duration. Entering Admin Mode requires step-up authentication and/or an explicit approval, and it is audited.
+
+Admin Mode limits blast radius: routine usage runs with minimal scopes; tenant administration is explicit and time-bounded.
+
+### Device tokens and enrollment
 
 When a device proves identity, the gateway can issue a **device token** that is:
 
@@ -101,5 +143,6 @@ AuthN/authZ decisions must be observable and durable:
 - log and event failed auth attempts (rate-limited)
 - audit device enroll/approve/revoke/rotate actions
 - record the scope set used for each privileged action (method/route + scope check result)
+- include `tenant_id`, `user_id`, and `device_id` (when available) in audit records and events
 
 This is foundational for “many remote coworkers”: the system should answer **who did what, when, and why it was allowed**.

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -71,9 +71,29 @@ The system of record for durable state and logs (sessions, approvals, run/job st
 
 A cross-instance event delivery mechanism used in clustered deployments so workers/schedulers can publish events that the gateway edge instances deliver to their connected clients/nodes.
 
+## Tenant
+
+An isolation boundary for identity, policy, and durable state. A deployment hosts one or more tenants; every request, event, and durable record is scoped to exactly one `tenant_id`.
+
 ## Worker
 
 A step execution process that claims work (leases) and performs tool/capability calls. Workers scale horizontally.
+
+## User
+
+A human principal authenticated via a tenant-configured auth provider (built-in or OIDC). Users act through client devices.
+
+## Membership
+
+A durable binding of a user into a tenant, including a role and effective scopes. Membership is the unit of authorization and auditing for human actions.
+
+## Device
+
+A cryptographic endpoint identity derived from a long-lived signing keypair. Devices connect to the gateway as WebSocket peers (`role: client` or `role: node`) and are registered, pairable, and revocable.
+
+## Admin mode
+
+A time-bounded elevated access posture within a client UI that grants tenant administration capabilities after step-up authentication and/or explicit approval.
 
 ## Scheduler
 
@@ -102,6 +122,10 @@ A typed operation and typed reply correlated by `request_id`. Either peer may in
 ## Session
 
 A durable conversation container with transcript history and queue state. Session keys and DM scope rules determine which messages share context.
+
+## Workspace (filesystem)
+
+The agent’s working directory boundary for workspace-backed tools. Workspaces make file operations explicit, containable, and durable across runs. Workspaces are not tenants.
 
 ## Skill
 

--- a/docs/architecture/identity.md
+++ b/docs/architecture/identity.md
@@ -1,14 +1,21 @@
 # Identity
 
-Identity is how Tyrum names and scopes authority. Several identities exist in the system, each with a different purpose.
+Identity is how Tyrum attributes authority and scopes access to durable state. Tyrum uses identity at three layers:
+
+- **Tenant** (isolation boundary)
+- **User** (human principal)
+- **Device** (cryptographic endpoint identity for clients and nodes)
 
 ## Identity types
 
-- **User identity:** the human operator(s). Single-user is the default, but team/remote deployments support multiple operators with explicit scopes and audited actions.
-- **Agent identity:** which agent a session belongs to.
-- **Client identity:** which operator device is connected (`role: client`).
-- **Node identity:** which capability provider device is connected (`role: node`).
-- **Channel identity:** which connector/account a message came from.
+- **Tenant identity (`tenant_id`):** the primary security boundary. All durable records and events are scoped to exactly one tenant.
+- **User identity (`user_id`):** a human principal authenticated via a tenant-configured auth provider.
+- **Membership:** a durable binding of a user into a tenant, including a role and effective scopes.
+- **Agent identity (`agent_id`):** the configured runtime persona that owns sessions, tools/skills, and memory within a tenant.
+- **Client device identity (`device_id`, `role: client`):** a specific operator device connected to the gateway.
+- **Node device identity (`device_id`, `role: node`):** a capability provider device connected to the gateway.
+- **Channel identity (`channel_key`):** which connector/account instance an inbound message or event belongs to.
+- **Connection identity (`connection_id`):** an ephemeral identifier for a single live WebSocket connection, bound to a device identity after handshake.
 
 ## Device identities
 
@@ -24,4 +31,4 @@ Where `base32_lower_nopad` uses the RFC 4648 alphabet (`a-z2-7`), rendered lower
 
 - Pairing and revocation (nodes and clients)
 - Audit trails (who/what performed an action)
-- Scoping (which sessions and workspaces an action can touch)
+- Scoping (which tenant, agents, and workspaces an action can touch)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -9,7 +9,7 @@ Tyrum is an autonomous worker.
 - In the simplest case, it’s a **personal assistant** you run for yourself.
 - In richer deployments, it’s a **remote coworker** you can share with a team.
 
-The same core architecture is intended to scale from “one assistant” to “many coworkers” without turning into an un-auditable pile of prompts and cronjobs: durable execution, least-privilege authorization, explicit approvals, and evidence-backed audit trails.
+The same core architecture scales from “one assistant” to “many coworkers” without turning into an un-auditable pile of prompts and cronjobs: durable execution, least-privilege authorization, explicit approvals, and evidence-backed audit trails.
 
 ## Engineering bar
 
@@ -26,7 +26,7 @@ Tyrum’s architecture is intentionally conservative:
 ```mermaid
 flowchart LR
   subgraph Operator["Operator surfaces"]
-    C["Client<br/>(Desktop • Mobile • CLI/TUI • Web UI)"]
+    C["Client<br/>(Desktop • Mobile • CLI/TUI • Web App)"]
   end
 
   subgraph Runtime["Tyrum runtime"]
@@ -68,6 +68,7 @@ flowchart LR
 ## Building blocks
 
 - **Gateway:** the long-lived service that owns edge connectivity (WebSocket), routing, and contract validation. See [Gateway](./gateway/index.md).
+- **Tenancy:** the isolation boundary for identity, policy, and durable state. See [Tenancy](./tenancy.md).
 - **StateStore:** durable state and logs (SQLite local; Postgres for HA/scale). See [Scaling and high availability](./scaling-ha.md).
 - **Event backplane:** cross-instance delivery via a durable outbox (in-process for replica count = 1; shared for clusters). See [Backplane](./backplane.md), [Scaling and high availability](./scaling-ha.md), and [Events](./protocol/events.md).
 - **Execution engine:** the durable orchestration runtime (retries, idempotency, pause/resume, evidence). See [Execution engine](./execution-engine.md).
@@ -107,7 +108,9 @@ flowchart LR
 
 - [Scaling and high availability](./scaling-ha.md)
 - [Gateway](./gateway/index.md)
+- [Tenancy](./tenancy.md)
 - [Gateway authN/authZ](./gateway-authz.md)
+- [Identity](./identity.md)
 - [Execution engine](./execution-engine.md)
 - [Messages and Sessions](./messages-sessions.md)
 - [Memory](./memory.md)

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -32,7 +32,7 @@ Context reports are generated deterministically by the gateway and persisted alo
 - **Local accounting:** tokens/time attributed to runs/steps/attempts (source of truth for budgets and approvals).
 - **Provider usage:** provider-reported quota/usage windows when a provider exposes a usage endpoint and credentials allow access.
 
-Usage is scoped to the current session by default, with agent-wide and deployment-wide rollups available in the control panel.
+Usage is scoped to the current session by default, with agent-wide and tenant-wide rollups available in operator clients. Platform-wide rollups are restricted to platform administration.
 
 ## Events, logs, and evidence
 

--- a/docs/architecture/operations.md
+++ b/docs/architecture/operations.md
@@ -5,9 +5,9 @@ This document describes Tyrum’s operational model and the onboarding/diagnosti
 ## Goals
 
 - Make the **hardened path** the easiest path.
-- Provide a clear separation between:
-  - **personal assistant mode** (single operator, local-first), and
-  - **remote coworker / team mode** (multiple operators, remote access).
+- Support both:
+  - frictionless single-user local installations, and
+  - multi-user and multi-tenant deployments with explicit access control.
 - Ensure operators can quickly answer: “is this safe, is it working, and what changed?”
 
 ## Hardened-by-default onboarding
@@ -22,15 +22,19 @@ Onboarding produces a configuration that is safe without additional customizatio
 
 ### Onboarding flow
 
-Tyrum provides a guided onboarding flow (CLI and/or gateway-served UI) that:
+Tyrum provides a guided onboarding flow (CLI/TUI and/or operator clients) that:
 
-1. Generates or imports gateway credentials.
-2. Picks an operating mode:
-   - local/personal (single operator)
-   - team/remote (multiple operators, device enrollment)
-3. Configures provider auth profiles and secret provider integration.
-4. Enables a minimal set of channels/nodes (explicitly).
-5. Runs a security and connectivity check.
+1. Establishes tenant context (create the first tenant or select an existing tenant) and creates the initial owner membership.
+2. Configures tenant authentication (built-in auth and/or OIDC) and sets enforcement defaults.
+3. Enrolls the first operator device:
+   - loopback-local devices may be auto-approved when the gateway is configured for loopback-only access
+   - non-local devices are enrolled via explicit approval from a trusted operator channel
+4. Enrolls additional devices and nodes with explicit pairing and revocation controls.
+5. Configures provider auth profiles and secret provider integration.
+6. Enables a minimal set of channels/nodes (explicitly).
+7. Runs a security and connectivity check.
+
+Operator clients implement an explicit **Admin Mode** (step-up) so tenant administration actions are time-bounded and auditable.
 
 ## Diagnostics (“doctor”)
 

--- a/docs/architecture/policy-overrides.md
+++ b/docs/architecture/policy-overrides.md
@@ -13,7 +13,7 @@ They are most commonly created when an operator resolves an approval with **appr
 
 Policy overrides are scoped and conservative by default:
 
-- scoped at least to `agent_id` (and typically also `workspace_id` for workspace-backed tools)
+- scoped at least to `tenant_id` and `agent_id` (and typically also `workspace_id` for workspace-backed tools)
 - **cannot** override an explicit `deny` by default
 - intended to relax only `require_approval → allow`
 
@@ -83,6 +83,7 @@ Policy overrides are durable records separate from approvals. A minimal record s
 - `policy_override_id`
 - `status` (`active`, `revoked`, `expired`)
 - `created_at`, `created_by` (user identity + client identity)
+- `tenant_id`
 - `agent_id`
 - optional `workspace_id` (recommended for workspace-backed tools)
 - `tool_id`

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -28,6 +28,7 @@ The canonical wire shape lives in `@tyrum/schemas` (`packages/schemas/src/protoc
 ## Notes
 
 - Some gateway→peer interactions are modeled as **requests** (with responses) rather than events, for example `task.execute` and `approval.request`.
+- Events are **tenant-scoped**. The gateway delivers an event only to peers authenticated within the same `tenant_id`.
 
 ## Delivery expectations
 

--- a/docs/architecture/tenancy.md
+++ b/docs/architecture/tenancy.md
@@ -1,0 +1,47 @@
+# Tenancy
+
+Tyrum is a multi-tenant system. A **tenant** is the isolation boundary for identity, policy, and durable state.
+
+Every request, event, and durable record is scoped to exactly one `tenant_id`.
+
+## Tenant isolation (hard requirements)
+
+- **No cross-tenant reads or writes:** a principal authorized in `tenant_a` cannot access data in `tenant_b`, even if it can guess identifiers.
+- **Deny-by-default routing:** if a request cannot be unambiguously associated with a tenant, the gateway must reject it.
+- **Audit by tenant:** audit logs and exported evidence must remain partitioned by tenant.
+
+## Users and membership
+
+Users are human principals. A user may belong to one or more tenants.
+
+Within a tenant, access is granted via a **membership** that binds:
+
+- `tenant_id`
+- `user_id`
+- `role` (for example `owner`, `admin`, `member`, `viewer`)
+
+Membership is the unit of authorization and auditing for human actions.
+
+## Tenant-scoped resources
+
+The following resources are tenant-scoped (non-exhaustive):
+
+- users, memberships, and device registry
+- agents and agent configuration
+- sessions, messages, runs, steps, attempts
+- approvals and policy overrides
+- artifacts (metadata and bytes access)
+- secrets (handles, resolution policy, audit)
+- node pairings and capability allowlists
+- presence/connection directory and event streams
+
+## API surfaces and administration boundaries
+
+Tyrum exposes two tenant-scoped API surfaces:
+
+- **Core product surface:** day-to-day operation (sessions, runs, approvals, artifacts, nodes).
+- **Tenant administration surface:** tenant configuration (users, devices, pairing policy, secrets, exports, enforcement defaults).
+
+In multi-tenant deployments, Tyrum also exposes a **platform administration surface** used to create and manage tenants and global configuration. Platform administration is not reachable with tenant-scoped credentials.
+
+See [Gateway authN/authZ](./gateway-authz.md) and [Identity](./identity.md).


### PR DESCRIPTION
Defines a tenant-centric architecture for Tyrum and aligns core docs to use tenant-scoped identity and authorization.

- Add Tenancy doc (tenant isolation, memberships, API surfaces)
- Update gateway authN/authZ to be tenant-scoped and describe Admin Mode step-up
- Update client + onboarding docs to assume a standalone SPA and elevated admin mode
- Align scoping language across approvals, policy overrides, artifacts, backplane, events, and observability