### PR TITLE
Docs: llms.txt + raw markdown + DocSearch

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Build docs site
         run: pnpm --filter @tyrum/docs build
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
 
       - name: Create Pages project (idempotent)
         uses: cloudflare/wrangler-action@v3

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -9,6 +9,31 @@ const repoDocsDir = resolve(currentDir, "../../docs");
 const sidebarsPath = resolve(currentDir, "./sidebars.ts");
 const customCssPath = resolve(currentDir, "./src/css/custom.css");
 
+const algoliaAppId = process.env.ALGOLIA_APP_ID;
+const algoliaSearchApiKey = process.env.ALGOLIA_SEARCH_API_KEY;
+const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME;
+const algolia =
+  algoliaAppId && algoliaSearchApiKey && algoliaIndexName
+    ? {
+        appId: algoliaAppId,
+        apiKey: algoliaSearchApiKey,
+        indexName: algoliaIndexName,
+        contextualSearch: true,
+      }
+    : undefined;
+
+const navbarItems = [
+  { to: "/install", label: "Install", position: "left" },
+  { to: "/getting-started", label: "Quick Start", position: "left" },
+  { to: "/architecture", label: "Architecture", position: "left" },
+  ...(algolia ? [{ type: "search", position: "right" }] : []),
+  {
+    href: "https://github.com/rhernaus/tyrum",
+    label: "GitHub",
+    position: "right",
+  },
+] satisfies NonNullable<Preset.ThemeConfig["navbar"]>["items"];
+
 const config: Config = {
   title: "Tyrum",
   tagline: "Documentation",
@@ -56,17 +81,9 @@ const config: Config = {
   themeConfig: {
     navbar: {
       title: "Tyrum",
-      items: [
-        { to: "/install", label: "Install", position: "left" },
-        { to: "/getting-started", label: "Quick Start", position: "left" },
-        { to: "/architecture", label: "Architecture", position: "left" },
-        {
-          href: "https://github.com/rhernaus/tyrum",
-          label: "GitHub",
-          position: "right",
-        },
-      ],
+      items: navbarItems,
     },
+    ...(algolia ? { algolia } : {}),
     colorMode: {
       defaultMode: "dark",
       respectPrefersColorScheme: true,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "scripts": {
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "docusaurus build && node ./scripts/publish-raw-docs-and-llms.mjs",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.8.1",
-    "@docusaurus/preset-classic": "^3.8.1",
-    "@docusaurus/theme-mermaid": "^3.8.1",
+    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/preset-classic": "^3.9.2",
+    "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",

--- a/apps/docs/scripts/publish-raw-docs-and-llms.mjs
+++ b/apps/docs/scripts/publish-raw-docs-and-llms.mjs
@@ -1,0 +1,173 @@
+import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRootDir = resolve(scriptDir, "../../..");
+const repoDocsDir = resolve(repoRootDir, "docs");
+const buildDir = resolve(scriptDir, "..", "build");
+const outDocsDir = resolve(buildDir, "docs");
+
+function normalizeBaseUrl(url) {
+  return url.replace(/\/+$/, "");
+}
+
+function toUrlPath(filePath) {
+  return filePath.split(/[/\\\\]/).join("/");
+}
+
+function docUrl(baseUrl, relativeFilePath) {
+  return `${baseUrl}/docs/${toUrlPath(relativeFilePath)}`;
+}
+
+async function walkFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(fullPath)));
+      continue;
+    }
+    if (entry.isFile()) files.push(fullPath);
+  }
+  return files;
+}
+
+function sortPaths(paths) {
+  return [...paths].sort((a, b) => a.localeCompare(b));
+}
+
+function addSection(lines, header, urls) {
+  if (urls.length === 0) return;
+  lines.push(`## ${header}`);
+  lines.push("");
+  for (const url of urls) lines.push(`- ${url}`);
+  lines.push("");
+}
+
+async function main() {
+  await stat(repoDocsDir);
+  await stat(buildDir);
+
+  await rm(outDocsDir, { recursive: true, force: true });
+  await mkdir(outDocsDir, { recursive: true });
+  await cp(repoDocsDir, outDocsDir, { recursive: true });
+
+  const baseUrl = normalizeBaseUrl(
+    process.env.CF_PAGES_URL ?? process.env.DOCS_BASE_URL ?? "https://docs.tyrum.ai",
+  );
+
+  const repoDocFiles = await walkFiles(repoDocsDir);
+  const markdownFiles = sortPaths(
+    repoDocFiles
+      .map((fullPath) => relative(repoDocsDir, fullPath))
+      .filter((relPath) => [".md", ".mdx"].includes(extname(relPath))),
+  );
+
+  const remaining = new Set(markdownFiles);
+  const takeExact = (relPath) => {
+    if (!remaining.has(relPath)) return null;
+    remaining.delete(relPath);
+    return relPath;
+  };
+
+  const getStartedFiles = ["index.md", "install.md", "getting-started.md"]
+    .map(takeExact)
+    .filter(Boolean);
+
+  const advancedFiles = sortPaths(
+    [...remaining].filter((relPath) => relPath.startsWith("advanced/")),
+  );
+  for (const relPath of advancedFiles) remaining.delete(relPath);
+
+  const referenceFiles = [];
+  const policyService = takeExact("policy_service.md");
+  if (policyService) referenceFiles.push(policyService);
+
+  const executorFiles = sortPaths(
+    [...remaining].filter((relPath) => relPath.startsWith("executors/")),
+  );
+  for (const relPath of executorFiles) remaining.delete(relPath);
+  referenceFiles.push(...executorFiles);
+
+  const architectureIndex = takeExact("architecture/index.md");
+  const protocolIndex = takeExact("architecture/protocol/index.md");
+  const protocolChildren = sortPaths(
+    [...remaining].filter((relPath) => relPath.startsWith("architecture/protocol/")),
+  );
+  for (const relPath of protocolChildren) remaining.delete(relPath);
+
+  const architectureOther = sortPaths(
+    [...remaining].filter((relPath) => relPath.startsWith("architecture/")),
+  );
+  for (const relPath of architectureOther) remaining.delete(relPath);
+
+  const metaFiles = ["_README.md"].map(takeExact).filter(Boolean);
+
+  const otherFiles = sortPaths([...remaining]);
+
+  const lines = ["# Tyrum Documentation", ""];
+
+  addSection(
+    lines,
+    "Get Started",
+    getStartedFiles.map((relPath) => docUrl(baseUrl, relPath)),
+  );
+
+  addSection(
+    lines,
+    "Advanced",
+    advancedFiles.map((relPath) => docUrl(baseUrl, relPath)),
+  );
+
+  addSection(
+    lines,
+    "Reference",
+    referenceFiles.map((relPath) => docUrl(baseUrl, relPath)),
+  );
+
+  if (
+    architectureIndex ||
+    protocolIndex ||
+    protocolChildren.length > 0 ||
+    architectureOther.length > 0
+  ) {
+    lines.push("## Architecture");
+    lines.push("");
+
+    if (architectureIndex) lines.push(`- ${docUrl(baseUrl, architectureIndex)}`);
+
+    if (protocolIndex) {
+      lines.push(`- ${docUrl(baseUrl, protocolIndex)}`);
+      for (const relPath of protocolChildren) {
+        lines.push(`  - ${docUrl(baseUrl, relPath)}`);
+      }
+    } else {
+      for (const relPath of protocolChildren) {
+        lines.push(`- ${docUrl(baseUrl, relPath)}`);
+      }
+    }
+
+    for (const relPath of architectureOther) {
+      lines.push(`- ${docUrl(baseUrl, relPath)}`);
+    }
+    lines.push("");
+  }
+
+  addSection(
+    lines,
+    "Meta",
+    metaFiles.map((relPath) => docUrl(baseUrl, relPath)),
+  );
+
+  addSection(
+    lines,
+    "Other",
+    otherFiles.map((relPath) => docUrl(baseUrl, relPath)),
+  );
+
+  await writeFile(resolve(buildDir, "llms.txt"), `${lines.join("\n")}\n`, "utf8");
+}
+
+await main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,13 +97,13 @@ importers:
   apps/docs:
     dependencies:
       '@docusaurus/core':
