### PR TITLE
feat(client): Subagent WS helpers + events (#598)

### DIFF
--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -41,6 +41,16 @@ import type {
   WsResponseEnvelope,
   WsSessionSendPayload,
   WsSessionSendResult as WsSessionSendResultT,
+  WsSubagentClosePayload,
+  WsSubagentCloseResult as WsSubagentCloseResultT,
+  WsSubagentGetPayload,
+  WsSubagentGetResult as WsSubagentGetResultT,
+  WsSubagentListPayload,
+  WsSubagentListResult as WsSubagentListResultT,
+  WsSubagentSendPayload,
+  WsSubagentSendResult as WsSubagentSendResultT,
+  WsSubagentSpawnPayload,
+  WsSubagentSpawnResult as WsSubagentSpawnResultT,
   WsWorkArtifactCreatePayload,
   WsWorkArtifactCreateResult as WsWorkArtifactCreateResultT,
   WsWorkArtifactGetPayload,
@@ -95,6 +105,16 @@ import {
   WsPairingResolveResult,
   WsPresenceBeaconResult,
   WsSessionSendResult,
+  WsSubagentClosePayload as WsSubagentClosePayloadSchema,
+  WsSubagentCloseResult,
+  WsSubagentGetPayload as WsSubagentGetPayloadSchema,
+  WsSubagentGetResult,
+  WsSubagentListPayload as WsSubagentListPayloadSchema,
+  WsSubagentListResult,
+  WsSubagentSendPayload as WsSubagentSendPayloadSchema,
+  WsSubagentSendResult,
+  WsSubagentSpawnPayload as WsSubagentSpawnPayloadSchema,
+  WsSubagentSpawnResult,
   WsWorkflowCancelResult,
   WsWorkflowResumeResult,
   WsWorkflowRunResult,
@@ -575,8 +595,53 @@ export class TyrumClient {
   }
 
   // -----------------------------------------------------------------------
+  // Subagent helpers
+  // -----------------------------------------------------------------------
+
+  async subagentSpawn(payload: WsSubagentSpawnPayload): Promise<WsSubagentSpawnResultT> {
+    const parsed = this.parsePayload("subagent.spawn", payload, WsSubagentSpawnPayloadSchema);
+    return this.request("subagent.spawn", parsed, WsSubagentSpawnResult);
+  }
+
+  async subagentList(payload: WsSubagentListPayload): Promise<WsSubagentListResultT> {
+    const parsed = this.parsePayload("subagent.list", payload, WsSubagentListPayloadSchema);
+    return this.request("subagent.list", parsed, WsSubagentListResult);
+  }
+
+  async subagentGet(payload: WsSubagentGetPayload): Promise<WsSubagentGetResultT> {
+    const parsed = this.parsePayload("subagent.get", payload, WsSubagentGetPayloadSchema);
+    return this.request("subagent.get", parsed, WsSubagentGetResult);
+  }
+
+  async subagentSend(payload: WsSubagentSendPayload): Promise<WsSubagentSendResultT> {
+    const parsed = this.parsePayload("subagent.send", payload, WsSubagentSendPayloadSchema);
+    return this.request("subagent.send", parsed, WsSubagentSendResult);
+  }
+
+  async subagentClose(payload: WsSubagentClosePayload): Promise<WsSubagentCloseResultT> {
+    const parsed = this.parsePayload("subagent.close", payload, WsSubagentClosePayloadSchema);
+    return this.request("subagent.close", parsed, WsSubagentCloseResult);
+  }
+
+  // -----------------------------------------------------------------------
   // Internal
   // -----------------------------------------------------------------------
+
+  private parsePayload<T>(
+    type: string,
+    payload: unknown,
+    schema: {
+      safeParse: (
+        input: unknown,
+      ) => { success: true; data: T } | { success: false; error: { message: string } };
+    },
+  ): T {
+    const parsed = schema.safeParse(payload);
+    if (!parsed.success) {
+      throw new Error(`${type} invalid payload: ${parsed.error.message}`);
+    }
+    return parsed.data;
+  }
 
   private buildProtocols(): string[] {
     const token = toBase64UrlUtf8(this.opts.token);

--- a/packages/client/tests/ws-client.test.ts
+++ b/packages/client/tests/ws-client.test.ts
@@ -1457,6 +1457,236 @@ describe("TyrumClient", () => {
     expect(kvSetRes.entry.key).toBe("branch");
   });
 
+  it("sends typed subagent.* requests and returns validated results", async () => {
+    server = createTestServer();
+    client = new TyrumClient({
+      url: server.url,
+      token: "t",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const connectedP = new Promise<void>((resolve) => {
+      client!.on("connected", () => resolve());
+    });
+
+    client.connect();
+    const ws = await server.waitForClient();
+    await acceptConnect(ws);
+    await connectedP;
+
+    const scope = { tenant_id: "t-1", agent_id: "agent-1", workspace_id: "default" };
+    const workItemId = "11111111-2222-3333-8aaa-555555555555";
+    const workItemTaskId = "22222222-3333-4444-8aaa-555555555555";
+    const subagentId = "123e4567-e89b-12d3-a456-426614174000";
+
+    const subagent = {
+      subagent_id: subagentId,
+      ...scope,
+      work_item_id: workItemId,
+      work_item_task_id: workItemTaskId,
+      execution_profile: "subagent",
+      session_key: `agent:${scope.agent_id}:subagent:${subagentId}`,
+      lane: "subagent",
+      status: "running",
+      created_at: "2026-02-19T12:00:00Z",
+      last_heartbeat_at: null,
+    };
+
+    async function expectSubagentRequest<T>(
+      call: () => Promise<T>,
+      expectedType: string,
+      payload: unknown,
+      result: unknown,
+    ): Promise<T> {
+      const pending = call();
+      const req = (await waitForMessage(ws)) as Record<string, unknown>;
+      expect(req["type"]).toBe(expectedType);
+      expect(req["payload"]).toEqual(payload);
+
+      ws.send(
+        JSON.stringify({
+          request_id: req["request_id"],
+          type: expectedType,
+          ok: true,
+          result,
+        }),
+      );
+
+      return await pending;
+    }
+
+    const spawnPayload = {
+      ...scope,
+      execution_profile: "subagent",
+      work_item_id: workItemId,
+      work_item_task_id: workItemTaskId,
+    };
+    const spawnRes = await expectSubagentRequest(
+      () => client!.subagentSpawn(spawnPayload),
+      "subagent.spawn",
+      spawnPayload,
+      { subagent },
+    );
+    expect(spawnRes.subagent.subagent_id).toBe(subagentId);
+
+    const listPayload = { ...scope, statuses: ["running"], limit: 1 };
+    const listRes = await expectSubagentRequest(
+      () => client!.subagentList(listPayload),
+      "subagent.list",
+      listPayload,
+      { subagents: [subagent] },
+    );
+    expect(listRes.subagents[0].subagent_id).toBe(subagentId);
+
+    const getPayload = { ...scope, subagent_id: subagentId };
+    const getRes = await expectSubagentRequest(
+      () => client!.subagentGet(getPayload),
+      "subagent.get",
+      getPayload,
+      { subagent },
+    );
+    expect(getRes.subagent.subagent_id).toBe(subagentId);
+
+    const sendPayload = { ...scope, subagent_id: subagentId, content: "hello" };
+    const sendRes = await expectSubagentRequest(
+      () => client!.subagentSend(sendPayload),
+      "subagent.send",
+      sendPayload,
+      { accepted: true },
+    );
+    expect(sendRes.accepted).toBe(true);
+
+    const closeSubagent = {
+      ...subagent,
+      status: "closed",
+      closed_at: "2026-02-19T12:00:01Z",
+    };
+    const closePayload = { ...scope, subagent_id: subagentId, reason: "done" };
+    const closeRes = await expectSubagentRequest(
+      () => client!.subagentClose(closePayload),
+      "subagent.close",
+      closePayload,
+      { subagent: closeSubagent },
+    );
+    expect(closeRes.subagent.status).toBe("closed");
+  });
+
+  it("rejects invalid subagent.* payloads without sending", async () => {
+    server = createTestServer();
+    client = new TyrumClient({
+      url: server.url,
+      token: "t",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const connectedP = new Promise<void>((resolve) => {
+      client!.on("connected", () => resolve());
+    });
+
+    client.connect();
+    const ws = await server.waitForClient();
+    await acceptConnect(ws);
+    await connectedP;
+
+    const outbound: unknown[] = [];
+    ws.on("message", (data) => {
+      outbound.push(JSON.parse(data.toString()));
+    });
+
+    const scope = { tenant_id: "t-1", agent_id: "agent-1", workspace_id: "default" };
+    const invalidPayload = {
+      ...scope,
+      subagent_id: "123e4567-e89b-12d3-a456-426614174000",
+      content: "   ",
+    };
+
+    await expect(
+      withTimeout(
+        client!.subagentSend(invalidPayload as any),
+        200,
+        "subagent.send invalid payload",
+      ),
+    ).rejects.toThrow(/invalid payload/i);
+
+    await delay(25);
+    expect(outbound).toEqual([]);
+  });
+
+  it("emits subagent.* events", async () => {
+    server = createTestServer();
+    client = new TyrumClient({
+      url: server.url,
+      token: "t",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const connectedP = new Promise<void>((resolve) => {
+      client!.on("connected", () => resolve());
+    });
+
+    const scope = { tenant_id: "t-1", agent_id: "agent-1", workspace_id: "default" };
+    const workItemId = "11111111-2222-3333-8aaa-555555555555";
+    const workItemTaskId = "22222222-3333-4444-8aaa-555555555555";
+    const subagentId = "123e4567-e89b-12d3-a456-426614174000";
+    const subagent = {
+      subagent_id: subagentId,
+      ...scope,
+      work_item_id: workItemId,
+      work_item_task_id: workItemTaskId,
+      execution_profile: "subagent",
+      session_key: `agent:${scope.agent_id}:subagent:${subagentId}`,
+      lane: "subagent",
+      status: "running",
+      created_at: "2026-02-19T12:00:00Z",
+      last_heartbeat_at: null,
+    };
+
+    const spawnedReceivedP = new Promise<unknown>((resolve) => {
+      client!.on("subagent.spawned", resolve);
+    });
+    const outputReceivedP = new Promise<unknown>((resolve) => {
+      client!.on("subagent.output", resolve);
+    });
+
+    client.connect();
+    const ws = await server.waitForClient();
+    await acceptConnect(ws);
+    await connectedP;
+
+    const spawnedMsg = {
+      event_id: "evt-subagent-1",
+      type: "subagent.spawned",
+      occurred_at: "2026-02-19T12:00:00Z",
+      payload: { subagent },
+    };
+    ws.send(JSON.stringify(spawnedMsg));
+
+    const outputMsg = {
+      event_id: "evt-subagent-2",
+      type: "subagent.output",
+      occurred_at: "2026-02-19T12:00:00Z",
+      payload: {
+        ...scope,
+        subagent_id: subagentId,
+        work_item_id: workItemId,
+        work_item_task_id: workItemTaskId,
+        kind: "delta",
+        content: "hello",
+      },
+    };
+    ws.send(JSON.stringify(outputMsg));
+
+    await expect(withTimeout(spawnedReceivedP, 2_000, "subagent.spawned")).resolves.toEqual(
+      spawnedMsg,
+    );
+    await expect(withTimeout(outputReceivedP, 2_000, "subagent.output")).resolves.toEqual(
+      outputMsg,
+    );
+  });
+
   it("rejects void helper responses with non-empty ack payloads", async () => {
     server = createTestServer();
     client = new TyrumClient({


### PR DESCRIPTION
Closes #598

## Summary
- Add `TyrumClient` WS helpers for `subagent.*` operations (spawn/list/get/send/close), with Zod payload validation and Zod-validated results.
- Add client tests covering `subagent.*` requests + event emission.

## Test Evidence
- `pnpm test` (1991 passed, 2 skipped)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
