### PR TITLE
fix(operator-ui): Wire ErrorBoundary into render tree root (#839)

### DIFF
--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,5 +1,5 @@
 import { createRoot } from "react-dom/client";
-import { ThemeProvider } from "@tyrum/operator-ui";
+import { ErrorBoundary, ThemeProvider } from "@tyrum/operator-ui";
 import "@tyrum/operator-ui/globals.css";
 import { App } from "./App.js";
 
@@ -7,7 +7,9 @@ function bootstrap(): void {
   const root = document.getElementById("root")!;
   createRoot(root).render(
     <ThemeProvider>
-      <App />
+      <ErrorBoundary onReloadPage={() => window.location.reload()}>
+        <App />
+      </ErrorBoundary>
     </ThemeProvider>,
   );
 }

--- a/apps/desktop/src/renderer/pages/Gateway.tsx
+++ b/apps/desktop/src/renderer/pages/Gateway.tsx
@@ -36,5 +36,5 @@ export function Gateway({ core, busy, errorMessage }: GatewayProps) {
     );
   }
 
-  return <OperatorUiApp core={core} mode="desktop" />;
+  return <OperatorUiApp core={core} mode="desktop" onReloadPage={() => window.location.reload()} />;
 }

--- a/apps/desktop/tests/renderer-main-theme-sync.test.ts
+++ b/apps/desktop/tests/renderer-main-theme-sync.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createRootMock, renderMock, ThemeProviderMock } = vi.hoisted(() => {
+const { createRootMock, renderMock, ThemeProviderMock, ErrorBoundaryMock } = vi.hoisted(() => {
   const renderMock = vi.fn();
   const createRootMock = vi.fn(() => ({ render: renderMock }));
   const ThemeProviderMock = vi.fn(({ children }: { children: unknown }) => children);
+  const ErrorBoundaryMock = vi.fn(({ children }: { children: unknown }) => children);
 
-  return { createRootMock, renderMock, ThemeProviderMock };
+  return { createRootMock, renderMock, ThemeProviderMock, ErrorBoundaryMock };
 });
 
 vi.mock("react-dom/client", () => ({
@@ -15,6 +16,7 @@ vi.mock("react-dom/client", () => ({
 
 vi.mock("@tyrum/operator-ui", () => ({
   ThemeProvider: ThemeProviderMock,
+  ErrorBoundary: ErrorBoundaryMock,
 }));
 
 vi.mock("../src/renderer/App.js", () => ({

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -62,7 +62,11 @@ const root = createRoot(container);
 const render = (): void => {
   root.render(
     <React.StrictMode>
-      <OperatorUiApp core={manager.getCore()} mode="web" />
+      <OperatorUiApp
+        core={manager.getCore()}
+        mode="web"
+        onReloadPage={() => window.location.reload()}
+      />
     </React.StrictMode>,
   );
 };

--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -33,6 +33,7 @@ export type OperatorUiMode = "web" | "desktop";
 export interface OperatorUiAppProps {
   core: OperatorCore;
   mode: OperatorUiMode;
+  onReloadPage?: () => void;
 }
 
 type OperatorUiRouteId =
@@ -93,7 +94,15 @@ function MaybeThemeProvider({ children }: { children: ReactNode }) {
   return <ThemeProvider>{children}</ThemeProvider>;
 }
 
-export function OperatorUiApp({ core, mode }: OperatorUiAppProps) {
+export function OperatorUiApp({ core, mode, onReloadPage }: OperatorUiAppProps) {
+  return (
+    <ErrorBoundary onReloadPage={onReloadPage}>
+      <OperatorUiAppRoot core={core} mode={mode} />
+    </ErrorBoundary>
+  );
+}
+
+function OperatorUiAppRoot({ core, mode }: Pick<OperatorUiAppProps, "core" | "mode">) {
   const [route, setRoute] = useState<OperatorUiRouteId>("connect");
   const connection = useOperatorStore(core.connectionStore);
 
@@ -140,39 +149,37 @@ export function OperatorUiApp({ core, mode }: OperatorUiAppProps) {
   return (
     <MaybeThemeProvider>
       <ToastProvider>
-        <ErrorBoundary>
-          <AppShell
-            mode={mode}
-            sidebar={
-              <Sidebar
-                items={sidebarItems}
-                secondaryItems={desktopItems}
-                activeItemId={route}
-                onNavigate={navigate}
-                connectionStatus={connection.status}
-              />
-            }
-            mobileNav={
-              <MobileNav
-                items={mobileItems}
-                overflowItems={mobileOverflowItems}
-                activeItemId={route}
-                onNavigate={navigate}
-              />
-            }
-          >
-            <AdminModeProvider core={core} mode={mode}>
-              {route === "connect" && <ConnectPage core={core} mode={mode} />}
-              {route === "dashboard" && <DashboardPage core={core} onNavigate={navigate} />}
-              {route === "memory" && <MemoryPage core={core} />}
-              {route === "approvals" && <ApprovalsPage core={core} />}
-              {route === "runs" && <RunsPage core={core} />}
-              {route === "pairing" && <PairingPage core={core} />}
-              {route === "settings" && <SettingsPage core={core} mode={mode} />}
-              {route === "desktop" && mode === "desktop" && <DesktopPage core={core} />}
-            </AdminModeProvider>
-          </AppShell>
-        </ErrorBoundary>
+        <AppShell
+          mode={mode}
+          sidebar={
+            <Sidebar
+              items={sidebarItems}
+              secondaryItems={desktopItems}
+              activeItemId={route}
+              onNavigate={navigate}
+              connectionStatus={connection.status}
+            />
+          }
+          mobileNav={
+            <MobileNav
+              items={mobileItems}
+              overflowItems={mobileOverflowItems}
+              activeItemId={route}
+              onNavigate={navigate}
+            />
+          }
+        >
+          <AdminModeProvider core={core} mode={mode}>
+            {route === "connect" && <ConnectPage core={core} mode={mode} />}
+            {route === "dashboard" && <DashboardPage core={core} onNavigate={navigate} />}
+            {route === "memory" && <MemoryPage core={core} />}
+            {route === "approvals" && <ApprovalsPage core={core} />}
+            {route === "runs" && <RunsPage core={core} />}
+            {route === "pairing" && <PairingPage core={core} />}
+            {route === "settings" && <SettingsPage core={core} mode={mode} />}
+            {route === "desktop" && mode === "desktop" && <DesktopPage core={core} />}
+          </AdminModeProvider>
+        </AppShell>
       </ToastProvider>
     </MaybeThemeProvider>
   );

--- a/packages/operator-ui/tests/error/operator-ui-app-error-boundary.test.ts
+++ b/packages/operator-ui/tests/error/operator-ui-app-error-boundary.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import React from "react";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+let capturedOnReloadPage: unknown = undefined;
+
+vi.mock("../../src/components/error/error-boundary.js", () => ({
+  ErrorBoundary({
+    children,
+    onReloadPage,
+  }: {
+    children: React.ReactNode;
+    onReloadPage?: () => void;
+  }) {
+    capturedOnReloadPage = onReloadPage;
+    return children;
+  },
+}));
+
+describe("OperatorUiApp error boundary wiring", () => {
+  it("passes onReloadPage to ErrorBoundary", async () => {
+    capturedOnReloadPage = undefined;
+    const { OperatorUiApp } = await import("../../src/index.js");
+    const OperatorUiAppAny = OperatorUiApp as unknown as React.ComponentType<
+      Record<string, unknown>
+    >;
+
+    const connectionSnapshot = { status: "disconnected" } as const;
+    const adminModeSnapshot = {
+      status: "inactive",
+      elevatedToken: null,
+      enteredAt: null,
+      expiresAt: null,
+      remainingMs: null,
+    } as const;
+
+    const core = {
+      connectionStore: {
+        subscribe: (_listener: () => void) => () => {},
+        getSnapshot: () => connectionSnapshot,
+      },
+      adminModeStore: {
+        subscribe: (_listener: () => void) => () => {},
+        getSnapshot: () => adminModeSnapshot,
+        enter: () => {},
+        exit: () => {},
+        dispose: () => {},
+      },
+      httpBaseUrl: "http://localhost",
+    } as unknown;
+
+    const onReloadPage = vi.fn();
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(OperatorUiAppAny, { core, mode: "web", onReloadPage }),
+    );
+
+    try {
+      expect(capturedOnReloadPage).toBe(onReloadPage);
+    } finally {
+      cleanupTestRoot({ container, root });
+    }
+  });
+});


### PR DESCRIPTION
Closes #839

## What
- Wrap `OperatorUiApp` root render with `ErrorBoundary` (and pass `onReloadPage`).
- Wire `onReloadPage` in `apps/web` and `apps/desktop` entrypoints.
- Add regression test ensuring `OperatorUiApp` forwards `onReloadPage` to `ErrorBoundary`.

## Verification (Node 24.14.0)
- `pnpm test` (472 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`