### PR TITLE
[WS-D] [D3] Build Markdown IR parser with style/link/block spans and deterministic output (#401)

### DIFF
--- a/packages/gateway/src/modules/markdown/ir.ts
+++ b/packages/gateway/src/modules/markdown/ir.ts
@@ -164,7 +164,13 @@ function parseInlineMarkdown(input: string): { text: string; spans: MarkdownIrSp
     }
 
     if (input[idx] === "*" && !input.startsWith("**", idx)) {
-      const end = input.indexOf("*", idx + 1);
+      let end = -1;
+      for (let i = idx + 1; i < input.length; i += 1) {
+        if (input[i] !== "*") continue;
+        if (input[i - 1] === "*" || input[i + 1] === "*") continue;
+        end = i;
+        break;
+      }
       if (end !== -1) {
         const start = out.length;
         const inner = parseInlineMarkdown(input.slice(idx + 1, end));
@@ -340,28 +346,44 @@ export function markdownToIr(markdown: string): MarkdownIr {
   let text = "";
   const spans: MarkdownIrSpan[] = [];
   let prevEmittedKind: MarkdownBlock["kind"] | undefined;
+  let pendingSep: MarkdownBlockSeparator = "";
+
+  const maxSep = (a: MarkdownBlockSeparator, b: MarkdownBlockSeparator): MarkdownBlockSeparator => {
+    if (a === "\n\n" || b === "\n\n") return "\n\n";
+    if (a === "\n" || b === "\n") return "\n";
+    return "";
+  };
 
   for (const block of scanBlocks(input)) {
-    const separator =
+    const baseSeparator: MarkdownBlockSeparator =
       prevEmittedKind === undefined
         ? ""
         : prevEmittedKind === "list_item" && block.kind === "list_item" && block.sepBefore === "\n"
           ? "\n"
           : "\n\n";
 
+    const separator = prevEmittedKind === undefined ? "" : maxSep(pendingSep, baseSeparator);
+
     if (block.kind === "code_block") {
-      if (block.code.length === 0) continue;
+      if (block.code.length === 0) {
+        pendingSep = maxSep(pendingSep, baseSeparator);
+        continue;
+      }
       text += separator;
       const start = text.length;
       text += block.code;
       const end = text.length;
       spans.push({ kind: "block", block: "code_block", language: block.language, start, end });
+      pendingSep = "";
       prevEmittedKind = block.kind;
       continue;
     }
 
     const inline = parseInlineMarkdown(block.raw);
-    if (inline.text.length === 0) continue;
+    if (inline.text.length === 0) {
+      pendingSep = maxSep(pendingSep, baseSeparator);
+      continue;
+    }
 
     text += separator;
     const start = text.length;
@@ -387,6 +409,7 @@ export function markdownToIr(markdown: string): MarkdownIr {
     for (const span of inline.spans) {
       spans.push({ ...span, start: span.start + start, end: span.end + start });
     }
+    pendingSep = "";
     prevEmittedKind = block.kind;
   }
 

--- a/packages/gateway/tests/unit/markdown-ir.test.ts
+++ b/packages/gateway/tests/unit/markdown-ir.test.ts
@@ -41,6 +41,17 @@ describe("markdownToIr", () => {
     });
   });
 
+  it("does not close italic spans on bold delimiters", () => {
+    expect(markdownToIr("*foo **bar** baz*")).toEqual({
+      text: "foo bar baz",
+      spans: [
+        { kind: "block", block: "paragraph", start: 0, end: 11 },
+        { kind: "style", style: "italic", start: 0, end: 11 },
+        { kind: "style", style: "bold", start: 4, end: 7 },
+      ],
+    });
+  });
+
   it("captures strike spans and strips formatting markers from text", () => {
     expect(markdownToIr("~~strike~~")).toEqual({
       text: "strike",
@@ -174,6 +185,16 @@ describe("markdownToIr", () => {
       text: "two",
       spans: [
         { kind: "block", block: "list_item", ordered: false, depth: 0, start: 0, end: 3 },
+      ],
+    });
+  });
+
+  it("preserves blank line separators when skipping empty list items", () => {
+    expect(markdownToIr("- a\n\n- \n- c")).toEqual({
+      text: "a\n\nc",
+      spans: [
+        { kind: "block", block: "list_item", ordered: false, depth: 0, start: 0, end: 1 },
+        { kind: "block", block: "list_item", ordered: false, depth: 0, start: 3, end: 4 },
       ],
     });
   });


### PR DESCRIPTION
Closes #401
Parent: #370
Epic: #366
Related: #400

## Summary
- Adds deterministic Markdown → IR parser (`text` + spans for blocks/styles/links).
- Adds plain-text fallback renderer (`irToPlainText`) that rehydrates block markers and renders links as `label (url)`.
- Adds unit coverage for parsing + fallback rendering, including fence regressions and empty-block behavior.

## Verification (fresh)
- pnpm lint (0 warnings, 0 errors)
- pnpm typecheck (tsc -b exit 0)
- pnpm test (195 test files passed, 1 skipped; 1336 tests passed, 2 skipped)

## Notes
- TDD: wrote tests first for each span kind + regressions.
- Playwright: not run (no UI changes).

