### PR TITLE
Gateway: Artifactize desktop evidence + strip bytes from tool outputs (#783)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
@@ -2492,6 +2492,7 @@ export class AgentRuntime {
         ownerPrefix: this.instanceOwner,
       },
       nodeDispatchService,
+      this.opts.container.artifactStore,
     );
 
     const sessionCtx = formatSessionContext(session.summary, session.turns);

--- a/packages/gateway/src/modules/agent/tool-executor.ts
+++ b/packages/gateway/src/modules/agent/tool-executor.ts
@@ -21,6 +21,8 @@ import type { SecretResolutionAuditDal } from "../secret/resolution-audit-dal.js
 import type { RedactionEngine } from "../redaction/engine.js";
 import type { SqlDb } from "../../statestore/types.js";
 import { acquireWorkspaceLease, releaseWorkspaceLease } from "../workspace/lease.js";
+import type { ArtifactStore } from "../artifact/store.js";
+import { persistExecutionArtifactBytes } from "../artifact/execution-artifacts.js";
 
 const MAX_RESPONSE_BYTES = 32_768;
 const TRUNCATION_MARKER = "...(truncated)";
@@ -311,6 +313,7 @@ export class ToolExecutor {
     private readonly secretResolutionAuditDal?: SecretResolutionAuditDal,
     private readonly workspaceLease?: WorkspaceLeaseConfig,
     private readonly nodeDispatchService?: NodeDispatchService,
+    private readonly artifactStore?: ArtifactStore,
   ) {}
 
   private workspaceLeaseOwner(toolCallId: string): string {
@@ -560,10 +563,15 @@ export class ToolExecutor {
         { timeoutMs },
       );
 
+      const evidence = await this.shapeNodeDispatchEvidence(parsedAction.data, result.evidence, {
+        runId,
+        stepId,
+      });
+
       const payload = {
         ok: result.ok,
         task_id: taskId,
-        evidence: result.evidence,
+        evidence,
         error: result.error,
       };
 
@@ -600,6 +608,109 @@ export class ToolExecutor {
       output: sanitizeForModel(tagged),
       provenance: tagged,
     };
+  }
+
+  private async shapeNodeDispatchEvidence(
+    actionKind: ActionPrimitive["type"],
+    evidence: unknown,
+    scope: { runId: string; stepId: string },
+  ): Promise<unknown> {
+    if (actionKind !== "Desktop") return evidence;
+    if (!this.artifactStore) return evidence;
+    const db = this.workspaceLease?.db;
+    if (!db) return evidence;
+    if (evidence === undefined) return evidence;
+    if (evidence === null || typeof evidence !== "object" || Array.isArray(evidence)) {
+      return evidence;
+    }
+
+    const evidenceObj = evidence as Record<string, unknown>;
+    const bytesBase64 =
+      typeof evidenceObj["bytesBase64"] === "string" ? evidenceObj["bytesBase64"] : undefined;
+    const treeValue = evidenceObj["tree"];
+
+    if (!bytesBase64 && treeValue === undefined) return evidence;
+
+    const mime = typeof evidenceObj["mime"] === "string" ? evidenceObj["mime"] : undefined;
+    const evidenceType =
+      typeof evidenceObj["type"] === "string" ? evidenceObj["type"] : "screenshot";
+    const width = typeof evidenceObj["width"] === "number" ? evidenceObj["width"] : undefined;
+    const height = typeof evidenceObj["height"] === "number" ? evidenceObj["height"] : undefined;
+    const timestamp =
+      typeof evidenceObj["timestamp"] === "string" ? evidenceObj["timestamp"] : undefined;
+
+    const shaped: Record<string, unknown> = { ...evidenceObj };
+
+    if (bytesBase64) {
+      delete shaped["bytesBase64"];
+
+      let stored = null as Awaited<ReturnType<typeof persistExecutionArtifactBytes>>;
+      try {
+        stored = await persistExecutionArtifactBytes(db, this.artifactStore, {
+          runId: scope.runId,
+          stepId: scope.stepId,
+          workspaceId: this.workspaceLease?.workspaceId,
+          kind: "screenshot",
+          body: Buffer.from(bytesBase64, "base64"),
+          mimeType: mime ?? "image/png",
+          labels: [evidenceType, "desktop"],
+          metadata: {
+            width,
+            height,
+            timestamp,
+            mime: mime ?? "image/png",
+            evidence_type: evidenceType,
+          },
+          sensitivity: "sensitive",
+        });
+      } catch {
+        stored = null;
+      }
+
+      if (!stored) {
+        shaped["bytes_omitted"] = true;
+      } else {
+        shaped["artifact"] = stored;
+      }
+    }
+
+    if (treeValue !== undefined) {
+      delete shaped["tree"];
+
+      const treeJson = (() => {
+        if (typeof treeValue === "string") return treeValue;
+        if (treeValue === null) return "null";
+        return JSON.stringify(treeValue);
+      })();
+
+      let storedTree = null as Awaited<ReturnType<typeof persistExecutionArtifactBytes>>;
+      try {
+        storedTree = await persistExecutionArtifactBytes(db, this.artifactStore, {
+          runId: scope.runId,
+          stepId: scope.stepId,
+          workspaceId: this.workspaceLease?.workspaceId,
+          kind: "dom_snapshot",
+          body: Buffer.from(treeJson, "utf8"),
+          mimeType: "application/json",
+          labels: ["a11y-tree", "desktop"],
+          metadata: {
+            timestamp,
+            evidence_type: evidenceType,
+          },
+          sensitivity: "sensitive",
+        });
+      } catch {
+        storedTree = null;
+      }
+
+      if (!storedTree) {
+        shaped["tree_omitted"] = true;
+      } else {
+        shaped["tree_artifact"] = storedTree;
+      }
+    }
+
+    return shaped;
   }
 
   private async executeFsRead(toolCallId: string, args: unknown): Promise<ToolResult> {

--- a/packages/gateway/src/modules/artifact/execution-artifacts.ts
+++ b/packages/gateway/src/modules/artifact/execution-artifacts.ts
@@ -1,0 +1,208 @@
+import type { ArtifactRef as ArtifactRefT } from "@tyrum/schemas";
+import { randomUUID } from "node:crypto";
+import type { SqlDb } from "../../statestore/types.js";
+import type { ArtifactKind } from "@tyrum/schemas";
+import type { ArtifactStore } from "./store.js";
+import type { WsEventEnvelope as WsEventEnvelopeT } from "@tyrum/schemas";
+import { enqueueWsBroadcastMessage } from "../../ws/outbox.js";
+
+export type ExecutionArtifactSensitivity = "normal" | "sensitive";
+
+export type ResolvedExecutionArtifactScope = {
+  workspaceId: string;
+  agentId: string | null;
+  policySnapshotId: string | null;
+  attemptId: string | null;
+};
+
+export function deriveAgentIdFromExecutionKey(key: string): string | null {
+  if (!key.startsWith("agent:")) return null;
+  const parts = key.split(":");
+  const agentId = parts.length > 1 ? parts[1] : undefined;
+  return agentId && agentId.trim().length > 0 ? agentId : null;
+}
+
+export async function resolveExecutionArtifactScope(
+  db: SqlDb,
+  ids: { runId: string; stepId: string; workspaceId?: string },
+): Promise<ResolvedExecutionArtifactScope | null> {
+  const run = await db.get<{ key: string; policy_snapshot_id: string | null }>(
+    `SELECT key, policy_snapshot_id
+     FROM execution_runs
+     WHERE run_id = ?`,
+    [ids.runId],
+  );
+  if (!run) return null;
+
+  const step = await db.get<{ run_id: string }>(
+    `SELECT run_id
+     FROM execution_steps
+     WHERE step_id = ?`,
+    [ids.stepId],
+  );
+  if (!step) return null;
+  if (step.run_id !== ids.runId) return null;
+
+  const attempt = await db.get<{ attempt_id: string }>(
+    `SELECT attempt_id
+     FROM execution_attempts
+     WHERE step_id = ?
+     ORDER BY attempt DESC
+     LIMIT 1`,
+    [ids.stepId],
+  );
+
+  return {
+    workspaceId: ids.workspaceId?.trim() || "default",
+    agentId: deriveAgentIdFromExecutionKey(run.key) ?? null,
+    policySnapshotId: run.policy_snapshot_id ?? null,
+    attemptId: attempt?.attempt_id ?? null,
+  };
+}
+
+export async function insertExecutionArtifactRowTx(
+  tx: SqlDb,
+  input: {
+    artifact: ArtifactRefT;
+    labelsJson?: string;
+    metadataJson?: string;
+    scope: {
+      workspaceId: string;
+      agentId: string | null;
+      runId: string;
+      stepId: string;
+      attemptId: string | null;
+      sensitivity: ExecutionArtifactSensitivity;
+      policySnapshotId: string | null;
+    };
+  },
+): Promise<{ inserted: boolean }> {
+  const labelsJson = input.labelsJson ?? JSON.stringify(input.artifact.labels ?? []);
+  const metadataJson = input.metadataJson ?? JSON.stringify(input.artifact.metadata ?? {});
+
+  const insertResult = await tx.run(
+    `INSERT INTO execution_artifacts (
+       artifact_id,
+       workspace_id,
+       agent_id,
+       run_id,
+       step_id,
+       attempt_id,
+       kind,
+       uri,
+       created_at,
+       mime_type,
+       size_bytes,
+       sha256,
+       labels_json,
+       metadata_json,
+       sensitivity,
+       policy_snapshot_id
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (artifact_id) DO NOTHING`,
+    [
+      input.artifact.artifact_id,
+      input.scope.workspaceId,
+      input.scope.agentId,
+      input.scope.runId,
+      input.scope.stepId,
+      input.scope.attemptId,
+      input.artifact.kind,
+      input.artifact.uri,
+      input.artifact.created_at,
+      input.artifact.mime_type ?? null,
+      input.artifact.size_bytes ?? null,
+      input.artifact.sha256 ?? null,
+      labelsJson,
+      metadataJson,
+      input.scope.sensitivity,
+      input.scope.policySnapshotId,
+    ],
+  );
+
+  return { inserted: insertResult.changes > 0 };
+}
+
+export async function emitArtifactCreatedTx(tx: SqlDb, runId: string, artifact: ArtifactRefT) {
+  const evt: WsEventEnvelopeT = {
+    event_id: randomUUID(),
+    type: "artifact.created",
+    occurred_at: new Date().toISOString(),
+    scope: { kind: "run", run_id: runId },
+    payload: { artifact },
+  };
+  await enqueueWsBroadcastMessage(tx, evt);
+}
+
+export async function emitArtifactAttachedTx(
+  tx: SqlDb,
+  runId: string,
+  stepId: string,
+  attemptId: string,
+  artifact: ArtifactRefT,
+) {
+  const evt: WsEventEnvelopeT = {
+    event_id: randomUUID(),
+    type: "artifact.attached",
+    occurred_at: new Date().toISOString(),
+    scope: { kind: "run", run_id: runId },
+    payload: { artifact, step_id: stepId, attempt_id: attemptId },
+  };
+  await enqueueWsBroadcastMessage(tx, evt);
+}
+
+export async function persistExecutionArtifactBytes(
+  db: SqlDb,
+  artifactStore: ArtifactStore,
+  input: {
+    runId: string;
+    stepId: string;
+    workspaceId?: string;
+    kind: ArtifactKind;
+    body: Buffer;
+    mimeType?: string;
+    labels?: string[];
+    metadata?: unknown;
+    sensitivity: ExecutionArtifactSensitivity;
+  },
+): Promise<ArtifactRefT | null> {
+  const scope = await resolveExecutionArtifactScope(db, {
+    runId: input.runId,
+    stepId: input.stepId,
+    workspaceId: input.workspaceId,
+  });
+  if (!scope) return null;
+
+  const artifact = await artifactStore.put({
+    kind: input.kind,
+    body: input.body,
+    mime_type: input.mimeType,
+    labels: input.labels,
+    metadata: input.metadata,
+  });
+
+  await db.transaction(async (tx) => {
+    const { inserted } = await insertExecutionArtifactRowTx(tx, {
+      artifact,
+      scope: {
+        workspaceId: scope.workspaceId,
+        agentId: scope.agentId,
+        runId: input.runId,
+        stepId: input.stepId,
+        attemptId: scope.attemptId,
+        sensitivity: input.sensitivity,
+        policySnapshotId: scope.policySnapshotId,
+      },
+    });
+
+    if (inserted) {
+      await emitArtifactCreatedTx(tx, input.runId, artifact);
+    }
+    if (scope.attemptId) {
+      await emitArtifactAttachedTx(tx, input.runId, input.stepId, scope.attemptId, artifact);
+    }
+  });
+
+  return artifact;
+}

--- a/packages/gateway/src/modules/execution/engine/execution-engine.ts
+++ b/packages/gateway/src/modules/execution/engine/execution-engine.ts
@@ -36,6 +36,10 @@ import { normalizeDbDateTime } from "../../../utils/db-time.js";
 import { safeJsonParse } from "../../../utils/json.js";
 import { WorkboardDal } from "../../workboard/dal.js";
 import { sha256HexFromString, stableJsonStringify } from "../../policy/canonical-json.js";
+import {
+  deriveAgentIdFromExecutionKey,
+  insertExecutionArtifactRowTx,
+} from "../../artifact/execution-artifacts.js";
 import { defaultClock } from "./clock.js";
 import { normalizePositiveInt } from "../normalize-positive-int.js";
 import { parseConcurrencyLimitsFromEnv } from "./concurrency.js";
@@ -494,13 +498,6 @@ export class ExecutionEngine {
     await this.enqueueWsEvent(tx, evt);
   }
 
-  private deriveAgentIdFromKey(key: string): string | null {
-    if (!key.startsWith("agent:")) return null;
-    const parts = key.split(":");
-    const agentId = parts.length > 1 ? parts[1] : undefined;
-    return agentId && agentId.trim().length > 0 ? agentId : null;
-  }
-
   private async recordArtifactsTx(
     tx: SqlDb,
     scope: {
@@ -514,7 +511,7 @@ export class ExecutionEngine {
   ): Promise<void> {
     if (artifacts.length === 0) return;
 
-    const agentId = this.deriveAgentIdFromKey(scope.key);
+    const agentId = deriveAgentIdFromExecutionKey(scope.key);
     const run = await tx.get<{ policy_snapshot_id: string | null }>(
       "SELECT policy_snapshot_id FROM execution_runs WHERE run_id = ?",
       [scope.runId],
@@ -525,48 +522,22 @@ export class ExecutionEngine {
       const labelsJson = JSON.stringify(this.redactUnknown(artifact.labels ?? []));
       const metadataJson = JSON.stringify(this.redactUnknown(artifact.metadata ?? {}));
 
-      const insertResult = await tx.run(
-        `INSERT INTO execution_artifacts (
-           artifact_id,
-           workspace_id,
-           agent_id,
-           run_id,
-           step_id,
-           attempt_id,
-           kind,
-           uri,
-           created_at,
-           mime_type,
-           size_bytes,
-           sha256,
-           labels_json,
-           metadata_json,
-           sensitivity,
-           policy_snapshot_id
-         )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT (artifact_id) DO NOTHING`,
-        [
-          artifact.artifact_id,
-          scope.workspaceId,
+      const { inserted } = await insertExecutionArtifactRowTx(tx, {
+        artifact,
+        labelsJson,
+        metadataJson,
+        scope: {
+          workspaceId: scope.workspaceId,
           agentId,
-          scope.runId,
-          scope.stepId,
-          scope.attemptId,
-          artifact.kind,
-          artifact.uri,
-          artifact.created_at,
-          artifact.mime_type ?? null,
-          artifact.size_bytes ?? null,
-          artifact.sha256 ?? null,
-          labelsJson,
-          metadataJson,
-          "normal",
+          runId: scope.runId,
+          stepId: scope.stepId,
+          attemptId: scope.attemptId,
+          sensitivity: "normal",
           policySnapshotId,
-        ],
-      );
+        },
+      });
 
-      if (insertResult.changes > 0) {
+      if (inserted) {
         await this.emitArtifactCreatedTx(tx, { runId: scope.runId, artifact });
       }
       await this.emitArtifactAttachedTx(tx, {
@@ -1294,7 +1265,7 @@ export class ExecutionEngine {
             }
 
             if (this.policyService?.isEnabled()) {
-              const agentId = this.deriveAgentIdFromKey(run.key) ?? "default";
+              const agentId = deriveAgentIdFromExecutionKey(run.key) ?? "default";
               const evaluation = await this.policyService.evaluateToolCallFromSnapshot({
                 policySnapshotId,
                 agentId,
@@ -1698,7 +1669,7 @@ export class ExecutionEngine {
         }
       }
 
-      const agentId = this.deriveAgentIdFromKey(run.key) ?? "default";
+      const agentId = deriveAgentIdFromExecutionKey(run.key) ?? "default";
       const capability = actionType ? requiredCapability(actionType) : undefined;
 
       const concurrencyOk = await this.tryAcquireConcurrencyForAttemptTx(tx, {
@@ -2297,7 +2268,7 @@ export class ExecutionEngine {
 
     if (!this.policyService?.isEnabled()) return;
 
-    const agentId = this.deriveAgentIdFromKey(opts.key) ?? "default";
+    const agentId = deriveAgentIdFromExecutionKey(opts.key) ?? "default";
     const secretScopes = await this.resolveSecretScopesFromArgs(opts.action.args ?? {});
     const evaluation = await this.policyService.evaluateToolCallFromSnapshot({
       policySnapshotId,
@@ -2807,7 +2778,7 @@ export class ExecutionEngine {
     const agentId =
       typeof agentIdRaw === "string" && agentIdRaw.trim()
         ? agentIdRaw.trim()
-        : (this.deriveAgentIdFromKey(opts.run.key) ?? "default");
+        : (deriveAgentIdFromExecutionKey(opts.run.key) ?? "default");
 
     const scope = {
       tenant_id: tenantId,

--- a/packages/gateway/tests/integration/node-dispatch-desktop-artifacts.test.ts
+++ b/packages/gateway/tests/integration/node-dispatch-desktop-artifacts.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createApp } from "../../src/app.js";
+import type { McpManager } from "../../src/modules/agent/mcp-manager.js";
+import { ToolExecutor } from "../../src/modules/agent/tool-executor.js";
+import { createTestContainer } from "./helpers.js";
+
+type SqlRunner = {
+  run(sql: string, params?: unknown[]): Promise<unknown>;
+};
+
+type ExecutionScopeIds = {
+  jobId: string;
+  runId: string;
+  stepId: string;
+  attemptId: string;
+};
+
+async function seedExecutionScope(db: SqlRunner, ids: ExecutionScopeIds): Promise<void> {
+  await db.run(
+    `INSERT INTO execution_jobs (job_id, key, lane, status, trigger_json, input_json, latest_run_id)
+     VALUES (?, ?, ?, 'running', ?, ?, ?)`,
+    [ids.jobId, "agent:agent-1:thread:thread-1", "main", "{}", "{}", ids.runId],
+  );
+
+  await db.run(
+    `INSERT INTO execution_runs (run_id, job_id, key, lane, status, attempt)
+     VALUES (?, ?, ?, ?, 'running', 1)`,
+    [ids.runId, ids.jobId, "agent:agent-1:thread:thread-1", "main"],
+  );
+
+  await db.run(
+    `INSERT INTO execution_steps (step_id, run_id, step_index, status, action_json)
+     VALUES (?, ?, 0, 'running', ?)`,
+    [ids.stepId, ids.runId, "{}"],
+  );
+
+  await db.run(
+    `INSERT INTO execution_attempts (attempt_id, step_id, attempt, status, artifacts_json)
+     VALUES (?, ?, 1, 'running', '[]')`,
+    [ids.attemptId, ids.stepId],
+  );
+}
+
+function stubMcpManager(): McpManager {
+  return {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({ content: [] }),
+  } as unknown as McpManager;
+}
+
+describe("tool.node.dispatch desktop evidence artifacts", () => {
+  let originalTyrumHome: string | undefined;
+  let homeDir: string | undefined;
+
+  beforeEach(async () => {
+    originalTyrumHome = process.env["TYRUM_HOME"];
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-node-dispatch-"));
+    process.env["TYRUM_HOME"] = homeDir;
+  });
+
+  afterEach(async () => {
+    if (originalTyrumHome === undefined) {
+      delete process.env["TYRUM_HOME"];
+    } else {
+      process.env["TYRUM_HOME"] = originalTyrumHome;
+    }
+
+    if (homeDir) {
+      await rm(homeDir, { recursive: true, force: true });
+      homeDir = undefined;
+    }
+  });
+
+  it("stores screenshot bytes as a run-scoped artifact and strips base64 from tool output", async () => {
+    const container = await createTestContainer();
+    const app = createApp(container);
+
+    const scope: ExecutionScopeIds = {
+      jobId: "job-node-dispatch-1",
+      runId: "run-node-dispatch-1",
+      stepId: "step-node-dispatch-1",
+      attemptId: "attempt-node-dispatch-1",
+    };
+    await seedExecutionScope(container.db, scope);
+
+    const pngBytes = Buffer.from("fake-png-bytes", "utf8");
+    const bytesBase64 = pngBytes.toString("base64");
+
+    const nodeDispatchService = {
+      dispatchAndWait: vi.fn(async () => {
+        return {
+          taskId: "task-123",
+          result: {
+            ok: true,
+            evidence: {
+              type: "screenshot",
+              mime: "image/png",
+              width: 1,
+              height: 1,
+              timestamp: new Date().toISOString(),
+              bytesBase64,
+            },
+          },
+        };
+      }),
+    };
+
+    const executor = new ToolExecutor(
+      homeDir!,
+      stubMcpManager(),
+      new Map(),
+      fetch,
+      undefined,
+      undefined,
+      container.redactionEngine,
+      undefined,
+      {
+        db: container.db,
+        workspaceId: "default",
+        ownerPrefix: "test-tool",
+      },
+      nodeDispatchService as any,
+      container.artifactStore as any,
+    );
+
+    const result = await executor.execute(
+      "tool.node.dispatch",
+      "call-1",
+      {
+        capability: "tyrum.desktop",
+        action: "Desktop",
+        args: { op: "screenshot", display: "primary" },
+      },
+      {
+        execution_run_id: scope.runId,
+        execution_step_id: scope.stepId,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.output).toContain("artifact://");
+    expect(result.output).not.toContain("bytesBase64");
+    expect(result.output).not.toContain(bytesBase64);
+
+    const row = await container.db.get<{
+      artifact_id: string;
+      run_id: string | null;
+      step_id: string | null;
+      attempt_id: string | null;
+      sensitivity: string;
+      labels_json: string;
+    }>(
+      `SELECT artifact_id, run_id, step_id, attempt_id, sensitivity, labels_json
+       FROM execution_artifacts
+       WHERE run_id = ? AND step_id = ?`,
+      [scope.runId, scope.stepId],
+    );
+    expect(row).toBeTruthy();
+    expect(row?.attempt_id).toBe(scope.attemptId);
+    expect(row?.sensitivity).toBe("sensitive");
+    expect(row?.labels_json).toContain("desktop");
+
+    const res = await app.request(`/runs/${scope.runId}/artifacts/${row!.artifact_id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(Buffer.from(await res.arrayBuffer())).toEqual(pngBytes);
+
+    await container.db.close();
+  });
+
+  it("stores a11y tree JSON as a run-scoped artifact and strips it from tool output", async () => {
+    const container = await createTestContainer();
+    const app = createApp(container);
+
+    const scope: ExecutionScopeIds = {
+      jobId: "job-node-dispatch-2",
+      runId: "run-node-dispatch-2",
+      stepId: "step-node-dispatch-2",
+      attemptId: "attempt-node-dispatch-2",
+    };
+    await seedExecutionScope(container.db, scope);
+
+    const tree = {
+      root: {
+        role: "window",
+        name: "root",
+        states: [],
+        bounds: { x: 0, y: 0, width: 1, height: 1 },
+        actions: [],
+        children: [],
+      },
+    };
+
+    const nodeDispatchService = {
+      dispatchAndWait: vi.fn(async () => {
+        return {
+          taskId: "task-456",
+          result: {
+            ok: true,
+            evidence: {
+              type: "snapshot",
+              mode: "a11y",
+              timestamp: new Date().toISOString(),
+              tree,
+            },
+          },
+        };
+      }),
+    };
+
+    const executor = new ToolExecutor(
+      homeDir!,
+      stubMcpManager(),
+      new Map(),
+      fetch,
+      undefined,
+      undefined,
+      container.redactionEngine,
+      undefined,
+      {
+        db: container.db,
+        workspaceId: "default",
+        ownerPrefix: "test-tool",
+      },
+      nodeDispatchService as any,
+      container.artifactStore as any,
+    );
+
+    const result = await executor.execute(
+      "tool.node.dispatch",
+      "call-2",
+      {
+        capability: "tyrum.desktop",
+        action: "Desktop",
+        args: { op: "snapshot", include_tree: true },
+      },
+      {
+        execution_run_id: scope.runId,
+        execution_step_id: scope.stepId,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.output).toContain("artifact://");
+    expect(result.output).toContain("tree_artifact");
+    expect(result.output).not.toContain('"tree":{');
+
+    const row = await container.db.get<{
+      artifact_id: string;
+      kind: string;
+      mime_type: string | null;
+      sensitivity: string;
+      labels_json: string;
+    }>(
+      `SELECT artifact_id, kind, mime_type, sensitivity, labels_json
+       FROM execution_artifacts
+       WHERE run_id = ? AND step_id = ?`,
+      [scope.runId, scope.stepId],
+    );
+    expect(row).toBeTruthy();
+    expect(row?.kind).toBe("dom_snapshot");
+    expect(row?.mime_type).toBe("application/json");
+    expect(row?.sensitivity).toBe("sensitive");
+    expect(row?.labels_json).toContain("a11y-tree");
+
+    const res = await app.request(`/runs/${scope.runId}/artifacts/${row!.artifact_id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(await res.json()).toEqual(tree);
+
+    await container.db.close();
+  });
+});


### PR DESCRIPTION
Closes #783

## What
- Stores Desktop node-dispatch evidence (screenshot bytes + a11y tree) as run-scoped artifacts and strips large payloads from tool outputs.
- Persists evidence into ArtifactStore + execution_artifacts for fetch via GET /runs/:runId/artifacts/:id.

## Tests
- PATH=/home/linuxbrew/.linuxbrew/opt/node@24/bin:$PATH pnpm format:check
- PATH=/home/linuxbrew/.linuxbrew/opt/node@24/bin:$PATH pnpm typecheck
- PATH=/home/linuxbrew/.linuxbrew/opt/node@24/bin:$PATH pnpm lint
- PATH=/home/linuxbrew/.linuxbrew/opt/node@24/bin:$PATH pnpm test