### PR TITLE
docs(architecture): define API surfaces (WS vs HTTP)

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "Protocol & Contracts",
           items: [
+            "architecture/api-surfaces",
             "architecture/protocol/index",
             "architecture/protocol/handshake",
             "architecture/protocol/requests-responses",

--- a/docs/architecture/api-surfaces.md
+++ b/docs/architecture/api-surfaces.md
@@ -1,0 +1,102 @@
+# API surfaces (WebSocket vs HTTP)
+
+Tyrum is **WebSocket-first**, but not WebSocket-only. The Gateway exposes two operator-facing API surfaces:
+
+- **WebSocket protocol (control plane):** typed requests/responses plus server-push events.
+- **HTTP API (resource plane):** bootstrap/auth flows, resource/blob transfer, and callback/webhook endpoints.
+
+The transport you pick is a **delivery detail**. **Scopes + per-method authorization** are the security boundary.
+
+## Principle: scopes are the boundary (not transport)
+
+- The same operator can perform both “day-to-day” actions and “admin” actions.
+- Whether an action is *allowed* is decided by **scopes** (and approvals/policy), not by “it was HTTP” or “it was WS”.
+- **Both** HTTP routes and WS request types MUST declare and enforce required scopes (deny-by-default).
+
+If you find yourself describing “operator = WS” and “admin = HTTP”, treat that as a *current implementation shape*, not an architectural rule.
+
+## When to use WebSocket
+
+Use WebSocket for **interactive, eventful, low-latency control plane** work:
+
+- streaming timelines (runs/steps/attempts), approvals, pairing, presence
+- any UX that benefits from immediate server-push updates
+- any operation where you want a single connection to carry: requests + events + heartbeats
+
+In practice: most operator interactions should be WS-first, even if some backing data is fetched over HTTP.
+
+## When to use HTTP
+
+Use HTTP for **resource and integration surfaces**:
+
+- **Browser auth/session bootstrap** (cookies, OIDC callbacks): redirects/callbacks are HTTP-native
+- **Artifacts and large payloads** (upload/download): HTTP is better suited than WS for blobs
+- **Webhooks/callback ingress** from third-party systems
+- **Health/status snapshots** and other “one-shot” reads
+
+HTTP endpoints should still publish events (or otherwise update durable state) so WS-connected clients observe consistent state transitions.
+
+## Avoid dual-surface drift
+
+Do not implement the *same mutation* twice (once in HTTP, once in WS) unless you have a strong reason.
+
+If you must duplicate a capability across transports:
+
+- share the same core business logic (one implementation, two adapters)
+- keep authZ, validation, and audit/event emission consistent
+- ensure semantics match (idempotency, error shapes, side effects)
+
+## Admin Mode crosses both surfaces
+
+Admin Mode (step-up) is intentionally **transport-agnostic**:
+
+- the client enters Admin Mode by obtaining a **short-lived elevated device token**
+- the SDK uses that token for both **WS requests** and **HTTP calls** during the TTL window
+- exiting Admin Mode returns to the baseline scoped token
+
+See: [Gateway authN/authZ](./gateway-authz.md).
+
+## Where to implement changes (map)
+
+This section exists to answer: “where does a new API capability go?”
+
+### Contracts and schemas
+
+- WS wire shapes: `packages/schemas/src/protocol/*` and `packages/schemas/src/protocol.ts`
+- HTTP request/response schemas: `packages/schemas/src/*.ts` (for example `packages/schemas/src/device-token.ts`)
+- Operator scopes: `packages/schemas/src/scope.ts`
+
+### Gateway (WebSocket surface)
+
+- WS upgrade + auth + connection lifecycle: `packages/gateway/src/routes/ws.ts`
+- Request dispatch + per-request authZ: `packages/gateway/src/ws/protocol/handler.ts`, `packages/gateway/src/ws/protocol/dispatch.ts`
+- Scope matrix (request type → required scope): `packages/gateway/src/modules/authz/ws-scope-matrix.ts`
+
+### Gateway (HTTP surface)
+
+- HTTP routes: `packages/gateway/src/routes/*.ts`
+- Scope enforcement middleware: `packages/gateway/src/modules/authz/http-scope-middleware.ts`
+- Cookie/bearer extraction helpers: `packages/gateway/src/modules/auth/http.ts`
+
+### Client SDK (`@tyrum/client`)
+
+- WS client: `packages/client/src/ws-client.ts`
+- HTTP client: `packages/client/src/http/client.ts` + `packages/client/src/http/*`
+- Public surface: `packages/client/src/index.ts`
+
+### Operator apps / shared operator layers
+
+- Shared state + workflows (should call SDK, not raw fetch/ws): `packages/operator-core/src/operator-core.ts`
+- UI components: `packages/operator-ui/src/*`
+- App shells: `apps/web/src/*`, `apps/desktop/src/renderer/*`, `packages/cli/src/*`, `packages/tui/src/*`
+
+## Testing expectations
+
+When adding a new capability:
+
+- Add/adjust schemas in `packages/schemas` + tests in `packages/schemas/tests`.
+- Add gateway tests for authZ + behavior in `packages/gateway/tests`.
+- Add SDK tests/fixtures in `packages/client/tests`.
+
+Docs are part of the contract: if you change a surface, update the relevant `docs/architecture/*` page(s).
+

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -21,6 +21,12 @@ A client is an operator interface that connects to the gateway and participates 
 - Provide onboarding and diagnostics surfaces so hardened configuration is easy to reach (see [Operations and onboarding](./operations.md)).
 - Support **Admin Mode** (time-bounded step-up) for tenant administration actions.
 
+## Transports and API surfaces
+
+Clients are **WebSocket-first** (interactive control plane) but will often also use HTTP endpoints for resource and bootstrap flows (auth/session, artifacts, callbacks).
+
+See: [API surfaces (WebSocket vs HTTP)](./api-surfaces.md).
+
 ## Operator UI expectations
 
 Operator clients provide oversight and administration. At minimum they should expose:

--- a/docs/architecture/gateway-authz.md
+++ b/docs/architecture/gateway-authz.md
@@ -86,6 +86,8 @@ Example operator scopes:
 
 **Per-method authorization:** every HTTP route and WS request type declares the scopes required to call it. Deny-by-default is the baseline.
 
+Transport is not a security boundary. The same scope model applies to **both** HTTP and WS surfaces; the choice of transport is driven by UX and payload semantics. See: [API surfaces (WebSocket vs HTTP)](./api-surfaces.md).
+
 **HTTP scope enforcement:** HTTP requests authenticated with **device tokens** are authorized per-route based on required scopes (for example `operator.read`, `operator.write`). Requests missing the required scope are rejected with `403 forbidden`. The **admin bootstrap token** is break-glass and is treated as wildcard scope for HTTP (intentionally not scope-limited).
 
 **WebSocket scope enforcement:** WebSocket requests authenticated with **device tokens** are authorized per-request based on required scopes. WS requests missing the required scope are rejected with a `forbidden` error response. Deny-by-default applies: if a request type has no scope mapping, scoped tokens are forbidden. The **admin bootstrap token** is break-glass and is treated as wildcard scope for WS.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -118,6 +118,7 @@ flowchart LR
 - [Gateway](./gateway/index.md)
 - [Tenancy](./tenancy.md)
 - [Gateway authN/authZ](./gateway-authz.md)
+- [API surfaces (WebSocket vs HTTP)](./api-surfaces.md)
 - [Identity](./identity.md)
 - [Execution engine](./execution-engine.md)
 - [Work board and delegated execution](./workboard.md)

--- a/docs/architecture/protocol/index.md
+++ b/docs/architecture/protocol/index.md
@@ -19,6 +19,7 @@ The protocol is the primary interface for:
 
 - Primary transport is WebSocket for low-latency, long-lived connectivity.
 - Heartbeats detect dead connections and enable safe eviction/reconnect.
+- The gateway also exposes an HTTP API for bootstrap/resource surfaces (auth/session, artifacts, callbacks). See: [API surfaces (WebSocket vs HTTP)](../api-surfaces.md).
 
 ## Deployment notes (reconnect + dedupe)
 


### PR DESCRIPTION
Closes #636.

Adds a dedicated architecture page (`docs/architecture/api-surfaces.md`) describing transport best-practice:
- scopes are the security boundary (not transport)
- WS = interactive control-plane (requests/events)
- HTTP = resource/callback plane (auth/session, artifacts/blobs, webhooks/callbacks, health)
- guidance to avoid dual-surface drift
- repo “where to implement” map

Also cross-links from the relevant architecture pages and adds the doc to the Docusaurus sidebar.

Related: #541, #590.
