### PR TITLE
fix(gateway): allow /app/auth bootstrap

### DIFF
--- a/packages/gateway/src/modules/auth/middleware.ts
+++ b/packages/gateway/src/modules/auth/middleware.ts
@@ -23,6 +23,7 @@ const AUTH_ERROR_BODY = {
 
 const AUTH_SESSION_ROUTE_PATH = "/auth/session";
 const AUTH_LOGOUT_ROUTE_PATH = "/auth/logout";
+const APP_AUTH_ROUTE_PATH = "/app/auth";
 const UI_PATH_PREFIX = "/ui";
 const OAUTH_CALLBACK_ROUTE_PATH_SUFFIX = "/providers/:provider/oauth/callback";
 const OAUTH_CALLBACK_REQUEST_PATH_PATTERN = /(?:^|\/)providers\/[^/]+\/oauth\/callback$/;
@@ -59,6 +60,11 @@ export function createAuthMiddleware(
 
     // Cookie bootstrap/logout endpoints must be accessible before authentication.
     if (c.req.path === AUTH_SESSION_ROUTE_PATH || c.req.path === AUTH_LOGOUT_ROUTE_PATH) {
+      return next();
+    }
+
+    // Legacy web UI cookie bootstrap runs before authentication headers/cookies exist.
+    if (c.req.method === "GET" && c.req.path === APP_AUTH_ROUTE_PATH) {
       return next();
     }
 

--- a/packages/gateway/tests/unit/auth-middleware.test.ts
+++ b/packages/gateway/tests/unit/auth-middleware.test.ts
@@ -132,10 +132,10 @@ describe("Auth middleware", () => {
     expect(res.status).toBe(200);
   });
 
-  it("rejects /app/auth bootstrap even when query token is present", async () => {
+  it("allows /app/auth bootstrap when query token is present", async () => {
     const app = buildApp();
     const res = await app.request(`/app/auth?token=${encodeURIComponent(adminToken)}&next=%2Fapp`);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
   });
 
   it("rejects /app route even when query token is present", async () => {


### PR DESCRIPTION
## Summary
- Allow unauthenticated GET /app/auth so legacy bootstrap URLs (/app/auth?token=...&next=...) can set the auth cookie.
- Keep query-string token auth removed for all other routes (/app, /app/*, /api/* still require Authorization header or auth cookie).

## Testing
- pnpm exec vitest run packages/gateway/tests/unit/auth-middleware.test.ts
- pnpm exec oxlint packages/gateway/src/modules/auth/middleware.ts packages/gateway/tests/unit/auth-middleware.test.ts
- pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json
