### PR TITLE
[WS-D] [D4] Build IR-first chunker that preserves inline spans and fenced code integrity (#402)

### DIFF
--- a/packages/gateway/src/modules/markdown/ir.ts
+++ b/packages/gateway/src/modules/markdown/ir.ts
@@ -634,7 +634,7 @@ export function chunkIr(
   const text = ir.text ?? "";
   const measure = opts?.measure ?? ((chunk: MarkdownIr) => chunk.text.length);
 
-  if (text.length === 0) return [{ text: "", spans: [] }];
+  if (text.length === 0) return [];
   if (measure(ir) <= maxMeasure) return [ir];
 
   const chunks: MarkdownIr[] = [];

--- a/packages/gateway/src/modules/markdown/telegram.ts
+++ b/packages/gateway/src/modules/markdown/telegram.ts
@@ -2,6 +2,33 @@ import { chunkIr, chunkText, irToPlainText, markdownToIr } from "./ir.js";
 
 const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
 
+function trimOuterWhitespaceChunks(chunks: string[]): string[] {
+  const out = chunks.filter((chunk) => chunk.length > 0);
+
+  while (out.length > 0) {
+    const trimmed = out[0]!.trimStart();
+    if (trimmed.length === 0) {
+      out.shift();
+      continue;
+    }
+    out[0] = trimmed;
+    break;
+  }
+
+  while (out.length > 0) {
+    const idx = out.length - 1;
+    const trimmed = out[idx]!.trimEnd();
+    if (trimmed.length === 0) {
+      out.pop();
+      continue;
+    }
+    out[idx] = trimmed;
+    break;
+  }
+
+  return out;
+}
+
 export function renderMarkdownForTelegram(markdown: string, opts?: { maxChars?: number }): string[] {
   const maxChars = Math.max(
     1,
@@ -26,5 +53,5 @@ export function renderMarkdownForTelegram(markdown: string, opts?: { maxChars?: 
     chunks.push(...chunkText(chunk, maxChars));
   }
 
-  return chunks.filter((chunk) => chunk.length > 0);
+  return trimOuterWhitespaceChunks(chunks);
 }

--- a/packages/gateway/tests/unit/markdown-chunk.test.ts
+++ b/packages/gateway/tests/unit/markdown-chunk.test.ts
@@ -11,6 +11,10 @@ describe("chunkText", () => {
 });
 
 describe("chunkIr", () => {
+  it("returns no chunks for empty input", () => {
+    expect(chunkIr(markdownToIr(""), 5)).toEqual([]);
+  });
+
   it("does not emit a chunk that exceeds maxChars when a paragraph boundary begins at hardEnd - 1", () => {
     const ir = markdownToIr("abcd\n\nefgh");
     const chunks = chunkIr(ir, 5);

--- a/packages/gateway/tests/unit/markdown-telegram.test.ts
+++ b/packages/gateway/tests/unit/markdown-telegram.test.ts
@@ -23,4 +23,11 @@ describe("renderMarkdownForTelegram", () => {
     }
     expect(chunks.join("")).toBe("```ts\nX\n```");
   });
+
+  it("trims leading and trailing whitespace consistently when chunked", () => {
+    const chunks = renderMarkdownForTelegram("   0123456789   ", { maxChars: 4 });
+    expect(chunks.join("")).toBe("0123456789");
+    expect(chunks.at(0)?.startsWith(" ")).toBe(false);
+    expect(chunks.at(-1)?.endsWith(" ")).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #402
Parent: #370
Epic: #366

Related: #401

## Summary
- Added `chunkIr` to chunk Markdown IR while preserving inline spans and fenced code blocks.
- Updated Telegram formatting to chunk IR (measured by plain-text fallback length) so code fences stay balanced.

## TDD / Verification
- TDD: added failing tests first (chunking + Telegram), then implemented chunker and wired Telegram renderer.
- Tests: `pnpm test` (205 files passed, 1 skipped; 1398 tests passed, 2 skipped)
- Typecheck: `pnpm typecheck`
- Lint: `pnpm lint`
