### PR TITLE
chore(gateway): Convert Dockerfile to multi-stage build (#825)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM public.ecr.aws/docker/library/node:24-bookworm-slim
+FROM public.ecr.aws/docker/library/node:24-bookworm-slim AS base
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+FROM base AS builder
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
     python3 \
     make \
     g++ \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g pnpm
-
-WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig*.json ./
 COPY patches ./patches
@@ -24,7 +30,27 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @tyrum/schemas build \
   && pnpm --filter @tyrum/gateway build
 
+RUN mkdir -p /app/apps/desktop \
+  && printf '%s\n' \
+    '{' \
+    '  "name": "tyrum-desktop-stub",' \
+    '  "private": true,' \
+    '  "version": "0.0.0",' \
+    '  "dependencies": {' \
+    '    "@develar/schema-utils": "2.6.5",' \
+    '    "dmg-license": "1.0.11"' \
+    '  }' \
+    '}' \
+    > /app/apps/desktop/package.json \
+  && pnpm --filter @tyrum/gateway deploy --legacy --prod /app/deploy \
+  && cp -R /app/packages/gateway/migrations /app/deploy/migrations
+
+FROM base AS production
+
 ENV NODE_ENV=production
+
+COPY --from=builder /app/config ./config
+COPY --from=builder /app/deploy ./packages/gateway
 
 EXPOSE 8788
 

--- a/packages/gateway/tests/unit/dockerfile-multistage.test.ts
+++ b/packages/gateway/tests/unit/dockerfile-multistage.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+function collectFromLineIndexes(dockerfile: string): number[] {
+  const lines = dockerfile.split(/\r?\n/);
+  const indexes: number[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]?.trimStart() ?? "";
+    if (line.toUpperCase().startsWith("FROM ")) indexes.push(i);
+  }
+
+  return indexes;
+}
+
+describe("Dockerfile (multi-stage build)", () => {
+  const dockerfileUrl = new URL("../../../../Dockerfile", import.meta.url);
+
+  test("uses a builder and production stage", () => {
+    const dockerfile = readFileSync(fileURLToPath(dockerfileUrl), "utf8");
+
+    expect(dockerfile).toMatch(/^FROM\s+.+\s+AS\s+builder\b/im);
+    expect(dockerfile).toMatch(/^FROM\s+.+\s+AS\s+production\b/im);
+    expect(collectFromLineIndexes(dockerfile).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("does not install build tools in the final stage", () => {
+    const dockerfile = readFileSync(fileURLToPath(dockerfileUrl), "utf8");
+    const fromIndexes = collectFromLineIndexes(dockerfile);
+    expect(fromIndexes.length).toBeGreaterThanOrEqual(2);
+
+    const lines = dockerfile.split(/\r?\n/);
+    const finalStageStart = fromIndexes.at(-1) ?? 0;
+    const finalStage = lines.slice(finalStageStart).join("\n");
+
+    expect(finalStage).not.toMatch(/\bpython3\b/i);
+    expect(finalStage).not.toMatch(/g\+\+/i);
+    expect(finalStage).not.toMatch(/\bmake\b/i);
+  });
+});


### PR DESCRIPTION
Closes #825

## Verification
- `docker build -t tyrum:issue825 .`
  - Image size: `1.65GB` → `454MB` (~72% smaller)
- `docker run --rm --entrypoint sh tyrum:issue825 -lc 'command -v python3 || echo "python3: not found"'` → `python3: not found`
- `docker run --rm --entrypoint sh tyrum:issue825 -lc 'command -v g++ || echo "g++: not found"'` → `g++: not found`
- `docker run --rm --entrypoint sh tyrum:issue825 -lc 'command -v make || echo "make: not found"'` → `make: not found`
- `bash scripts/smoke-sqlite-single-host.sh`

## Local checks
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
