### PR TITLE
Desktop: OS integrations (About, notifications, dock/taskbar progress) (#696)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import type { GatewayManager } from "./gateway-manager.js";
 import { MAIN_WINDOW_OPTIONS } from "./window-options.js";
 import { configExists, loadConfig } from "./config/store.js";
 import { setWindowsAppUserModelId, setupSingleInstance } from "./single-instance.js";
+import { configureMacAboutPanel } from "./platform/os-integrations.js";
 
 app.setName?.("Tyrum");
 
@@ -125,7 +126,10 @@ function createWindow(): void {
 }
 
 if (didAcquireSingleInstanceLock) {
-  app.whenReady().then(createWindow);
+  app.whenReady().then(() => {
+    configureMacAboutPanel(app, process.platform);
+    createWindow();
+  });
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin") app.quit();
   });

--- a/apps/desktop/src/main/ipc/update-ipc.ts
+++ b/apps/desktop/src/main/ipc/update-ipc.ts
@@ -2,6 +2,7 @@ import {
   app,
   dialog,
   ipcMain,
+  Notification,
   shell,
   type BrowserWindow,
   type FileFilter,
@@ -14,6 +15,7 @@ import {
   isAllowedReleaseFilePath,
   releaseFileDialogExtensions,
 } from "../updater.js";
+import { createDesktopUpdateOsIntegration } from "../platform/os-integrations.js";
 import { createWindowSender } from "./window-sender.js";
 
 const sender = createWindowSender();
@@ -21,6 +23,7 @@ const sender = createWindowSender();
 let updater: DesktopUpdaterService | null = null;
 let ipcRegistered = false;
 let dialogWindow: BrowserWindow | null = null;
+let updateOsIntegration: ReturnType<typeof createDesktopUpdateOsIntegration> | null = null;
 
 export interface ManualReleaseFileResult {
   opened: boolean;
@@ -34,11 +37,47 @@ export interface UpdateIpcOptions {
   clearQuitForUpdate?: () => void;
 }
 
+function ensureUpdateOsIntegration(): ReturnType<typeof createDesktopUpdateOsIntegration> {
+  if (updateOsIntegration) return updateOsIntegration;
+
+  updateOsIntegration = createDesktopUpdateOsIntegration({
+    platform: process.platform,
+    setProgressBar: (progress) => {
+      const window = dialogWindow;
+      if (!window) return;
+      if (window.isDestroyed()) return;
+      const setProgressBar = (window as { setProgressBar?: unknown }).setProgressBar;
+      if (typeof setProgressBar !== "function") return;
+      (setProgressBar as (value: number) => void).call(window, progress);
+    },
+    clearProgressBar: () => {
+      const window = dialogWindow;
+      if (!window) return;
+      if (window.isDestroyed()) return;
+      const setProgressBar = (window as { setProgressBar?: unknown }).setProgressBar;
+      if (typeof setProgressBar !== "function") return;
+      (setProgressBar as (value: number) => void).call(window, -1);
+    },
+    notify: (title, body) => {
+      try {
+        if (!Notification.isSupported()) return;
+        const notification = new Notification({ title, body });
+        notification.show();
+      } catch (error) {
+        console.error("Failed to show update notification", error);
+      }
+    },
+  });
+
+  return updateOsIntegration;
+}
+
 function ensureUpdater(): DesktopUpdaterService {
   if (updater) {
     return updater;
   }
 
+  const osIntegration = ensureUpdateOsIntegration();
   updater = new DesktopUpdaterService({
     appUpdater: autoUpdater as unknown as ConstructorParameters<
       typeof DesktopUpdaterService
@@ -47,6 +86,7 @@ function ensureUpdater(): DesktopUpdaterService {
     isPackaged: app.isPackaged,
     onStateChange: (state) => {
       sender.send("update:state", state);
+      osIntegration.onStateChange(state);
     },
   });
 

--- a/apps/desktop/src/main/platform/os-integrations.ts
+++ b/apps/desktop/src/main/platform/os-integrations.ts
@@ -1,0 +1,88 @@
+import type { DesktopUpdateState } from "../updater.js";
+
+export interface AboutPanelAppLike {
+  getName: () => string;
+  getVersion: () => string;
+  setAboutPanelOptions?: (options: Record<string, unknown>) => void;
+}
+
+export function configureMacAboutPanel(app: AboutPanelAppLike, platform: NodeJS.Platform): void {
+  if (platform !== "darwin") return;
+  if (typeof app.setAboutPanelOptions !== "function") return;
+
+  app.setAboutPanelOptions({
+    applicationName: app.getName(),
+    applicationVersion: app.getVersion(),
+  });
+}
+
+export interface DesktopUpdateOsIntegrationOptions {
+  platform: NodeJS.Platform;
+  setProgressBar: (progress: number) => void;
+  clearProgressBar: () => void;
+  notify: (title: string, body: string) => void;
+}
+
+export interface DesktopUpdateOsIntegration {
+  onStateChange: (state: DesktopUpdateState) => void;
+}
+
+export function createDesktopUpdateOsIntegration(
+  options: DesktopUpdateOsIntegrationOptions,
+): DesktopUpdateOsIntegration {
+  const shouldShowProgress = options.platform === "win32" || options.platform === "darwin";
+  let progressActive = false;
+  let lastAvailableNotifiedVersion: string | null = null;
+  let lastDownloadedNotifiedVersion: string | null = null;
+  let notifiedAvailableWithoutVersion = false;
+  let notifiedDownloadedWithoutVersion = false;
+
+  return {
+    onStateChange: (state) => {
+      if (shouldShowProgress) {
+        if (state.stage === "downloading") {
+          const percent =
+            typeof state.progressPercent === "number" && !Number.isNaN(state.progressPercent)
+              ? state.progressPercent
+              : 0;
+          const clamped = Math.min(100, Math.max(0, percent));
+          options.setProgressBar(clamped / 100);
+          progressActive = true;
+        } else if (progressActive) {
+          options.clearProgressBar();
+          progressActive = false;
+        }
+      }
+
+      if (state.stage === "available") {
+        if (state.availableVersion === null) {
+          if (!notifiedAvailableWithoutVersion) {
+            notifiedAvailableWithoutVersion = true;
+            options.notify("Update available", "An update is available to download.");
+          }
+        } else if (state.availableVersion !== lastAvailableNotifiedVersion) {
+          lastAvailableNotifiedVersion = state.availableVersion;
+          options.notify(
+            "Update available",
+            `Version ${state.availableVersion} is available to download.`,
+          );
+        }
+      }
+
+      if (state.stage === "downloaded") {
+        if (state.downloadedVersion === null) {
+          if (!notifiedDownloadedWithoutVersion) {
+            notifiedDownloadedWithoutVersion = true;
+            options.notify("Update ready to install", "An update is ready to install.");
+          }
+        } else if (state.downloadedVersion !== lastDownloadedNotifiedVersion) {
+          lastDownloadedNotifiedVersion = state.downloadedVersion;
+          options.notify(
+            "Update ready to install",
+            `Version ${state.downloadedVersion} is ready to install.`,
+          );
+        }
+      }
+    },
+  };
+}

--- a/apps/desktop/tests/os-integrations.test.ts
+++ b/apps/desktop/tests/os-integrations.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopUpdateState } from "../src/main/updater.js";
+import {
+  configureMacAboutPanel,
+  createDesktopUpdateOsIntegration,
+} from "../src/main/platform/os-integrations.js";
+
+function makeState(patch: Partial<DesktopUpdateState>): DesktopUpdateState {
+  return {
+    stage: "idle",
+    currentVersion: "1.0.0",
+    availableVersion: null,
+    downloadedVersion: null,
+    releaseDate: null,
+    releaseNotes: null,
+    progressPercent: null,
+    message: null,
+    checkedAt: null,
+    ...patch,
+  };
+}
+
+describe("configureMacAboutPanel", () => {
+  it("uses app.setAboutPanelOptions on macOS", () => {
+    const setAboutPanelOptions = vi.fn();
+    const appStub = {
+      getName: () => "Tyrum",
+      getVersion: () => "1.2.3",
+      setAboutPanelOptions,
+    };
+
+    configureMacAboutPanel(appStub, "darwin");
+
+    expect(setAboutPanelOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationName: "Tyrum",
+        applicationVersion: "1.2.3",
+      }),
+    );
+  });
+
+  it("does nothing on non-macOS platforms", () => {
+    const setAboutPanelOptions = vi.fn();
+    const appStub = {
+      getName: () => "Tyrum",
+      getVersion: () => "1.2.3",
+      setAboutPanelOptions,
+    };
+
+    configureMacAboutPanel(appStub, "win32");
+
+    expect(setAboutPanelOptions).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDesktopUpdateOsIntegration", () => {
+  it("updates taskbar/dock progress during download", () => {
+    const setProgressBar = vi.fn();
+    const clearProgressBar = vi.fn();
+    const notify = vi.fn();
+    const integration = createDesktopUpdateOsIntegration({
+      platform: "win32",
+      setProgressBar,
+      clearProgressBar,
+      notify,
+    });
+
+    integration.onStateChange(makeState({ stage: "downloading", progressPercent: 41.2 }));
+
+    expect(setProgressBar).toHaveBeenCalledWith(expect.closeTo(0.412, 5));
+
+    integration.onStateChange(
+      makeState({
+        stage: "downloaded",
+        availableVersion: "1.1.0",
+        downloadedVersion: "1.1.0",
+        progressPercent: 100,
+      }),
+    );
+
+    expect(clearProgressBar).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies when update becomes available and when it is ready to install", () => {
+    const notify = vi.fn();
+    const integration = createDesktopUpdateOsIntegration({
+      platform: "darwin",
+      setProgressBar: vi.fn(),
+      clearProgressBar: vi.fn(),
+      notify,
+    });
+
+    integration.onStateChange(makeState({ stage: "available", availableVersion: "1.2.0" }));
+    integration.onStateChange(makeState({ stage: "available", availableVersion: "1.2.0" }));
+    integration.onStateChange(
+      makeState({
+        stage: "downloaded",
+        availableVersion: "1.2.0",
+        downloadedVersion: "1.2.0",
+        progressPercent: 100,
+      }),
+    );
+    integration.onStateChange(
+      makeState({
+        stage: "downloaded",
+        availableVersion: "1.2.0",
+        downloadedVersion: "1.2.0",
+        progressPercent: 100,
+      }),
+    );
+
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenNthCalledWith(1, "Update available", expect.stringContaining("1.2.0"));
+    expect(notify).toHaveBeenNthCalledWith(
+      2,
+      "Update ready to install",
+      expect.stringContaining("1.2.0"),
+    );
+  });
+});

--- a/apps/desktop/tests/update-ipc-handlers.test.ts
+++ b/apps/desktop/tests/update-ipc-handlers.test.ts
@@ -6,10 +6,12 @@ const {
   showOpenDialogMock,
   openPathMock,
   appGetVersionMock,
+  notificationShowMock,
   autoUpdaterMock,
   checkForUpdatesMock,
   downloadUpdateMock,
   quitAndInstallMock,
+  NotificationMock,
   listeners,
 } = vi.hoisted(() => {
   const ipcMainHandleMock = vi.fn();
@@ -17,10 +19,19 @@ const {
   const showOpenDialogMock = vi.fn();
   const openPathMock = vi.fn();
   const appGetVersionMock = vi.fn(() => "1.0.0");
+  const notificationShowMock = vi.fn();
   const checkForUpdatesMock = vi.fn(async () => undefined);
   const downloadUpdateMock = vi.fn(async () => undefined);
   const quitAndInstallMock = vi.fn();
   const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  class NotificationMock {
+    static isSupported = vi.fn(() => true);
+
+    constructor(_options: { title: string; body?: string }) {}
+
+    show = notificationShowMock;
+  }
 
   const autoUpdaterMock = {
     autoDownload: true,
@@ -48,10 +59,12 @@ const {
     showOpenDialogMock,
     openPathMock,
     appGetVersionMock,
+    notificationShowMock,
     autoUpdaterMock,
     checkForUpdatesMock,
     downloadUpdateMock,
     quitAndInstallMock,
+    NotificationMock,
     listeners,
   };
 });
@@ -70,6 +83,7 @@ vi.mock("electron", () => ({
   shell: {
     openPath: openPathMock,
   },
+  Notification: NotificationMock,
 }));
 
 vi.mock("electron-updater", () => ({
@@ -88,6 +102,9 @@ describe("registerUpdateIpc handlers", () => {
     checkForUpdatesMock.mockReset();
     downloadUpdateMock.mockReset();
     quitAndInstallMock.mockReset();
+    notificationShowMock.mockReset();
+    NotificationMock.isSupported.mockReset();
+    NotificationMock.isSupported.mockReturnValue(true);
     listeners.clear();
     ipcMainHandleMock.mockImplementation(
       (channel: string, handler: (...args: unknown[]) => unknown) => {


### PR DESCRIPTION
Closes #696

## Summary
- Configure macOS About panel via `app.setAboutPanelOptions`.
- Show OS notifications when an update is available / ready to install (install remains user-initiated).
- Show update download progress in the Windows taskbar (and macOS dock) via `BrowserWindow.setProgressBar`.

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (313 files passed, 2027 tests passed)