### PR TITLE
[WS-I] [I1] Enforce required plugin manifest fields and reject undeclared contributions at load time (#435)

### DIFF
--- a/packages/gateway/src/modules/plugins/registry.ts
+++ b/packages/gateway/src/modules/plugins/registry.ts
@@ -179,6 +179,10 @@ function commandAllowed(manifest: PluginManifestT, name: string): boolean {
   return Boolean(manifest.contributes?.commands?.includes(name));
 }
 
+function cloneManifest(manifest: PluginManifestT): PluginManifestT {
+  return structuredClone(manifest) as PluginManifestT;
+}
+
 function selectContainerForPlugin(manifest: PluginManifestT, container?: GatewayContainer): GatewayContainer | undefined {
   if (!container) return undefined;
   if (manifest.permissions?.db) return container;
@@ -365,7 +369,7 @@ export class PluginRegistry {
           continue;
         }
 
-        const manifest = { ...manifestFile.manifest, id };
+        const manifest = cloneManifest({ ...manifestFile.manifest, id });
         if (!manifest.entry) {
           this.opts.logger.warn("plugins.missing_entry", {
             plugin_id: id,
@@ -405,8 +409,9 @@ export class PluginRegistry {
 
         let registration: PluginRegistration;
         try {
+          const manifestForRegistration = cloneManifest(manifest);
           registration = await Promise.resolve(
-            registerFn({ manifest, logger: this.opts.logger.child({ plugin_id: id }) }),
+            registerFn({ manifest: manifestForRegistration, logger: this.opts.logger.child({ plugin_id: id }) }),
           );
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -444,7 +449,7 @@ export class PluginRegistry {
           commands.set(name, cmd);
         }
 
-        const undeclaredRouter = Boolean(registration.router) && (manifest.contributes?.routes.length ?? 0) === 0;
+        const undeclaredRouter = Boolean(registration.router) && (manifest.contributes?.routes?.length ?? 0) === 0;
         if (undeclaredTools.length > 0 || undeclaredCommands.length > 0 || undeclaredRouter) {
           this.opts.logger.warn("plugins.undeclared_contributions", {
             plugin_id: id,

--- a/packages/gateway/tests/unit/plugin-registry.test.ts
+++ b/packages/gateway/tests/unit/plugin-registry.test.ts
@@ -88,6 +88,47 @@ export function registerPlugin() {
 `;
 }
 
+function pluginEntryModuleMutatesRoutesAndRegistersRouter(): string {
+  return `
+export function registerPlugin({ manifest }) {
+  if (manifest.contributes) {
+    delete manifest.contributes.routes;
+  }
+  return {
+    router: { fake: true }
+  };
+}
+`;
+}
+
+function pluginEntryModuleMutatesAllowlistForUndeclaredTool(): string {
+  return `
+export function registerPlugin({ manifest }) {
+  manifest.contributes.tools.push("plugin.echo.undeclared");
+  return {
+    tools: [
+      {
+        descriptor: {
+          id: "plugin.echo.undeclared",
+          description: "Should remain undeclared by static manifest.",
+          risk: "low",
+          requires_confirmation: false,
+          keywords: ["echo"],
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+            additionalProperties: false
+          }
+        },
+        execute: async () => ({ output: "mutated" })
+      }
+    ]
+  };
+}
+`;
+}
+
 describe("PluginRegistry", () => {
   let home: string | undefined;
 
@@ -192,6 +233,52 @@ describe("PluginRegistry", () => {
     expect(
       await plugins.executeTool({
         toolId: "plugin.echo.echo",
+        args: { text: "hi" },
+        home,
+        agentId: "default",
+        workspaceId: "default",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not crash when plugin mutates manifest routes before returning a router contribution", async () => {
+    home = await mkdtemp(join(tmpdir(), "tyrum-plugin-home-"));
+    const pluginDir = join(home, "plugins/echo");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, "plugin.yml"), pluginManifestYaml(), "utf-8");
+    await writeFile(join(pluginDir, "index.mjs"), pluginEntryModuleMutatesRoutesAndRegistersRouter(), "utf-8");
+
+    const plugins = await PluginRegistry.load({
+      home,
+      logger: new Logger({ level: "silent" }),
+    });
+
+    expect(plugins.list()).toEqual([]);
+  });
+
+  it("rejects undeclared tools even when registerPlugin mutates manifest allowlists", async () => {
+    home = await mkdtemp(join(tmpdir(), "tyrum-plugin-home-"));
+    const pluginDir = join(home, "plugins/echo");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, "plugin.yml"),
+      pluginManifestYaml({
+        tools: [],
+        commands: [],
+      }),
+      "utf-8",
+    );
+    await writeFile(join(pluginDir, "index.mjs"), pluginEntryModuleMutatesAllowlistForUndeclaredTool(), "utf-8");
+
+    const plugins = await PluginRegistry.load({
+      home,
+      logger: new Logger({ level: "silent" }),
+    });
+
+    expect(plugins.list()).toEqual([]);
+    expect(
+      await plugins.executeTool({
+        toolId: "plugin.echo.undeclared",
         args: { text: "hi" },
         home,
         agentId: "default",


### PR DESCRIPTION
## Summary
- enforce required plugin manifest keys at discovery (`id`, `name`, `version`, `entry`, `contributes`, `permissions`) and reject invalid manifests per plugin without aborting global plugin load
- reject plugin load when runtime registration includes undeclared contributions (tools, commands, or router) instead of partially loading
- add unit regression coverage for missing required manifest fields and undeclared contribution registration

## Issue Links
- Closes #435
- Parent: #375
- Epic: #366
- Related: #366, #375

## TDD
- Red: added failing tests in `packages/gateway/tests/unit/plugin-registry.test.ts` for:
  - missing `contributes`
  - missing `permissions`
  - undeclared runtime contributions
- Green: implemented strict manifest key enforcement + undeclared contribution rejection in `PluginRegistry`
- Refactor: consolidated manifest validation with `REQUIRED_MANIFEST_FIELDS` + helper function

## Verification
- `pnpm exec vitest run packages/gateway/tests/unit/plugin-registry.test.ts` ✅ (4 passed)
- `pnpm lint` ✅
- `pnpm typecheck` ✅
