### PR TITLE
feat(gateway): Pre-compaction memory flush (silent turn before compaction) (#658)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
@@ -126,6 +126,8 @@ const TURN_ENGINE_MIN_BACKOFF_MS = 5;
 const TURN_ENGINE_MAX_BACKOFF_MS = 250;
 
 const DEFAULT_PRE_COMPACTION_FLUSH_TIMEOUT_MS = 2_500;
+const PRE_COMPACTION_FLUSH_TRUNCATION_MARKER = "...(truncated)";
+const MAX_PRE_COMPACTION_FLUSH_MESSAGE_CHARS = 2_000;
 
 const WITHIN_TURN_LOOP_STOP_REPLY =
   "Loop detected (repeated tool calls); stopping to avoid runaway execution. " +
@@ -1650,7 +1652,19 @@ export class AgentRuntime {
   private formatPreCompactionFlushPrompt(droppedTurns: readonly SessionMessage[]): string {
     const lines = droppedTurns.map((turn) => {
       const role = turn.role === "assistant" ? "Assistant" : "User";
-      return `${role} (${turn.timestamp}): ${redactSecretLikeText(turn.content.trim())}`;
+      const redacted = redactSecretLikeText(turn.content.trim());
+      const content =
+        redacted.length <= MAX_PRE_COMPACTION_FLUSH_MESSAGE_CHARS
+          ? redacted
+          : `${redacted.slice(
+              0,
+              Math.max(
+                0,
+                MAX_PRE_COMPACTION_FLUSH_MESSAGE_CHARS -
+                  PRE_COMPACTION_FLUSH_TRUNCATION_MARKER.length,
+              ),
+            )}${PRE_COMPACTION_FLUSH_TRUNCATION_MARKER}`;
+      return `${role} (${turn.timestamp}): ${content}`;
     });
 
     return [
@@ -1751,20 +1765,25 @@ export class AgentRuntime {
         timeout: flushTimeoutMs,
       });
 
-      const flushText = (flushResult.text ?? "").trim();
-      if (flushText.length === 0 || flushText.toUpperCase() === "NOOP") {
+      const rawFlushText = (flushResult.text ?? "").trim();
+      if (rawFlushText.length === 0 || rawFlushText.toUpperCase() === "NOOP") {
         return;
       }
 
-      const entry = ["Pre-compaction memory flush", "", flushText].join("\n").trim();
-      if (looksLikeSecretText(entry)) {
-        this.opts.container.logger.warn("memory.flush_skipped_secret_like", {
+      const flushText = redactSecretLikeText(rawFlushText).trim();
+      if (flushText.length === 0) {
+        return;
+      }
+
+      if (flushText !== rawFlushText) {
+        this.opts.container.logger.warn("memory.flush_redacted_secret_like", {
           session_id: input.session.session_id,
           channel: input.session.channel,
           thread_id: input.session.thread_id,
         });
-        return;
       }
+
+      const entry = ["Pre-compaction memory flush", "", flushText].join("\n").trim();
 
       if (v1Enabled) {
         try {

--- a/packages/gateway/tests/integration/pre-compaction-memory-flush.test.ts
+++ b/packages/gateway/tests/integration/pre-compaction-memory-flush.test.ts
@@ -225,6 +225,157 @@ describe("Pre-compaction memory flush", () => {
     expect(flushPromptText).toContain("[REDACTED]");
   });
 
+  it("redacts secret-like text from the flush result before storing it in memory v1", async () => {
+    const secret = "ghp_123456789012345678901234567890";
+
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-preflush-secret-out-"));
+    container = await createContainer({ dbPath: ":memory:", migrationsDir });
+
+    await writeFile(
+      join(homeDir, "agent.yml"),
+      [
+        "model:",
+        "  model: openai/gpt-4.1",
+        "skills:",
+        "  enabled: []",
+        "mcp:",
+        "  enabled: []",
+        "tools:",
+        "  allow: []",
+        "sessions:",
+        "  ttl_days: 30",
+        "  max_turns: 1",
+        "memory:",
+        "  markdown_enabled: false",
+        "  v1:",
+        "    enabled: true",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const languageModel = createSequencedTextLanguageModel([
+      "a1",
+      `Remember this: ${secret}`,
+      "a2",
+    ]);
+
+    const mcpManager = {
+      listToolDescriptors: vi.fn(async () => []),
+      shutdown: vi.fn(async () => {}),
+      callTool: vi.fn(async () => ({ content: [] })),
+    };
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      languageModel,
+      mcpManager: mcpManager as unknown as ConstructorParameters<
+        typeof AgentRuntime
+      >[0]["mcpManager"],
+    });
+
+    const first = await runtime.turn({
+      channel: "test",
+      thread_id: "thread-secret-out",
+      message: "first",
+    });
+    expect(first.reply).toBe("a1");
+
+    const second = await runtime.turn({
+      channel: "test",
+      thread_id: "thread-secret-out",
+      message: "second",
+    });
+    expect(second.reply).toBe("a2");
+
+    const memory = new MemoryV1Dal(container.db);
+    const list = await memory.list({ agentId: "default", limit: 50 });
+    expect(list.items).toHaveLength(1);
+    const item = list.items[0];
+    if (!item || item.kind !== "note") {
+      throw new Error("expected memory v1 note item");
+    }
+
+    expect(item.body_md).not.toContain(secret);
+    expect(item.body_md).toContain("[REDACTED]");
+  });
+
+  it("truncates very long message content in the flush prompt", async () => {
+    const tail = "TAIL_SHOULD_NOT_APPEAR_IN_PROMPT";
+    const longMessage = `prefix ${"x".repeat(10_000)} ${tail}`;
+
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-preflush-truncate-"));
+    container = await createContainer({ dbPath: ":memory:", migrationsDir });
+
+    await writeFile(
+      join(homeDir, "agent.yml"),
+      [
+        "model:",
+        "  model: openai/gpt-4.1",
+        "skills:",
+        "  enabled: []",
+        "mcp:",
+        "  enabled: []",
+        "tools:",
+        "  allow: []",
+        "sessions:",
+        "  ttl_days: 30",
+        "  max_turns: 1",
+        "memory:",
+        "  markdown_enabled: false",
+        "  v1:",
+        "    enabled: true",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const languageModel = createSequencedTextLanguageModel(["a1", "NOOP", "a2"]);
+
+    const mcpManager = {
+      listToolDescriptors: vi.fn(async () => []),
+      shutdown: vi.fn(async () => {}),
+      callTool: vi.fn(async () => ({ content: [] })),
+    };
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      languageModel,
+      mcpManager: mcpManager as unknown as ConstructorParameters<
+        typeof AgentRuntime
+      >[0]["mcpManager"],
+    });
+
+    const first = await runtime.turn({
+      channel: "test",
+      thread_id: "thread-truncate",
+      message: longMessage,
+    });
+    expect(first.reply).toBe("a1");
+
+    const second = await runtime.turn({
+      channel: "test",
+      thread_id: "thread-truncate",
+      message: "second",
+    });
+    expect(second.reply).toBe("a2");
+
+    expect(languageModel.doGenerateCalls).toHaveLength(3);
+    const flushCall = languageModel.doGenerateCalls[1];
+    const flushPromptText = flushCall
+      ? flushCall.prompt
+          .filter((msg) => msg.role === "user")
+          .flatMap((msg) => (Array.isArray(msg.content) ? msg.content : []))
+          .filter((part) => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+      : "";
+
+    expect(flushPromptText).toContain("prefix");
+    expect(flushPromptText).not.toContain(tail);
+    expect(flushPromptText).toContain("...(truncated)");
+  });
+
   it("only triggers the flush when the next append would compact (threshold behavior)", async () => {
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-preflush-threshold-"));
     container = await createContainer({ dbPath: ":memory:", migrationsDir });


### PR DESCRIPTION
Closes #658

### What
- Runs a silent pre-compaction flush when the next append would drop turns due to `sessions.max_turns`.
- Dedupe via Memory v1 tag lookup to avoid repeated flushes for the same dropped content.
- Persists flush output as a Memory v1 note with provenance + tags (and optionally appends to markdown memory if enabled).
- Redacts secret-like patterns in both the flush prompt and stored flush output; truncates very long dropped-turn content in the flush prompt.

### Verification
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
