### PR TITLE
fix(client): prevent concurrent generated device identity races

### DIFF
--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -122,6 +122,19 @@ export interface TyrumClientOptions {
   maxSeenRequestIds?: number;
 }
 
+type GeneratedDevice = {
+  publicKey: string;
+  privateKey: string;
+  deviceId: string;
+};
+
+type ResolvedConnectDevice = GeneratedDevice & {
+  label?: string;
+  platform?: string;
+  version?: string;
+  mode?: string;
+};
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -200,11 +213,8 @@ export class TyrumClient {
   private connectionAttempt = 0;
   private transportErrorHint: string | null = null;
   private suppressReconnect = false;
-  private generatedDevice: {
-    publicKey: string;
-    privateKey: string;
-    deviceId: string;
-  } | null = null;
+  private generatedDevice: GeneratedDevice | null = null;
+  private generatedDevicePromise: Promise<GeneratedDevice> | null = null;
 
   constructor(options: TyrumClientOptions) {
     this.emitter = mitt<TyrumClientEvents>();
@@ -610,15 +620,7 @@ export class TyrumClient {
     }
   }
 
-  private async resolveConnectDevice(): Promise<{
-    publicKey: string;
-    privateKey: string;
-    deviceId: string;
-    label?: string;
-    platform?: string;
-    version?: string;
-    mode?: string;
-  }> {
+  private async resolveConnectDevice(): Promise<ResolvedConnectDevice> {
     const provided = this.opts.device;
     if (provided) {
       const pubkey = provided.publicKey.trim();
@@ -634,7 +636,18 @@ export class TyrumClient {
       return { ...provided, deviceId: computed };
     }
     if (!this.generatedDevice) {
-      this.generatedDevice = await createDeviceIdentity();
+      if (!this.generatedDevicePromise) {
+        this.generatedDevicePromise = createDeviceIdentity()
+          .then((generatedDevice) => {
+            this.generatedDevice = generatedDevice;
+            return generatedDevice;
+          })
+          .catch((error) => {
+            this.generatedDevicePromise = null;
+            throw error;
+          });
+      }
+      this.generatedDevice = await this.generatedDevicePromise;
     }
     return this.generatedDevice;
   }

--- a/packages/client/tests/ws-client.test.ts
+++ b/packages/client/tests/ws-client.test.ts
@@ -182,6 +182,65 @@ describe("TyrumClient", () => {
     });
   });
 
+  it("reuses one auto-generated device identity across concurrent resolution", async () => {
+    client = new TyrumClient({
+      url: "ws://127.0.0.1:65535",
+      token: "t",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const firstIdentity = {
+      deviceId: "device-A",
+      publicKey: "pub-A",
+      privateKey: "priv-A",
+    };
+    const secondIdentity = {
+      deviceId: "device-B",
+      publicKey: "pub-B",
+      privateKey: "priv-B",
+    };
+
+    let resolveFirstIdentity!: (value: typeof firstIdentity) => void;
+    let resolveSecondIdentity!: (value: typeof secondIdentity) => void;
+    const firstIdentityPromise = new Promise<typeof firstIdentity>((resolve) => {
+      resolveFirstIdentity = resolve;
+    });
+    const secondIdentityPromise = new Promise<typeof secondIdentity>((resolve) => {
+      resolveSecondIdentity = resolve;
+    });
+
+    const createSpy = vi
+      .spyOn(deviceIdentity, "createDeviceIdentity")
+      .mockImplementationOnce(async () => await firstIdentityPromise)
+      .mockImplementationOnce(async () => await secondIdentityPromise);
+
+    const resolveConnectDevice = (
+      client as unknown as {
+        resolveConnectDevice: () => Promise<{
+          publicKey: string;
+          privateKey: string;
+          deviceId: string;
+        }>;
+      }
+    ).resolveConnectDevice.bind(client);
+
+    const firstCall = resolveConnectDevice();
+    const secondCall = resolveConnectDevice();
+
+    resolveSecondIdentity(secondIdentity);
+    await Promise.resolve();
+    resolveFirstIdentity(firstIdentity);
+
+    const [resolvedFirst, resolvedSecond] = await Promise.all([firstCall, secondCall]);
+    const resolvedThird = await resolveConnectDevice();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(resolvedFirst).toEqual(firstIdentity);
+    expect(resolvedSecond).toEqual(firstIdentity);
+    expect(resolvedThird).toEqual(firstIdentity);
+  });
+
   it("derives device id using shared base64url decoder", async () => {
     server = createTestServer();
     const spy = vi.spyOn(deviceIdentity, "fromBase64Url");


### PR DESCRIPTION
## Summary
- cache in-flight auto-generated device identity creation in `TyrumClient` so concurrent handshake paths share one Promise
- reset the cached Promise on rejection so subsequent connect attempts can retry identity creation
- add a regression test that reproduces concurrent resolution and verifies a single stable cached identity

## Test Plan
- pnpm exec vitest run packages/client/tests/ws-client.test.ts -t "reuses one auto-generated device identity across concurrent resolution" (verified red then green)
- pnpm exec vitest run packages/client/tests/ws-client.test.ts
- pnpm exec vitest run packages/client/tests
- pnpm typecheck
- pnpm lint
- pnpm test
