### PR TITLE
[WS-H] [H2] Require scope-bound artifact fetch APIs and reject bare artifact_id-only access paths (#429)

### DIFF
--- a/packages/gateway/src/routes/artifact.ts
+++ b/packages/gateway/src/routes/artifact.ts
@@ -45,6 +45,8 @@ type DurableExecutionScope = {
   attempt_id: string | null;
 };
 
+const ARTIFACT_NOT_FOUND_BODY = { error: "not_found", message: "artifact not found" } as const;
+
 function normalizeDbDateTime(value: string | Date | null): string | null {
   if (value === null) return null;
   const raw = value instanceof Date ? value.toISOString() : value;
@@ -200,7 +202,7 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
       [parsedId.data],
     );
     if (!row) {
-      return c.json({ error: "not_found", message: "artifact not found" }, 404);
+      return c.json(ARTIFACT_NOT_FOUND_BODY, 404);
     }
 
     const durableScope = await resolveDurableExecutionScope(deps, row);
@@ -214,13 +216,7 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
       );
     }
     if (durableScope.run_id !== runId) {
-      return c.json(
-        {
-          error: "forbidden",
-          message: "artifact access denied: requested run scope does not match artifact linkage",
-        },
-        403,
-      );
+      return c.json(ARTIFACT_NOT_FOUND_BODY, 404);
     }
 
     if (deps.policyService?.isEnabled() && !deps.policyService.isObserveOnly()) {
@@ -279,7 +275,7 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
       [parsedId.data],
     );
     if (!row) {
-      return c.json({ error: "not_found", message: "artifact not found" }, 404);
+      return c.json(ARTIFACT_NOT_FOUND_BODY, 404);
     }
 
     const durableScope = await resolveDurableExecutionScope(deps, row);
@@ -293,13 +289,7 @@ export function createArtifactRoutes(deps: ArtifactRouteDeps): Hono {
       );
     }
     if (durableScope.run_id !== runId) {
-      return c.json(
-        {
-          error: "forbidden",
-          message: "artifact access denied: requested run scope does not match artifact linkage",
-        },
-        403,
-      );
+      return c.json(ARTIFACT_NOT_FOUND_BODY, 404);
     }
 
     if (deps.policyService?.isEnabled() && !deps.policyService.isObserveOnly()) {

--- a/packages/gateway/tests/integration/artifact.test.ts
+++ b/packages/gateway/tests/integration/artifact.test.ts
@@ -355,10 +355,28 @@ describe("artifact routes", () => {
     );
 
     const metaRes = await app.request(`/runs/run-wrong-scope/artifacts/${ref.artifact_id}/metadata`);
-    expect(metaRes.status).toBe(403);
+    expect(metaRes.status).toBe(404);
+    const metaBody = (await metaRes.json()) as { error: string; message: string };
+    expect(metaBody).toEqual({ error: "not_found", message: "artifact not found" });
 
     const res = await app.request(`/runs/run-wrong-scope/artifacts/${ref.artifact_id}`);
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body).toEqual({ error: "not_found", message: "artifact not found" });
+
+    const missingMetaRes = await app.request(
+      `/runs/${scope.runId}/artifacts/550e8400-e29b-41d4-a716-446655440000/metadata`,
+    );
+    expect(missingMetaRes.status).toBe(404);
+    const missingMetaBody = (await missingMetaRes.json()) as { error: string; message: string };
+    expect(missingMetaBody).toEqual(metaBody);
+
+    const missingRes = await app.request(
+      `/runs/${scope.runId}/artifacts/550e8400-e29b-41d4-a716-446655440000`,
+    );
+    expect(missingRes.status).toBe(404);
+    const missingBody = (await missingRes.json()) as { error: string; message: string };
+    expect(missingBody).toEqual(body);
 
     await container.db.close();
   });


### PR DESCRIPTION
Closes #429
Parent: #374
Epic: #366
Depends on: #428

Related: #366, #374, #428

## What
- Add scope-bound artifact fetch routes: `GET /runs/:runId/artifacts/:id` and `GET /runs/:runId/artifacts/:id/metadata`.
- Reject legacy bare artifact_id-only routes: `GET /artifacts/:id` and `GET /artifacts/:id/metadata` now return 400 `invalid_request`.
- Deny scope mismatches (requested `runId` must match the artifact's durable execution linkage).

## TDD / Verification
- RED: updated `packages/gateway/tests/integration/artifact.test.ts` to cover new scope-bound routes + legacy rejection + scope mismatch.
- GREEN: `pnpm exec vitest run packages/gateway/tests/integration/artifact.test.ts`
- Full gates: `pnpm test`, `pnpm typecheck`, `pnpm lint`}