### PR TITLE
fix(gateway): Replace hardcoded PBKDF2 salt in FileSecretProvider (#832)

### DIFF
--- a/packages/gateway/src/modules/secret/provider.ts
+++ b/packages/gateway/src/modules/secret/provider.ts
@@ -261,7 +261,6 @@ export class FileSecretProvider implements SecretProvider {
     }
 
     const store = await FileSecretProvider.readStoreFromPath(secretsPath);
-    const legacyKey = deriveFileSecretKey(adminToken, FILE_SECRET_LEGACY_PBKDF2_SALT);
     const entries = Object.entries(store.handles);
 
     if (entries.length === 0) {
@@ -276,6 +275,7 @@ export class FileSecretProvider implements SecretProvider {
     const instanceKey = storedSalt ? deriveFileSecretKey(adminToken, storedSalt) : null;
     const firstEntry = entries[0];
     if (!firstEntry) {
+      const legacyKey = deriveFileSecretKey(adminToken, FILE_SECRET_LEGACY_PBKDF2_SALT);
       return new FileSecretProvider(secretsPath, instanceKey ?? legacyKey);
     }
     const [, sample] = firstEntry;
@@ -289,17 +289,23 @@ export class FileSecretProvider implements SecretProvider {
       }
     }
 
+    const legacyKey = deriveFileSecretKey(adminToken, FILE_SECRET_LEGACY_PBKDF2_SALT);
     try {
       decryptWithKey(legacyKey, sample);
+    } catch {
+      if (instanceKey) return new FileSecretProvider(secretsPath, instanceKey);
+      return new FileSecretProvider(secretsPath, legacyKey);
+    }
 
-      let saltToUse = storedSalt;
-      if (!saltToUse) {
-        saltToUse = randomBytes(32);
+    try {
+      const saltToUse = storedSalt ?? randomBytes(32);
+      const migratedKey = instanceKey ?? deriveFileSecretKey(adminToken, saltToUse);
+
+      if (!storedSalt) {
         await ensureParentDirExists(saltPath);
         await writeFile(saltPath, saltToUse, { mode: 0o600 });
       }
 
-      const migratedKey = deriveFileSecretKey(adminToken, saltToUse);
       const migrated: SecretStore = { handles: {} };
 
       for (const [handleId, existing] of entries) {
@@ -311,9 +317,6 @@ export class FileSecretProvider implements SecretProvider {
       await FileSecretProvider.writeStoreToPath(secretsPath, migrated);
       return new FileSecretProvider(secretsPath, migratedKey);
     } catch {
-      if (instanceKey) {
-        return new FileSecretProvider(secretsPath, instanceKey);
-      }
       return new FileSecretProvider(secretsPath, legacyKey);
     }
   }

--- a/packages/gateway/tests/unit/secret-provider.test.ts
+++ b/packages/gateway/tests/unit/secret-provider.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
-import { mkdtempSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import {
   EnvSecretProvider,
   FileSecretProvider,
@@ -185,6 +193,32 @@ describe("FileSecretProvider", () => {
 
     expect(() => decryptWithKey(legacyKey, migratedEntry)).toThrow();
     expect(decryptWithKey(instanceKey, migratedEntry)).toBe("legacy-value");
+  });
+
+  it("falls back to the legacy key when migration cannot write the store", async () => {
+    if (process.platform === "win32") return;
+
+    const handle = {
+      handle_id: "legacy-handle-with-salt",
+      provider: "file" as const,
+      scope: "LEGACY",
+      created_at: new Date().toISOString(),
+    };
+
+    const legacyKey = pbkdf2Sync(adminToken, legacySalt, 100_000, 32, "sha256");
+    const legacyEncrypted = encryptWithKey(legacyKey, "legacy-value");
+    const legacyStore = { handles: { [handle.handle_id]: { handle, ...legacyEncrypted } } };
+    writeFileSync(secretsPath, JSON.stringify(legacyStore), { mode: 0o600 });
+
+    writeFileSync(saltPath, randomBytes(32), { mode: 0o600 });
+    chmodSync(secretsPath, 0o400);
+
+    try {
+      const provider = await FileSecretProvider.create(secretsPath, adminToken);
+      expect(await provider.resolve(handle)).toBe("legacy-value");
+    } finally {
+      chmodSync(secretsPath, 0o600);
+    }
   });
 
   it("store persists to disk", async () => {


### PR DESCRIPTION
Closes #832

## What
- Replace the hardcoded PBKDF2 salt with a per-instance random 32-byte salt stored at `TYRUM_HOME/.salt`.
- Auto-migrate legacy `secrets.json` entries (old hardcoded salt) by decrypting with the legacy key, re-encrypting with the instance-salted key, and writing the `.salt` file with `0600` perms.

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
