### PR TITLE
feat(web): Wire Admin Mode into apps/web (auth switching + UI hooks) (#640)

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import {
+  createAdminModeStore,
   createBearerTokenAuth,
   createBrowserCookieAuth,
-  createOperatorCore,
 } from "@tyrum/operator-core";
 import { OperatorUiApp } from "@tyrum/operator-ui";
+import { createWebOperatorCoreManager } from "./operator-core-manager.js";
 import { readAuthTokenFromUrl, stripAuthTokenFromUrl } from "./url-auth.js";
 
 function scrubAuthTokenFromUrl(): void {
@@ -43,18 +44,31 @@ if (!container) {
   throw new Error("Missing root element (#root).");
 }
 
-const core = createOperatorCore({
+const adminModeStore = createAdminModeStore();
+const manager = createWebOperatorCoreManager({
   wsUrl: resolveGatewayWsUrl(),
   httpBaseUrl: resolveGatewayHttpBaseUrl(),
-  auth: resolveAuthFromLocation(),
+  baselineAuth: resolveAuthFromLocation(),
+  adminModeStore,
+});
+
+const root = createRoot(container);
+const render = (): void => {
+  root.render(
+    <React.StrictMode>
+      <OperatorUiApp core={manager.getCore()} mode="web" />
+    </React.StrictMode>,
+  );
+};
+
+const unsubscribe = manager.subscribe(() => {
+  render();
 });
 
 window.addEventListener("beforeunload", () => {
-  core.dispose();
+  unsubscribe();
+  manager.dispose();
+  adminModeStore.dispose();
 });
 
-createRoot(container).render(
-  <React.StrictMode>
-    <OperatorUiApp core={core} mode="web" />
-  </React.StrictMode>,
-);
+render();

--- a/apps/web/src/operator-core-manager.ts
+++ b/apps/web/src/operator-core-manager.ts
@@ -1,0 +1,131 @@
+import {
+  createOperatorCore,
+  selectAuthForAdminMode,
+  type AdminModeStore,
+  type OperatorAuthStrategy,
+  type OperatorCore,
+} from "@tyrum/operator-core";
+
+export type WebOperatorCoreFactory = (options: {
+  wsUrl: string;
+  httpBaseUrl: string;
+  auth: OperatorAuthStrategy;
+  adminModeStore: AdminModeStore;
+}) => OperatorCore;
+
+export type WebOperatorCoreManagerOptions = {
+  wsUrl: string;
+  httpBaseUrl: string;
+  baselineAuth: OperatorAuthStrategy;
+  adminModeStore: AdminModeStore;
+  createCore?: WebOperatorCoreFactory;
+};
+
+export type WebOperatorCoreManager = {
+  getCore(): OperatorCore;
+  subscribe(listener: () => void): () => void;
+  dispose(): void;
+};
+
+function isSameAuth(a: OperatorAuthStrategy, b: OperatorAuthStrategy): boolean {
+  switch (a.type) {
+    case "bearer-token":
+      return b.type === "bearer-token" && a.token === b.token;
+    case "browser-cookie":
+      return b.type === "browser-cookie" && a.credentials === b.credentials;
+    default:
+      return false;
+  }
+}
+
+function shouldReconnectCore(core: OperatorCore): boolean {
+  const status = core.connectionStore.getSnapshot().status;
+  return status === "connecting" || status === "connected";
+}
+
+export function createWebOperatorCoreManager(
+  options: WebOperatorCoreManagerOptions,
+): WebOperatorCoreManager {
+  const createCore: WebOperatorCoreFactory =
+    options.createCore ??
+    ((coreOptions) =>
+      createOperatorCore({
+        wsUrl: coreOptions.wsUrl,
+        httpBaseUrl: coreOptions.httpBaseUrl,
+        auth: coreOptions.auth,
+        adminModeStore: coreOptions.adminModeStore,
+      }));
+
+  let auth = selectAuthForAdminMode({
+    baseline: options.baselineAuth,
+    adminMode: options.adminModeStore.getSnapshot(),
+  });
+
+  let core = createCore({
+    wsUrl: options.wsUrl,
+    httpBaseUrl: options.httpBaseUrl,
+    auth,
+    adminModeStore: options.adminModeStore,
+  });
+
+  const listeners = new Set<() => void>();
+  const emit = (): void => {
+    let firstError: unknown = null;
+    for (const listener of listeners) {
+      try {
+        listener();
+      } catch (error) {
+        if (firstError === null) {
+          firstError = error;
+        }
+      }
+    }
+    if (firstError !== null) {
+      throw firstError;
+    }
+  };
+
+  const unsubAdminMode = options.adminModeStore.subscribe(() => {
+    const nextAuth = selectAuthForAdminMode({
+      baseline: options.baselineAuth,
+      adminMode: options.adminModeStore.getSnapshot(),
+    });
+    if (isSameAuth(auth, nextAuth)) return;
+
+    const prevCore = core;
+    const reconnect = shouldReconnectCore(prevCore);
+
+    core = createCore({
+      wsUrl: options.wsUrl,
+      httpBaseUrl: options.httpBaseUrl,
+      auth: nextAuth,
+      adminModeStore: options.adminModeStore,
+    });
+    auth = nextAuth;
+
+    prevCore.dispose();
+
+    if (reconnect) {
+      core.connect();
+    }
+
+    emit();
+  });
+
+  return {
+    getCore() {
+      return core;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      unsubAdminMode();
+      core.dispose();
+      listeners.clear();
+    },
+  };
+}

--- a/apps/web/tests/admin-mode-core-switcher.test.ts
+++ b/apps/web/tests/admin-mode-core-switcher.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AdminModeStore, OperatorAuthStrategy, OperatorCore } from "@tyrum/operator-core";
+import {
+  createAdminModeStore,
+  createBearerTokenAuth,
+} from "../../../packages/operator-core/src/index.js";
+import { createWebOperatorCoreManager } from "../src/operator-core-manager.js";
+
+type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+function createFakeCore(options: {
+  status: ConnectionStatus;
+  adminModeStore: AdminModeStore;
+}): OperatorCore {
+  return {
+    wsUrl: "ws://example.test/ws",
+    httpBaseUrl: "http://example.test",
+    ws: { connected: options.status === "connected" } as unknown as OperatorCore["ws"],
+    http: {} as unknown as OperatorCore["http"],
+    adminModeStore: options.adminModeStore,
+    connectionStore: {
+      getSnapshot() {
+        return {
+          status: options.status,
+        } as OperatorCore["connectionStore"]["getSnapshot"] extends () => infer T ? T : never;
+      },
+      subscribe() {
+        return () => {};
+      },
+    } as unknown as OperatorCore["connectionStore"],
+    approvalsStore: {} as unknown as OperatorCore["approvalsStore"],
+    runsStore: {} as unknown as OperatorCore["runsStore"],
+    pairingStore: {} as unknown as OperatorCore["pairingStore"],
+    statusStore: {} as unknown as OperatorCore["statusStore"],
+    connect: vi.fn(() => {}),
+    disconnect: vi.fn(() => {}),
+    dispose: vi.fn(() => {}),
+  };
+}
+
+describe("apps/web operator-core-manager", () => {
+  it("switches auth and reconnects when Admin Mode toggles while connected", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-27T00:00:00.000Z"));
+
+    let adminModeStore: AdminModeStore | null = null;
+    let manager: ReturnType<typeof createWebOperatorCoreManager> | null = null;
+    try {
+      adminModeStore = createAdminModeStore({ tickIntervalMs: 0 });
+      const store = adminModeStore;
+      const baselineAuth = createBearerTokenAuth("baseline-token");
+
+      const created: Array<{ auth: OperatorAuthStrategy; core: OperatorCore }> = [];
+      const statuses: ConnectionStatus[] = ["connected", "connected", "disconnected"];
+
+      const createCore = vi.fn(
+        (options: {
+          wsUrl: string;
+          httpBaseUrl: string;
+          auth: OperatorAuthStrategy;
+          adminModeStore: AdminModeStore;
+        }): OperatorCore => {
+          const status = statuses[created.length] ?? "disconnected";
+          const core = createFakeCore({ status, adminModeStore: options.adminModeStore });
+          created.push({ auth: options.auth, core });
+          return core;
+        },
+      );
+
+      manager = createWebOperatorCoreManager({
+        wsUrl: "ws://example.test/ws",
+        httpBaseUrl: "http://example.test",
+        baselineAuth,
+        adminModeStore: store,
+        createCore,
+      });
+
+      expect(createCore).toHaveBeenCalledTimes(1);
+      expect(created[0]?.auth).toMatchObject({ type: "bearer-token", token: "baseline-token" });
+
+      store.enter({
+        elevatedToken: "elevated-token",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+
+      expect(createCore).toHaveBeenCalledTimes(2);
+      expect(created[1]?.auth).toMatchObject({ type: "bearer-token", token: "elevated-token" });
+      expect(created[0]?.core.dispose).toHaveBeenCalledTimes(1);
+      expect(created[1]?.core.connect).toHaveBeenCalledTimes(1);
+
+      store.exit();
+
+      expect(createCore).toHaveBeenCalledTimes(3);
+      expect(created[2]?.auth).toMatchObject({ type: "bearer-token", token: "baseline-token" });
+      expect(created[1]?.core.dispose).toHaveBeenCalledTimes(1);
+      expect(created[2]?.core.connect).toHaveBeenCalledTimes(1);
+    } finally {
+      manager?.dispose();
+      adminModeStore?.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not recreate the core when the elevated token is unchanged", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-27T00:00:00.000Z"));
+
+    let adminModeStore: AdminModeStore | null = null;
+    let manager: ReturnType<typeof createWebOperatorCoreManager> | null = null;
+    try {
+      adminModeStore = createAdminModeStore({ tickIntervalMs: 0 });
+      const store = adminModeStore;
+      const baselineAuth = createBearerTokenAuth("baseline-token");
+
+      const createCore = vi.fn(
+        (options: {
+          wsUrl: string;
+          httpBaseUrl: string;
+          auth: OperatorAuthStrategy;
+          adminModeStore: AdminModeStore;
+        }): OperatorCore =>
+          createFakeCore({ status: "disconnected", adminModeStore: options.adminModeStore }),
+      );
+
+      manager = createWebOperatorCoreManager({
+        wsUrl: "ws://example.test/ws",
+        httpBaseUrl: "http://example.test",
+        baselineAuth,
+        adminModeStore: store,
+        createCore,
+      });
+
+      expect(createCore).toHaveBeenCalledTimes(1);
+
+      store.enter({
+        elevatedToken: "elevated-token",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+      expect(createCore).toHaveBeenCalledTimes(2);
+
+      store.enter({
+        elevatedToken: "elevated-token",
+        expiresAt: new Date(Date.now() + 120_000).toISOString(),
+      });
+      expect(createCore).toHaveBeenCalledTimes(2);
+    } finally {
+      manager?.dispose();
+      adminModeStore?.dispose();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/operator-core/src/deps.ts
+++ b/packages/operator-core/src/deps.ts
@@ -15,6 +15,7 @@ export interface OperatorWsClient {
   off(event: string, handler: (data: unknown) => void): void;
   approvalList(payload?: unknown): Promise<{ approvals: Approval[]; next_cursor?: string }>;
   approvalResolve(payload: unknown): Promise<{ approval: Approval }>;
+  commandExecute?(command: string, context?: unknown): Promise<unknown>;
 }
 
 export interface OperatorHttpClient {

--- a/packages/operator-core/src/operator-core.ts
+++ b/packages/operator-core/src/operator-core.ts
@@ -26,6 +26,7 @@ export interface OperatorCoreOptions {
   httpBaseUrl: string;
   auth: OperatorAuthStrategy;
   capabilities?: ClientCapability[];
+  adminModeStore?: AdminModeStore;
   deps?: {
     ws?: OperatorWsClient;
     http?: OperatorHttpClient;
@@ -80,7 +81,8 @@ function readPayload(data: unknown): Record<string, unknown> | null {
 }
 
 export function createOperatorCore(options: OperatorCoreOptions): OperatorCore {
-  const adminModeStore = createAdminModeStore();
+  const adminModeStore = options.adminModeStore ?? createAdminModeStore();
+  const adminModeStoreOwned = options.adminModeStore === undefined;
 
   const ws: OperatorWsClient =
     options.deps?.ws ??
@@ -223,7 +225,9 @@ export function createOperatorCore(options: OperatorCoreOptions): OperatorCore {
 
   const dispose = (): void => {
     connection.store.disconnect();
-    adminModeStore.dispose();
+    if (adminModeStoreOwned) {
+      adminModeStore.dispose();
+    }
     for (const unsub of unsubscribes) {
       unsub();
     }

--- a/packages/operator-core/tests/operator-core.test.ts
+++ b/packages/operator-core/tests/operator-core.test.ts
@@ -14,7 +14,7 @@ import type {
   TyrumHttpClient,
   UsageResponse,
 } from "@tyrum/client";
-import { createBearerTokenAuth, createOperatorCore } from "../src/index.js";
+import { createAdminModeStore, createBearerTokenAuth, createOperatorCore } from "../src/index.js";
 
 type Handler = (data: unknown) => void;
 
@@ -642,6 +642,39 @@ describe("operator-core wiring", () => {
     core.dispose();
 
     expect(ws.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispose an injected adminModeStore", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-27T00:00:00.000Z"));
+
+    try {
+      const ws = new FakeWsClient();
+      const http = createFakeHttpClient();
+      const adminModeStore = createAdminModeStore({ tickIntervalMs: 0 });
+
+      adminModeStore.enter({
+        elevatedToken: "elevated-token",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+
+      const core = createOperatorCore({
+        wsUrl: "ws://127.0.0.1:8788/ws",
+        httpBaseUrl: "http://127.0.0.1:8788",
+        auth: createBearerTokenAuth("baseline-token"),
+        deps: { ws, http },
+        adminModeStore,
+      });
+
+      expect(core.adminModeStore).toBe(adminModeStore);
+
+      core.dispose();
+
+      expect(adminModeStore.getSnapshot().status).toBe("active");
+      adminModeStore.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("re-syncs on reconnect", async () => {

--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -1,6 +1,6 @@
 import type { OperatorCore } from "@tyrum/operator-core";
 import { useEffect, useRef, useState } from "react";
-import { AdminModeProvider } from "./admin-mode.js";
+import { AdminModeGate, AdminModeProvider } from "./admin-mode.js";
 import { getDesktopApi } from "./desktop-api.js";
 import { OPERATOR_UI_CSS } from "./style.js";
 import { useOperatorStore } from "./use-operator-store.js";
@@ -800,6 +800,33 @@ function RunsPage({ core }: { core: OperatorCore }) {
 function SettingsPage({ core, mode }: { core: OperatorCore; mode: OperatorUiMode }) {
   const statusState = useOperatorStore(core.statusStore);
   const totalTokens = statusState.usage?.local.totals.total_tokens;
+  const [adminCommandBusy, setAdminCommandBusy] = useState(false);
+  const [adminCommandError, setAdminCommandError] = useState<string | null>(null);
+
+  const toErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) return error.message;
+    return String(error);
+  };
+
+  const runAdminCommand = async (): Promise<void> => {
+    if (adminCommandBusy) return;
+
+    setAdminCommandBusy(true);
+    setAdminCommandError(null);
+
+    try {
+      if (!core.ws.commandExecute) {
+        setAdminCommandError("Admin commands are not supported by this client.");
+        return;
+      }
+      await core.ws.commandExecute("/help");
+    } catch (error) {
+      setAdminCommandError(toErrorMessage(error));
+    } finally {
+      setAdminCommandBusy(false);
+    }
+  };
+
   return (
     <>
       <h1>Settings</h1>
@@ -814,6 +841,30 @@ function SettingsPage({ core, mode }: { core: OperatorCore; mode: OperatorUiMode
         Refresh usage
       </button>
       <div>Total tokens: {totalTokens ?? "-"}</div>
+
+      <h2 style={{ marginTop: 24 }}>Admin</h2>
+      <AdminModeGate>
+        <div className="card stack">
+          <div style={{ fontSize: 13, color: "var(--muted)" }}>
+            Admin Mode is required for privileged operator actions.
+          </div>
+          <button
+            type="button"
+            data-testid="settings-admin-command-execute"
+            disabled={adminCommandBusy}
+            onClick={() => {
+              void runAdminCommand();
+            }}
+          >
+            {adminCommandBusy ? "Running..." : "Run admin command"}
+          </button>
+          {adminCommandError ? (
+            <div className="alert error" role="alert">
+              {adminCommandError}
+            </div>
+          ) : null}
+        </div>
+      </AdminModeGate>
     </>
   );
 }

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -24,6 +24,7 @@ class FakeWsClient implements OperatorWsClient {
   approvalResolve = vi.fn(async () => {
     throw new Error("not implemented");
   });
+  commandExecute = vi.fn(async () => ({}));
 
   private readonly handlers = new Map<string, Set<Handler>>();
 
@@ -1337,6 +1338,114 @@ describe("operator-ui", () => {
     });
 
     expect(container.querySelector('[data-testid="admin-mode-banner"]')).toBeNull();
+
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+  });
+
+  it("gates an admin-only Settings action behind Admin Mode", async () => {
+    const issuedAt = "2026-02-27T00:00:00.000Z";
+    const expiresAt = "2026-02-27T00:10:00.000Z";
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(issuedAt));
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(init?.method).toBe("POST");
+      expect(headers.get("authorization")).toBe("Bearer admin-token");
+
+      return new Response(
+        JSON.stringify({
+          token_kind: "device",
+          token: "elevated-device-token",
+          token_id: "token-1",
+          device_id: "operator-ui",
+          role: "client",
+          scopes: ["operator.admin"],
+          issued_at: issuedAt,
+          expires_at: expiresAt,
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const ws = new FakeWsClient();
+    const { http } = createFakeHttpClient();
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deps: { ws, http },
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    act(() => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "web" }));
+    });
+
+    const settingsLink = container.querySelector<HTMLButtonElement>('[data-testid="nav-settings"]');
+    expect(settingsLink).not.toBeNull();
+
+    act(() => {
+      settingsLink?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="settings-admin-command-execute"]')).toBeNull();
+    expect(container.textContent).toContain("Enter Admin Mode to continue");
+
+    const enterButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="admin-mode-enter"]',
+    );
+    expect(enterButton).not.toBeNull();
+
+    act(() => {
+      enterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const tokenField = container.querySelector<HTMLInputElement>(
+      '[data-testid="admin-mode-token"]',
+    );
+    expect(tokenField).not.toBeNull();
+    act(() => {
+      tokenField!.value = "admin-token";
+    });
+
+    const confirmCheckbox = container.querySelector<HTMLInputElement>(
+      '[data-testid="admin-mode-confirm"]',
+    );
+    expect(confirmCheckbox).not.toBeNull();
+    act(() => {
+      confirmCheckbox!.checked = true;
+      confirmCheckbox!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const submitButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="admin-mode-submit"]',
+    );
+    expect(submitButton).not.toBeNull();
+
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(core.adminModeStore.getSnapshot()).toMatchObject({
+      status: "active",
+      elevatedToken: "elevated-device-token",
+      expiresAt,
+    });
+    expect(container.querySelector('[data-testid="admin-mode-banner"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="settings-admin-command-execute"]'),
+    ).not.toBeNull();
 
     act(() => {
       root?.unmount();


### PR DESCRIPTION
Closes #640

## What
- `apps/web` owns a shared Admin Mode store and recreates OperatorCore when Admin Mode toggles, reconnecting WS when switching tokens.
- `@tyrum/operator-ui` Settings now includes an Admin Mode-gated admin action (entry point + gating).
- `@tyrum/operator-core` `createOperatorCore()` supports an injected `adminModeStore` and will not dispose it when externally provided.

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
