### PR TITLE
fix(ci): use coverage.enabled with vitest dot flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: >
           xvfb-run -a --server-args="-screen 0 1920x1080x24"
           pnpm test
-          --coverage
+          --coverage.enabled
           --coverage.reporter=text-summary
           --coverage.reporter=html
           --coverage.reporter=clover

--- a/packages/schemas/tests/ci-workflow-coverage-summary.test.ts
+++ b/packages/schemas/tests/ci-workflow-coverage-summary.test.ts
@@ -2,10 +2,14 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
+function readCiWorkflow(): string {
+  const workflowPath = resolve(process.cwd(), ".github/workflows/ci.yml");
+  return readFileSync(workflowPath, "utf8");
+}
+
 describe("CI coverage summary parser", () => {
   it("does not double-escape regex tokens in the embedded Python", () => {
-    const workflowPath = resolve(process.cwd(), ".github/workflows/ci.yml");
-    const workflow = readFileSync(workflowPath, "utf8");
+    const workflow = readCiWorkflow();
 
     const match = workflow.match(/python3 - <<'PY'\n([\s\S]*?)\n\s*PY\n/);
     expect(match, "expected to find python heredoc block").not.toBeNull();
@@ -14,5 +18,22 @@ describe("CI coverage summary parser", () => {
 
     expect(python).not.toContain("\\\\s");
     expect(python).not.toContain("\\\\d");
+  });
+
+  it("uses the supported vitest coverage CLI flag combination", () => {
+    const workflow = readCiWorkflow();
+
+    const match = workflow.match(
+      /- name: Test \+ coverage[\s\S]*?run:\s*>\n([\s\S]*?)\n\s*- name:/,
+    );
+    expect(match, "expected to find Test + coverage run block").not.toBeNull();
+
+    const command = match![1];
+
+    expect(command).toContain("--coverage.enabled");
+    expect(command).toContain("--coverage.reporter=text-summary");
+    expect(command).toContain("--coverage.reporter=html");
+    expect(command).toContain("--coverage.reporter=clover");
+    expect(command).not.toMatch(/(^|\s)--coverage(?=\s|$)/m);
   });
 });


### PR DESCRIPTION
## Summary
- switch CI Vitest coverage invocation from `--coverage` to `--coverage.enabled` when using dot-notation coverage options
- add a workflow regression test that enforces the supported coverage flag combination in `.github/workflows/ci.yml`
- refactor workflow test setup with a small helper for shared file loading

## Test Plan
- pnpm exec vitest run packages/schemas/tests/ci-workflow-coverage-summary.test.ts