### PR TITLE
ci: lower diff coverage threshold to 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
             base="$(git rev-parse HEAD^1)"
           fi
-          node scripts/coverage/diff-lines.mjs --base "$base" --min 80
+          node scripts/coverage/diff-lines.mjs --base "$base" --min 70
 
       - name: Test desktop suite
         if: matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
## Summary
- Lower PR diff line coverage threshold in CI from 80 to 70.\n\n## Testing\n- Not run locally; CI will enforce threshold change.\n,