### PR TITLE
[WS-H] [H1] Enforce anti-IDOR artifact authorization via durable linkage to authorized execution scope (#428)

### DIFF
--- a/packages/gateway/src/routes/artifact.ts
+++ b/packages/gateway/src/routes/artifact.ts
@@ -39,6 +39,12 @@ type ExecutionArtifactRow = {
   policy_snapshot_id: string | null;
 };
 
+type DurableExecutionScope = {
+  run_id: string;
+  step_id: string | null;
+  attempt_id: string | null;
+};
+
 function normalizeDbDateTime(value: string | Date | null): string | null {
   if (value === null) return null;
   const raw = value instanceof Date ? value.toISOString() : value;
@@ -100,6 +106,58 @@ async function evaluateAccessDecision(
   return decision;
 }
 
+async function resolveDurableExecutionScope(
+  deps: ArtifactRouteDeps,
+  row: ExecutionArtifactRow,
+): Promise<DurableExecutionScope | null> {
+  if (row.attempt_id) {
+    const attemptScope = await deps.db.get<{ run_id: string; step_id: string }>(
+      `SELECT s.run_id AS run_id, a.step_id AS step_id
+       FROM execution_attempts a
+       JOIN execution_steps s ON s.step_id = a.step_id
+       WHERE a.attempt_id = ?`,
+      [row.attempt_id],
+    );
+    if (!attemptScope) return null;
+    if (row.step_id && row.step_id !== attemptScope.step_id) return null;
+    if (row.run_id && row.run_id !== attemptScope.run_id) return null;
+    return {
+      run_id: attemptScope.run_id,
+      step_id: attemptScope.step_id,
+      attempt_id: row.attempt_id,
+    };
+  }
+
+  if (row.step_id) {
+    const stepScope = await deps.db.get<{ run_id: string }>(
+      "SELECT run_id FROM execution_steps WHERE step_id = ?",
+      [row.step_id],
+    );
+    if (!stepScope) return null;
+    if (row.run_id && row.run_id !== stepScope.run_id) return null;
+    return {
+      run_id: stepScope.run_id,
+      step_id: row.step_id,
+      attempt_id: null,
+    };
+  }
+
+  if (row.run_id) {
+    const runScope = await deps.db.get<{ run_id: string }>(
+      "SELECT run_id FROM execution_runs WHERE run_id = ?",
+      [row.run_id],
+    );
+    if (!runScope) return null;
+    return {
+      run_id: runScope.run_id,
+      step_id: null,
+      attempt_id: null,
+    };
+  }
+
+  return null;
+}
+
 export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
   const app = new Hono();
 
@@ -116,6 +174,17 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
     );
     if (!row) {
       return c.json({ error: "not_found", message: "artifact not found" }, 404);
+    }
+
+    const durableScope = await resolveDurableExecutionScope(deps, row);
+    if (!durableScope) {
+      return c.json(
+        {
+          error: "forbidden",
+          message: "artifact access denied: durable execution scope linkage is required",
+        },
+        403,
+      );
     }
 
     if (deps.policyService?.isEnabled() && !deps.policyService.isObserveOnly()) {
@@ -146,9 +215,9 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
         scope: {
           workspace_id: row.workspace_id,
           agent_id: row.agent_id,
-          run_id: row.run_id,
-          step_id: row.step_id,
-          attempt_id: row.attempt_id,
+          run_id: durableScope.run_id,
+          step_id: durableScope.step_id,
+          attempt_id: durableScope.attempt_id,
           sensitivity: row.sensitivity,
           policy_snapshot_id: row.policy_snapshot_id,
         },
@@ -170,6 +239,17 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
     );
     if (!row) {
       return c.json({ error: "not_found", message: "artifact not found" }, 404);
+    }
+
+    const durableScope = await resolveDurableExecutionScope(deps, row);
+    if (!durableScope) {
+      return c.json(
+        {
+          error: "forbidden",
+          message: "artifact access denied: durable execution scope linkage is required",
+        },
+        403,
+      );
     }
 
     if (deps.policyService?.isEnabled() && !deps.policyService.isObserveOnly()) {
@@ -207,7 +287,7 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
         event_id: randomUUID(),
         type: "artifact.fetched",
         occurred_at: new Date().toISOString(),
-        scope: row.run_id ? { kind: "run", run_id: row.run_id } : undefined,
+        scope: { kind: "run", run_id: durableScope.run_id },
         payload: {
           artifact: ref,
           fetched_by: {

--- a/packages/gateway/tests/integration/artifact.test.ts
+++ b/packages/gateway/tests/integration/artifact.test.ts
@@ -5,6 +5,43 @@ import { tmpdir } from "node:os";
 import { createApp } from "../../src/app.js";
 import { createTestContainer } from "./helpers.js";
 
+type SqlRunner = {
+  run(sql: string, params?: unknown[]): Promise<unknown>;
+};
+
+type ExecutionScopeIds = {
+  jobId: string;
+  runId: string;
+  stepId: string;
+  attemptId: string;
+};
+
+async function seedExecutionScope(db: SqlRunner, ids: ExecutionScopeIds): Promise<void> {
+  await db.run(
+    `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json, input_json, latest_run_id)
+     VALUES (?, ?, ?, 'running', ?, ?, ?)`,
+    [ids.jobId, "agent:agent-1:thread:thread-1", "main", "{}", "{}", ids.runId],
+  );
+
+  await db.run(
+    `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt)
+     VALUES (?, ?, ?, ?, 'running', 1)`,
+    [ids.runId, ids.jobId, "agent:agent-1:thread:thread-1", "main"],
+  );
+
+  await db.run(
+    `INSERT INTO execution_steps (step_id, run_id, step_index, status, action_json)
+     VALUES (?, ?, 0, 'running', ?)`,
+    [ids.stepId, ids.runId, "{}"],
+  );
+
+  await db.run(
+    `INSERT INTO execution_attempts (attempt_id, step_id, attempt, status, artifacts_json)
+     VALUES (?, ?, 1, 'running', '[]')`,
+    [ids.attemptId, ids.stepId],
+  );
+}
+
 describe("artifact routes", () => {
   let originalTyrumHome: string | undefined;
   let homeDir: string | undefined;
@@ -29,6 +66,79 @@ describe("artifact routes", () => {
   });
 
   it("GET /artifacts/:id streams bytes for stored artifacts with metadata", async () => {
+    const container = await createTestContainer();
+    const app = createApp(container);
+    const scope: ExecutionScopeIds = {
+      jobId: "job-artifacts-1",
+      runId: "run-artifacts-1",
+      stepId: "step-artifacts-1",
+      attemptId: "attempt-artifacts-1",
+    };
+    await seedExecutionScope(container.db, scope);
+
+    const ref = await container.artifactStore.put({
+      kind: "log",
+      mime_type: "text/plain",
+      body: Buffer.from("hello", "utf8"),
+      labels: ["log"],
+      metadata: { test: true },
+    });
+
+    await container.db.run(
+      `INSERT INTO execution_artifacts (
+         artifact_id,
+         workspace_id,
+         agent_id,
+         run_id,
+         step_id,
+         attempt_id,
+         kind,
+         uri,
+         created_at,
+         mime_type,
+         size_bytes,
+         sha256,
+         labels_json,
+         metadata_json,
+         sensitivity,
+         policy_snapshot_id
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        ref.artifact_id,
+        "default",
+        "agent-1",
+        scope.runId,
+        scope.stepId,
+        scope.attemptId,
+        ref.kind,
+        ref.uri,
+        ref.created_at,
+        ref.mime_type ?? null,
+        ref.size_bytes ?? null,
+        ref.sha256 ?? null,
+        JSON.stringify(ref.labels ?? []),
+        JSON.stringify(ref.metadata ?? {}),
+        "normal",
+        null,
+      ],
+    );
+
+    const metaRes = await app.request(`/artifacts/${ref.artifact_id}/metadata`);
+    expect(metaRes.status).toBe(200);
+    const metaBody = (await metaRes.json()) as { artifact: { uri: string; kind: string } };
+    expect(metaBody.artifact.uri).toBe(ref.uri);
+    expect(metaBody.artifact.kind).toBe(ref.kind);
+
+    const res = await app.request(`/artifacts/${ref.artifact_id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(await res.text()).toBe("hello");
+
+    await container.db.close();
+  });
+
+  it("GET /artifacts/:id denies unlinked artifacts that lack durable execution scope", async () => {
     const container = await createTestContainer();
     const app = createApp(container);
 
@@ -81,17 +191,86 @@ describe("artifact routes", () => {
     );
 
     const metaRes = await app.request(`/artifacts/${ref.artifact_id}/metadata`);
-    expect(metaRes.status).toBe(200);
-    const metaBody = (await metaRes.json()) as { artifact: { uri: string; kind: string } };
-    expect(metaBody.artifact.uri).toBe(ref.uri);
-    expect(metaBody.artifact.kind).toBe(ref.kind);
+    expect(metaRes.status).toBe(403);
 
     const res = await app.request(`/artifacts/${ref.artifact_id}`);
-    expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toBe("text/plain");
-    expect(await res.text()).toBe("hello");
+    expect(res.status).toBe(403);
+
+    await container.db.close();
+  });
+
+  it("GET /artifacts/:id denies artifacts with inconsistent execution linkage", async () => {
+    const container = await createTestContainer();
+    const app = createApp(container);
+    const scopeA: ExecutionScopeIds = {
+      jobId: "job-artifacts-a",
+      runId: "run-artifacts-a",
+      stepId: "step-artifacts-a",
+      attemptId: "attempt-artifacts-a",
+    };
+    const scopeB: ExecutionScopeIds = {
+      jobId: "job-artifacts-b",
+      runId: "run-artifacts-b",
+      stepId: "step-artifacts-b",
+      attemptId: "attempt-artifacts-b",
+    };
+    await seedExecutionScope(container.db, scopeA);
+    await seedExecutionScope(container.db, scopeB);
+
+    const ref = await container.artifactStore.put({
+      kind: "log",
+      mime_type: "text/plain",
+      body: Buffer.from("hello", "utf8"),
+      labels: ["log"],
+      metadata: { test: true },
+    });
+
+    await container.db.run(
+      `INSERT INTO execution_artifacts (
+         artifact_id,
+         workspace_id,
+         agent_id,
+         run_id,
+         step_id,
+         attempt_id,
+         kind,
+         uri,
+         created_at,
+         mime_type,
+         size_bytes,
+         sha256,
+         labels_json,
+         metadata_json,
+         sensitivity,
+         policy_snapshot_id
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        ref.artifact_id,
+        "default",
+        "agent-1",
+        scopeA.runId,
+        scopeB.stepId,
+        scopeB.attemptId,
+        ref.kind,
+        ref.uri,
+        ref.created_at,
+        ref.mime_type ?? null,
+        ref.size_bytes ?? null,
+        ref.sha256 ?? null,
+        JSON.stringify(ref.labels ?? []),
+        JSON.stringify(ref.metadata ?? {}),
+        "normal",
+        null,
+      ],
+    );
+
+    const metaRes = await app.request(`/artifacts/${ref.artifact_id}/metadata`);
+    expect(metaRes.status).toBe(403);
+
+    const res = await app.request(`/artifacts/${ref.artifact_id}`);
+    expect(res.status).toBe(403);
 
     await container.db.close();
   });
 });
-


### PR DESCRIPTION
## Summary
- enforce durable execution-scope linkage checks before serving artifact metadata/bytes
- deny unlinked artifacts and artifacts with inconsistent run/step/attempt linkage
- keep valid execution-engine artifacts fetchable and emit fetch audit events with the resolved durable run scope
- add integration coverage for deny/allow behavior

## Required Links
Closes #428
Parent: #374
Epic: #366
Related: #366, #374

## TDD
- Red: added failing integration tests in `packages/gateway/tests/integration/artifact.test.ts` for:
  - unlinked artifacts (`run_id`, `step_id`, `attempt_id` all null) must be denied
  - inconsistent scope linkage (`run_id` mismatched with `step_id`/`attempt_id`) must be denied
- Green: implemented minimal route guard in `packages/gateway/src/routes/artifact.ts` and re-ran tests to pass.

## Verification Evidence
- `pnpm exec vitest run packages/gateway/tests/integration/artifact.test.ts`
  - before fix: 2 failed, 1 passed
  - after fix: 3 passed
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (`1083 passed`, `2 skipped`)

## Risk / Rollback
- Risk: legacy manually inserted artifacts without durable execution scope are now denied (intentional anti-IDOR hardening).
- Rollback: revert this PR to restore prior artifact fetch behavior.
