### PR TITLE
[WS-F] [F1] Replace enum-only capability IDs with namespaced capability descriptors and versioning (#415)

### DIFF
--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -24,6 +24,8 @@ import type { WsApprovalResolveResult as WsApprovalResolveResultT } from "@tyrum
 import type { WsCommandExecuteResult as WsCommandExecuteResultT } from "@tyrum/schemas";
 import type { WsPeerRole } from "@tyrum/schemas";
 import {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  descriptorIdForClientCapability,
   deviceIdFromSha256Digest,
   WsApprovalDecision,
   WsApprovalRequest,
@@ -504,7 +506,10 @@ export class TyrumClient {
             version: toOptionalTrimmedString(device.version),
             mode: toOptionalTrimmedString(device.mode),
           },
-          capabilities: this.opts.capabilities.map((id) => ({ id })),
+          capabilities: this.opts.capabilities.map((capability) => ({
+            id: descriptorIdForClientCapability(capability),
+            version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+          })),
         },
       };
 

--- a/packages/client/tests/ws-client.test.ts
+++ b/packages/client/tests/ws-client.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { WebSocket as WsWebSocket } from "ws";
 import { generateKeyPairSync } from "node:crypto";
+import {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  descriptorIdForClientCapability,
+} from "@tyrum/schemas";
 import { TyrumClient } from "../src/ws-client.js";
 
 // ---------------------------------------------------------------------------
@@ -178,6 +182,39 @@ describe("TyrumClient", () => {
     expect(Object.prototype.hasOwnProperty.call(device, "platform")).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(device, "version")).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(device, "mode")).toBe(false);
