### PR TITLE
test(gateway): Add first E2E smoke test for login-to-turn flow (#831)

### DIFF
--- a/packages/gateway/tests/e2e/smoke-turn-harness.ts
+++ b/packages/gateway/tests/e2e/smoke-turn-harness.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createServer } from "node:http";
 import type { Server } from "node:http";
+import type { Socket } from "node:net";
 import { getRequestListener } from "@hono/node-server";
 import { createContainer } from "../../src/container.js";
 import type { ProtocolDeps } from "../../src/ws/protocol.js";
@@ -88,6 +89,14 @@ export async function startSmokeGateway(opts: { modelReply: string }): Promise<{
 
   const requestListener = getRequestListener(app.fetch);
   const server: Server = createServer(requestListener);
+  const sockets = new Set<Socket>();
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+  });
   server.on("upgrade", (req, socket, head) => {
     const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
     if (pathname === "/ws") {
@@ -110,8 +119,25 @@ export async function startSmokeGateway(opts: { modelReply: string }): Promise<{
   const stop = async () => {
     wsHandler.stopHeartbeat();
 
+    for (const client of connectionManager.allClients()) {
+      try {
+        client.ws.terminate();
+      } catch {
+        // ignore
+      }
+    }
+
     await agentRuntime.shutdown();
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      for (const socket of sockets) {
+        try {
+          socket.destroy();
+        } catch {
+          // ignore
+        }
+      }
+    });
     await container.db.close();
 
     await rm(tyrumHome, { recursive: true, force: true });
@@ -119,4 +145,3 @@ export async function startSmokeGateway(opts: { modelReply: string }): Promise<{
 
   return { baseUrl, wsUrl, adminToken, stop };
 }
-

--- a/packages/gateway/tests/e2e/smoke-turn.test.ts
+++ b/packages/gateway/tests/e2e/smoke-turn.test.ts
@@ -4,60 +4,59 @@ import { TyrumClient } from "@tyrum/client";
 
 describe("gateway e2e smoke: login-to-turn", () => {
   let stopGateway: (() => Promise<void>) | undefined;
+  let client: TyrumClient | undefined;
 
   afterEach(async () => {
+    client?.disconnect();
+    client = undefined;
     await stopGateway?.();
     stopGateway = undefined;
   });
 
-  it(
-    "starts gateway, authenticates via /auth/session, connects WS, sends session.send, receives reply",
-    async () => {
-      const gateway = await startSmokeGateway({ modelReply: "smoke-ok" });
-      stopGateway = gateway.stop;
+  it("starts gateway, authenticates via /auth/session, connects WS, sends session.send, receives reply", async () => {
+    const gateway = await startSmokeGateway({ modelReply: "smoke-ok" });
+    stopGateway = gateway.stop;
 
-      const healthRes = await fetch(`${gateway.baseUrl}/healthz`);
-      expect(healthRes.status).toBe(200);
+    const healthRes = await fetch(`${gateway.baseUrl}/healthz`);
+    expect(healthRes.status).toBe(200);
 
-      const authRes = await fetch(`${gateway.baseUrl}/auth/session`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: gateway.adminToken }),
-      });
-      expect(authRes.status).toBe(204);
+    const authRes = await fetch(`${gateway.baseUrl}/auth/session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: gateway.adminToken }),
+    });
+    expect(authRes.status).toBe(204);
 
-      const setCookie =
-        authRes.headers.get("set-cookie") ??
-        ("getSetCookie" in authRes.headers && typeof authRes.headers.getSetCookie === "function"
-          ? authRes.headers.getSetCookie()[0]
-          : null);
-      expect(setCookie ?? "").toContain("tyrum_admin_token=");
+    const setCookie =
+      authRes.headers.get("set-cookie") ??
+      ("getSetCookie" in authRes.headers && typeof authRes.headers.getSetCookie === "function"
+        ? authRes.headers.getSetCookie()[0]
+        : null);
+    expect(setCookie ?? "").toContain("tyrum_admin_token=");
 
-      const client = new TyrumClient({
-        url: gateway.wsUrl,
-        token: gateway.adminToken,
-        capabilities: [],
-        reconnect: false,
-        role: "client",
-        protocolRev: 2,
-      });
+    client = new TyrumClient({
+      url: gateway.wsUrl,
+      token: gateway.adminToken,
+      capabilities: [],
+      reconnect: false,
+      role: "client",
+      protocolRev: 2,
+    });
 
-      const connectedP = new Promise<void>((resolve) => {
-        client.on("connected", () => resolve());
-      });
-      client.connect();
-      await connectedP;
+    const connectedP = new Promise<void>((resolve) => {
+      client!.on("connected", () => resolve());
+    });
+    client.connect();
+    await connectedP;
 
-      const result = await client.sessionSend({
-        channel: "ui",
-        thread_id: "thread-1",
-        content: "hello",
-      });
-      expect(result.assistant_message).toBe("smoke-ok");
+    const result = await client.sessionSend({
+      channel: "ui",
+      thread_id: "thread-1",
+      content: "hello",
+    });
+    expect(result.assistant_message).toBe("smoke-ok");
 
-      client.disconnect();
-    },
-    30_000,
-  );
+    client.disconnect();
+    client = undefined;
+  }, 30_000);
 });
-


### PR DESCRIPTION
Closes #831

## Summary
- Adds a single gateway E2E smoke test that starts an in-process gateway, POSTs `/auth/session`, connects WS via `@tyrum/client`, sends `session.send`, and asserts an agent reply using a static stub model.

## Test Evidence
- `pnpm exec vitest run packages/gateway/tests/e2e/smoke-turn.test.ts`
- `pnpm test -- packages/gateway/tests/e2e`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
