### PR TITLE
feat(gateway): /auth/session + /auth/logout (cookie bootstrap), remove query-token auth (#555)

### DIFF
--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -27,6 +27,7 @@ import { createPlaybookRoutes } from "./routes/playbook.js";
 import { createConnectionsRoute } from "./routes/connections.js";
 import { createPairingRoutes } from "./routes/pairing.js";
 import { createAuthProfileRoutes } from "./routes/auth-profiles.js";
+import { createAuthSessionRoutes } from "./routes/auth-session.js";
 import { createDeviceTokenRoutes } from "./routes/device-token.js";
 import { createPluginRoutes } from "./routes/plugins.js";
 import { createModelsDevRoutes } from "./routes/models-dev.js";
@@ -245,6 +246,9 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
         : undefined,
     }),
   );
+  if (opts.tokenStore) {
+    app.route("/", createAuthSessionRoutes({ tokenStore: opts.tokenStore }));
+  }
   app.route("/", createAuthProfileRoutes({ authProfileDal, pinDal }));
   if (opts.tokenStore) {
     app.route("/", createDeviceTokenRoutes({ tokenStore: opts.tokenStore }));

--- a/packages/gateway/src/modules/auth/middleware.ts
+++ b/packages/gateway/src/modules/auth/middleware.ts
@@ -1,14 +1,14 @@
 /**
  * HTTP authentication middleware for Hono.
  *
- * Enforces token authentication on all routes except /healthz.
- * Web UI routes under /app may also authenticate via ?token=...
+ * Enforces token authentication on all routes except a small public allowlist
+ * (health checks, web UI shell, and auth bootstrap endpoints).
  */
 
 import type { Context, Next } from "hono";
 import { getCookie } from "hono/cookie";
 import { matchedRoutes } from "hono/route";
-import { APP_PATH_PREFIX, matchesPathPrefixSegment } from "../../app-path.js";
+import { matchesPathPrefixSegment } from "../../app-path.js";
 import { getClientIp } from "./client-ip.js";
 import { requestIdForAudit } from "../observability/request-id.js";
 import type { TokenStore } from "./token-store.js";
@@ -21,17 +21,11 @@ const AUTH_ERROR_BODY = {
   message: "Provide a valid token via Authorization: Bearer <token> header",
 };
 
-const APP_TOKEN_QUERY_KEY = "token";
+const AUTH_SESSION_ROUTE_PATH = "/auth/session";
+const AUTH_LOGOUT_ROUTE_PATH = "/auth/logout";
+const UI_PATH_PREFIX = "/ui";
 const OAUTH_CALLBACK_ROUTE_PATH_SUFFIX = "/providers/:provider/oauth/callback";
 const OAUTH_CALLBACK_REQUEST_PATH_PATTERN = /(?:^|\/)providers\/[^/]+\/oauth\/callback$/;
-
-function extractAppQueryToken(c: Context): string | undefined {
-  // Guard against prefix-collisions like "/application" or "/appdata".
-  if (!matchesPathPrefixSegment(c.req.path, APP_PATH_PREFIX)) {
-    return undefined;
-  }
-  return c.req.query(APP_TOKEN_QUERY_KEY)?.trim() || undefined;
-}
 
 function isPublicOAuthCallbackRoute(c: Context): boolean {
   if (c.req.method !== "GET") return false;
@@ -58,25 +52,26 @@ export function createAuthMiddleware(
       return next();
     }
 
+    // /ui/* is public (static operator SPA).
+    if (matchesPathPrefixSegment(c.req.path, UI_PATH_PREFIX)) {
+      return next();
+    }
+
+    // Cookie bootstrap/logout endpoints must be accessible before authentication.
+    if (c.req.path === AUTH_SESSION_ROUTE_PATH || c.req.path === AUTH_LOGOUT_ROUTE_PATH) {
+      return next();
+    }
+
     // OAuth callback is public (state/PKCE-protected) and should not require an admin token.
     // Use the router's matched route to avoid accidentally exempting other paths with similar suffixes.
     if (isPublicOAuthCallbackRoute(c)) {
       return next();
     }
 
-    // Accept query-token auth for the web UI path subtree. This keeps
-    // embedded desktop navigation working when third-party cookies are blocked.
-    const appQueryToken = extractAppQueryToken(c);
     const bearerToken = extractBearerToken(c.req.header("authorization"));
     const cookieToken = getCookie(c, AUTH_COOKIE_NAME);
-    const token = appQueryToken ?? bearerToken ?? cookieToken;
-    const tokenTransport = appQueryToken
-      ? "query"
-      : bearerToken
-        ? "authorization"
-        : cookieToken
-          ? "cookie"
-          : "missing";
+    const token = bearerToken ?? cookieToken;
+    const tokenTransport = bearerToken ? "authorization" : cookieToken ? "cookie" : "missing";
     if (!token) {
       await opts?.audit?.recordAuthFailed({
         surface: "http",

--- a/packages/gateway/src/routes/auth-session.ts
+++ b/packages/gateway/src/routes/auth-session.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { setCookie } from "hono/cookie";
+import type { TokenStore } from "../modules/auth/token-store.js";
+import { AUTH_COOKIE_NAME } from "../modules/auth/http.js";
+
+export interface AuthSessionRouteDeps {
+  tokenStore: TokenStore;
+}
+
+function isHttpsRequest(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function createAuthSessionRoutes(deps: AuthSessionRouteDeps): Hono {
+  const app = new Hono();
+
+  app.post("/auth/session", async (c) => {
+    let body: unknown;
+    try {
+      body = (await c.req.json()) as unknown;
+    } catch {
+      return c.json({ error: "invalid_request", message: "invalid json" }, 400);
+    }
+
+    const tokenRaw =
+      body && typeof body === "object" && !Array.isArray(body)
+        ? (body as Record<string, unknown>)["token"]
+        : undefined;
+    const token = typeof tokenRaw === "string" ? tokenRaw.trim() : "";
+    if (!token) {
+      return c.json({ error: "invalid_request", message: "token is required" }, 400);
+    }
+
+    const claims = deps.tokenStore.authenticate(token);
+    if (!claims) {
+      return c.json({ error: "unauthorized", message: "invalid token" }, 401);
+    }
+
+    setCookie(c, AUTH_COOKIE_NAME, token, {
+      path: "/",
+      httpOnly: true,
+      sameSite: "Strict",
+      maxAge: 604800,
+      secure: isHttpsRequest(c.req.url),
+    });
+
+    return c.body(null, 204);
+  });
+
+  app.post("/auth/logout", (c) => {
+    setCookie(c, AUTH_COOKIE_NAME, "", {
+      path: "/",
+      httpOnly: true,
+      sameSite: "Strict",
+      maxAge: 0,
+      secure: isHttpsRequest(c.req.url),
+    });
+
+    return c.body(null, 204);
+  });
+
+  return app;
+}

--- a/packages/gateway/tests/integration/auth.test.ts
+++ b/packages/gateway/tests/integration/auth.test.ts
@@ -185,20 +185,17 @@ describe("Auth integration", () => {
       expect(res.status).toBe(200);
     });
 
-    it("bootstraps web auth cookie via /app/auth and grants /app access", async () => {
-      const bootstrapRes = await app.request(
-        `/app/auth?token=${encodeURIComponent(adminToken)}&next=%2Fapp`,
-      );
-      expect(bootstrapRes.status).toBe(302);
-      const location = bootstrapRes.headers.get("location");
-      expect(location).toBeTruthy();
-      const redirectUrl = new URL(location ?? "/app", "http://localhost");
-      expect(redirectUrl.pathname).toBe("/app");
-      expect(redirectUrl.searchParams.get("token")).toBe(adminToken);
+    it("bootstraps auth cookie via /auth/session, supports logout, and grants /app access", async () => {
+      const loginRes = await app.request("/auth/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: adminToken }),
+      });
+      expect(loginRes.status).toBe(204);
 
-      const setCookie = bootstrapRes.headers.get("set-cookie");
-      expect(setCookie).toBeTruthy();
-      const cookie = setCookie?.split(";")[0] ?? "";
+      const loginSetCookie = loginRes.headers.get("set-cookie");
+      expect(loginSetCookie).toBeTruthy();
+      const cookie = loginSetCookie?.split(";")[0] ?? "";
 
       const appRes = await app.request("/app", {
         headers: { Cookie: cookie },
@@ -206,6 +203,21 @@ describe("Auth integration", () => {
       expect(appRes.status).toBe(200);
       const html = await appRes.text();
       expect(html).toContain("Dashboard");
+
+      const logoutRes = await app.request("/auth/logout", {
+        method: "POST",
+        headers: { Cookie: cookie },
+      });
+      expect(logoutRes.status).toBe(204);
+
+      const logoutSetCookie = logoutRes.headers.get("set-cookie");
+      expect(logoutSetCookie).toBeTruthy();
+      const clearedCookie = logoutSetCookie?.split(";")[0] ?? "";
+
+      const afterLogoutRes = await app.request("/app", {
+        headers: { Cookie: clearedCookie },
+      });
+      expect(afterLogoutRes.status).toBe(401);
     });
   });
 });

--- a/packages/gateway/tests/unit/auth-middleware.test.ts
+++ b/packages/gateway/tests/unit/auth-middleware.test.ts
@@ -26,9 +26,12 @@ describe("Auth middleware", () => {
     const app = new Hono();
     app.use("*", createAuthMiddleware(tokenStore));
     app.get("/healthz", (c) => c.json({ status: "ok" }));
+    app.post("/auth/session", (c) => c.json({ ok: true }));
+    app.post("/auth/logout", (c) => c.json({ ok: true }));
     app.get("/app", (c) => c.json({ ok: true }));
     app.get("/app/settings", (c) => c.json({ ok: true }));
     app.get("/app/auth", (c) => c.json({ ok: true }));
+    app.get("/ui/index.html", (c) => c.json({ ok: true }));
     app.get("/providers/:provider/oauth/callback", (c) => c.json({ ok: true }));
     // These routes are intentionally *not* part of the /app subtree, but share a prefix.
     // Query-string token auth must not apply to them.
@@ -59,6 +62,24 @@ describe("Auth middleware", () => {
     app.route("/prefix", sub);
 
     const res = await app.request("/prefix/providers/test/oauth/callback?state=s&code=c");
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /auth/session without token", async () => {
+    const app = buildApp();
+    const res = await app.request("/auth/session", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /auth/logout without token", async () => {
+    const app = buildApp();
+    const res = await app.request("/auth/logout", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /ui routes without token", async () => {
+    const app = buildApp();
+    const res = await app.request("/ui/index.html");
     expect(res.status).toBe(200);
   });
 
@@ -111,53 +132,39 @@ describe("Auth middleware", () => {
     expect(res.status).toBe(200);
   });
 
-  it("allows /app/auth bootstrap with query token", async () => {
+  it("rejects /app/auth bootstrap even when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/app/auth?token=${encodeURIComponent(adminToken)}&next=%2Fapp`);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 
-  it("allows /app route with query token", async () => {
+  it("rejects /app route even when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/app?token=${encodeURIComponent(adminToken)}`);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 
-  it("allows /app subtree route with query token", async () => {
+  it("rejects /app subtree route even when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/app/settings?token=${encodeURIComponent(adminToken)}`);
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(401);
   });
 
-  it("rejects non-app route even when query token is present", async () => {
+  it("rejects non-app route when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/api/data?token=${encodeURIComponent(adminToken)}`);
     expect(res.status).toBe(401);
   });
 
-  it("rejects prefix-collision route even when query token is present", async () => {
+  it("rejects prefix-collision route when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/application?token=${encodeURIComponent(adminToken)}`);
     expect(res.status).toBe(401);
   });
 
-  it("rejects /appdata route even when query token is present", async () => {
+  it("rejects /appdata route when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/appdata?token=${encodeURIComponent(adminToken)}`);
-    expect(res.status).toBe(401);
-  });
-
-  it("rejects /app/auth bootstrap with invalid query token", async () => {
-    const app = buildApp();
-    const res = await app.request("/app/auth?token=invalid-token");
-    expect(res.status).toBe(401);
-  });
-
-  it("prefers /app/auth query token over cookie token", async () => {
-    const app = buildApp();
-    const res = await app.request("/app/auth?token=invalid-token", {
-      headers: { Cookie: `${AUTH_COOKIE_NAME}=${encodeURIComponent(adminToken)}` },
-    });
     expect(res.status).toBe(401);
   });
 


### PR DESCRIPTION
Closes #555

## Summary
- Added `POST /auth/session` to validate a token and set the `tyrum_admin_token` HttpOnly cookie (SameSite=Strict; Secure on https).
- Added `POST /auth/logout` to clear the auth cookie.
- Updated HTTP auth middleware allowlist (`/ui/*`, `/auth/session`, `/auth/logout`, `/healthz`, OAuth callback).
- Removed all `?token=` query-string auth acceptance in HTTP middleware.

## Verification
- `pnpm test` (1806 tests passed)
- `pnpm typecheck`
- `pnpm lint`}