### PR TITLE
feat(gateway): Add CORS configuration (#836)

### DIFF
--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -3,6 +3,7 @@
  */
 
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import type { GatewayContainer } from "./container.js";
 import { createHealthRoute } from "./routes/health.js";
@@ -182,6 +183,23 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
 
   // Prometheus request metrics.
   app.use("*", createMetricsMiddleware(gatewayMetrics));
+
+  const corsOrigins = (process.env["TYRUM_CORS_ORIGINS"] ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  if (corsOrigins.length > 0) {
+    app.use(
+      "*",
+      cors({
+        origin: corsOrigins,
+        allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+        allowHeaders: ["Authorization", "Content-Type"],
+        maxAge: 3600,
+      }),
+    );
+  }
 
   // Apply auth middleware if a token store is provided
   if (opts.authRateLimiter) {

--- a/packages/gateway/tests/integration/cors.test.ts
+++ b/packages/gateway/tests/integration/cors.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../src/app.js";
+import { createTestContainer } from "./helpers.js";
+
+async function withEnvVar(
+  key: string,
+  value: string | undefined,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = process.env[key];
+  try {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+    await fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = prev;
+    }
+  }
+}
+
+function parseCommaHeader(value: string | null): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+describe("CORS", () => {
+  it("adds CORS headers only for configured origins", async () => {
+    await withEnvVar("TYRUM_CORS_ORIGINS", "http://localhost:3000", async () => {
+      const container = await createTestContainer();
+      try {
+        const app = createApp(container);
+
+        const allowed = await app.request("/healthz", {
+          headers: { Origin: "http://localhost:3000" },
+        });
+        expect(allowed.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+
+        const blocked = await app.request("/healthz", {
+          headers: { Origin: "http://evil.com" },
+        });
+        expect(blocked.headers.get("Access-Control-Allow-Origin")).toBeNull();
+
+        const sameOrigin = await app.request("/healthz");
+        expect(sameOrigin.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      } finally {
+        await container.db.close();
+      }
+    });
+
+    await withEnvVar("TYRUM_CORS_ORIGINS", undefined, async () => {
+      const container = await createTestContainer();
+      try {
+        const app = createApp(container);
+        const res = await app.request("/healthz", {
+          headers: { Origin: "http://localhost:3000" },
+        });
+        expect(res.headers.get("Access-Control-Allow-Origin")).toBeNull();
+      } finally {
+        await container.db.close();
+      }
+    });
+  });
+
+  it("responds to preflight OPTIONS with expected headers", async () => {
+    await withEnvVar("TYRUM_CORS_ORIGINS", "http://localhost:3000", async () => {
+      const container = await createTestContainer();
+      try {
+        const app = createApp(container);
+        const res = await app.request("/healthz", {
+          method: "OPTIONS",
+          headers: {
+            Origin: "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization, Content-Type",
+          },
+        });
+
+        expect(res.status).toBe(204);
+        expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+        expect(res.headers.get("Access-Control-Max-Age")).toBe("3600");
+
+        const methods = parseCommaHeader(res.headers.get("Access-Control-Allow-Methods"));
+        expect(methods.sort()).toEqual(["DELETE", "GET", "OPTIONS", "PATCH", "POST", "PUT"].sort());
+
+        const headers = parseCommaHeader(res.headers.get("Access-Control-Allow-Headers"));
+        expect(headers.sort()).toEqual(["Authorization", "Content-Type"].sort());
+      } finally {
+        await container.db.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #836

## Test evidence
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

## Notes
- Configure allowed origins with `TYRUM_CORS_ORIGINS` (comma-separated).
- Default remains restrictive (no cross-origin allow header unless configured).
