### PR TITLE
feat(desktop): Integrate embedded-gateway controls + local node runtime UX into operator shell (#563)

### DIFF
--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -429,13 +429,11 @@ function DesktopSetupPage({ core }: { core: OperatorCore }) {
     if (!api?.checkMacPermissions) return;
     setErrorMessage(null);
     try {
-      const snapshot = (await api.checkMacPermissions()) as
-        | {
-            accessibility: boolean | null;
-            screenRecording: boolean | null;
-            instructions?: string;
-          }
-        | null;
+      const snapshot = (await api.checkMacPermissions()) as {
+        accessibility: boolean | null;
+        screenRecording: boolean | null;
+        instructions?: string;
+      } | null;
       if (!snapshot) {
         setMacPermissionSummary("Not macOS (skipped).");
       } else {
@@ -464,12 +462,12 @@ function DesktopSetupPage({ core }: { core: OperatorCore }) {
     setErrorMessage(null);
     try {
       await api.requestMacPermission(permission);
+      void checkMacPermissions();
     } catch (error) {
       setErrorMessage(toErrorMessage(error));
     } finally {
       setRequestingPermission(null);
     }
-    void checkMacPermissions();
   };
 
   if (!api) {

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -630,6 +630,79 @@ describe("operator-ui", () => {
     delete (window as unknown as Record<string, unknown>)["tyrumDesktop"];
   });
 
+  it("keeps mac permission request errors visible", async () => {
+    const ws = new FakeWsClient();
+    const { http } = createFakeHttpClient();
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("test"),
+      deps: { ws, http },
+    });
+
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({
+        mode: "embedded",
+        embedded: { port: 8788 },
+        capabilities: { desktop: true, playwright: false, cli: false, http: false },
+      })),
+      setConfig: vi.fn(async () => {}),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "stopped", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connecting" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+      checkMacPermissions: vi.fn(async () => null),
+      requestMacPermission: vi.fn(async () => {
+        throw new Error("Permission request failed.");
+      }),
+    };
+
+    (window as unknown as Record<string, unknown>)["tyrumDesktop"] = desktopApi;
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    act(() => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+    });
+
+    const desktopLink = container.querySelector<HTMLButtonElement>('[data-testid="nav-desktop"]');
+    expect(desktopLink).not.toBeNull();
+
+    await act(async () => {
+      desktopLink?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const requestAccessibilityButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="desktop-request-accessibility"]',
+    );
+    expect(requestAccessibilityButton).not.toBeNull();
+
+    await act(async () => {
+      requestAccessibilityButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(desktopApi.requestMacPermission).toHaveBeenCalledTimes(1);
+    expect(desktopApi.checkMacPermissions).toHaveBeenCalledTimes(0);
+    expect(container.textContent).toContain("Permission request failed.");
+
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    delete (window as unknown as Record<string, unknown>)["tyrumDesktop"];
+  });
+
   it("disables browser assistance on the login token field", () => {
     const ws = new FakeWsClient();
     const { http } = createFakeHttpClient();


### PR DESCRIPTION
Closes #563

## What
- Add a Desktop Setup page to the shared operator UI (desktop mode only) with:
  - embedded gateway start/stop + status
  - local node runtime connect/disconnect
  - capability toggles (desktop/playwright/cli/http) + save
  - macOS permission check/request hooks (when available)
- Keep desktop-only controls separated under a dedicated "Desktop" nav section.

## Test Evidence
- `pnpm test` (297 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm lint`

Notes:
- Local env used Node v25.6.1 so pnpm prints an engine warning (repo targets Node 24.x).}