### PR TITLE
test(gateway): Add execution worker loop and K8s step executor tests (#828)

### DIFF
--- a/packages/gateway/src/modules/execution/kubernetes-toolrunner-step-executor.ts
+++ b/packages/gateway/src/modules/execution/kubernetes-toolrunner-step-executor.ts
@@ -12,7 +12,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function sanitizeDnsLabelSuffix(raw: string): string {
+export function sanitizeDnsLabelSuffix(raw: string): string {
   const s = raw.toLowerCase().replace(/[^a-z0-9-]/g, "-");
   return s.replace(/^-+/, "").replace(/-+$/, "");
 }
@@ -22,7 +22,7 @@ function unwrapBody<T>(res: unknown): T {
   return (anyRes && typeof anyRes === "object" && "body" in anyRes ? anyRes.body : res) as T;
 }
 
-function buildEnv(
+export function buildEnv(
   base: NodeJS.ProcessEnv,
   overrides: Record<string, string>,
 ): Array<{ name: string; value: string }> {
@@ -42,7 +42,7 @@ function buildEnv(
   return [...out.entries()].map(([name, value]) => ({ name, value }));
 }
 
-function parseStepResultFromLogs(raw: string): StepResult | null {
+export function parseStepResultFromLogs(raw: string): StepResult | null {
   const lines = raw
     .split(/\r?\n/)
     .map((l) => l.trim())

--- a/packages/gateway/tests/unit/kubernetes-step-executor.test.ts
+++ b/packages/gateway/tests/unit/kubernetes-step-executor.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let createdJobBody: any;
+
+const batchClient = {
+  createNamespacedJob: vi.fn(async (input: { body: unknown }) => {
+    createdJobBody = input.body;
+    return { body: {} };
+  }),
+  readNamespacedJobStatus: vi.fn(async () => ({ body: { status: { succeeded: 1 } } })),
+  deleteNamespacedJob: vi.fn(async () => ({ body: {} })),
+};
+
+const coreClient = {
+  listNamespacedPod: vi.fn(async () => ({ body: { items: [{ metadata: { name: "pod-1" } }] } })),
+  readNamespacedPodLog: vi.fn(async () => `{"success":true}\n`),
+};
+
+vi.mock("@kubernetes/client-node", () => {
+  class BatchV1Api {}
+  class CoreV1Api {}
+
+  class KubeConfig {
+    loadFromCluster(): void {
+      // no-op
+    }
+    loadFromDefault(): void {
+      // no-op
+    }
+    makeApiClient(api: unknown): unknown {
+      if (api === BatchV1Api) return batchClient;
+      if (api === CoreV1Api) return coreClient;
+      throw new Error("unexpected api client");
+    }
+  }
+
+  return { BatchV1Api, CoreV1Api, KubeConfig };
+});
+
+beforeEach(() => {
+  createdJobBody = undefined;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Kubernetes toolrunner step executor", () => {
+  it("buildEnv merges base and overrides (overrides win)", async () => {
+    const { buildEnv } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    const env = buildEnv({ FOO: "bar", OVERRIDE: "base" }, { OVERRIDE: "override", NEW: "x" });
+
+    expect(Object.fromEntries(env.map((e) => [e.name, e.value]))).toEqual({
+      FOO: "bar",
+      OVERRIDE: "override",
+      NEW: "x",
+    });
+  });
+
+  it("buildEnv filters non-string and very large values", async () => {
+    const { buildEnv } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    const env = buildEnv(
+      {
+        SMALL: "ok",
+        EXACT: "x".repeat(32_000),
+        BIG: "x".repeat(32_001),
+        UNDEF: undefined,
+      },
+      {},
+    );
+
+    expect(Object.fromEntries(env.map((e) => [e.name, e.value]))).toEqual({
+      SMALL: "ok",
+      EXACT: "x".repeat(32_000),
+    });
+  });
+
+  it("sanitizeDnsLabelSuffix lowercases, replaces invalid chars, and trims hyphens", async () => {
+    const { sanitizeDnsLabelSuffix } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    expect(sanitizeDnsLabelSuffix("--My_Suffix!!--")).toBe("my-suffix");
+  });
+
+  it("sanitizeDnsLabelSuffix returns empty string when the label is entirely invalid", async () => {
+    const { sanitizeDnsLabelSuffix } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    expect(sanitizeDnsLabelSuffix("---")).toBe("");
+    expect(sanitizeDnsLabelSuffix("___")).toBe("");
+  });
+
+  it("parseStepResultFromLogs returns the last valid StepResult JSON", async () => {
+    const { parseStepResultFromLogs } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    const parsed = parseStepResultFromLogs(
+      [
+        "hello",
+        JSON.stringify({ success: true }),
+        JSON.stringify({ nope: true }),
+        JSON.stringify({ success: false, error: "nope" }),
+      ].join("\n"),
+    );
+
+    expect(parsed).toEqual({ success: false, error: "nope" });
+  });
+
+  it("parseStepResultFromLogs returns null when no StepResult JSON is present", async () => {
+    const { parseStepResultFromLogs } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    expect(parseStepResultFromLogs("hello\n")).toBeNull();
+    expect(parseStepResultFromLogs(JSON.stringify({ nope: true }))).toBeNull();
+  });
+
+  it("creates a Job and returns parsed StepResult from logs on success", async () => {
+    const { createKubernetesToolRunnerStepExecutor } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    const executor = createKubernetesToolRunnerStepExecutor({
+      namespace: "default",
+      image: "tyrum/gateway:dev",
+      workspacePvcClaim: "workspace",
+      tyrumHome: "/var/lib/tyrum",
+      env: { BASE: "1", BIG: "x".repeat(32_001) },
+      deleteJobAfter: false,
+    });
+
+    const result = await executor.execute(
+      { type: "CLI", args: { cmd: "echo", args: ["hi"] } },
+      "plan-1",
+      0,
+      1_000,
+      {
+        runId: "run-1",
+        stepId: "step-1",
+        attemptId: "attempt-1",
+        approvalId: null,
+        key: "k",
+        lane: "main",
+        workspaceId: "default",
+        policySnapshotId: null,
+      },
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(batchClient.createNamespacedJob).toHaveBeenCalledTimes(1);
+    expect(createdJobBody.metadata.name).toMatch(/^tyrum-toolrunner-[a-z0-9-]+$/);
+    expect(createdJobBody.metadata.name.length).toBeLessThanOrEqual(63);
+
+    const container = createdJobBody.spec.template.spec.containers[0];
+    expect(container.image).toBe("tyrum/gateway:dev");
+    expect(container.env).toEqual(
+      expect.arrayContaining([
+        { name: "BASE", value: "1" },
+        expect.objectContaining({ name: "TYRUM_HOME" }),
+      ]),
+    );
+    expect(container.env).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "BIG" })]),
+    );
+  });
+
+  it("returns parsed StepResult from logs when the Job fails", async () => {
+    const { createKubernetesToolRunnerStepExecutor } =
+      await import("../../src/modules/execution/kubernetes-toolrunner-step-executor.js");
+
+    batchClient.readNamespacedJobStatus.mockImplementationOnce(async () => ({
+      body: { status: { failed: 1 } },
+    }));
+    coreClient.readNamespacedPodLog.mockImplementationOnce(
+      async () => `{"success":false,"error":"boom"}\n`,
+    );
+
+    const executor = createKubernetesToolRunnerStepExecutor({
+      namespace: "default",
+      image: "tyrum/gateway:dev",
+      workspacePvcClaim: "workspace",
+      tyrumHome: "/var/lib/tyrum",
+      deleteJobAfter: false,
+    });
+
+    const result = await executor.execute(
+      { type: "CLI", args: { cmd: "echo", args: ["hi"] } },
+      "plan-1",
+      0,
+      1_000,
+      {
+        runId: "run-1",
+        stepId: "step-1",
+        attemptId: "attempt-1",
+        approvalId: null,
+        key: "k",
+        lane: "main",
+        workspaceId: "default",
+        policySnapshotId: null,
+      },
+    );
+
+    expect(result).toEqual({ success: false, error: "boom" });
+  });
+});

--- a/packages/gateway/tests/unit/worker-loop.test.ts
+++ b/packages/gateway/tests/unit/worker-loop.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startExecutionWorkerLoop } from "../../src/modules/execution/worker-loop.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function waitForCalls(mockFn: { mock: { calls: unknown[] } }, count: number): Promise<void> {
+  for (let i = 0; i < 100; i += 1) {
+    if (mockFn.mock.calls.length >= count) return;
+    await Promise.resolve();
+  }
+  throw new Error(`timed out waiting for ${count} call(s)`);
+}
+
+describe("Execution worker loop", () => {
+  it("logs started/stopped and resolves done after stop", async () => {
+    vi.useFakeTimers();
+
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const engine = {
+      workerTick: vi.fn(async () => false),
+    };
+
+    const executor = {
+      execute: vi.fn(async () => ({ success: true })),
+    };
+
+    const loop = startExecutionWorkerLoop({
+      engine: engine as any,
+      workerId: "w-1",
+      executor: executor as any,
+      logger: logger as any,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "worker.loop.started",
+      expect.objectContaining({ worker_id: "w-1" }),
+    );
+
+    try {
+      await waitForCalls(engine.workerTick, 1);
+      expect(engine.workerTick).toHaveBeenCalledWith(
+        expect.objectContaining({ workerId: "w-1", executor }),
+      );
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "worker.loop.stopped",
+      expect.objectContaining({ worker_id: "w-1" }),
+    );
+  });
+
+  it("sleeps idleSleepMs between ticks when no work is done", async () => {
+    vi.useFakeTimers();
+
+    const engine = {
+      workerTick: vi.fn(async () => false),
+    };
+
+    const executor = {
+      execute: vi.fn(async () => ({ success: true })),
+    };
+
+    const loop = startExecutionWorkerLoop({
+      engine: engine as any,
+      workerId: "w-idle",
+      executor: executor as any,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick, 1);
+
+      await vi.advanceTimersByTimeAsync(9);
+      expect(engine.workerTick).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForCalls(engine.workerTick, 2);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("yields with a 0ms sleep after doing work", async () => {
+    vi.useFakeTimers();
+
+    let calls = 0;
+    const engine = {
+      workerTick: vi.fn(async () => {
+        calls += 1;
+        return calls === 1;
+      }),
+    };
+
+    const executor = {
+      execute: vi.fn(async () => ({ success: true })),
+    };
+
+    const loop = startExecutionWorkerLoop({
+      engine: engine as any,
+      workerId: "w-yield",
+      executor: executor as any,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 5,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick, 2);
+
+      await vi.advanceTimersByTimeAsync(0);
+      await waitForCalls(engine.workerTick, 3);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("recovers from workerTick errors and continues after errorSleepMs", async () => {
+    vi.useFakeTimers();
+
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    let calls = 0;
+    const engine = {
+      workerTick: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("db down");
+        return false;
+      }),
+    };
+
+    const executor = {
+      execute: vi.fn(async () => ({ success: true })),
+    };
+
+    const loop = startExecutionWorkerLoop({
+      engine: engine as any,
+      workerId: "w-error",
+      executor: executor as any,
+      logger: logger as any,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick, 1);
+      expect(logger.error).toHaveBeenCalledWith(
+        "worker.loop.error",
+        expect.objectContaining({ error: "db down" }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      await waitForCalls(engine.workerTick, 2);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("does not exceed maxTicksPerCycle per loop cycle", async () => {
+    vi.useFakeTimers();
+
+    const engine = {
+      workerTick: vi.fn(async () => true),
+    };
+
+    const executor = {
+      execute: vi.fn(async () => ({ success: true })),
+    };
+
+    const loop = startExecutionWorkerLoop({
+      engine: engine as any,
+      workerId: "w-max",
+      executor: executor as any,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 3,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick, 3);
+      await Promise.resolve();
+      expect(engine.workerTick).toHaveBeenCalledTimes(3);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+});


### PR DESCRIPTION
Closes #828

Adds unit coverage for execution worker loop and Kubernetes toolrunner step executor (13 tests total).

Verification:
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