+  });
+
+  it("sends namespaced, versioned capability descriptors in connect.init", async () => {
+    server = createTestServer();
+    client = new TyrumClient({
+      url: server.url,
+      token: "t",
+      capabilities: ["cli", "http"],
+      reconnect: false,
+      useDeviceProof: true,
+      role: "node",
+      device: {
+        publicKey: "AQID",
+        privateKey: "BAUG",
+      },
+    });
+
+    client.connect();
+    const ws = await server.waitForClient();
+    const init = (await waitForMessage(ws)) as Record<string, unknown>;
+    expect(init["type"]).toBe("connect.init");
+
+    const payload = init["payload"] as Record<string, unknown>;
+    expect(payload["capabilities"]).toEqual([
+      {
+        id: descriptorIdForClientCapability("cli"),
+        version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+      },
+      {
+        id: descriptorIdForClientCapability("http"),
+        version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+      },
+    ]);
   });
 
   it("responds to ping with pong", async () => {

--- a/packages/gateway/src/routes/ws.ts
+++ b/packages/gateway/src/routes/ws.ts
@@ -13,7 +13,9 @@ import {
   WsConnectInitRequest,
   WsConnectProofRequest,
   WsConnectRequest,
+  clientCapabilityFromDescriptorId,
   deviceIdFromSha256Digest,
+  type CapabilityDescriptor,
   type ClientCapability,
   type WsPeerRole,
   type WsResponseEnvelope,
@@ -57,9 +59,15 @@ function buildConnectProofTranscript(input: {
 }
 
 function parseCapabilitiesFromInit(
-  payload: { capabilities: Array<{ id: ClientCapability }> },
+  payload: { capabilities: CapabilityDescriptor[] },
 ): ClientCapability[] {
-  return [...new Set(payload.capabilities.map((c) => c.id))];
+  return [
+    ...new Set(
+      payload.capabilities
+        .map((capability) => clientCapabilityFromDescriptorId(capability.id))
+        .filter((capability): capability is ClientCapability => capability !== undefined),
+    ),
+  ];
 }
 
 function parseRemoteIp(req: IncomingMessage): string | undefined {

--- a/packages/gateway/tests/integration/failure-matrix.test.ts
+++ b/packages/gateway/tests/integration/failure-matrix.test.ts
@@ -5,7 +5,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
-import { deviceIdFromSha256Digest } from "@tyrum/schemas";
+import {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  descriptorIdForClientCapability,
+  deviceIdFromSha256Digest,
+} from "@tyrum/schemas";
 
 import type { StepExecutor, StepResult } from "../../src/modules/execution/engine.js";
 import { ExecutionEngine } from "../../src/modules/execution/engine.js";
@@ -138,7 +142,10 @@ async function connectClientWithProof(input: {
         protocol_rev: 2,
         role: input.role,
         device: { device_id: deviceId, pubkey, label: "test" },
-        capabilities: input.capabilities.map((id) => ({ id })),
+        capabilities: input.capabilities.map((capability) => ({
+          id: descriptorIdForClientCapability(capability),
+          version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+        })),
       },
     }),
   );

--- a/packages/gateway/tests/integration/ws-handler.test.ts
+++ b/packages/gateway/tests/integration/ws-handler.test.ts
@@ -9,7 +9,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
-import { deviceIdFromSha256Digest } from "@tyrum/schemas";
+import {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  descriptorIdForClientCapability,
+  deviceIdFromSha256Digest,
+} from "@tyrum/schemas";
 
 function authProtocols(token: string): string[] {
   return [
@@ -267,7 +271,12 @@ describe("WS handler integration", () => {
           protocol_rev: 2,
           role: "client",
           device: { device_id: deviceId, pubkey: pubkeyB64Url, label: "test" },
-          capabilities: [{ id: "http" }],
+          capabilities: [
+            {
+              id: descriptorIdForClientCapability("http"),
+              version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+            },
+          ],
         },
       }),
     );
@@ -375,7 +384,12 @@ describe("WS handler integration", () => {
           protocol_rev: 2,
           role: "node",
           device: { device_id: deviceId, pubkey: pubkeyB64Url, label: "node-1" },
-          capabilities: [{ id: "cli" }],
+          capabilities: [
+            {
+              id: descriptorIdForClientCapability("cli"),
+              version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+            },
+          ],
         },
       }),
     );

--- a/packages/schemas/src/capability.ts
+++ b/packages/schemas/src/capability.ts
@@ -4,17 +4,59 @@ import { z } from "zod";
 export const ClientCapability = z.enum(["playwright", "android", "desktop", "cli", "http"]);
 export type ClientCapability = z.infer<typeof ClientCapability>;
 
+const CAPABILITY_ID_SEGMENT = "[a-z][a-z0-9-]*";
+const CAPABILITY_ID_PATTERN = new RegExp(`^${CAPABILITY_ID_SEGMENT}(?:\\.${CAPABILITY_ID_SEGMENT})+$`);
+const CAPABILITY_VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export const CAPABILITY_DESCRIPTOR_DEFAULT_VERSION = "1.0.0" as const;
+
+export const CapabilityDescriptorId = z
+  .string()
+  .trim()
+  .min(3)
+  .regex(CAPABILITY_ID_PATTERN, "capability IDs must be namespaced (example: system.shell.exec)");
+
+export const CapabilityDescriptorVersion = z
+  .string()
+  .trim()
+  .regex(CAPABILITY_VERSION_PATTERN, "capability versions must use semantic version format (x.y.z)");
+
+const LEGACY_TO_DESCRIPTOR_ID = {
+  playwright: "tyrum.playwright",
+  android: "tyrum.android",
+  desktop: "tyrum.desktop",
+  cli: "tyrum.cli",
+  http: "tyrum.http",
+} as const;
+
+type LegacyCapabilityDescriptorId = (typeof LEGACY_TO_DESCRIPTOR_ID)[ClientCapability];
+
+const DESCRIPTOR_TO_LEGACY = Object.fromEntries(
+  (Object.entries(LEGACY_TO_DESCRIPTOR_ID) as Array<[ClientCapability, LegacyCapabilityDescriptorId]>)
+    .map(([capability, id]) => [id, capability]),
+) as Record<LegacyCapabilityDescriptorId, ClientCapability>;
+
 /**
  * Capability descriptor used in the vNext handshake.
  *
- * Today this is intentionally minimal and uses the existing capability enum.
- * The target architecture allows richer, namespaced capabilities over time.
+ * Descriptors are namespaced and explicitly versioned so nodes can advertise
+ * stable contracts independently from legacy enum routing keys.
  */
 export const CapabilityDescriptor = z
   .object({
-    id: ClientCapability,
-    version: z.string().trim().min(1).optional(),
+    id: CapabilityDescriptorId,
+    version: CapabilityDescriptorVersion.default(CAPABILITY_DESCRIPTOR_DEFAULT_VERSION),
   })
   .strict();
 export type CapabilityDescriptor = z.infer<typeof CapabilityDescriptor>;
 
+export function descriptorIdForClientCapability(
+  capability: ClientCapability,
+): LegacyCapabilityDescriptorId {
+  return LEGACY_TO_DESCRIPTOR_ID[capability];
+}
+
+export function clientCapabilityFromDescriptorId(id: string): ClientCapability | undefined {
+  return DESCRIPTOR_TO_LEGACY[id as LegacyCapabilityDescriptorId];
+}

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -116,8 +116,11 @@ export type {
 } from "./postcondition.js";
 
 export {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
   CapabilityDescriptor,
   ClientCapability,
+  clientCapabilityFromDescriptorId,
+  descriptorIdForClientCapability,
   WsPeerRole,
   WsDeviceDescriptor,
   WsError,

--- a/packages/schemas/src/protocol.ts
+++ b/packages/schemas/src/protocol.ts
@@ -17,7 +17,13 @@ import { AgentId, Lane, TyrumKey } from "./keys.js";
 import { PresenceBeacon, PresenceEntry } from "./presence.js";
 import { PolicyOverride } from "./policy-bundle.js";
 
-export { CapabilityDescriptor, ClientCapability };
+export {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  CapabilityDescriptor,
+  ClientCapability,
+  clientCapabilityFromDescriptorId,
+  descriptorIdForClientCapability,
+} from "./capability.js";
 
 // ---------------------------------------------------------------------------
 // WebSocket protocol (v1) — request/response envelopes + events

--- a/packages/schemas/tests/capability.test.ts
+++ b/packages/schemas/tests/capability.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+  CapabilityDescriptor,
+  clientCapabilityFromDescriptorId,
+  descriptorIdForClientCapability,
+} from "../src/capability.js";
+
+describe("CapabilityDescriptor", () => {
+  it("parses namespaced descriptor IDs", () => {
+    const descriptor = CapabilityDescriptor.parse({
+      id: "system.shell.exec",
+      version: "2.3.1",
+    });
+    expect(descriptor).toEqual({
+      id: "system.shell.exec",
+      version: "2.3.1",
+    });
+  });
+
+  it("defaults version when omitted", () => {
+    const descriptor = CapabilityDescriptor.parse({
+      id: "tyrum.http",
+    });
+    expect(descriptor.version).toBe(CAPABILITY_DESCRIPTOR_DEFAULT_VERSION);
+  });
+
+  it("rejects enum-only IDs that are not namespaced", () => {
+    const parsed = CapabilityDescriptor.safeParse({
+      id: "http",
+      version: "1.0.0",
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("descriptor legacy mappings", () => {
+  it("maps core client capability to namespaced ID", () => {
+    expect(descriptorIdForClientCapability("cli")).toBe("tyrum.cli");
+  });
+
+  it("maps namespaced core descriptor ID back to client capability", () => {
+    expect(clientCapabilityFromDescriptorId("tyrum.http")).toBe("http");
+  });
+
+  it("returns undefined for unknown namespaced descriptor IDs", () => {
+    expect(clientCapabilityFromDescriptorId("camera.capture")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- replace enum-only `CapabilityDescriptor.id` with namespaced descriptor IDs and semver-style versioning
- add descriptor mapping helpers between legacy `ClientCapability` values and canonical namespaced IDs
- update `connect.init` device-proof handshake to advertise namespaced, versioned capability descriptors
- update gateway handshake parsing to map descriptors back to legacy routing capabilities
- add regression coverage for schema validation/mappings and handshake payload/acceptance paths

## Links
- Closes #415
- Parent: #372
- Epic: #366
- Related: #366, #372

## TDD
- RED: added failing tests in `packages/schemas/tests/capability.test.ts` and `packages/client/tests/ws-client.test.ts` (new connect.init descriptor assertion)
- GREEN: implemented descriptor schemas/mappings, client handshake serialization, and gateway descriptor parsing
- REFACTOR: centralized descriptor mapping/version constants in `packages/schemas/src/capability.ts`

## Test Evidence
- `pnpm exec vitest run packages/schemas/tests/capability.test.ts` ✅ (6 passed)
- `pnpm exec vitest run packages/client/tests/ws-client.test.ts` ✅ (22 passed)
- `pnpm exec vitest run packages/schemas/tests` ✅ (16 files, 166 passed)
- `pnpm exec vitest run packages/gateway/tests/integration/ws-handler.test.ts` ✅ (4 passed)
- `pnpm exec vitest run packages/gateway/tests/integration/failure-matrix.test.ts` ✅ (6 passed)
- `pnpm typecheck` ✅
- `pnpm lint` ✅
