### PR TITLE
Desktop node: pixel-mode snapshot/query/act/wait_for (NutJS baseline) (#770)

### DIFF
--- a/packages/desktop-node/src/providers/desktop-provider.ts
+++ b/packages/desktop-node/src/providers/desktop-provider.ts
@@ -598,7 +598,11 @@ export class DesktopProvider implements CapabilityProvider {
 
       lastMatch = matches[0] ?? lastMatch;
 
-      const satisfied = args.state === "hidden" ? matches.length === 0 : matches.length > 0;
+      const satisfied = queryResult.success
+        ? args.state === "hidden"
+          ? matches.length === 0
+          : matches.length > 0
+        : false;
       if (satisfied) {
         const elapsed = Date.now() - start;
         return {

--- a/packages/desktop-node/tests/desktop-provider-wait-for.test.ts
+++ b/packages/desktop-node/tests/desktop-provider-wait-for.test.ts
@@ -133,4 +133,33 @@ describe("DesktopProvider (wait_for)", () => {
       status: "satisfied",
     });
   });
+
+  it("wait_for(hidden) does not satisfy when query fails (OCR unavailable)", async () => {
+    const backend = new MockDesktopBackend();
+    const permissions = {
+      desktopScreenshot: true,
+      desktopInput: false,
+      desktopInputRequiresConfirmation: false,
+    };
+
+    const provider = new DesktopProvider(backend, permissions, vi.fn<ConfirmationFn>());
+
+    const result = await provider.execute(
+      makeAction({
+        op: "wait_for",
+        selector: { kind: "ocr", text: "missing" },
+        state: "hidden",
+        timeout_ms: 0,
+        poll_ms: 50,
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.result).toMatchObject({
+      op: "wait_for",
+      state: "hidden",
+      status: "timeout",
+    });
+    expect(backend.calls).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #770

## What
- Implement `desktop.wait_for` polling using the existing `query` path (OCR/a11y), returning `satisfied` + first match when found.
- Add regression tests for `wait_for` satisfied/hidden/polling behavior.

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
