### PR TITLE
Gateway WS: task result registry + wire protocolDeps.onTaskResult (#769)

### DIFF
--- a/apps/desktop/tests/integration/e2e-dispatch.test.ts
+++ b/apps/desktop/tests/integration/e2e-dispatch.test.ts
@@ -67,6 +67,7 @@ async function waitForCapabilities(
 interface TaskResultEntry {
   taskId: string;
   success: boolean;
+  result: unknown;
   evidence: unknown;
   error: string | undefined;
 }
@@ -96,8 +97,8 @@ async function startServer(): Promise<{
 
   const protocolDeps: ProtocolDeps = {
     connectionManager,
-    onTaskResult(taskId, success, evidence, error) {
-      taskResults.push({ taskId, success, evidence, error });
+    onTaskResult(taskId, success, result, evidence, error) {
+      taskResults.push({ taskId, success, result, evidence, error });
     },
   };
 

--- a/packages/client/tests/conformance/ws-conformance.test.ts
+++ b/packages/client/tests/conformance/ws-conformance.test.ts
@@ -126,11 +126,18 @@ describe("WS SDK conformance (client <-> gateway)", () => {
 
   it("gateway dispatches task.execute, client responds, gateway receives result", async () => {
     let resolveTaskResult:
-      | ((v: { taskId: string; success: boolean; evidence: unknown; error?: string }) => void)
+      | ((v: {
+          taskId: string;
+          success: boolean;
+          result: unknown;
+          evidence: unknown;
+          error?: string;
+        }) => void)
       | undefined;
     const taskResultP = new Promise<{
       taskId: string;
       success: boolean;
+      result: unknown;
       evidence: unknown;
       error?: string;
     }>((resolve) => {
@@ -139,8 +146,8 @@ describe("WS SDK conformance (client <-> gateway)", () => {
 
     gw = await startGateway((cm) => ({
       connectionManager: cm,
-      onTaskResult(taskId, success, evidence, error) {
-        resolveTaskResult?.({ taskId, success, evidence, error });
+      onTaskResult(taskId, success, result, evidence, error) {
+        resolveTaskResult?.({ taskId, success, result, evidence, error });
       },
     }));
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1153,17 +1153,24 @@ export async function main(role: GatewayRole = "all"): Promise<void> {
   const taskResults = new TaskResultRegistry();
   const toTaskResult = (
     success: boolean,
+    result: unknown,
     evidence: unknown,
     error: string | undefined,
   ): TaskResult => {
     if (success) {
-      return evidence === undefined ? { ok: true } : { ok: true, evidence };
+      const taskResult: TaskResult = { ok: true };
+      if (result !== undefined) taskResult.result = result;
+      if (evidence !== undefined) taskResult.evidence = evidence;
+      return taskResult;
     }
-    const result: TaskResult = { ok: false, error: error ?? "task failed" };
+    const taskResult: TaskResult = { ok: false, error: error ?? "task failed" };
+    if (result !== undefined) {
+      taskResult.result = result;
+    }
     if (evidence !== undefined) {
-      result.evidence = evidence;
+      taskResult.evidence = evidence;
     }
-    return result;
+    return taskResult;
   };
   const protocolDeps: ProtocolDeps = {
     connectionManager,
@@ -1198,8 +1205,8 @@ export async function main(role: GatewayRole = "all"): Promise<void> {
       : undefined,
     taskResults,
     hooks: hooksRuntime,
-    onTaskResult: (taskId, success, evidence, error) => {
-      taskResults.resolve(taskId, toTaskResult(success, evidence, error));
+    onTaskResult: (taskId, success, result, evidence, error) => {
+      taskResults.resolve(taskId, toTaskResult(success, result, evidence, error));
     },
     onConnectionClosed: (connectionId) => {
       taskResults.rejectAllForConnection(connectionId);

--- a/packages/gateway/src/ws/protocol/handler.ts
+++ b/packages/gateway/src/ws/protocol/handler.ts
@@ -191,6 +191,11 @@ export async function handleClientMessage(
         msg.ok,
         msg.ok
           ? evidenceAndResult?.success
+            ? evidenceAndResult.data.result
+            : undefined
+          : undefined,
+        msg.ok
+          ? evidenceAndResult?.success
             ? evidenceAndResult.data.evidence
             : undefined
           : failureEvidence,

--- a/packages/gateway/src/ws/protocol/task-result-registry.ts
+++ b/packages/gateway/src/ws/protocol/task-result-registry.ts
@@ -1,5 +1,6 @@
 export type TaskResult = {
   ok: boolean;
+  result?: unknown;
   evidence?: unknown;
   error?: string;
 };

--- a/packages/gateway/src/ws/protocol/types.ts
+++ b/packages/gateway/src/ws/protocol/types.ts
@@ -75,6 +75,7 @@ export interface ProtocolDeps {
   onTaskResult?: (
     taskId: string,
     success: boolean,
+    result: unknown,
     evidence: unknown,
     error: string | undefined,
   ) => void;

--- a/packages/gateway/tests/contract/ws-contract-conformance.test.ts
+++ b/packages/gateway/tests/contract/ws-contract-conformance.test.ts
@@ -163,11 +163,18 @@ describe("WS contract conformance (gateway <-> client <-> schemas)", () => {
 
   it("vNext handshake + task.execute exchange conform to @tyrum/schemas contracts", async () => {
     let resolveTaskResult:
-      | ((value: { taskId: string; success: boolean; evidence: unknown; error?: string }) => void)
+      | ((value: {
+          taskId: string;
+          success: boolean;
+          result: unknown;
+          evidence: unknown;
+          error?: string;
+        }) => void)
       | undefined;
     const taskResultP = new Promise<{
       taskId: string;
       success: boolean;
+      result: unknown;
       evidence: unknown;
       error?: string;
     }>((resolve) => {
@@ -177,8 +184,8 @@ describe("WS contract conformance (gateway <-> client <-> schemas)", () => {
     server = await startInstrumentedGateway((connectionManager) => {
       return {
         connectionManager,
-        onTaskResult(taskId, success, evidence, error) {
-          resolveTaskResult?.({ taskId, success, evidence, error });
+        onTaskResult(taskId, success, result, evidence, error) {
+          resolveTaskResult?.({ taskId, success, result, evidence, error });
         },
       };
     });

--- a/packages/gateway/tests/integration/desktop-sandbox-e2e.test.ts
+++ b/packages/gateway/tests/integration/desktop-sandbox-e2e.test.ts
@@ -168,10 +168,10 @@ describe("e2e: tool.node.dispatch against docker desktop-sandbox", () => {
           logger: container.logger,
           taskResults,
           nodePairingDal: container.nodePairingDal,
-          onTaskResult(taskId, success, evidence, error) {
+          onTaskResult(taskId, success, result, evidence, error) {
             taskResults.resolve(
               taskId,
-              success ? { ok: true, evidence } : { ok: false, evidence, error },
+              success ? { ok: true, result, evidence } : { ok: false, result, evidence, error },
             );
           },
           onConnectionClosed(connectionId) {

--- a/packages/gateway/tests/integration/e2e-smoke.test.ts
+++ b/packages/gateway/tests/integration/e2e-smoke.test.ts
@@ -42,6 +42,7 @@ async function startServer(app: Hono): Promise<{
   taskResults: Array<{
     taskId: string;
     success: boolean;
+    result: unknown;
     evidence: unknown;
     error: string | undefined;
   }>;
@@ -50,14 +51,15 @@ async function startServer(app: Hono): Promise<{
   const taskResults: Array<{
     taskId: string;
     success: boolean;
+    result: unknown;
     evidence: unknown;
     error: string | undefined;
   }> = [];
 
   const protocolDeps: ProtocolDeps = {
     connectionManager,
-    onTaskResult(taskId, success, evidence, error) {
-      taskResults.push({ taskId, success, evidence, error });
+    onTaskResult(taskId, success, result, evidence, error) {
+      taskResults.push({ taskId, success, result, evidence, error });
     },
   };
 

--- a/packages/gateway/tests/unit/ws-protocol.test.ts
+++ b/packages/gateway/tests/unit/ws-protocol.test.ts
@@ -143,7 +143,13 @@ describe("handleClientMessage", () => {
     );
 
     expect(result).toBeUndefined();
-    expect(onTaskResult).toHaveBeenCalledWith("t-1", true, { screenshot: "base64..." }, undefined);
+    expect(onTaskResult).toHaveBeenCalledWith(
+      "t-1",
+      true,
+      undefined,
+      { screenshot: "base64..." },
+      undefined,
+    );
   });
 
   it("fires command.execute lifecycle hooks after executing a command", async () => {
@@ -229,7 +235,7 @@ describe("handleClientMessage", () => {
       deps,
     );
 
-    expect(onTaskResult).toHaveBeenCalledWith("t-2", false, undefined, "command failed");
+    expect(onTaskResult).toHaveBeenCalledWith("t-2", false, undefined, undefined, "command failed");
   });
 
   it("dispatches task.execute error response evidence from error details", async () => {
@@ -259,6 +265,7 @@ describe("handleClientMessage", () => {
     expect(onTaskResult).toHaveBeenCalledWith(
       "t-3",
       false,
+      undefined,
       { screenshot: "base64...", dom: "<html></html>" },
       "browser action failed",
     );

--- a/packages/gateway/tests/unit/ws-task-result-plumbing.test.ts
+++ b/packages/gateway/tests/unit/ws-task-result-plumbing.test.ts
@@ -22,7 +22,66 @@ function createMockWs(): MockWebSocket {
   };
 }
 
+function toTaskResult(
+  success: boolean,
+  result: unknown,
+  evidence: unknown,
+  error: string | undefined,
+) {
+  const taskResult: {
+    ok: boolean;
+    result?: unknown;
+    evidence?: unknown;
+    error?: string;
+  } = { ok: success };
+
+  if (result !== undefined) taskResult.result = result;
+  if (evidence !== undefined) taskResult.evidence = evidence;
+  if (!success) taskResult.error = error ?? "task failed";
+
+  return taskResult;
+}
+
 describe("WS task.execute result plumbing", () => {
+  it("plumbs task.execute result + evidence to onTaskResult", async () => {
+    const cm = new ConnectionManager();
+    const nodeWs = createMockWs();
+    const connectionId = cm.addClient(nodeWs as never, ["desktop"], {
+      id: "conn-1",
+      role: "node",
+      deviceId: "node-1",
+      protocolRev: 2,
+    });
+
+    const onTaskResult = vi.fn();
+    const deps: ProtocolDeps = {
+      connectionManager: cm,
+      onTaskResult,
+    };
+
+    const taskId = "task-1";
+    const nodeClient = cm.getClient(connectionId)!;
+    await handleClientMessage(
+      nodeClient,
+      JSON.stringify({
+        request_id: taskId,
+        type: "task.execute",
+        ok: true,
+        result: { result: { ok: true }, evidence: { foo: "bar" } },
+      }),
+      deps,
+    );
+
+    expect(onTaskResult).toHaveBeenCalledOnce();
+    expect(onTaskResult).toHaveBeenCalledWith(
+      taskId,
+      true,
+      { ok: true },
+      { foo: "bar" },
+      undefined,
+    );
+  });
+
   it("dispatches task.execute and resolves the awaiting caller exactly once", async () => {
     const cm = new ConnectionManager();
     const nodeWs = createMockWs();
@@ -52,15 +111,8 @@ describe("WS task.execute result plumbing", () => {
           };
         },
       } as never,
-      onTaskResult: (taskId, success, evidence, error) => {
-        registry.resolve(
-          taskId,
-          success
-            ? evidence === undefined
-              ? { ok: true }
-              : { ok: true, evidence }
-            : { ok: false, error: error ?? "task failed", evidence },
-        );
+      onTaskResult: (taskId, success, result, evidence, error) => {
+        registry.resolve(taskId, toTaskResult(success, result, evidence, error));
       },
       onConnectionClosed: (connectionId) => {
         registry.rejectAllForConnection(connectionId);
@@ -142,15 +194,8 @@ describe("WS task.execute result plumbing", () => {
           };
         },
       } as never,
-      onTaskResult: (taskId, success, evidence, error) => {
-        registry.resolve(
-          taskId,
-          success
-            ? evidence === undefined
-              ? { ok: true }
-              : { ok: true, evidence }
-            : { ok: false, error: error ?? "task failed", evidence },
-        );
+      onTaskResult: (taskId, success, result, evidence, error) => {
+        registry.resolve(taskId, toTaskResult(success, result, evidence, error));
       },
       onConnectionClosed: (connectionId) => {
         registry.rejectAllForConnection(connectionId);


### PR DESCRIPTION
Closes #769

## What changed
- Plumb `task.execute` response `result` and `evidence` through `protocolDeps.onTaskResult` and into the gateway task result registry.

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