-        specifier: ^3.8.1
+        specifier: ^3.9.2
         version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/preset-classic':
-        specifier: ^3.8.1
+        specifier: ^3.9.2
         version: 3.9.2(@algolia/client-search@5.49.0)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/theme-mermaid':
-        specifier: ^3.8.1
+        specifier: ^3.9.2
         version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@mdx-js/react':
         specifier: ^3.1.1
@@ -3041,48 +3041,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.50.0':
     resolution: {integrity: sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.50.0':
     resolution: {integrity: sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.50.0':
     resolution: {integrity: sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.50.0':
     resolution: {integrity: sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.50.0':
     resolution: {integrity: sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.50.0':
     resolution: {integrity: sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.50.0':
     resolution: {integrity: sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.50.0':
     resolution: {integrity: sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw==}
@@ -3229,24 +3237,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
@@ -3308,66 +3320,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}


### PR DESCRIPTION
## What
- Upgrade docs site to Docusaurus 3.9.x
- Add optional Algolia DocSearch (search box appears when `ALGOLIA_*` env vars are set)
- Publish raw Markdown sources at `/docs/**` and generate Cursor-style `/llms.txt`

## CI / deploy
- Docs workflow passes `ALGOLIA_APP_ID`, `ALGOLIA_SEARCH_API_KEY`, `ALGOLIA_INDEX_NAME` (if configured as repo secrets)

## Tests
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint` (0 errors; 1 pre-existing warning)

## Notes
- Increased timeout for the Playwright browser recovery test (Chromium relaunch can exceed 5s on slower disks).
