### PR TITLE
Gateway: artifactize desktop evidence + strip bytes from tool outputs (#772)

### DIFF
--- a/packages/gateway/src/modules/agent/tool-executor.ts
+++ b/packages/gateway/src/modules/agent/tool-executor.ts
@@ -22,7 +22,10 @@ import type { RedactionEngine } from "../redaction/engine.js";
 import type { SqlDb } from "../../statestore/types.js";
 import { acquireWorkspaceLease, releaseWorkspaceLease } from "../workspace/lease.js";
 import type { ArtifactStore } from "../artifact/store.js";
-import { persistExecutionArtifactBytes } from "../artifact/execution-artifacts.js";
+import {
+  persistExecutionArtifactBytes,
+  type ExecutionArtifactSensitivity,
+} from "../artifact/execution-artifacts.js";
 import { NoCapableNodeError, NodeNotPairedError } from "../../ws/protocol/errors.js";
 
 const MAX_RESPONSE_BYTES = 32_768;
@@ -564,10 +567,12 @@ export class ToolExecutor {
         { timeoutMs },
       );
 
-      const evidence = await this.shapeNodeDispatchEvidence(parsedAction.data, result.evidence, {
-        runId,
-        stepId,
-      });
+      const evidence = await this.shapeNodeDispatchEvidence(
+        parsedAction.data,
+        result.evidence,
+        result.result,
+        { runId, stepId },
+      );
 
       const payload = {
         ok: result.ok,
@@ -623,6 +628,7 @@ export class ToolExecutor {
   private async shapeNodeDispatchEvidence(
     actionKind: ActionPrimitive["type"],
     evidence: unknown,
+    result: unknown,
     scope: { runId: string; stepId: string },
   ): Promise<unknown> {
     if (actionKind !== "Desktop") return evidence;
@@ -637,7 +643,12 @@ export class ToolExecutor {
     const evidenceObj = evidence as Record<string, unknown>;
     const bytesBase64 =
       typeof evidenceObj["bytesBase64"] === "string" ? evidenceObj["bytesBase64"] : undefined;
-    const treeValue = evidenceObj["tree"];
+    const treeFromEvidence = evidenceObj["tree"];
+    const treeFromResult =
+      result && typeof result === "object" && !Array.isArray(result)
+        ? (result as Record<string, unknown>)["tree"]
+        : undefined;
+    const treeValue = treeFromEvidence !== undefined ? treeFromEvidence : treeFromResult;
 
     if (!bytesBase64 && treeValue === undefined) return evidence;
 
@@ -648,6 +659,8 @@ export class ToolExecutor {
     const height = typeof evidenceObj["height"] === "number" ? evidenceObj["height"] : undefined;
     const timestamp =
       typeof evidenceObj["timestamp"] === "string" ? evidenceObj["timestamp"] : undefined;
+
+    const sensitivity = await this.resolveDesktopEvidenceSensitivity(db, scope);
 
     const shaped: Record<string, unknown> = { ...evidenceObj };
 
@@ -671,7 +684,7 @@ export class ToolExecutor {
             mime: mime ?? "image/png",
             evidence_type: evidenceType,
           },
-          sensitivity: "sensitive",
+          sensitivity,
         });
       } catch {
         stored = null;
@@ -685,7 +698,9 @@ export class ToolExecutor {
     }
 
     if (treeValue !== undefined) {
-      delete shaped["tree"];
+      if (treeFromEvidence !== undefined) {
+        delete shaped["tree"];
+      }
 
       const treeJson = (() => {
         if (typeof treeValue === "string") return treeValue;
@@ -707,7 +722,7 @@ export class ToolExecutor {
             timestamp,
             evidence_type: evidenceType,
           },
-          sensitivity: "sensitive",
+          sensitivity,
         });
       } catch {
         storedTree = null;
@@ -721,6 +736,96 @@ export class ToolExecutor {
     }
 
     return shaped;
+  }
+
+  private parseEvidenceSensitivity(
+    raw: string | undefined,
+    fallback: ExecutionArtifactSensitivity,
+  ): ExecutionArtifactSensitivity {
+    const normalized = raw?.trim().toLowerCase();
+    if (normalized === "normal" || normalized === "sensitive") return normalized;
+    return fallback;
+  }
+
+  private resolveDesktopSandboxEvidenceSensitivity(): ExecutionArtifactSensitivity {
+    return this.parseEvidenceSensitivity(
+      process.env["TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY"],
+      "normal",
+    );
+  }
+
+  private resolveDesktopEvidenceSensitivityForMode(
+    mode: string | undefined,
+  ): ExecutionArtifactSensitivity {
+    const normalizedMode = mode?.trim().toLowerCase();
+    if (normalizedMode === "desktop-sandbox") {
+      return this.resolveDesktopSandboxEvidenceSensitivity();
+    }
+
+    return this.parseEvidenceSensitivity(
+      process.env["TYRUM_DESKTOP_ARTIFACT_SENSITIVITY"],
+      "sensitive",
+    );
+  }
+
+  private async resolveDesktopEvidenceSensitivity(
+    db: SqlDb,
+    scope: { runId: string; stepId: string },
+  ): Promise<ExecutionArtifactSensitivity> {
+    let executorNodeId: string | undefined;
+
+    try {
+      const attemptRow = await db.get<{ metadata_json: string | null }>(
+        `SELECT ea.metadata_json
+         FROM execution_attempts ea
+         JOIN execution_steps es ON es.step_id = ea.step_id
+         WHERE ea.step_id = ? AND es.run_id = ?
+         ORDER BY ea.attempt DESC
+         LIMIT 1`,
+        [scope.stepId, scope.runId],
+      );
+      const rawAttemptMeta = attemptRow?.metadata_json;
+      if (typeof rawAttemptMeta === "string" && rawAttemptMeta.trim().length > 0) {
+        const parsed = JSON.parse(rawAttemptMeta) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          const executor = (parsed as Record<string, unknown>)["executor"];
+          if (executor && typeof executor === "object" && !Array.isArray(executor)) {
+            const nodeId = (executor as Record<string, unknown>)["node_id"];
+            if (typeof nodeId === "string" && nodeId.trim().length > 0) {
+              executorNodeId = nodeId.trim();
+            }
+          }
+        }
+      }
+    } catch {
+      executorNodeId = undefined;
+    }
+
+    if (!executorNodeId) {
+      return this.resolveDesktopEvidenceSensitivityForMode(undefined);
+    }
+
+    let nodeMode: string | undefined;
+    try {
+      const pairingRow = await db.get<{ metadata_json: string }>(
+        "SELECT metadata_json FROM node_pairings WHERE node_id = ?",
+        [executorNodeId],
+      );
+      const rawPairingMeta = pairingRow?.metadata_json;
+      if (typeof rawPairingMeta === "string" && rawPairingMeta.trim().length > 0) {
+        const parsed = JSON.parse(rawPairingMeta) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          const mode = (parsed as Record<string, unknown>)["mode"];
+          if (typeof mode === "string" && mode.trim().length > 0) {
+            nodeMode = mode.trim();
+          }
+        }
+      }
+    } catch {
+      nodeMode = undefined;
+    }
+
+    return this.resolveDesktopEvidenceSensitivityForMode(nodeMode);
   }
 
   private async executeFsRead(toolCallId: string, args: unknown): Promise<ToolResult> {

--- a/packages/gateway/tests/integration/node-dispatch-desktop-artifacts.test.ts
+++ b/packages/gateway/tests/integration/node-dispatch-desktop-artifacts.test.ts
@@ -18,9 +18,34 @@ function stubMcpManager(): McpManager {
 describe("tool.node.dispatch desktop evidence artifacts", () => {
   let originalTyrumHome: string | undefined;
   let homeDir: string | undefined;
+  let originalDesktopSandboxSensitivity: string | undefined;
+
+  function createExecutor(
+    container: Awaited<ReturnType<typeof createTestContainer>>,
+    service: any,
+  ) {
+    return new ToolExecutor(
+      homeDir!,
+      stubMcpManager(),
+      new Map(),
+      fetch,
+      undefined,
+      undefined,
+      container.redactionEngine,
+      undefined,
+      {
+        db: container.db,
+        workspaceId: "default",
+        ownerPrefix: "test-tool",
+      },
+      service,
+      container.artifactStore as any,
+    );
+  }
 
   beforeEach(async () => {
     originalTyrumHome = process.env["TYRUM_HOME"];
+    originalDesktopSandboxSensitivity = process.env["TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY"];
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-node-dispatch-"));
     process.env["TYRUM_HOME"] = homeDir;
   });
@@ -35,6 +60,12 @@ describe("tool.node.dispatch desktop evidence artifacts", () => {
     if (homeDir) {
       await rm(homeDir, { recursive: true, force: true });
       homeDir = undefined;
+    }
+
+    if (originalDesktopSandboxSensitivity === undefined) {
+      delete process.env["TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY"];
+    } else {
+      process.env["TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY"] = originalDesktopSandboxSensitivity;
     }
   });
 
@@ -72,23 +103,7 @@ describe("tool.node.dispatch desktop evidence artifacts", () => {
       }),
     };
 
-    const executor = new ToolExecutor(
-      homeDir!,
-      stubMcpManager(),
-      new Map(),
-      fetch,
-      undefined,
-      undefined,
-      container.redactionEngine,
-      undefined,
-      {
-        db: container.db,
-        workspaceId: "default",
-        ownerPrefix: "test-tool",
-      },
-      nodeDispatchService as any,
-      container.artifactStore as any,
-    );
+    const executor = createExecutor(container, nodeDispatchService as any);
 
     const result = await executor.execute(
       "tool.node.dispatch",
@@ -137,6 +152,106 @@ describe("tool.node.dispatch desktop evidence artifacts", () => {
     await container.db.close();
   });
 
+  it("stores a11y tree JSON returned in Desktop result as a run-scoped artifact and strips it from tool output", async () => {
+    const container = await createTestContainer();
+    const app = createApp(container);
+
+    const scope: ExecutionScopeIds = {
+      jobId: "job-node-dispatch-3",
+      runId: "run-node-dispatch-3",
+      stepId: "step-node-dispatch-3",
+      attemptId: "attempt-node-dispatch-3",
+    };
+    await seedExecutionScope(container.db, scope);
+
+    const tree = {
+      root: {
+        role: "window",
+        name: "root",
+        states: [],
+        bounds: { x: 0, y: 0, width: 1, height: 1 },
+        actions: [],
+        children: [],
+      },
+    };
+
+    const pngBytes = Buffer.from("fake-snapshot-bytes", "utf8");
+    const bytesBase64 = pngBytes.toString("base64");
+
+    const nodeDispatchService = {
+      dispatchAndWait: vi.fn(async () => {
+        return {
+          taskId: "task-789",
+          result: {
+            ok: true,
+            result: {
+              op: "snapshot",
+              tree,
+            },
+            evidence: {
+              type: "snapshot",
+              mode: "hybrid",
+              mime: "image/png",
+              width: 1,
+              height: 1,
+              timestamp: new Date().toISOString(),
+              bytesBase64,
+            },
+          },
+        };
+      }),
+    };
+
+    const executor = createExecutor(container, nodeDispatchService as any);
+
+    const result = await executor.execute(
+      "tool.node.dispatch",
+      "call-3",
+      {
+        capability: "tyrum.desktop",
+        action: "Desktop",
+        args: { op: "snapshot", include_tree: true },
+      },
+      {
+        execution_run_id: scope.runId,
+        execution_step_id: scope.stepId,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.output).toContain("artifact://");
+    expect(result.output).toContain("tree_artifact");
+    expect(result.output).not.toContain("bytesBase64");
+    expect(result.output).not.toContain(bytesBase64);
+
+    const row = await container.db.get<{
+      artifact_id: string;
+      kind: string;
+      mime_type: string | null;
+      sensitivity: string;
+      labels_json: string;
+    }>(
+      `SELECT artifact_id, kind, mime_type, sensitivity, labels_json
+       FROM execution_artifacts
+       WHERE run_id = ? AND step_id = ? AND kind = 'dom_snapshot'
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [scope.runId, scope.stepId],
+    );
+    expect(row).toBeTruthy();
+    expect(row?.kind).toBe("dom_snapshot");
+    expect(row?.mime_type).toBe("application/json");
+    expect(row?.sensitivity).toBe("sensitive");
+    expect(row?.labels_json).toContain("a11y-tree");
+
+    const res = await app.request(`/runs/${scope.runId}/artifacts/${row!.artifact_id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(await res.json()).toEqual(tree);
+
+    await container.db.close();
+  });
+
   it("stores a11y tree JSON as a run-scoped artifact and strips it from tool output", async () => {
     const container = await createTestContainer();
     const app = createApp(container);
@@ -177,23 +292,7 @@ describe("tool.node.dispatch desktop evidence artifacts", () => {
       }),
     };
 
-    const executor = new ToolExecutor(
-      homeDir!,
-      stubMcpManager(),
-      new Map(),
-      fetch,
-      undefined,
-      undefined,
-      container.redactionEngine,
-      undefined,
-      {
-        db: container.db,
-        workspaceId: "default",
-        ownerPrefix: "test-tool",
-      },
-      nodeDispatchService as any,
-      container.artifactStore as any,
-    );
+    const executor = createExecutor(container, nodeDispatchService as any);
 
     const result = await executor.execute(
       "tool.node.dispatch",
@@ -238,6 +337,118 @@ describe("tool.node.dispatch desktop evidence artifacts", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("application/json");
     expect(await res.json()).toEqual(tree);
+
+    await container.db.close();
+  });
+
+  it("defaults sandbox desktop evidence artifacts to normal sensitivity and allows env override", async () => {
+    const container = await createTestContainer();
+
+    const scope: ExecutionScopeIds = {
+      jobId: "job-node-dispatch-4",
+      runId: "run-node-dispatch-4",
+      stepId: "step-node-dispatch-4",
+      attemptId: "attempt-node-dispatch-4",
+    };
+    await seedExecutionScope(container.db, scope);
+
+    const nodeId = "node-sandbox-1";
+    await container.db.run("UPDATE execution_attempts SET metadata_json = ? WHERE attempt_id = ?", [
+      JSON.stringify({
+        executor: {
+          kind: "node",
+          node_id: nodeId,
+          connection_id: "conn-1",
+        },
+      }),
+      scope.attemptId,
+    ]);
+    await container.db.run(
+      "INSERT INTO node_pairings (status, node_id, metadata_json) VALUES ('approved', ?, ?)",
+      [nodeId, JSON.stringify({ mode: "desktop-sandbox" })],
+    );
+
+    const pngBytes = Buffer.from("fake-sandbox-bytes", "utf8");
+    const bytesBase64 = pngBytes.toString("base64");
+
+    const nodeDispatchService = {
+      dispatchAndWait: vi.fn(async () => {
+        return {
+          taskId: "task-sandbox",
+          result: {
+            ok: true,
+            evidence: {
+              type: "screenshot",
+              mime: "image/png",
+              width: 1,
+              height: 1,
+              timestamp: new Date().toISOString(),
+              bytesBase64,
+            },
+          },
+        };
+      }),
+    };
+
+    const executor = createExecutor(container, nodeDispatchService as any);
+
+    const result = await executor.execute(
+      "tool.node.dispatch",
+      "call-4",
+      {
+        capability: "tyrum.desktop",
+        action: "Desktop",
+        args: { op: "screenshot", display: "primary" },
+      },
+      {
+        execution_run_id: scope.runId,
+        execution_step_id: scope.stepId,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.output).toContain("artifact://");
+    expect(result.output).not.toContain(bytesBase64);
+
+    const row = await container.db.get<{ sensitivity: string }>(
+      `SELECT sensitivity
+       FROM execution_artifacts
+       WHERE run_id = ? AND step_id = ? AND kind = 'screenshot'
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [scope.runId, scope.stepId],
+    );
+    expect(row).toBeTruthy();
+    expect(row?.sensitivity).toBe("normal");
+
+    process.env["TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY"] = "sensitive";
+
+    const result2 = await executor.execute(
+      "tool.node.dispatch",
+      "call-5",
+      {
+        capability: "tyrum.desktop",
+        action: "Desktop",
+        args: { op: "screenshot", display: "primary" },
+      },
+      {
+        execution_run_id: scope.runId,
+        execution_step_id: scope.stepId,
+      },
+    );
+
+    expect(result2.error).toBeUndefined();
+
+    const row2 = await container.db.get<{ sensitivity: string }>(
+      `SELECT sensitivity
+       FROM execution_artifacts
+       WHERE run_id = ? AND step_id = ? AND kind = 'screenshot'
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [scope.runId, scope.stepId],
+    );
+    expect(row2).toBeTruthy();
+    expect(row2?.sensitivity).toBe("sensitive");
 
     await container.db.close();
   });


### PR DESCRIPTION
Closes #772

## What
- Stores Desktop screenshot bytes in the ArtifactStore and returns only artifact refs from `tool.node.dispatch`.
- Stores Desktop UI tree snapshots as JSON artifacts and returns `tree_artifact` refs (supports trees returned via `result.tree` or `evidence.tree`).
- Defaults sandbox (`desktop-sandbox`) desktop artifacts to `normal` sensitivity (override via `TYRUM_DESKTOP_SANDBOX_ARTIFACT_SENSITIVITY`; real desktop default override via `TYRUM_DESKTOP_ARTIFACT_SENSITIVITY`).

## Tests
- `pnpm test -- packages/gateway/tests/integration/node-dispatch-desktop-artifacts.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
}