### PR TITLE
[WS-J] [J7] Implement control-panel unified session timeline with lane filters and queue visibility (#448)

### DIFF
--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -366,6 +366,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
   app.route(
     "/",
     createWebUiRoutes({
+      db: container.db,
       approvalDal: container.approvalDal,
       memoryDal: container.memoryDal,
       watcherProcessor: container.watcherProcessor,

--- a/packages/gateway/src/routes/web-ui.ts
+++ b/packages/gateway/src/routes/web-ui.ts
@@ -8,6 +8,7 @@ import type { Playbook } from "@tyrum/schemas";
 import type { PlaybookRunner } from "../modules/playbook/runner.js";
 import { APP_PATH_PREFIX, matchesPathPrefixSegment } from "../app-path.js";
 import { AUTH_COOKIE_NAME } from "../modules/auth/http.js";
+import type { SqlDb } from "../statestore/types.js";
 import {
   buildAuditTaskResponse,
   getPlanTimeline,
@@ -25,6 +26,7 @@ import {
 } from "../modules/web/consent-store.js";
 
 export interface WebUiDeps {
+  db?: SqlDb;
   approvalDal: ApprovalDal;
   memoryDal: MemoryDal;
   watcherProcessor: WatcherProcessor;
@@ -301,6 +303,27 @@ function fmtDate(value: string | null | undefined): string {
   return esc(date.toLocaleString());
 }
 
+function extractThreadMessageText(payloadJson: string): string {
+  try {
+    const parsed = JSON.parse(payloadJson) as unknown;
+    if (!parsed || typeof parsed !== "object") return "";
+    const message = (parsed as Record<string, unknown>)["message"];
+    if (!message || typeof message !== "object") return "";
+    const content = (message as Record<string, unknown>)["content"];
+    if (!content || typeof content !== "object") return "";
+
+    const kind = (content as Record<string, unknown>)["kind"];
+    if (kind === "text") {
+      const text = (content as Record<string, unknown>)["text"];
+      return typeof text === "string" ? text : "";
+    }
+    const caption = (content as Record<string, unknown>)["caption"];
+    return typeof caption === "string" ? caption : "";
+  } catch {
+    return "";
+  }
+}
+
 function messageBanner(search: URLSearchParams): string {
   const msg = search.get("msg");
   if (!msg) return "";
@@ -341,6 +364,7 @@ function withAuthToken(path: string, search: URLSearchParams): string {
 function shell(title: string, activePath: string, search: URLSearchParams, body: string): string {
   const links = [
     ["/app", "Dashboard"],
+    ["/app/session", "Session"],
     ["/app/live", "Live"],
     ["/app/approvals", "Approvals"],
     ["/app/activity", "Activity"],
@@ -986,6 +1010,413 @@ export function createWebUiRoutes(deps: WebUiDeps): Hono {
       </div>
     `;
     return c.html(shell("Dashboard", "/app", search, body));
+  });
+
+  app.get("/app/session", async (c) => {
+    const search = new URL(c.req.url).searchParams;
+    const db = deps.db;
+
+    const key = (search.get("key") ?? "").trim();
+    const laneInputs = search
+      .getAll("lanes")
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0);
+    const allowedLanes = new Set(["main", "subagent", "cron", "heartbeat"]);
+    const selectedLanes = Array.from(
+      new Set(laneInputs.filter((lane) => allowedLanes.has(lane))),
+    );
+    const lanes = selectedLanes.length > 0 ? selectedLanes : ["main"];
+
+    const laneCheckboxes = ["main", "subagent", "cron", "heartbeat"]
+      .map((lane) => {
+        const checked = lanes.includes(lane) ? "checked" : "";
+        return `<label><input type="checkbox" name="lanes" value="${lane}" ${checked}/> ${lane}</label>`;
+      })
+      .join("\n");
+
+    const filterForm = `
+      <form method="get" action="/app/session">
+        <article class="card">
+          <label for="sessionKey">Session key</label>
+          <input id="sessionKey" name="key" placeholder="agent:<agentId>:<channel>:<account>:<container>:<id>" value="${esc(key)}" />
+          <h2>Lane filters</h2>
+          <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));">
+            ${laneCheckboxes}
+          </div>
+          <div class="actions"><button type="submit">Load timeline</button></div>
+        </article>
+      </form>
+    `;
+
+    if (!db) {
+      const body = `
+        <div class="page-header">
+          <h1>Session Timeline</h1>
+          <p class="muted">DB access is required to render session timelines.</p>
+        </div>
+        ${filterForm}
+        <div class="card"><p class="notice error">Gateway DB handle not available in web UI deps.</p></div>
+      `;
+      return c.html(shell("Session", "/app/session", search, body), 500);
+    }
+
+    if (!key) {
+      const body = `
+        <div class="page-header">
+          <h1>Session Timeline</h1>
+          <p>Unified timeline merged from durable state (chat, execution, approvals, artifacts).</p>
+        </div>
+        ${filterForm}
+      `;
+      return c.html(shell("Session", "/app/session", search, body));
+    }
+
+    const lanePlaceholders = lanes.map(() => "?").join(", ");
+    const laneSql = `(${lanePlaceholders})`;
+    const laneParams = lanes.slice();
+
+    const queryErrors: string[] = [];
+    const safeAll = async <T>(label: string, fn: () => Promise<T[]>) => {
+      try {
+        return await fn();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        queryErrors.push(`${label}: ${message}`);
+        return [];
+      }
+    };
+
+    const [queueOverrides, queueRows, inboxRows, runs, steps, attempts, approvals, artifacts] =
+      await Promise.all([
+        safeAll("lane_queue_mode_overrides", () =>
+          db.all<{ lane: string; queue_mode: string; updated_at_ms: number }>(
+            `SELECT lane, queue_mode, updated_at_ms
+             FROM lane_queue_mode_overrides
+             WHERE key = ? AND lane IN ${laneSql}
+             ORDER BY updated_at_ms DESC`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("channel_inbox.pending", () =>
+          db.all<{
+            inbox_id: number;
+            lane: string;
+            status: string;
+            received_at_ms: number;
+            message_id: string;
+            queue_mode: string;
+            payload_json: string;
+          }>(
+            `SELECT inbox_id, lane, status, received_at_ms, message_id, queue_mode, payload_json
+             FROM channel_inbox
+             WHERE key = ?
+               AND lane IN ${laneSql}
+               AND status IN ('queued', 'processing')
+             ORDER BY received_at_ms ASC, inbox_id ASC
+             LIMIT 200`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("channel_inbox.recent", () =>
+          db.all<{
+            inbox_id: number;
+            lane: string;
+            status: string;
+            received_at_ms: number;
+            processed_at: string | null;
+            reply_text: string | null;
+            message_id: string;
+            payload_json: string;
+          }>(
+            `SELECT inbox_id, lane, status, received_at_ms, processed_at, reply_text, message_id, payload_json
+             FROM channel_inbox
+             WHERE key = ?
+               AND lane IN ${laneSql}
+             ORDER BY received_at_ms DESC, inbox_id DESC
+             LIMIT 200`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("execution_runs", () =>
+          db.all<{
+            run_id: string;
+            lane: string;
+            status: string;
+            created_at: string;
+            started_at: string | null;
+            finished_at: string | null;
+          }>(
+            `SELECT run_id, lane, status, created_at, started_at, finished_at
+             FROM execution_runs
+             WHERE key = ?
+               AND lane IN ${laneSql}
+             ORDER BY created_at DESC, run_id DESC
+             LIMIT 200`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("execution_steps", () =>
+          db.all<{
+            step_id: string;
+            run_id: string;
+            lane: string;
+            step_index: number;
+            status: string;
+            created_at: string;
+          }>(
+            `SELECT s.step_id, s.run_id, r.lane AS lane, s.step_index, s.status, s.created_at
+             FROM execution_steps s
+             JOIN execution_runs r ON r.run_id = s.run_id
+             WHERE r.key = ?
+               AND r.lane IN ${laneSql}
+             ORDER BY s.created_at DESC, s.step_id DESC
+             LIMIT 400`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("execution_attempts", () =>
+          db.all<{
+            attempt_id: string;
+            step_id: string;
+            lane: string;
+            attempt: number;
+            status: string;
+            started_at: string;
+            finished_at: string | null;
+          }>(
+            `SELECT a.attempt_id, a.step_id, r.lane AS lane, a.attempt, a.status, a.started_at, a.finished_at
+             FROM execution_attempts a
+             JOIN execution_steps s ON s.step_id = a.step_id
+             JOIN execution_runs r ON r.run_id = s.run_id
+             WHERE r.key = ?
+               AND r.lane IN ${laneSql}
+             ORDER BY a.started_at DESC, a.attempt_id DESC
+             LIMIT 600`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("approvals", () =>
+          db.all<{
+            id: number;
+            lane: string | null;
+            status: string;
+            created_at: string;
+            prompt: string;
+            run_id: string | null;
+          }>(
+            `SELECT id, lane, status, created_at, prompt, run_id
+             FROM approvals
+             WHERE key = ?
+               AND COALESCE(lane, 'main') IN ${laneSql}
+             ORDER BY created_at DESC, id DESC
+             LIMIT 200`,
+            [key, ...laneParams],
+          ),
+        ),
+        safeAll("execution_artifacts", () =>
+          db.all<{
+            artifact_id: string;
+            kind: string;
+            uri: string;
+            created_at: string;
+            run_id: string | null;
+            step_id: string | null;
+            attempt_id: string | null;
+            lane: string;
+          }>(
+            `SELECT a.artifact_id, a.kind, a.uri, a.created_at, a.run_id, a.step_id, a.attempt_id, r.lane AS lane
+             FROM execution_artifacts a
+             JOIN execution_runs r ON r.run_id = a.run_id
+             WHERE r.key = ?
+               AND r.lane IN ${laneSql}
+             ORDER BY a.created_at DESC, a.artifact_id DESC
+             LIMIT 200`,
+            [key, ...laneParams],
+          ),
+        ),
+      ]);
+
+    type TimelineItem = {
+      ts: number;
+      occurred_at: string;
+      lane: string;
+      kind: string;
+      detail: string;
+    };
+
+    const items: TimelineItem[] = [];
+
+    for (const row of inboxRows) {
+      const messageText = extractThreadMessageText(row.payload_json) || row.message_id;
+      const occurredAt = new Date(row.received_at_ms).toISOString();
+      items.push({
+        ts: row.received_at_ms,
+        occurred_at: occurredAt,
+        lane: row.lane,
+        kind: "message.in",
+        detail: `${row.status} ${row.message_id}: ${messageText}`,
+      });
+
+      if (row.reply_text) {
+        const replyTs = (() => {
+          const parsed = row.processed_at ? Date.parse(row.processed_at) : NaN;
+          return Number.isFinite(parsed) ? parsed : row.received_at_ms;
+        })();
+        items.push({
+          ts: replyTs,
+          occurred_at: row.processed_at ?? occurredAt,
+          lane: row.lane,
+          kind: "message.out",
+          detail: row.reply_text,
+        });
+      }
+    }
+
+    for (const run of runs) {
+      const ts = Date.parse(run.created_at);
+      items.push({
+        ts: Number.isFinite(ts) ? ts : 0,
+        occurred_at: run.created_at,
+        lane: run.lane,
+        kind: "run",
+        detail: `${run.run_id} status=${run.status}`,
+      });
+    }
+
+    for (const step of steps) {
+      const ts = Date.parse(step.created_at);
+      items.push({
+        ts: Number.isFinite(ts) ? ts : 0,
+        occurred_at: step.created_at,
+        lane: step.lane,
+        kind: "step",
+        detail: `${step.step_id} run=${step.run_id} index=${String(step.step_index)} status=${step.status}`,
+      });
+    }
+
+    for (const attempt of attempts) {
+      const ts = Date.parse(attempt.started_at);
+      items.push({
+        ts: Number.isFinite(ts) ? ts : 0,
+        occurred_at: attempt.started_at,
+        lane: attempt.lane,
+        kind: "attempt",
+        detail: `${attempt.attempt_id} step=${attempt.step_id} attempt=${String(attempt.attempt)} status=${attempt.status}`,
+      });
+    }
+
+    for (const approval of approvals) {
+      const ts = Date.parse(approval.created_at);
+      items.push({
+        ts: Number.isFinite(ts) ? ts : 0,
+        occurred_at: approval.created_at,
+        lane: approval.lane ?? "main",
+        kind: "approval",
+        detail: `#${String(approval.id)} status=${approval.status} run=${approval.run_id ?? ""} ${approval.prompt}`,
+      });
+    }
+
+    for (const artifact of artifacts) {
+      const ts = Date.parse(artifact.created_at);
+      items.push({
+        ts: Number.isFinite(ts) ? ts : 0,
+        occurred_at: artifact.created_at,
+        lane: artifact.lane,
+        kind: "artifact",
+        detail: `${artifact.artifact_id} kind=${artifact.kind} uri=${artifact.uri}`,
+      });
+    }
+
+    items.sort((a, b) => b.ts - a.ts);
+
+    const overridesByLane = new Map<string, string>();
+    for (const override of queueOverrides) {
+      if (!overridesByLane.has(override.lane)) {
+        overridesByLane.set(override.lane, override.queue_mode);
+      }
+    }
+
+    const queueSummaryRows = lanes
+      .map((lane) => {
+        const mode = overridesByLane.get(lane) ?? "default";
+        const queued = queueRows.filter((row) => row.lane === lane && row.status === "queued").length;
+        const processing = queueRows.filter((row) => row.lane === lane && row.status === "processing").length;
+        return `<tr>
+          <td>${esc(lane)}</td>
+          <td>${esc(mode)}</td>
+          <td>${String(queued)}</td>
+          <td>${String(processing)}</td>
+        </tr>`;
+      })
+      .join("");
+
+    const queueRowsHtml = queueRows
+      .map((row) => {
+        const msg = extractThreadMessageText(row.payload_json) || row.message_id;
+        return `<tr>
+          <td>${esc(row.lane)}</td>
+          <td>${esc(row.status)}</td>
+          <td>${esc(row.queue_mode)}</td>
+          <td>${fmtDate(new Date(row.received_at_ms).toISOString())}</td>
+          <td><code>${esc(row.message_id)}</code></td>
+          <td>${esc(msg)}</td>
+        </tr>`;
+      })
+      .join("");
+
+    const timelineRows = items
+      .slice(0, 400)
+      .map(
+        (item) => `<tr>
+          <td>${fmtDate(item.occurred_at)}</td>
+          <td>${esc(item.lane)}</td>
+          <td>${esc(item.kind)}</td>
+          <td><pre><code>${esc(item.detail)}</code></pre></td>
+        </tr>`,
+      )
+      .join("");
+
+    const queryErrorsHtml =
+      queryErrors.length > 0
+        ? `<article class="card">
+            <p class="notice error">DB query errors</p>
+            <ul>${queryErrors.map((value) => `<li><code>${esc(value)}</code></li>`).join("")}</ul>
+          </article>`
+        : "";
+
+    const body = `
+      <div class="page-header">
+        <h1>Session Timeline</h1>
+        <p>Unified timeline merged from durable state. Lane filters control visibility.</p>
+      </div>
+      ${filterForm}
+      ${queryErrorsHtml}
+      <article class="card">
+        <h2>Queue visibility</h2>
+        <p class="muted">Inbound queue mode and pending items per lane.</p>
+        <table>
+          <thead><tr><th>Lane</th><th>Queue mode</th><th>Queued</th><th>Processing</th></tr></thead>
+          <tbody>${queueSummaryRows}</tbody>
+        </table>
+      </article>
+      <article class="card">
+        <h3>Pending items</h3>
+        <table>
+          <thead><tr><th>Lane</th><th>Status</th><th>Mode</th><th>Received</th><th>Message</th><th>Preview</th></tr></thead>
+          <tbody>${queueRowsHtml || "<tr><td colspan='6' class='muted'>No queued items.</td></tr>"}</tbody>
+        </table>
+      </article>
+      <article class="card">
+        <h2>Timeline</h2>
+        <table>
+          <thead><tr><th>Occurred</th><th>Lane</th><th>Kind</th><th>Detail</th></tr></thead>
+          <tbody>${timelineRows || "<tr><td colspan='4' class='muted'>No timeline items.</td></tr>"}</tbody>
+        </table>
+      </article>
+    `;
+
+    return c.html(shell("Session", "/app/session", search, body));
   });
 
   app.get("/app/live", (c) => {

--- a/packages/gateway/tests/integration/permission-scenarios-agent.test.ts
+++ b/packages/gateway/tests/integration/permission-scenarios-agent.test.ts
@@ -10,6 +10,7 @@ import type { SecretProvider } from "../../src/modules/secret/provider.js";
 import type { SecretHandle } from "@tyrum/schemas";
 import { simulateReadableStream } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
+import { ExecutionEngine } from "../../src/modules/execution/engine.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
@@ -207,6 +208,8 @@ describe("AgentRuntime approval/permission scenarios (e2e)", () => {
       approvalPollMs: 100,
     });
 
+    const approvalEngine = new ExecutionEngine({ db: container.db });
+
     const turnPromise = runtime.turn({
       channel: "test",
       thread_id: "thread-approval-expire-1",
@@ -217,7 +220,31 @@ describe("AgentRuntime approval/permission scenarios (e2e)", () => {
     expect(pending.prompt).toContain("tool.exec");
     expect(pending.status).toBe("pending");
 
-    const result = await turnPromise;
+    let resumed = false;
+    const expiryTimer = setInterval(() => {
+      void (async () => {
+        const c = container;
+        if (!c) return;
+        await c.approvalDal.expireStale();
+        const current = await c.approvalDal.getById(pending.id);
+        if (!current || resumed) return;
+        if (current.status !== "expired") return;
+        if (current.resume_token) {
+          resumed = true;
+          await approvalEngine.resumeRun(current.resume_token);
+        }
+      })().catch(() => {
+        // ignore (tests may tear down while the timer is running)
+      });
+    }, 50);
+    expiryTimer.unref();
+
+    let result: Awaited<ReturnType<AgentRuntime["turn"]>>;
+    try {
+      result = await turnPromise;
+    } finally {
+      clearInterval(expiryTimer);
+    }
     expect(result.reply).toBe("done");
     expect(result.used_tools).not.toContain("tool.exec");
 
@@ -355,9 +382,13 @@ describe("AgentRuntime approval/permission scenarios (e2e)", () => {
       message: "read a file then run a command",
     });
 
+    const approvalEngine = new ExecutionEngine({ db: container.db });
     const pending = await waitForPendingApproval(container);
     expect(pending.prompt).toContain("tool.exec");
-    await container.approvalDal.respond(pending.id, true, "approved in test");
+    const updated = await container.approvalDal.respond(pending.id, true, "approved in test");
+    if (updated?.resume_token) {
+      await approvalEngine.resumeRun(updated.resume_token);
+    }
 
     const result = await turnPromise;
     expect(result.reply).toBe("done");
@@ -480,11 +511,15 @@ describe("AgentRuntime approval/permission scenarios (e2e)", () => {
       message: "fetch a url using a secret header",
     });
 
+    const approvalEngine = new ExecutionEngine({ db: container.db });
     const pending = await waitForPendingApproval(container);
     expect(secretProvider.list).toHaveBeenCalled();
     expect(secretProvider.resolve).not.toHaveBeenCalled();
 
-    await container.approvalDal.respond(pending.id, true, "approved in test");
+    const updated = await container.approvalDal.respond(pending.id, true, "approved in test");
+    if (updated?.resume_token) {
+      await approvalEngine.resumeRun(updated.resume_token);
+    }
 
     const result = await turnPromise;
     expect(result.reply).toBe("done");

--- a/packages/gateway/tests/unit/web-ui-session-timeline.test.ts
+++ b/packages/gateway/tests/unit/web-ui-session-timeline.test.ts
@@ -1,0 +1,507 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createWebUiRoutes, type WebUiDeps } from "../../src/routes/web-ui.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { ApprovalDal } from "../../src/modules/approval/dal.js";
+import { MemoryDal } from "../../src/modules/memory/dal.js";
+import { CanvasDal } from "../../src/modules/canvas/dal.js";
+
+describe("/app/session", () => {
+  let db: ReturnType<typeof openTestSqliteDb>;
+
+  beforeEach(() => {
+    db = openTestSqliteDb();
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("renders a unified session timeline with lane filters and queue visibility", async () => {
+    const key = "agent:default:telegram:default:channel:thread-123";
+    const lane = "main";
+    const threadId = "thread-123";
+    const nowMs = Date.now();
+
+    await db.run(
+      `INSERT INTO lane_queue_mode_overrides (key, lane, queue_mode, updated_at_ms)
+       VALUES (?, ?, ?, ?)`,
+      [key, lane, "collect", nowMs],
+    );
+
+    const queuedPayload = {
+      thread: { id: threadId, kind: "channel", title: "Test" },
+      message: {
+        id: "msg-queued",
+        thread_id: threadId,
+        source: "telegram",
+        content: { kind: "text", text: "Queued hello" },
+        timestamp: new Date(nowMs - 2000).toISOString(),
+      },
+    };
+
+    await db.run(
+      `INSERT INTO channel_inbox (
+         source,
+         thread_id,
+         message_id,
+         key,
+         lane,
+         received_at_ms,
+         payload_json,
+         status,
+         attempt,
+         queue_mode
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "telegram",
+        threadId,
+        "msg-queued",
+        key,
+        lane,
+        nowMs - 2000,
+        JSON.stringify(queuedPayload),
+        "queued",
+        0,
+        "collect",
+      ],
+    );
+
+    const completedPayload = {
+      thread: { id: threadId, kind: "channel", title: "Test" },
+      message: {
+        id: "msg-done",
+        thread_id: threadId,
+        source: "telegram",
+        content: { kind: "text", text: "Completed hello" },
+        timestamp: new Date(nowMs - 4000).toISOString(),
+      },
+    };
+
+    await db.run(
+      `INSERT INTO channel_inbox (
+         source,
+         thread_id,
+         message_id,
+         key,
+         lane,
+         received_at_ms,
+         payload_json,
+         status,
+         attempt,
+         processed_at,
+         reply_text,
+         queue_mode
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "telegram",
+        threadId,
+        "msg-done",
+        key,
+        lane,
+        nowMs - 4000,
+        JSON.stringify(completedPayload),
+        "completed",
+        1,
+        new Date(nowMs - 3000).toISOString(),
+        "Assistant reply",
+        "collect",
+      ],
+    );
+
+    const jobId = "job-1";
+    const runId = "run-1";
+    const stepId = "step-1";
+    const attemptId = "attempt-1";
+
+    await db.run(
+      `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json)
+       VALUES (?, ?, ?, ?, ?)`,
+      [jobId, key, lane, "running", JSON.stringify({ kind: "manual" })],
+    );
+
+    await db.run(
+      `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt, created_at, started_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        runId,
+        jobId,
+        key,
+        lane,
+        "running",
+        1,
+        new Date(nowMs - 3500).toISOString(),
+        new Date(nowMs - 3400).toISOString(),
+      ],
+    );
+
+    await db.run(
+      `INSERT INTO execution_steps (step_id, run_id, step_index, status, action_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        stepId,
+        runId,
+        0,
+        "running",
+        JSON.stringify({ type: "Decide", args: {} }),
+        new Date(nowMs - 3300).toISOString(),
+      ],
+    );
+
+    await db.run(
+      `INSERT INTO execution_attempts (attempt_id, step_id, attempt, status, started_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [attemptId, stepId, 1, "running", new Date(nowMs - 3200).toISOString()],
+    );
+
+    const approvalDal = new ApprovalDal(db);
+    const approval = await approvalDal.create({
+      planId: "plan-1",
+      stepIndex: 0,
+      prompt: "Need approval",
+      key,
+      lane,
+      runId,
+    });
+
+    await db.run(
+      `INSERT INTO execution_artifacts (artifact_id, run_id, step_id, attempt_id, kind, uri, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "artifact-1",
+        runId,
+        stepId,
+        attemptId,
+        "screenshot",
+        "artifact://artifact-1",
+        new Date(nowMs - 3100).toISOString(),
+      ],
+    );
+
+    const deps: WebUiDeps = {
+      approvalDal,
+      memoryDal: new MemoryDal(db),
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: new CanvasDal(db),
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+      db,
+    };
+
+    const app = createWebUiRoutes(deps);
+    const res = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=main`,
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain("Session Timeline");
+    expect(html).toContain("Lane filters");
+    expect(html).toContain("Queue visibility");
+
+    expect(html).toContain("Queued hello");
+    expect(html).toContain("Assistant reply");
+
+    expect(html).toContain(runId);
+    expect(html).toContain(stepId);
+    expect(html).toContain(attemptId);
+    expect(html).toContain(String(approval.id));
+    expect(html).toContain("artifact-1");
+  });
+
+  it("filters timeline items by lane", async () => {
+    const key = "agent:default:telegram:default:channel:thread-123";
+    const threadId = "thread-123";
+    const nowMs = Date.now();
+
+    const payloadFor = (messageId: string, text: string) => ({
+      thread: { id: threadId, kind: "channel", title: "Test" },
+      message: {
+        id: messageId,
+        thread_id: threadId,
+        source: "telegram",
+        content: { kind: "text", text },
+        timestamp: new Date(nowMs).toISOString(),
+      },
+    });
+
+    await db.run(
+      `INSERT INTO channel_inbox (source, thread_id, message_id, key, lane, received_at_ms, payload_json, status, attempt, queue_mode)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "telegram",
+        threadId,
+        "msg-main",
+        key,
+        "main",
+        nowMs - 2000,
+        JSON.stringify(payloadFor("msg-main", "Main hello")),
+        "queued",
+        0,
+        "collect",
+      ],
+    );
+
+    await db.run(
+      `INSERT INTO channel_inbox (source, thread_id, message_id, key, lane, received_at_ms, payload_json, status, attempt, queue_mode)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "telegram",
+        threadId,
+        "msg-subagent",
+        key,
+        "subagent",
+        nowMs - 1000,
+        JSON.stringify(payloadFor("msg-subagent", "Subagent hello")),
+        "queued",
+        0,
+        "collect",
+      ],
+    );
+
+    await db.run(
+      `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json)
+       VALUES (?, ?, ?, ?, ?)`,
+      ["job-main", key, "main", "running", JSON.stringify({ kind: "manual" })],
+    );
+    await db.run(
+      `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json)
+       VALUES (?, ?, ?, ?, ?)`,
+      ["job-subagent", key, "subagent", "running", JSON.stringify({ kind: "manual" })],
+    );
+
+    await db.run(
+      `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "run-main",
+        "job-main",
+        key,
+        "main",
+        "running",
+        1,
+        new Date(nowMs - 1500).toISOString(),
+      ],
+    );
+    await db.run(
+      `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "run-subagent",
+        "job-subagent",
+        key,
+        "subagent",
+        "running",
+        1,
+        new Date(nowMs - 1200).toISOString(),
+      ],
+    );
+
+    const deps: WebUiDeps = {
+      approvalDal: new ApprovalDal(db),
+      memoryDal: new MemoryDal(db),
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: new CanvasDal(db),
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+      db,
+    };
+
+    const app = createWebUiRoutes(deps);
+
+    const onlyMain = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=main`,
+    );
+    expect(onlyMain.status).toBe(200);
+    const mainHtml = await onlyMain.text();
+    expect(mainHtml).toContain("Main hello");
+    expect(mainHtml).toContain("run-main");
+    expect(mainHtml).not.toContain("Subagent hello");
+    expect(mainHtml).not.toContain("run-subagent");
+
+    const onlySubagent = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=subagent`,
+    );
+    expect(onlySubagent.status).toBe(200);
+    const subHtml = await onlySubagent.text();
+    expect(subHtml).toContain("Subagent hello");
+    expect(subHtml).toContain("run-subagent");
+    expect(subHtml).not.toContain("Main hello");
+    expect(subHtml).not.toContain("run-main");
+  });
+
+  it("renders correct lanes for steps and attempts even when run results are truncated", async () => {
+    const key = "agent:default:telegram:default:channel:thread-123";
+    const nowMs = Date.now();
+
+    for (let i = 0; i < 200; i += 1) {
+      const jobId = `job-main-${i}`;
+      const runId = `run-main-${i}`;
+      const createdAt = new Date(nowMs - i).toISOString();
+
+      await db.run(
+        `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json)
+         VALUES (?, ?, ?, ?, ?)`,
+        [jobId, key, "main", "running", JSON.stringify({ kind: "manual" })],
+      );
+
+      await db.run(
+        `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [runId, jobId, key, "main", "running", 1, createdAt],
+      );
+    }
+
+    const oldJobId = "job-subagent-old";
+    const oldRunId = "run-subagent-old";
+    const stepId = "step-subagent-late";
+    const attemptId = "attempt-subagent-late";
+
+    await db.run(
+      `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json)
+       VALUES (?, ?, ?, ?, ?)`,
+      [oldJobId, key, "subagent", "running", JSON.stringify({ kind: "manual" })],
+    );
+    await db.run(
+      `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        oldRunId,
+        oldJobId,
+        key,
+        "subagent",
+        "running",
+        1,
+        new Date(nowMs - 1000 * 60 * 60).toISOString(),
+      ],
+    );
+    await db.run(
+      `INSERT INTO execution_steps (step_id, run_id, step_index, status, action_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        stepId,
+        oldRunId,
+        0,
+        "running",
+        JSON.stringify({ type: "Decide", args: {} }),
+        new Date(nowMs + 1000).toISOString(),
+      ],
+    );
+    await db.run(
+      `INSERT INTO execution_attempts (attempt_id, step_id, attempt, status, started_at)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+        attemptId,
+        stepId,
+        1,
+        "running",
+        new Date(nowMs + 2000).toISOString(),
+      ],
+    );
+
+    const deps: WebUiDeps = {
+      approvalDal: new ApprovalDal(db),
+      memoryDal: new MemoryDal(db),
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: new CanvasDal(db),
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+      db,
+    };
+
+    const app = createWebUiRoutes(deps);
+    const res = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=main&lanes=subagent`,
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toMatch(
+      new RegExp(
+        `<td>subagent</td>\\s*<td>step</td>\\s*<td><pre><code>[^<]*${stepId}`,
+      ),
+    );
+    expect(html).toMatch(
+      new RegExp(
+        `<td>subagent</td>\\s*<td>attempt</td>\\s*<td><pre><code>[^<]*${attemptId}`,
+      ),
+    );
+  });
+
+  it("treats approvals with a null lane as main for lane filtering", async () => {
+    const key = "agent:default:telegram:default:channel:thread-123";
+
+    const approvalDal = new ApprovalDal(db);
+    const approval = await approvalDal.create({
+      planId: "plan-1",
+      stepIndex: 0,
+      prompt: "Needs approval (null lane)",
+      key,
+      runId: "run-1",
+    });
+
+    const deps: WebUiDeps = {
+      approvalDal,
+      memoryDal: new MemoryDal(db),
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: new CanvasDal(db),
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+      db,
+    };
+
+    const app = createWebUiRoutes(deps);
+    const res = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=main`,
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain(String(approval.id));
+    expect(html).toContain("Needs approval (null lane)");
+  });
+
+  it("renders a query error banner when DB queries fail", async () => {
+    const key = "agent:default:telegram:default:channel:thread-123";
+
+    const failingDb = {
+      all: async (sql: string) => {
+        if (sql.includes("FROM lane_queue_mode_overrides")) {
+          throw new Error("simulated query failure");
+        }
+        return [];
+      },
+    } as unknown as WebUiDeps["db"];
+
+    const deps: WebUiDeps = {
+      approvalDal: new ApprovalDal(db),
+      memoryDal: new MemoryDal(db),
+      watcherProcessor: {} as WebUiDeps["watcherProcessor"],
+      canvasDal: new CanvasDal(db),
+      playbooks: [],
+      playbookRunner: {} as WebUiDeps["playbookRunner"],
+      isLocalOnly: true,
+      db: failingDb,
+    };
+
+    const app = createWebUiRoutes(deps);
+    const res = await app.request(
+      `/app/session?key=${encodeURIComponent(key)}&lanes=main`,
+    );
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain("DB query errors");
+    expect(html).toContain("lane_queue_mode_overrides");
+    expect(html).toContain("simulated query failure");
+  });
+});


### PR DESCRIPTION
Closes #448
Parent: #376
Epic: #366
Depends on: #447

## Summary
- Adds control-panel `GET /app/session` page with a unified session timeline (chat + execution + approvals + artifacts).
- Adds lane filters (main/subagent/cron/heartbeat) and queue visibility (lane mode overrides + pending inbox items).

## Notes
- Timeline lane attribution for steps/attempts is sourced from joined `execution_runs` to avoid truncation-induced mislabeling.
- DB query failures are surfaced as an in-page “DB query errors” banner instead of silently rendering empty.

## TDD / Verification
- Added failing unit tests first (lane truncation regression, null-lane approvals treated as main, query-error banner), then implemented fixes.
- `pnpm typecheck` (exit 0)
- `pnpm lint` (exit 0; 1 oxlint warning in existing `packages/gateway/tests/unit/execution-engine.test.ts`)
- `pnpm test` (exit 0; Test Files: 253 passed | 1 skipped; Tests: 1679 passed | 2 skipped)
