### PR TITLE
[WS-G] [G3] Persist policy decisions with reasons, snapshot IDs, and applied override IDs on execution attempts (#423)

### DIFF
--- a/packages/gateway/migrations/postgres/020_execution_attempt_policy.sql
+++ b/packages/gateway/migrations/postgres/020_execution_attempt_policy.sql
@@ -1,0 +1,7 @@
+-- Persist policy decisions on execution attempts (Postgres).
+-- Adds structured policy evaluation fields for auditability.
+
+ALTER TABLE execution_attempts ADD COLUMN IF NOT EXISTS policy_snapshot_id TEXT;
+ALTER TABLE execution_attempts ADD COLUMN IF NOT EXISTS policy_decision_json TEXT;
+ALTER TABLE execution_attempts ADD COLUMN IF NOT EXISTS policy_applied_override_ids_json TEXT;
+

--- a/packages/gateway/migrations/sqlite/020_execution_attempt_policy.sql
+++ b/packages/gateway/migrations/sqlite/020_execution_attempt_policy.sql
@@ -1,0 +1,7 @@
+-- Persist policy decisions on execution attempts (SQLite).
+-- Adds structured policy evaluation fields for auditability.
+
+ALTER TABLE execution_attempts ADD COLUMN policy_snapshot_id TEXT;
+ALTER TABLE execution_attempts ADD COLUMN policy_decision_json TEXT;
+ALTER TABLE execution_attempts ADD COLUMN policy_applied_override_ids_json TEXT;
+

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -94,6 +94,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
       return new ExecutionEngine({
         db: container.db,
         redactionEngine: container.redactionEngine,
+        policyService: container.policyService,
         logger: container.logger,
       });
     })();

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -459,6 +459,7 @@ export async function main(role: GatewayRole = "all"): Promise<void> {
       ? new ExecutionEngine({
           db: container.db,
           redactionEngine: container.redactionEngine,
+          policyService: container.policyService,
           logger,
         })
       : undefined;
@@ -665,6 +666,7 @@ export async function main(role: GatewayRole = "all"): Promise<void> {
         const engine = new ExecutionEngine({
           db: container.db,
           redactionEngine: container.redactionEngine,
+          policyService: container.policyService,
           logger,
         });
 

--- a/packages/gateway/src/modules/execution/engine.ts
+++ b/packages/gateway/src/modules/execution/engine.ts
@@ -20,6 +20,8 @@ import { randomUUID } from "node:crypto";
 import type { RedactionEngine } from "../redaction/engine.js";
 import type { Logger } from "../observability/logger.js";
 import type { SqlDb } from "../../statestore/types.js";
+import type { PolicyService } from "../policy/service.js";
+import { canonicalizeToolMatchTarget } from "../policy/match-target.js";
 
 export interface StepResult {
   success: boolean;
@@ -90,6 +92,7 @@ interface RunnableRunRow {
   status: "queued" | "running";
   trigger_json: string;
   workspace_id: string;
+  policy_snapshot_id: string | null;
 }
 
 interface StepRow {
@@ -220,6 +223,7 @@ export class ExecutionEngine {
   private readonly clock: ClockFn;
   private readonly redactionEngine?: RedactionEngine;
   private readonly logger?: Logger;
+  private readonly policyService?: PolicyService;
   private readonly eventsEnabled: boolean;
   private readonly concurrencyLimits?: ExecutionConcurrencyLimits;
 
@@ -228,6 +232,7 @@ export class ExecutionEngine {
     clock?: ClockFn;
     redactionEngine?: RedactionEngine;
     logger?: Logger;
+    policyService?: PolicyService;
     eventsEnabled?: boolean;
     concurrencyLimits?: ExecutionConcurrencyLimits;
   }) {
@@ -235,6 +240,7 @@ export class ExecutionEngine {
     this.clock = opts.clock ?? defaultClock;
     this.redactionEngine = opts.redactionEngine;
     this.logger = opts.logger;
+    this.policyService = opts.policyService;
     this.eventsEnabled = opts.eventsEnabled ?? true;
     this.concurrencyLimits =
       opts.concurrencyLimits ??
@@ -395,6 +401,9 @@ export class ExecutionEngine {
       artifacts_json: string;
       cost_json: string | null;
       metadata_json: string | null;
+      policy_snapshot_id: string | null;
+      policy_decision_json: string | null;
+      policy_applied_override_ids_json: string | null;
     }>(
       `SELECT
          attempt_id,
@@ -408,7 +417,10 @@ export class ExecutionEngine {
          postcondition_report_json,
          artifacts_json,
          cost_json,
-         metadata_json
+         metadata_json,
+         policy_snapshot_id,
+         policy_decision_json,
+         policy_applied_override_ids_json
        FROM execution_attempts
        WHERE attempt_id = ?`,
       [attemptId],
@@ -439,6 +451,9 @@ export class ExecutionEngine {
           artifacts: safeJsonParse(row.artifacts_json, [] as unknown[]),
           cost: safeJsonParse(row.cost_json, undefined as unknown),
           metadata: safeJsonParse(row.metadata_json, undefined as unknown),
+          policy_snapshot_id: row.policy_snapshot_id ?? undefined,
+          policy_decision: safeJsonParse(row.policy_decision_json, undefined as unknown),
+          policy_applied_override_ids: safeJsonParse(row.policy_applied_override_ids_json, undefined as unknown),
         },
       },
     };
@@ -818,7 +833,8 @@ export class ExecutionEngine {
          r.lane,
          r.status,
          j.trigger_json,
-         j.workspace_id
+         j.workspace_id,
+         r.policy_snapshot_id
        FROM execution_runs r
        JOIN execution_jobs j ON j.job_id = r.job_id
        WHERE r.status IN ('running', 'queued')
@@ -1151,16 +1167,18 @@ export class ExecutionEngine {
                  status,
                  started_at,
                  finished_at,
+                 policy_snapshot_id,
                  artifacts_json,
                  result_json,
                  error
-               ) VALUES (?, ?, ?, 'succeeded', ?, ?, '[]', ?, NULL)`,
+               ) VALUES (?, ?, ?, 'succeeded', ?, ?, ?, '[]', ?, NULL)`,
               [
                 attemptId,
                 next.step_id,
                 attemptNum,
                 clock.nowIso,
                 clock.nowIso,
+                run.policy_snapshot_id ?? null,
                 record.result_json ?? null,
               ],
             );
@@ -1223,15 +1241,17 @@ export class ExecutionEngine {
            attempt,
            status,
            started_at,
+           policy_snapshot_id,
            artifacts_json,
            lease_owner,
            lease_expires_at_ms
-         ) VALUES (?, ?, ?, 'running', ?, '[]', ?, ?)`,
+         ) VALUES (?, ?, ?, 'running', ?, ?, '[]', ?, ?)`,
         [
           attemptId,
           next.step_id,
           attemptNum,
           clock.nowIso,
+          run.policy_snapshot_id ?? null,
           input.workerId,
           clock.nowMs + leaseTtlMs,
         ],
@@ -1333,6 +1353,16 @@ export class ExecutionEngine {
       worker_id: opts.workerId,
       step_index: opts.stepIndex,
       action_type: opts.action.type,
+    });
+
+    await this.persistAttemptPolicyContext(opts).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger?.warn("execution.attempt.policy_persist_failed", {
+        run_id: opts.runId,
+        step_id: opts.stepId,
+        attempt_id: opts.attemptId,
+        error: message,
+      });
     });
 
     const result = await this.executeWithTimeout(
@@ -1666,6 +1696,85 @@ export class ExecutionEngine {
     });
 
     return true;
+  }
+
+  private async persistAttemptPolicyContext(opts: {
+    runId: string;
+    stepId: string;
+    attemptId: string;
+    key: string;
+    workspaceId: string;
+    action: ActionPrimitiveT;
+  }): Promise<void> {
+    const run = await this.db.get<{ policy_snapshot_id: string | null }>(
+      "SELECT policy_snapshot_id FROM execution_runs WHERE run_id = ?",
+      [opts.runId],
+    );
+    const policySnapshotId = run?.policy_snapshot_id?.trim() ?? "";
+    if (!policySnapshotId) return;
+
+    const tool = this.toolCallFromAction(opts.action);
+    await this.db.run(
+      `UPDATE execution_attempts
+       SET policy_snapshot_id = ?
+       WHERE attempt_id = ?`,
+      [policySnapshotId, opts.attemptId],
+    );
+
+    if (!this.policyService?.isEnabled()) return;
+    if (!tool) return;
+
+    const agentId = this.deriveAgentIdFromKey(opts.key) ?? "default";
+    const evaluation = await this.policyService.evaluateToolCallFromSnapshot({
+      policySnapshotId,
+      agentId,
+      workspaceId: opts.workspaceId,
+      toolId: tool.toolId,
+      toolMatchTarget: tool.matchTarget,
+      url: tool.url,
+      inputProvenance: { source: "workflow", trusted: true },
+    });
+
+    const decisionJson = JSON.stringify(
+      evaluation.decision_record ?? { decision: evaluation.decision, rules: [] },
+    );
+    const appliedOverrideIdsJson = JSON.stringify(evaluation.applied_override_ids ?? []);
+
+    await this.db.run(
+      `UPDATE execution_attempts
+       SET policy_decision_json = ?,
+           policy_applied_override_ids_json = ?
+       WHERE attempt_id = ?`,
+      [
+        decisionJson,
+        appliedOverrideIdsJson,
+        opts.attemptId,
+      ],
+    );
+  }
+
+  private toolCallFromAction(action: ActionPrimitiveT): { toolId: string; matchTarget: string; url?: string } | null {
+    const args = action.args as unknown;
+    if (!args || typeof args !== "object" || Array.isArray(args)) return null;
+    const rec = args as Record<string, unknown>;
+
+    if (action.type === "CLI") {
+      const cmd = typeof rec["cmd"] === "string" ? rec["cmd"].trim() : "";
+      const argv = Array.isArray(rec["args"])
+        ? (rec["args"] as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+      const command = [cmd, ...argv].filter((t) => t.trim().length > 0).join(" ").trim();
+      const matchTarget = canonicalizeToolMatchTarget("tool.exec", { command });
+      return { toolId: "tool.exec", matchTarget };
+    }
+
+    if (action.type === "Http") {
+      const url = typeof rec["url"] === "string" ? rec["url"].trim() : "";
+      const matchTarget = canonicalizeToolMatchTarget("tool.http.fetch", { url });
+      return { toolId: "tool.http.fetch", matchTarget, url };
+    }
+
+    return null;
   }
 
   private async markAttemptSucceeded(

--- a/packages/gateway/src/modules/policy/service.ts
+++ b/packages/gateway/src/modules/policy/service.ts
@@ -1,4 +1,9 @@
-import type { PolicyBundle as PolicyBundleT, Decision } from "@tyrum/schemas";
+import type {
+  PolicyBundle as PolicyBundleT,
+  Decision,
+  PolicyDecision as PolicyDecisionT,
+  RuleDecision as RuleDecisionT,
+} from "@tyrum/schemas";
 import { PolicyBundle } from "@tyrum/schemas";
 import { access } from "node:fs/promises";
 import { wildcardMatch } from "./wildcard.js";
@@ -122,6 +127,7 @@ export interface PolicyEvaluation {
   decision: Decision;
   policy_snapshot?: PolicySnapshotRow;
   applied_override_ids?: string[];
+  decision_record?: PolicyDecisionT;
 }
 
 export class PolicyService {
@@ -195,19 +201,97 @@ export class PolicyService {
   }): Promise<PolicyEvaluation> {
     const effective = await this.loadEffectiveBundle({ playbookBundle: params.playbookBundle });
     const snapshot = await this.getOrCreateSnapshot(effective.bundle);
+    return await this.evaluateToolCallAgainstBundle({
+      bundle: effective.bundle,
+      snapshot,
+      agentId: params.agentId,
+      workspaceId: params.workspaceId,
+      toolId: params.toolId,
+      toolMatchTarget: params.toolMatchTarget,
+      url: params.url,
+      secretScopes: params.secretScopes,
+      inputProvenance: params.inputProvenance,
+    });
+  }
 
-    const toolsDomain = normalizeDomain(effective.bundle.tools, "require_approval");
-    const egressDomain = normalizeDomain(effective.bundle.network_egress, "require_approval");
-    const secretsDomain = normalizeDomain(effective.bundle.secrets, "require_approval");
+  async evaluateToolCallFromSnapshot(params: {
+    policySnapshotId: string;
+    agentId: string;
+    workspaceId?: string;
+    toolId: string;
+    toolMatchTarget: string;
+    url?: string;
+    secretScopes?: string[];
+    inputProvenance?: { source: string; trusted: boolean };
+  }): Promise<PolicyEvaluation> {
+    const snapshot = await this.opts.snapshotDal.getById(params.policySnapshotId);
+    if (!snapshot) {
+      const record: PolicyDecisionT = {
+        decision: "require_approval",
+        rules: [
+          {
+            rule: "tool_policy",
+            outcome: "require_approval",
+            detail: `missing policy snapshot: ${params.policySnapshotId}`,
+          },
+        ],
+      };
+      return {
+        decision: "require_approval",
+        policy_snapshot: undefined,
+        applied_override_ids: undefined,
+        decision_record: record,
+      };
+    }
+
+    return await this.evaluateToolCallAgainstBundle({
+      bundle: snapshot.bundle,
+      snapshot,
+      agentId: params.agentId,
+      workspaceId: params.workspaceId,
+      toolId: params.toolId,
+      toolMatchTarget: params.toolMatchTarget,
+      url: params.url,
+      secretScopes: params.secretScopes,
+      inputProvenance: params.inputProvenance,
+    });
+  }
+
+  private async evaluateToolCallAgainstBundle(params: {
+    bundle: PolicyBundleT;
+    snapshot: PolicySnapshotRow;
+    agentId: string;
+    workspaceId?: string;
+    toolId: string;
+    toolMatchTarget: string;
+    url?: string;
+    secretScopes?: string[];
+    inputProvenance?: { source: string; trusted: boolean };
+  }): Promise<PolicyEvaluation> {
+    const toolsDomain = normalizeDomain(params.bundle.tools, "require_approval");
+    const egressDomain = normalizeDomain(params.bundle.network_egress, "require_approval");
+    const secretsDomain = normalizeDomain(params.bundle.secrets, "require_approval");
 
     let toolDecision = evaluateDomain(toolsDomain, params.toolId);
+    const rules: RuleDecisionT[] = [
+      {
+        rule: "tool_policy",
+        outcome: toolDecision,
+        detail: `tool_id=${params.toolId}`,
+      },
+    ];
 
     if (
-      effective.bundle.provenance?.untrusted_shell_requires_approval === true &&
+      params.bundle.provenance?.untrusted_shell_requires_approval === true &&
       params.inputProvenance?.trusted === false &&
       params.toolId.trim() === "tool.exec"
     ) {
       toolDecision = mostRestrictive(toolDecision, "require_approval");
+      rules.push({
+        rule: "provenance",
+        outcome: "require_approval",
+        detail: `untrusted_shell_requires_approval=true (source=${params.inputProvenance?.source ?? "unknown"})`,
+      });
     }
 
     let egressDecision: Decision = "allow";
@@ -215,6 +299,11 @@ export class PolicyService {
       const normalizedUrl = normalizeUrlForPolicy(params.url);
       if (normalizedUrl.length > 0) {
         egressDecision = evaluateDomain(egressDomain, normalizedUrl);
+        rules.push({
+          rule: "network_egress",
+          outcome: egressDecision,
+          detail: normalizedUrl,
+        });
       }
     }
 
@@ -225,6 +314,11 @@ export class PolicyService {
         decision = mostRestrictive(decision, evaluateDomain(secretsDomain, scope));
       }
       secretsDecision = decision;
+      rules.push({
+        rule: "secrets",
+        outcome: secretsDecision,
+        detail: `scopes=${params.secretScopes.length}`,
+      });
     }
 
     let decision = mostRestrictive(toolDecision, mostRestrictive(egressDecision, secretsDecision));
@@ -244,13 +338,21 @@ export class PolicyService {
       if (appliedOverrides.length > 0) {
         toolDecision = "allow";
         decision = mostRestrictive(toolDecision, mostRestrictive(egressDecision, secretsDecision));
+        rules.push({
+          rule: "policy_override",
+          outcome: "allow",
+          detail: `applied_overrides=${appliedOverrides.join(",")}`,
+        });
       }
     }
 
+    const decisionRecord: PolicyDecisionT = { decision, rules };
+
     return {
       decision,
-      policy_snapshot: snapshot,
+      policy_snapshot: params.snapshot,
       applied_override_ids: appliedOverrides.length > 0 ? appliedOverrides : undefined,
+      decision_record: decisionRecord,
     };
   }
 

--- a/packages/gateway/tests/unit/execution-engine.test.ts
+++ b/packages/gateway/tests/unit/execution-engine.test.ts
@@ -9,6 +9,10 @@ import {
   type StepResult,
 } from "../../src/modules/execution/engine.js";
 import { RedactionEngine } from "../../src/modules/redaction/engine.js";
+import { PolicySnapshotDal } from "../../src/modules/policy/snapshot-dal.js";
+import { PolicyOverrideDal } from "../../src/modules/policy/override-dal.js";
+import { defaultPolicyBundle } from "../../src/modules/policy/bundle-loader.js";
+import { PolicyService } from "../../src/modules/policy/service.js";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
 import type { SqliteDb } from "../../src/statestore/sqlite.js";
 
@@ -329,6 +333,60 @@ describe("ExecutionEngine (normalized)", () => {
     const cost = JSON.parse(row!.cost_json!) as { total_tokens?: number; duration_ms?: number };
     expect(cost.total_tokens).toBe(30);
     expect(typeof cost.duration_ms).toBe("number");
+  });
+
+  it("persists policy decisions (reasons + snapshot + applied override ids) on attempts", async () => {
+    db = openTestSqliteDb();
+
+    const home = await mkdtemp(join(tmpdir(), "tyrum-policy-home-"));
+    const snapshotDal = new PolicySnapshotDal(db);
+    const overrideDal = new PolicyOverrideDal(db);
+    const policyService = new PolicyService({ home, snapshotDal, overrideDal });
+
+    const snapshot = await snapshotDal.getOrCreate(defaultPolicyBundle());
+    const override = await overrideDal.create({
+      agentId: "agent-1",
+      workspaceId: "default",
+      toolId: "tool.exec",
+      pattern: "echo hi",
+      createdFromPolicySnapshotId: snapshot.policy_snapshot_id,
+    });
+
+    const engine = new ExecutionEngine({ db, policyService });
+    await engine.enqueuePlan({
+      key: "agent:agent-1:telegram-1:group:thread-1",
+      lane: "main",
+      planId: "plan-policy-attempt-1",
+      requestId: "req-policy-attempt-1",
+      policySnapshotId: snapshot.policy_snapshot_id,
+      steps: [action("CLI", { cmd: "echo", args: ["hi"] })],
+    });
+
+    const executor: StepExecutor = {
+      execute: vi.fn(async (): Promise<StepResult> => ({ success: true, result: { ok: true } })),
+    };
+
+    await drain(engine, "w1", executor);
+
+    const row = await db.get<{
+      policy_snapshot_id?: string | null;
+      policy_decision_json?: string | null;
+      policy_applied_override_ids_json?: string | null;
+    }>("SELECT * FROM execution_attempts LIMIT 1");
+
+    expect(row?.policy_snapshot_id).toBe(snapshot.policy_snapshot_id);
+
+    expect(row?.policy_decision_json).toBeTruthy();
+    const policyDecision = JSON.parse(row!.policy_decision_json!) as { decision?: unknown; rules?: unknown };
+    expect(policyDecision.decision).toBe("allow");
+    expect(Array.isArray(policyDecision.rules)).toBe(true);
+
+    expect(row?.policy_applied_override_ids_json).toBeTruthy();
+    const applied = JSON.parse(row!.policy_applied_override_ids_json!) as unknown;
+    expect(Array.isArray(applied)).toBe(true);
+    expect(applied).toContain(override.policy_override_id);
+
+    await rm(home, { recursive: true, force: true });
   });
 
   it("retries a failed step until it succeeds (within max_attempts)", async () => {

--- a/packages/schemas/src/execution.ts
+++ b/packages/schemas/src/execution.ts
@@ -4,6 +4,8 @@ import { Lane, TyrumKey } from "./keys.js";
 import { ActionPrimitive } from "./planner.js";
 import { ArtifactRef } from "./artifact.js";
 import { PostconditionReport } from "./postcondition.js";
+import { PolicyDecision } from "./policy.js";
+import { PolicyOverrideId, PolicySnapshotId } from "./policy-bundle.js";
 
 export const ExecutionJobId = UuidSchema;
 export type ExecutionJobId = z.infer<typeof ExecutionJobId>;
@@ -226,6 +228,9 @@ export const ExecutionAttempt = z
     artifacts: z.array(ArtifactRef).default([]),
     cost: AttemptCost.optional(),
     metadata: z.unknown().optional(),
+    policy_snapshot_id: PolicySnapshotId.optional(),
+    policy_decision: PolicyDecision.optional(),
+    policy_applied_override_ids: z.array(PolicyOverrideId).optional(),
   })
   .strict();
 export type ExecutionAttempt = z.infer<typeof ExecutionAttempt>;

--- a/packages/schemas/src/policy.ts
+++ b/packages/schemas/src/policy.ts
@@ -9,6 +9,12 @@ export const RuleKind = z.enum([
   "pii_guardrail",
   "legal_compliance",
   "connector_scope",
+  // Tool-policy domains (docs/architecture/sandbox-policy.md, tools.md).
+  "tool_policy",
+  "network_egress",
+  "secrets",
+  "provenance",
+  "policy_override",
 ]);
 export type RuleKind = z.infer<typeof RuleKind>;
 


### PR DESCRIPTION
Closes #423
Parent: #373
Epic: #366
Related: #422

## Summary
- Persists policy snapshot id + decision (with reasons) + applied override ids onto execution attempts.
- Evaluates tool policy for workflow attempts using the run's `policy_snapshot_id` (snapshot bundle) and active `policy_overrides`.
- Includes persisted policy fields in `attempt.updated` WS event payloads.

## DB / Contracts
- Migrations (SQLite/Postgres): add `execution_attempts.policy_snapshot_id`, `execution_attempts.policy_decision_json`, `execution_attempts.policy_applied_override_ids_json`.
- Schemas: `ExecutionAttempt` gains `policy_snapshot_id`, `policy_decision`, `policy_applied_override_ids`.
- `RuleKind` extended with tool-policy domains for structured reasons.

## Tests (TDD)
- Added unit coverage for override-allowed execution attempts: `packages/gateway/tests/unit/execution-engine.test.ts`.

## Verification (local)
- `pnpm typecheck` (pass)
- `pnpm lint` (0 warnings, 0 errors)
- `pnpm test` (173 files passed, 1157 tests passed; 1 file skipped / 2 tests skipped)
