### PR TITLE
docs(architecture): make docs timeless

### DIFF
--- a/docs/architecture/agent-loop.md
+++ b/docs/architecture/agent-loop.md
@@ -1,9 +1,5 @@
 # Agent Loop
 
-## Status
-
-- **Status:** Implemented
-
 An agent loop is the end-to-end path from an inbound message to a final reply and/or actions. The gateway is responsible for keeping loop execution consistent and auditable.
 
 ## Loop stages

--- a/docs/architecture/agent.md
+++ b/docs/architecture/agent.md
@@ -1,9 +1,5 @@
 # Agent
 
-## Status
-
-- **Status:** Implemented
-
 An agent is a configured runtime persona that owns sessions, a workspace, enabled tools, enabled skills, and memory. The gateway runs agent loops on behalf of an agent identity.
 
 ## Agent inputs

--- a/docs/architecture/api-surfaces.md
+++ b/docs/architecture/api-surfaces.md
@@ -1,9 +1,5 @@
 # API surfaces (WebSocket vs HTTP)
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum is **WebSocket-first**, but not WebSocket-only. The Gateway exposes two operator-facing API surfaces:
 
 - **WebSocket protocol (control plane):** typed requests/responses plus server-push events.
@@ -17,7 +13,7 @@ The transport you pick is a **delivery detail**. **Scopes + per-method authoriza
 - Whether an action is _allowed_ is decided by **scopes** (and approvals/policy), not by “it was HTTP” or “it was WS”.
 - **Both** HTTP routes and WS request types MUST declare and enforce required scopes (deny-by-default).
 
-If you find yourself describing “operator = WS” and “admin = HTTP”, treat that as a _current implementation shape_, not an architectural rule.
+Do not define roles in terms of transport (for example “operator = WS” and “admin = HTTP”); define them in terms of scopes.
 
 ## When to use WebSocket
 
@@ -60,46 +56,4 @@ Admin Mode (step-up) is intentionally **transport-agnostic**:
 
 See: [Gateway authN/authZ](./gateway-authz.md).
 
-## Where to implement changes (map)
-
-This section exists to answer: “where does a new API capability go?”
-
-### Contracts and schemas
-
-- WS wire shapes: `packages/schemas/src/protocol/*` and `packages/schemas/src/protocol.ts`
-- HTTP request/response schemas: `packages/schemas/src/*.ts` (for example `packages/schemas/src/device-token.ts`)
-- Operator scopes: `packages/schemas/src/scope.ts`
-
-### Gateway (WebSocket surface)
-
-- WS upgrade + auth + connection lifecycle: `packages/gateway/src/routes/ws.ts`
-- Request dispatch + per-request authZ: `packages/gateway/src/ws/protocol/handler.ts`, `packages/gateway/src/ws/protocol/dispatch.ts`
-- Scope matrix (request type → required scope): `packages/gateway/src/modules/authz/ws-scope-matrix.ts`
-
-### Gateway (HTTP surface)
-
-- HTTP routes: `packages/gateway/src/routes/*.ts`
-- Scope enforcement middleware: `packages/gateway/src/modules/authz/http-scope-middleware.ts`
-- Cookie/bearer extraction helpers: `packages/gateway/src/modules/auth/http.ts`
-
-### Client SDK (`@tyrum/client`)
-
-- WS client: `packages/client/src/ws-client.ts`
-- HTTP client: `packages/client/src/http/client.ts` + `packages/client/src/http/*`
-- Public surface: `packages/client/src/index.ts`
-
-### Operator apps / shared operator layers
-
-- Shared state + workflows (should call SDK, not raw fetch/ws): `packages/operator-core/src/operator-core.ts`
-- UI components: `packages/operator-ui/src/*`
-- App shells: `apps/web/src/*`, `apps/desktop/src/renderer/*`, `packages/cli/src/*`, `packages/tui/src/*`
-
-## Testing expectations
-
-When adding a new capability:
-
-- Add/adjust schemas in `packages/schemas` + tests in `packages/schemas/tests`.
-- Add gateway tests for authZ + behavior in `packages/gateway/tests`.
-- Add SDK tests/fixtures in `packages/client/tests`.
-
-Docs are part of the contract: if you change a surface, update the relevant `docs/architecture/*` page(s).
+Changes to API surfaces are contract changes: update the relevant contracts, enforcement (authZ/audit), and documentation together.

--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -1,9 +1,5 @@
 # Approvals
 
-## Status
-
-- **Status:** Implemented
-
 Approvals are Tyrum’s durable mechanism for gating risky or side-effecting actions behind explicit operator consent. They are created by policy checks and by the execution engine when a workflow step requires confirmation.
 
 Approvals are **enforcement**, not prompt guidance.

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -1,9 +1,5 @@
 # Artifacts
 
-## Status
-
-- **Status:** Implemented
-
 Artifacts are evidence objects captured during execution (screenshots, diffs, logs, HTTP traces). They exist to make outcomes verifiable, auditable, and reviewable by operators.
 
 Artifacts are attached to execution scope (`run_id`, `step_id`, `attempt_id`) and referenced from events and UI timelines.

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -1,9 +1,5 @@
 # Provider Auth and Onboarding
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum supports multiple model providers and authentication mechanisms while preserving the invariant that raw credentials never enter model context.
 
 ## Principles

--- a/docs/architecture/automation.md
+++ b/docs/architecture/automation.md
@@ -1,9 +1,5 @@
 # Automation
 
-## Status
-
-- **Status:** Partially Implemented
-
 Automation lets Tyrum act on schedules and triggers while keeping behavior observable and policy-gated.
 
 ## Primitives
@@ -18,7 +14,7 @@ Automation lets Tyrum act on schedules and triggers while keeping behavior obser
 
 - Use **heartbeat** when the agent should be context-aware and prioritize across multiple signals inside the main session.
 - Use **cron** for independent, narrow tasks that should run on a fixed schedule.
-- WorkSignals can be implemented as heartbeat-driven checks (context-aware) or as cron/watchers (narrow); the key invariant is that firings are durable, deduped, and policy-gated.
+- WorkSignals can be realized as heartbeat-driven checks (context-aware) or as cron/watchers (narrow); the key invariant is that firings are durable, deduped, and policy-gated.
 
 ## Safety expectations
 
@@ -36,7 +32,7 @@ Lifecycle hooks are allowlisted automation workflows that enqueue execution runs
 
 **Configuration (explicit allowlist):**
 
-- Hooks are loaded from `TYRUM_HOME/hooks.yml` (or `hooks.yaml` / `hooks.json`).
+- Hooks are loaded from a configured hooks allowlist file (YAML or JSON).
 - Only hooks listed in this file can run (no directory discovery by default).
 
 Example:

--- a/docs/architecture/backplane.md
+++ b/docs/architecture/backplane.md
@@ -1,9 +1,5 @@
 # Backplane (Outbox Contract)
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum is WebSocket-first: most operator UX is powered by server-push events delivered over long-lived WebSocket connections.
 When the gateway is replicated, only the edge instance that owns a connection can write to that socket. The **backplane** is the cross-instance mechanism that makes “cluster with N replicas” behave like “cluster with 1 replica” for event delivery.
 
@@ -116,16 +112,10 @@ Replays happen in practice (restarts, takeovers, reconnect).
 
 If a peer is offline beyond the outbox retention window, it may miss incremental events; recovery MUST be possible by re-reading durable StateStore-backed state.
 
-### Implementation note (gateway defaults)
+Architecture notes:
 
-The gateway enforces outbox retention by periodically pruning:
-
-- `outbox` rows older than `TYRUM_OUTBOX_RETENTION_MS` (default: 24 hours)
-- stale `outbox_consumers` rows on the same window
-
-Compaction runs on the `all` and `scheduler` gateway roles, with tick interval configurable via `TYRUM_OUTBOX_COMPACTION_TICK_MS` (default: 5 minutes).
-Compaction prunes in batches of up to `TYRUM_OUTBOX_COMPACTION_BATCH_SIZE` rows (default: 10,000) per table and may run multiple batches per tick to catch up.
-In Postgres deployments, the gateway uses an advisory lock so only one instance performs compaction at a time.
+- Outbox retention is enforced by periodic compaction/pruning according to configured retention policies (time/size/consumer progress).
+- In clustered deployments, compaction runs under a single-writer lock/lease so pruning is correct and predictable.
 
 ## Safety and privacy
 

--- a/docs/architecture/capabilities.md
+++ b/docs/architecture/capabilities.md
@@ -1,9 +1,5 @@
 # Capabilities
 
-## Status
-
-- **Status:** Implemented
-
 A capability is a named interface a node can provide. Capabilities are the bridge between "what the agent wants to do" and "what a device can safely execute".
 
 ## Capability shape

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,9 +1,5 @@
 # Channels
 
-## Status
-
-- **Status:** Implemented
-
 Channels are message transports that connect Tyrum to external chat surfaces. A channel connector normalizes inbound messages into session events and sends outbound messages when the agent replies.
 
 Channel connectors are a high-risk integration boundary. They are responsible for preserving identity, provenance, and auditability while presenting a consistent messaging model to the gateway.

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -1,22 +1,15 @@
 # Client
 
-## Status
-
-- **Status:** Partially Implemented
-
 A client is an operator interface that connects to the gateway and participates in sessions. Clients are where humans read events, send requests, approve actions, and manage connected nodes.
 
 ## Client forms
 
-### Implemented
+Clients can take multiple forms, depending on deployment and operator preference:
 
 - Desktop app (Windows/Linux/macOS)
 - Operator web UI (SPA served by the gateway at `/ui`)
 - CLI (`tyrum-cli`)
 - TUI (`tyrum-tui`)
-
-### Planned
-
 - Mobile app (iOS/Android)
 
 ## Responsibilities
@@ -35,13 +28,13 @@ A client is an operator interface that connects to the gateway and participates 
 
 Clients are **WebSocket-first** (interactive control plane) but will often also use HTTP endpoints for resource and bootstrap flows (auth/session, artifacts, callbacks).
 
-All clients should use `@tyrum/client` for WebSocket + HTTP interactions rather than implementing the wire protocol directly.
+All clients should use the canonical client SDK for WebSocket + HTTP interactions rather than implementing the wire protocol directly.
 
 See: [API surfaces (WebSocket vs HTTP)](./api-surfaces.md).
 
-## Current State
+## Operator surfaces
 
-Operator clients currently expose:
+Operator clients can expose:
 
 - Connection/bootstrap (connect)
 - Dashboard/status summary
@@ -50,23 +43,15 @@ Operator clients currently expose:
 - Pairing workflow for nodes/devices
 - Settings (including Admin Mode gating)
 - Memory inspection
+- Context/usage inspection (for example `/context` and `/usage` equivalents)
 
-Desktop-only operator surfaces include:
+Clients that include local device integration can also expose:
 
 - WorkBoard UI (Kanban + drilldown)
 - Permissions + diagnostics + logs
 - Embedded gateway/node controls (start/stop + local permission prompts)
 
-There is no dedicated "Session timeline" page yet; runs and work items are the primary drilldown primitives today.
-
-## Target State
-
-Operator clients may add:
-
-- A unified "Session" timeline view that merges chat, runs/steps/attempts, approvals, and artifacts (reconstructible from durable state; live events stream updates).
-- Richer WorkBoard surfaces across all clients (not just desktop).
-- First-class context/usage panels (beyond `/context` and `/usage` command output).
-- Additional clients (for example a mobile app).
+Clients may also present a unified "Session" timeline view that merges chat, runs/steps/attempts, approvals, and artifacts (reconstructible from durable state; live events stream updates).
 
 ## What a client is not
 

--- a/docs/architecture/context-compaction.md
+++ b/docs/architecture/context-compaction.md
@@ -1,9 +1,5 @@
 # Context, Compaction, and Pruning
 
-## Status
-
-- **Status:** Implemented
-
 The context for a run is the message stack provided to the model. Context is bounded by the model's context window (token limit), so long-running sessions use compaction and pruning to stay within limits without losing safety-critical information.
 
 ## Context stack
@@ -69,7 +65,7 @@ The gateway applies deterministic pruning/compaction between tool-loop steps dur
 - Tool call/results are pruned before each step, keeping only the most recent tool interactions.
 - Total messages sent per step are capped (system + instruction head is preserved).
 
-Configuration (environment variables):
+Configuration:
 
-- `TYRUM_CONTEXT_TOOL_PRUNE_KEEP_LAST_MESSAGES` — number of trailing messages allowed to retain tool call/results (default `4`, minimum `2`).
-- `TYRUM_CONTEXT_MAX_MESSAGES` — hard cap on total messages sent to the model per step (default `32`, minimum `8`).
+- The number of trailing tool interactions retained per step is configurable and enforced deterministically.
+- The total number of messages sent per step is configurable and enforced deterministically.

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -1,9 +1,5 @@
 # Contracts
 
-## Status
-
-- **Status:** Implemented
-
 Contracts define the shapes and semantics of Tyrum interfaces. They are used to validate:
 
 - WebSocket protocol messages
@@ -23,19 +19,17 @@ JSON Schema is the default interchange format for contracts. Internally, contrac
 
 ## JSON Schema artifacts
 
-The canonical JSON Schema artifacts are generated from `@tyrum/schemas` during build and include:
+Contracts are exported to JSON Schema artifacts during build and include:
 
 - Individual `*.json` schemas (one per exported contract)
 - A `catalog.json` index (format: `tyrum.contracts.jsonschema.catalog.v1`)
-
-In a workspace checkout, run `pnpm --filter @tyrum/schemas build` to (re)generate artifacts under `packages/schemas/dist/jsonschema/`.
 
 The gateway publishes these artifacts for clients/operators to fetch:
 
 - `GET /contracts/jsonschema/catalog.json`
 - `GET /contracts/jsonschema/<SchemaName>.json`
 
-Operational note: when the gateway auth middleware is enabled, these endpoints require an admin token (`Authorization: Bearer <token>`), consistent with other HTTP routes.
+Security note: these endpoints require appropriate operator/admin authorization, consistent with other HTTP routes.
 
 ## Versioning rules
 
@@ -51,14 +45,14 @@ For the WebSocket protocol:
 
 Core contract families include:
 
-- **Keys and lanes:** `TyrumKey`, `Lane`, `QueueMode` (`packages/schemas/src/keys.ts`)
-- **Execution:** `ExecutionJob`, `ExecutionRun`, `ExecutionStep`, `ExecutionAttempt` + status enums (`packages/schemas/src/execution.ts`)
-- **Approvals:** `Approval` + request/response envelopes (`packages/schemas/src/approval.ts`)
-- **Artifacts and postconditions:** `ArtifactRef` + postcondition contracts (`packages/schemas/src/artifact.ts`, `packages/schemas/src/postcondition.ts`)
-- **Secrets:** `SecretHandle` + provider request/response contracts (`packages/schemas/src/secret.ts`)
-- **Nodes and pairing:** node identity and pairing contracts (`packages/schemas/src/node.ts`)
-- **Policy:** `PolicyBundle` and policy decision outputs (`@tyrum/schemas`)
-- **Protocol envelopes:** request/response/event base envelopes and typed unions (`packages/schemas/src/protocol.ts`)
+- **Keys and lanes:** session keys, lanes, and queueing modes.
+- **Execution:** jobs/runs/steps/attempts plus status enums.
+- **Approvals:** approval records and request/response envelopes.
+- **Artifacts and postconditions:** artifact references and postcondition contracts.
+- **Secrets:** secret handles and provider request/response contracts.
+- **Nodes and pairing:** node identity, pairing, and capability contracts.
+- **Policy:** policy bundles and policy decision outputs.
+- **Protocol envelopes:** request/response/event base envelopes and typed unions.
 - **Protocol operations:** handshake (`connect.init`, `connect.proof`), `ping`, `session.send`, `workflow.run|resume|cancel`, `approval.list|resolve`, `pairing.approve|deny`, `task.execute`
 - **Tools:** built-in tool schemas and the ToolRunner invocation envelope
 - **Playbooks:** workflow file schema (YAML/JSON) and compilation rules

--- a/docs/architecture/data-lifecycle.md
+++ b/docs/architecture/data-lifecycle.md
@@ -1,9 +1,5 @@
 # Data lifecycle and retention
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum is durable by design: the StateStore is the source of truth for sessions, execution, approvals, and audit evidence.
 That durability must be paired with explicit **retention** and **deletion** rules so deployments remain operable (bounded cost), safe (privacy), and explainable (audit).
 
@@ -57,11 +53,11 @@ Lifecycle expectations:
 - TTL pruning is safe under clustered edges (no correctness dependence on long-lived cache rows).
 - TTL windows are chosen to tolerate normal jitter and brief partitions without creating “ghost ownership”.
 
-Implementation note (gateway defaults):
+Architecture notes:
 
-- The gateway periodically prunes TTL-derived tables (`presence_entries`, `connection_directory`, `channel_inbound_dedupe`) based on their `expires_at_ms` columns.
-- The gateway also prunes expired sessions/transcripts by deleting `sessions` rows whose `updated_at` is older than `TYRUM_SESSIONS_TTL_DAYS` (default: 30 days), including dependent rows in `session_provider_pins` and `context_reports`.
-- Pruning runs on the `all` and `scheduler` gateway roles, with tick interval configurable via `TYRUM_STATESTORE_RETENTION_TICK_MS` (default: 5 minutes) and batch size configurable via `TYRUM_STATESTORE_RETENTION_BATCH_SIZE` (default: 10,000). In Postgres deployments, an advisory lock ensures only one instance runs per tick.
+- TTL-derived state is pruned periodically based on explicit expiry timestamps.
+- Session/transcript retention is enforced by configurable lifecycle policies (for example last-activity windows), with safe cascading to dependent derived records.
+- In clustered deployments, retention jobs run under a single-writer lock/lease so pruning is correct and predictable.
 
 ### Artifact bytes (FS/S3)
 
@@ -134,8 +130,7 @@ If a deployment supports “forget” or data deletion requests, it MUST define:
 - how linked artifacts are handled (metadata and bytes), and
 - how the system proves deletion occurred (auditable events).
 
-Implementation note (gateway audit streams):
+Architecture notes:
 
-- The gateway exposes `POST /audit/forget` to process explicit forget requests for audit streams stored in `planner_events`.
-- Requests must include an explicit decision (`delete`, `anonymize`, or `retain`) and a confirmation string.
-- The gateway records a `forget.proof` event with the decision and outcome; for destructive decisions it preserves hash-chain continuity via `prev_hash` linkage without retaining prior content.
+- “Forget” requests are explicit and confirmed, and require a declared decision (for example delete/anonymize/retain) with an auditable outcome.
+- Destructive decisions preserve audit-chain continuity (for example via hash chaining) without retaining the deleted content.

--- a/docs/architecture/execution-engine.md
+++ b/docs/architecture/execution-engine.md
@@ -1,9 +1,5 @@
 # Execution engine
 
-## Status
-
-- **Status:** Implemented
-
 The execution engine is the gateway subsystem responsible for turning a plan or workflow into **resilient, auditable execution**. It is where reliability guarantees live: retries, idempotency, budgets/timeouts, pause/resume, and evidence capture.
 
 ## Why it exists
@@ -50,15 +46,15 @@ Retry policy is per-step with conservative defaults. Automatic retries apply onl
 
 ## Workspace-backed execution (ToolRunner)
 
-Many Tyrum steps are filesystem- or process-oriented (for example running a CLI tool in a workspace, reading/writing files, generating evidence artifacts). To keep `TYRUM_HOME` durable across runs while still scaling to multi-node clusters, Tyrum treats workspace access as an explicit execution boundary:
+Many Tyrum steps are filesystem- or process-oriented (for example running a CLI tool in a workspace, reading/writing files, generating evidence artifacts). To keep the workspace directory durable across runs while still scaling to multi-node clusters, Tyrum treats workspace access as an explicit execution boundary:
 
 - **ToolRunner** is the execution context that mounts the workspace filesystem and runs side-effecting tools.
 - Workers coordinate work in the StateStore (claims/leases, idempotency, lane serialization) and delegate step execution to ToolRunner.
 
 ToolRunner has deployment-parity implementations:
 
-- **Single-host/desktop:** ToolRunner is a **local subprocess** (or in-process) operating on the local persistent `TYRUM_HOME`.
-- **Cluster/Kubernetes:** ToolRunner is a **sandboxed job/pod** that mounts the workspace PVC (RWO) and writes outcomes back to the StateStore.
+- **Single-host/desktop:** ToolRunner is a **local subprocess** (or in-process) operating on the local persistent workspace directory.
+- **Cluster:** ToolRunner is a **sandboxed job/container** that mounts the workspace volume (with single-writer semantics) and writes outcomes back to the StateStore.
 
 This keeps execution semantics identical while ensuring that long-lived edge/scheduler replicas do not need to mount shared workspace volumes.
 
@@ -122,17 +118,19 @@ flowchart TB
   Engine --> Evidence["Artifacts + Postconditions"]
   Engine --> Events["Events/AuditLog"]
   Engine <--> DB["StateStore (SQLite/Postgres)"]
-  ToolRunner --> WorkspaceFs["WorkspaceFs (TYRUM_HOME)"]
+  ToolRunner --> WorkspaceFs["WorkspaceFs (workspace root)"]
 ```
 
 ## Data model
 
-- `jobs(id, created_at, trigger_type, trigger_key, agent_id, lane, status, input, ...)`
-- `runs(id, job_id, started_at, finished_at, status, attempt, budgets, ...)`
-- `run_steps(id, run_id, index, kind, args, idempotency_key, approval_id?, postcondition, ...)`
-- `run_step_attempts(id, run_step_id, attempt, started_at, finished_at, status, result, error, artifacts[])`
+Durable execution entities include:
 
-Exact schemas belong in `@tyrum/schemas` and exported contracts.
+- `Job`: created by a trigger; references agent/lane and input.
+- `Run`: an execution attempt of a job; carries budgets and lifecycle timestamps/status.
+- `RunStep`: ordered steps with kind, args, idempotency key, optional approval, and optional postcondition.
+- `RunStepAttempt`: attempt-level results/errors and artifact references.
+
+Exact schemas belong in versioned contracts.
 
 ## Observability and cost
 

--- a/docs/architecture/gateway-authz.md
+++ b/docs/architecture/gateway-authz.md
@@ -1,9 +1,5 @@
 # Gateway authN/authZ
 
-## Status
-
-- **Status:** Implemented
-
 This document describes Tyrum’s **gateway authentication (authN)** and **authorization (authZ)** model.
 
 Tyrum is multi-tenant: every authenticated request and connection is bound to exactly one `tenant_id` (see [Tenancy](./tenancy.md)).
@@ -149,7 +145,7 @@ Requirements:
 
 Configuration:
 
-- Set `GATEWAY_TRUSTED_PROXIES` to a comma-separated list of IPs and/or CIDR subnets (example: `127.0.0.1,::1,10.0.0.0/8`).
+- Configure `trusted_proxies` as a comma-separated list of IPs and/or CIDR subnets (example: `127.0.0.1,::1,10.0.0.0/8`).
 - Avoid overly-broad ranges (for example `/0`); the gateway rejects `/0` allowlists to prevent accidentally trusting every hop.
 - When set and the socket remote address matches the allowlist, the gateway derives the client IP from `Forwarded` (preferred), then `X-Forwarded-For`, then `X-Real-IP` (falling back to the socket IP if parsing fails).
 - When unset, forwarding headers are ignored and the client IP is always taken from the socket.

--- a/docs/architecture/gateway/index.md
+++ b/docs/architecture/gateway/index.md
@@ -1,9 +1,5 @@
 # Gateway
 
-## Status
-
-- **Status:** Partially Implemented
-
 The gateway is Tyrum's long-lived service component. It is the system's authority for connectivity, policy enforcement, validation, routing, orchestration, and durable state coordination.
 
 Deployments range from a single host (replica count = 1) to multi-instance clusters (replicated gateway edges and workers). The gateway coordinates execution and event delivery via the StateStore and event backplane across deployment sizes. See [Scaling and High Availability](../scaling-ha.md).

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -1,9 +1,5 @@
 # Glossary
 
-## Status
-
-- **Status:** Implemented
-
 ## Agent
 
 A configured runtime identity that owns sessions, a workspace, enabled tools/skills, and memory.

--- a/docs/architecture/identity.md
+++ b/docs/architecture/identity.md
@@ -1,9 +1,5 @@
 # Identity
 
-## Status
-
-- **Status:** Implemented
-
 Identity is how Tyrum attributes authority and scopes access to durable state. Tyrum uses identity at three layers:
 
 - **Tenant** (isolation boundary)

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,9 +1,5 @@
 # Architecture
 
-## Status
-
-- **Status:** Partially Implemented
-
 Tyrum is a WebSocket-first autonomous worker agent platform built around a long-lived gateway that coordinates durable execution, approvals, and audit evidence.
 
 ## Positioning
@@ -30,7 +26,7 @@ Tyrum’s architecture is intentionally conservative:
 ```mermaid
 flowchart LR
   subgraph Operator["Operator surfaces"]
-    C["Client<br/>(Desktop • CLI/TUI • Web App)<br/>(Planned: Mobile)"]
+    C["Client<br/>(Desktop • CLI/TUI • Web App • Mobile)"]
   end
 
   subgraph Runtime["Tyrum runtime"]
@@ -80,7 +76,7 @@ flowchart LR
 
 - **Gateway:** the long-lived service that owns edge connectivity (WebSocket), routing, and contract validation. See [Gateway](./gateway/index.md).
 - **Tenancy:** the isolation boundary for identity, policy, and durable state. See [Tenancy](./tenancy.md).
-- **StateStore:** durable state and logs (SQLite local; Postgres for HA/scale). See [Scaling and high availability](./scaling-ha.md).
+- **StateStore:** durable state and logs (for example SQLite for single-host deployments; Postgres for HA/scale). See [Scaling and high availability](./scaling-ha.md).
 - **Event backplane:** cross-instance delivery via a durable outbox (in-process for replica count = 1; shared for clusters). See [Backplane](./backplane.md), [Scaling and high availability](./scaling-ha.md), and [Events](./protocol/events.md).
 - **Execution engine:** the durable orchestration runtime (retries, idempotency, pause/resume, evidence). See [Execution engine](./execution-engine.md).
 - **WorkBoard:** workspace-scoped work tracking (Kanban) plus a drilldown "global workspace" for artifacts/decisions/signals that keeps interactive sessions responsive by delegating long-running work. See [Work board and delegated execution](./workboard.md).
@@ -92,8 +88,8 @@ flowchart LR
 - **Secrets:** a first-class boundary; raw secrets stay behind a secret provider and are referenced via handles.
 - **Auth profiles:** provider credentials (API keys/OAuth) expressed as metadata + secret handles for deterministic selection and rotation. See [Provider Auth and Onboarding](./auth.md).
 - **Artifacts:** evidence objects stored outside the StateStore with policy-gated access. See [Artifacts](./artifacts.md).
-- **Client:** an operator interface connected to the gateway (desktop/web/CLI/TUI; planned: mobile).
-- **Node:** a capability provider connected to the gateway (desktop node today; planned: mobile/headless).
+- **Client:** an operator interface connected to the gateway (for example desktop/web/CLI/TUI/mobile).
+- **Node:** a capability provider connected to the gateway (for example desktop/mobile/headless nodes).
 - **Protocol:** typed WebSocket messages (requests/responses and server-push events).
 - **Contracts:** versioned schemas used to validate protocol messages and extension boundaries.
 

--- a/docs/architecture/markdown-formatting.md
+++ b/docs/architecture/markdown-formatting.md
@@ -1,9 +1,5 @@
 # Markdown Formatting
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum formats assistant output for outbound channels by converting Markdown into a neutral intermediate representation (IR) before chunking and rendering.
 
 ## Goals
@@ -60,7 +56,7 @@ If parsing or rendering fails for a chunk:
 - fall back to plain text for that chunk
 - emit an event indicating a formatting fallback occurred
 
-Current implementation emits a durable episodic event (`event_type=channel_formatting_fallback`) so operators can inspect fallbacks in the operator UI.
+The system emits a durable episodic event (`event_type=channel_formatting_fallback`) so operators can inspect fallbacks in operator surfaces.
 
 This keeps delivery robust under channel-specific formatting quirks without losing the underlying content.
 

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -1,9 +1,5 @@
 # Memory
 
-## Status
-
-- **Status:** Implemented
-
 Memory is Tyrum’s durable, **agent-scoped** knowledge system. It converts transient run context into reusable knowledge and retrieves that knowledge safely across future sessions — even when the same agent is communicating over multiple channels.
 
 ## Goals

--- a/docs/architecture/messages-sessions.md
+++ b/docs/architecture/messages-sessions.md
@@ -1,9 +1,5 @@
 # Messages and Sessions
 
-## Status
-
-- **Status:** Implemented
-
 This document defines how Tyrum turns inbound messages into durable sessions and serialized execution, while keeping chat UX responsive and safe across channels.
 
 ## Message flow (end-to-end)
@@ -69,7 +65,9 @@ Dedupe is keyed by stable identifiers, typically:
 
 Dedupe entries are time-bounded (TTL) and stored in a way that remains correct under clustered gateway edges. When a duplicate delivery is detected, Tyrum records an audit event and drops the duplicate without starting another run.
 
-Implementation note: the gateway persists inbound dedupe keys in `channel_inbound_dedupe` and prunes expired entries using `TYRUM_CHANNEL_INBOUND_DEDUPE_TTL_MS` (default 7 days).
+Architecture notes:
+
+- Inbound dedupe keys are persisted durably and pruned under a configurable TTL.
 
 ## Inbound debouncing (batch rapid bursts)
 
@@ -93,10 +91,10 @@ When a run is active for a `(session_key, lane)`, inbound messages are handled b
 - **`steer_backlog`:** steer now and also preserve the message for a follow-up turn.
 - **`interrupt`:** abort the active run (at the next safe boundary) and run the newest message.
 
-Implementation notes:
+Architecture notes:
 
-- Queue mode is persisted per message (for example `channel_inbox.queue_mode`, default `collect`) so batch/debounce behavior is deterministic.
-- `steer`/`interrupt` are represented as durable lane-scoped signals (for example `lane_queue_signals`) so they remain correct even if the gateway restarts mid-run.
+- Queue mode is persisted with the inbound message so queueing behavior is deterministic under retries and restarts.
+- `steer` and `interrupt` are represented as durable lane-scoped signals so they remain correct across restarts and multi-instance edges.
 
 ### Queue limits and overflow policy
 
@@ -109,11 +107,10 @@ Queueing is bounded to keep the system predictable:
   - `drop_newest`
   - `summarize_dropped` (creates a synthetic follow-up message that summarizes the dropped items)
 
-Implementation notes:
+Architecture notes:
 
-- `cap` is configured via `TYRUM_CHANNEL_INBOUND_QUEUE_CAP` (default `100`; set `0` to disable bounding).
-- `overflow` is configured via `TYRUM_CHANNEL_INBOUND_QUEUE_OVERFLOW` (default `drop_oldest`).
-- Overflow emits a WS event (`channel.queue.overflow`) so operators can see when messages were dropped or summarized.
+- Queue bounds (`cap`) and overflow behavior are configurable per deployment.
+- Overflow emits a structured event (for example `channel.queue.overflow`) so operators can see when messages were dropped or summarized.
 
 ### Interaction with execution guarantees
 
@@ -135,17 +132,17 @@ Tyrum uses multiple layers of loop control, because there is no single knob that
 - **Cross-turn repetition warning:** if the assistant reply repeats itself across multiple turns in the same session, Tyrum appends a short warning to prompt the operator/user to change constraints. This is **warning-only** (it does not block execution).
 - **Session context retention (`sessions.max_turns`):** this bounds how many recent user/assistant messages are retained in the session context before compaction; it is **not** an execution limiter.
 
-Loop detection configuration lives in `${TYRUM_HOME}/agent.yml` under `sessions.loop_detection`.
+Loop detection configuration lives in agent configuration under `sessions.loop_detection`.
 
-Configuration (defaults):
+Configuration (example):
 
 ```yaml
 sessions:
   loop_detection:
     within_turn:
       enabled: true
-      consecutive_repeat_limit: 3 # stop on AAA
-      cycle_repeat_limit: 3 # stop on ABABAB
+      consecutive_repeat_limit: 3
+      cycle_repeat_limit: 3
     cross_turn:
       enabled: true
       window_assistant_messages: 3
@@ -204,11 +201,11 @@ Typing start behavior is explicit and policy-driven:
 
 Typing refresh cadence is bounded and disabled for non-interactive automation lanes unless explicitly enabled.
 
-Implementation notes:
+Architecture notes:
 
-- `TYRUM_CHANNEL_TYPING_MODE`: `never|message|thinking|instant` (default `never`)
-- `TYRUM_CHANNEL_TYPING_REFRESH_MS`: refresh cadence in milliseconds (default `4000`, clamped to `1000–10000`, set `0` to disable refresh)
-- Typing is disabled for non-`main` lanes unless `TYRUM_CHANNEL_TYPING_AUTOMATION_ENABLED=1`.
+- Typing start mode is configurable per connector.
+- Typing refresh cadence is configurable and bounded.
+- Typing indicators are disabled by default for non-interactive automation lanes unless explicitly enabled.
 
 ## Markdown formatting and chunking (channel-safe)
 

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -1,9 +1,5 @@
 # Models
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum identifies models as `provider/model`.
 
 ## Model catalog

--- a/docs/architecture/multi-agent-routing.md
+++ b/docs/architecture/multi-agent-routing.md
@@ -1,9 +1,5 @@
 # Multi-Agent Routing
 
-## Status
-
-- **Status:** Implemented
-
 Multi-agent routing is the ability to run multiple isolated agents behind one gateway, each with its own workspace and sessions, while routing inbound messages from channels to the correct agent.
 
 ## Isolation model
@@ -21,13 +17,13 @@ Inbound events are mapped to an agent via explicit, auditable bindings.
 - The same rule shape can be stored in the StateStore and edited from the control panel.
 - Rule changes emit events and are reversible.
 
-### Durable routing state (implemented)
+### Durable routing state
 
 Routing rules are persisted as versioned config snapshots in the StateStore:
 
-- Table: `routing_configs` (append-only revisions; newest revision is effective)
-- Audit stream: `planner_events.plan_id = "routing.config"` (exportable via `/audit/export/routing.config`; action includes `revision`, `config_sha256`, and optional `reverted_from_revision`)
-- WS event: `routing.config.updated` (payload includes `revision`, optional `config_sha256`, and optional `reverted_from_revision`; clients should `GET /routing/config` to fetch the effective config)
+- Append-only revisions; the newest valid revision is effective.
+- Changes emit events and are recorded in an append-only audit stream suitable for export.
+- A `routing.config.updated` event notifies clients that a new revision is available; clients can `GET /routing/config` to fetch the effective config.
 
 Operator API:
 
@@ -37,12 +33,11 @@ Operator API:
 
 Authentication/authorization:
 
-- Requires a valid gateway token.
 - Scoped device tokens must include `operator.admin` for `/routing/*` routes.
 
 Bootstrap behavior:
 
-- If no durable routing config exists, the gateway falls back to the legacy static file config under `TYRUM_HOME` (for example `routing.yml` / `routing.yaml` / `routing.json`).
+- Initial routing rules may be seeded from static configuration.
 - Once a durable revision exists and validates against the routing config schema, it becomes the source of truth for routing decisions.
 
 ## Key taxonomy

--- a/docs/architecture/node.md
+++ b/docs/architecture/node.md
@@ -1,9 +1,5 @@
 # Node
 
-## Status
-
-- **Status:** Partially Implemented
-
 A node is a companion runtime that connects to the gateway with `role: node` and exposes capabilities (for example `camera.*`, `canvas.*`, `system.*`). Nodes let Tyrum safely use device-specific interfaces without baking that logic into the gateway.
 
 ## Integration quality bar
@@ -16,18 +12,11 @@ Nodes are “remote hands”, so Tyrum treats node capabilities as high-risk by 
 
 ## Node forms
 
-### Implemented
+Nodes can run on a variety of devices:
 
 - Desktop node (Windows/Linux/macOS)
-
-### Planned
-
 - Mobile node (iOS/Android)
 - Headless node (server or embedded device)
-
-## Current State
-
-The only shipped node runtime today is the desktop node (`@tyrum/desktop-node`), which is used by the desktop app.
 
 ## Responsibilities
 
@@ -45,8 +34,9 @@ without embedding full screenshots in tool outputs.
 When `selector.bounds` is provided, OCR matches are filtered to those whose bounds intersect the
 requested region.
 
-Implementation choice: **WASM OCR** (`tesseract.js`) is preferred over system binaries so the desktop
-node works out-of-the-box across macOS/Windows/Linux.
+Architecture notes:
+
+- Prefer self-contained, cross-platform OCR runtimes (for example WASM-based OCR) over system binaries so the desktop node works out-of-the-box across macOS/Windows/Linux.
 
 Tradeoffs:
 
@@ -55,15 +45,15 @@ Tradeoffs:
 
 Configuration:
 
-- `TYRUM_DESKTOP_OCR_TIMEOUT_MS` (default 30s; max 60s)
-- `TYRUM_DESKTOP_OCR_LANG` (default `eng`)
-- `TYRUM_DESKTOP_OCR_LANG_PATH` (optional override for offline/local language data)
-- `TYRUM_DESKTOP_OCR_CACHE_PATH` (optional; defaults to OS temp dir)
+- OCR timeout
+- OCR language(s)
+- Optional offline/local language data path
+- Optional cache directory
 
 ## Pairing posture
 
 - Nodes connect using a public-key device identity and prove possession of the private key during handshake.
-- When a node connects and is not yet paired, the gateway creates a pairing request for the node device.
+- When a node connects without an active pairing record, the gateway creates a pairing request for the node device.
 - Local nodes can be auto-approved by explicit policy; remote nodes require an explicit operator approval.
 - Pairing results in a scoped authorization (for example a node-scoped token and a capability allowlist) that can be revoked.
 
@@ -81,7 +71,7 @@ sequenceDiagram
   Node-->>Gateway: attempt.evidence(...)
 ```
 
-After pairing approval, nodes SHOULD report which capabilities are currently ready to execute via `capability.ready` (for example after verifying OS permissions, local dependencies, or warmup).
+After pairing approval, nodes SHOULD report which capabilities are ready to execute via `capability.ready` (for example after verifying OS permissions, local dependencies, or warmup).
 
 During capability execution, nodes MAY stream operator-visible evidence for a given attempt via `attempt.evidence` so UIs and audits can observe progress without polling.
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -2,10 +2,6 @@
 
 Tyrum is designed so operators can answer: “what happened, why, and what did it cost?” without guessing.
 
-## Status
-
-- **Status:** Implemented
-
 ## Core surfaces
 
 ### Status
@@ -40,7 +36,7 @@ Context reports are generated deterministically by the gateway and persisted alo
 
 Usage is scoped to the current session by default, with agent-wide and tenant-wide rollups available in operator clients. Platform-wide rollups are restricted to platform administration.
 
-Implementation notes (gateway HTTP):
+Architecture notes:
 
 - `GET /usage` returns a deployment rollup across all locally-accounted execution attempts.
 - `GET /usage?key=<sessionKey>` returns a session rollup (all lanes/runs for a single session key).

--- a/docs/architecture/operations.md
+++ b/docs/architecture/operations.md
@@ -1,9 +1,5 @@
 # Operations and onboarding
 
-## Status
-
-- **Status:** Partially Implemented
-
 This document describes Tyrum’s operational model and the onboarding/diagnostics surfaces that keep deployments hardened and maintainable. Ops ergonomics are part of the architecture: if the secure configuration is hard to reach, insecure defaults tend to win in practice.
 
 ## Goals
@@ -70,7 +66,7 @@ Check supports both:
 `tyrum check` prints a short, line-oriented report intended for humans and log capture.
 
 - `static.exposure`: host/port and whether the configured bind address is loopback-only.
-- `static.auth`: where the admin token is sourced from (`GATEWAY_TOKEN`, existing `.admin-token`, or generated) without printing the token value.
+- `static.auth`: where the admin token is sourced from (environment/config file/generated) without printing the token value.
 - `static.policy`: policy enablement and the effective policy bundle hash + sources.
 - `static.plugins`: manifest discovery counts per plugin source (workspace/user/bundled), without executing plugin entry code.
 - `static.secrets`: secret provider kind + basic initialization status.

--- a/docs/architecture/playbooks.md
+++ b/docs/architecture/playbooks.md
@@ -1,9 +1,5 @@
 # Playbooks (deterministic workflows)
 
-## Status
-
-- **Status:** Implemented
-
 A playbook is a **durable, reviewable workflow artifact** that the execution engine can run deterministically. Playbooks exist to make multi-step work:
 
 - **Composable:** a single run request executes many steps
@@ -38,7 +34,7 @@ The playbook runtime exposes a small contract that supports two operations:
 
 Notes:
 
-- When `pipeline` is an absolute file path, it must refer to a playbook file already loaded by the gateway (typically under `TYRUM_HOME/playbooks`).
+- When `pipeline` is an absolute file path, it must refer to a playbook file already loaded by the gateway (from a configured playbook directory).
 - `maxOutputBytes` is a positive integer cap applied by the runtime/executor to step output capture.
 - When omitted, a safe default cap is applied.
 
@@ -168,7 +164,7 @@ LLM steps use the `llm` command namespace plus an `llm` config block. They must 
 - id: extract
   command: llm
   llm:
-    model: openai/gpt-4.1
+    model: <provider>/<model>
     prompt: |
       Extract fields from the input and return JSON.
     max_tool_calls: 2

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -1,9 +1,5 @@
 # Gateway plugins
 
-## Status
-
-- **Status:** Implemented
-
 A gateway plugin is an **in-process** code module that extends Tyrum with additional features such as commands, tools, and gateway RPC endpoints.
 
 Gateway plugins are **trusted extensions** (they run inside the gateway process). They are not the primary mechanism for per-vendor/per-app integrations; those should generally live in **capability providers** (nodes and MCP servers) so scopes are explicit and blast radius is smaller.
@@ -55,9 +51,9 @@ Requirements:
 - Optional tools must be explicitly enabled via allowlists (global or per-agent), and must still respect policy/approvals/sandboxing.
 - Tool inputs/outputs are contract-validated, redacted, and sized-capped like built-in tools.
 
-Implementation note:
+Architecture notes:
 
-- Side-effecting plugin tools (`requires_confirmation: true`) are **not exposed** to the agent tool directory unless the effective `PolicyBundle.tools` explicitly opts them in via `allow` or `require_approval` (deployment or agent policy). This makes risky plugin tools opt-in per agent/workspace.
+- Side-effecting plugin tools (declared as requiring confirmation) are **not exposed** to the agent tool directory unless the effective tool policy explicitly opts them in (`allow` or `require_approval`). This makes risky plugin tools opt-in per agent/workspace.
 
 ## Relationship to capability providers
 
@@ -89,7 +85,7 @@ Plugin discovery/install must be hardened because plugins run in-process:
 - Prefer registry installs that can record integrity metadata (hashes) and pin versions.
 - Avoid executing arbitrary lifecycle scripts during install; prefer “pure JS/TS” dependency trees.
 
-Implementation notes:
+Architecture notes:
 
 - Entry points are validated twice: lexically (no `..` traversal outside the plugin directory) and by resolved real path (no symlink escape outside the plugin directory).
 - On POSIX systems, the gateway treats plugin search roots and plugin directories as unsafe when they are world-writable or owned by a different user than the gateway process (root ownership is permitted).

--- a/docs/architecture/policy-overrides.md
+++ b/docs/architecture/policy-overrides.md
@@ -1,9 +1,5 @@
 # Policy overrides (approve-always)
 
-## Status
-
-- **Status:** Implemented
-
 Policy overrides are durable, operator-created enforcement rules that reduce repeated prompts without weakening Tyrum’s auditability or safety model.
 
 They are most commonly created when an operator resolves an approval with **approve always** (see [Approvals](./approvals.md)).

--- a/docs/architecture/presence.md
+++ b/docs/architecture/presence.md
@@ -1,9 +1,5 @@
 # Presence and Instances
 
-## Status
-
-- **Status:** Implemented
-
 Presence is Tyrum’s lightweight, best-effort view of:
 
 - the gateway service itself, and

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -1,12 +1,8 @@
 # Events
 
-## Status
-
-- **Status:** Implemented
-
 Events are gateway-emitted, server-push messages delivered to connected clients (and sometimes nodes). Events make the system observable and keep operator interfaces in sync without polling.
 
-The canonical wire shape lives in `@tyrum/schemas` (`packages/schemas/src/protocol.ts`).
+The wire shapes are defined by shared, versioned contracts (see [Contracts](../contracts.md)).
 
 ## Event envelope
 
@@ -115,10 +111,10 @@ This is the canonical list of `type` values and payload contracts for the v1 Web
 - Deduplicate using `event_id` (and treat `occurred_at` as informational, not a strict ordering guarantee).
 - Clients should tolerate reconnect and resubscribe without losing safety invariants; durable state in the StateStore remains the source of truth.
 
-### SDK semantics (`@tyrum/client`)
+### Client SDK semantics
 
-- The SDK emits parsed events using their wire `type` names (for example `run.updated`, `message.delta`) so operator clients do not need to parse raw WS JSON.
-- Event dedupe is bounded and `event_id`-based across reconnects (`maxSeenEventIds`, default `1000`).
-- Reconnect uses exponential backoff when enabled (`reconnect`, `maxReconnectDelay`) and preserves dedupe/replay safety guarantees across socket churn.
+- Client SDKs emit parsed events using their wire `type` names (for example `run.updated`, `message.delta`) so operator clients do not need to parse raw WS JSON.
+- Event dedupe is bounded and `event_id`-based across reconnects.
+- Reconnect uses exponential backoff and preserves dedupe/replay safety guarantees across socket churn.
 
 In clustered deployments, events are delivered to the owning gateway edge via the **backplane/outbox** abstraction (see [Backplane](../backplane.md)).

--- a/docs/architecture/protocol/handshake.md
+++ b/docs/architecture/protocol/handshake.md
@@ -1,9 +1,5 @@
 # Handshake
 
-## Status
-
-- **Status:** Implemented
-
 Every WebSocket connection starts with a handshake that identifies the peer and establishes what it is allowed to do.
 
 ## Flow
@@ -20,9 +16,9 @@ sequenceDiagram
   Gateway-->>Peer: connect.proof (response) { client_id, device_id, role }
 ```
 
-## Legacy `connect` handshake (removed)
+## Legacy `connect` handshake (unsupported)
 
-The older single-step `connect` request is no longer supported. Peers MUST use `connect.init` / `connect.proof`.
+The older single-step `connect` request is not supported. Peers MUST use `connect.init` / `connect.proof`.
 
 If a peer sends a legacy `connect` request, the gateway closes the connection with close code `4003`.
 

--- a/docs/architecture/protocol/index.md
+++ b/docs/architecture/protocol/index.md
@@ -1,16 +1,12 @@
 # Protocol
 
-## Status
-
-- **Status:** Partially Implemented
-
 Tyrum uses a typed WebSocket protocol between the gateway, clients, and nodes. The protocol is designed to be:
 
 - **Typed:** messages are validated against contracts.
 - **Bidirectional:** requests/responses plus server-push events.
 - **Observable:** important state changes emit events.
 
-The canonical wire shapes live in `@tyrum/schemas` (`packages/schemas/src/protocol.ts`).
+The wire shapes are defined by shared, versioned contracts (see [Contracts](../contracts.md)).
 
 The protocol is the primary interface for:
 
@@ -42,7 +38,7 @@ Revisions allow evolving request types and fields without a major-version bump. 
 
 The protocol uses run-scoped identifiers (`run_id`, `step_id`, `attempt_id`) and avoids ambiguous plan identifiers.
 
-Operational note: the gateway currently expects `protocol_rev = 2` for `connect.init` handshakes and will reject mismatches (close code `4005`, reason `protocol_rev mismatch`).
+The gateway expects `protocol_rev = 2` for `connect.init` handshakes and rejects mismatches (close code `4005`, reason `protocol_rev mismatch`).
 
 ## Message classes
 

--- a/docs/architecture/protocol/requests-responses.md
+++ b/docs/architecture/protocol/requests-responses.md
@@ -1,12 +1,8 @@
 # Requests and Responses
 
-## Status
-
-- **Status:** Implemented
-
 Requests are typed operations initiated by either peer (gateway, client, or node). Responses are typed replies correlated by `request_id`.
 
-The canonical wire shapes live in `@tyrum/schemas` (`packages/schemas/src/protocol.ts`).
+The wire shapes are defined by shared, versioned contracts (see [Contracts](../contracts.md)).
 
 ## Request envelope
 

--- a/docs/architecture/sandbox-policy.md
+++ b/docs/architecture/sandbox-policy.md
@@ -1,9 +1,5 @@
 # Sandbox and Policy
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum enforces safety through layered controls that do not depend on prompt text alone. Policies, approvals, and sandboxing define what execution is allowed to do.
 
 ## Enforcement layers
@@ -25,11 +21,11 @@ Tyrum treats untrusted content as data. Inputs from tools, web pages, channels, 
 
 Policy rules can depend on provenance (for example: “deny shell when the input originated from web content”, or “require approval before sending an outbound message derived from an untrusted source”).
 
-### Current provenance rule (v1)
+### Provenance rule (v1)
 
-The initial provenance policy surface is a single conservative rule:
+A conservative provenance rule is:
 
-- `PolicyBundle.provenance.untrusted_shell_requires_approval` (default: `true`) escalates `tool.exec` from `allow → require_approval` when the tool call is driven by untrusted-input provenance.
+- `PolicyBundle.provenance.untrusted_shell_requires_approval` escalates `tool.exec` from `allow → require_approval` when enabled and when the tool call is driven by untrusted-input provenance.
 
 Operators can relax this behavior by setting `provenance.untrusted_shell_requires_approval: false` in policy bundles (deployment/agent/playbook). For narrow exceptions, prefer `approve always` policy overrides on stable tool match targets rather than broad allowlists.
 
@@ -108,12 +104,12 @@ Profiles:
 
 ### Configuration
 
-Set `TYRUM_TOOLRUNNER_HARDENING_PROFILE`:
+The hardening profile is deployment-configurable:
 
 - `baseline` (default)
 - `hardened`
 
-In Kubernetes deployments, the gateway uses this profile to harden ToolRunner job/pod specs. In local-subprocess deployments, the value is treated as **operator-provided signaling** (the runtime cannot reliably detect host/container hardening automatically).
+In containerized deployments, the gateway uses this profile to harden ToolRunner job/pod specs. In local-subprocess deployments, the value is treated as **operator-provided signaling** (the runtime cannot reliably detect host/container hardening automatically).
 
 ### Observability and signaling
 

--- a/docs/architecture/scaling-ha.md
+++ b/docs/architecture/scaling-ha.md
@@ -1,9 +1,5 @@
 # Scaling and High Availability
 
-## Status
-
-- **Status:** Partially Implemented
-
 Tyrum runs as a single-host local installation or as a horizontally scalable deployment with replicated gateway edges, workers, and lease-coordinated schedulers backed by HA Postgres.
 
 The system uses one logical architecture in all deployments. Components may be co-located or split across processes/hosts; coordination primitives (leases and the event backplane) are always present so a single-host deployment behaves like a cluster with one replica.
@@ -113,11 +109,11 @@ Schedulers must not double-fire triggers when multiple instances are running. To
 - The lease is renewed periodically; on expiry another instance can take over.
 - Each firing should have a durable, unique `firing_id` so downstream enqueue/execution can dedupe under retries.
 
-## Workspace durability and mount semantics (the `TYRUM_HOME` reality)
+## Workspace durability and mount semantics
 
 Tyrum treats the workspace filesystem as a durable operator-visible surface: an agent can write files and expect them to exist across restarts and future runs.
 
-In single-host deployments this is straightforward: `TYRUM_HOME` is a persistent local directory on disk.
+In single-host deployments this is straightforward: the workspace directory is a persistent local directory on disk.
 
 In clustered deployments, **durable workspaces** interact with Kubernetes volume semantics:
 
@@ -131,7 +127,7 @@ To keep the single-host and cluster behaviors aligned while avoiding RWX require
 
 Long-term memory does not depend on the workspace filesystem: it is stored in the **StateStore** and is scoped to the agent, making it available across channels and across gateway replicas without requiring shared POSIX mounts.
 
-ToolRunner runs as a **local subprocess** in single-host deployments and as a **sandboxed job/pod** in clustered deployments. Both forms mount the workspace at `TYRUM_HOME`, execute workspace-backed tools, persist outcomes/artifacts to the StateStore, and exit.
+ToolRunner runs as a **local subprocess** in single-host deployments and as a **sandboxed job/pod** in clustered deployments. Both forms mount the workspace directory, execute workspace-backed tools, persist outcomes/artifacts to the StateStore, and exit.
 
 ## Deployment topologies
 
@@ -158,7 +154,7 @@ flowchart TB
     WorkerPool <--> StateStore
     Scheduler <--> StateStore
     WorkerPool --> ToolRunner
-    ToolRunner --> WorkspaceFs["WorkspaceFs (TYRUM_HOME)"]
+    ToolRunner --> WorkspaceFs["WorkspaceFs (workspace root)"]
 
     WorkerPool --> Backplane
     ExecutionEngine --> Backplane

--- a/docs/architecture/secrets.md
+++ b/docs/architecture/secrets.md
@@ -1,9 +1,5 @@
 # Secrets
 
-## Status
-
-- **Status:** Implemented
-
 Secrets are a first-class architecture concept in Tyrum. The system is designed so that **the model never receives raw secret values** (passwords, API keys, tokens, card numbers).
 
 Instead, secrets are managed by a **secret provider** and referenced via **secret handles**.
@@ -34,7 +30,7 @@ An opaque reference to a stored secret. Handles are the only representation of s
 Deployments use different default providers:
 
 - **Desktop:** OS keychain provider.
-- **Kubernetes:** environment-backed provider (Kubernetes Secret → env).
+- **Kubernetes:** environment-backed provider (for example a secret injected into environment variables).
 - **Single host (non-keychain):** encrypted file-backed provider (volume-mounted).
 
 ## Access model

--- a/docs/architecture/sessions-lanes.md
+++ b/docs/architecture/sessions-lanes.md
@@ -1,9 +1,5 @@
 # Sessions and Lanes
 
-## Status
-
-- **Status:** Implemented
-
 A session is a durable conversation container. A lane is an execution stream within a session (for example `main` vs `cron` vs `heartbeat` vs `subagent`).
 
 ## Sessions

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,16 +1,12 @@
 # Skills
 
-## Status
-
-- **Status:** Implemented
-
 A skill is an instruction bundle that teaches the agent how to perform a specialized workflow. Skills are loaded on demand and are meant to be readable by humans.
 
 ## Load order
 
 Skills can be loaded from multiple locations. When the same skill id exists in more than one place, the more specific location wins:
 
-1. Bundled skills (shipped with Tyrum)
+1. Bundled skills (provided by Tyrum)
 2. User skills directory (for example under a home directory)
 3. Workspace skills directory (wins on conflicts **when trusted**)
 
@@ -32,8 +28,7 @@ Skills are discoverable and installable from a curated catalog.
 
 Workspace skill loading is gated by agent configuration:
 
-- Set `skills.workspace_trusted: true` in `agent.yml` (under `TYRUM_HOME`) to allow loading skills from the workspace skills directory.
-- This is a behavior change from the historical “workspace always wins” load order; set `workspace_trusted: true` to restore workspace overrides for a given `TYRUM_HOME`.
+- Enable workspace skills only in trusted workspaces (for example `skills.workspace_trusted: true`).
 - Operator clients can display provenance via `GET /agent/status` (`skills_detailed[].source`) and show whether workspace skills are trusted (`workspace_skills_trusted`).
 
-Security note: treat `workspace_trusted: true` as a workspace trust decision. Do not point `TYRUM_HOME` at an unreviewed checkout and expect skills to remain untrusted.
+Security note: treat enabling workspace skills as a workspace trust decision. Do not enable workspace skills for unreviewed checkouts.

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -1,9 +1,5 @@
 # Slash Commands
 
-## Status
-
-- **Status:** Implemented
-
 Slash commands are a client-facing command surface for common actions. Clients translate commands into typed requests to the gateway.
 
 Commands are handled by the gateway (not by the model). This keeps control-plane actions deterministic, policy-enforced, and auditable.

--- a/docs/architecture/system-prompt.md
+++ b/docs/architecture/system-prompt.md
@@ -1,9 +1,5 @@
 # System Prompt
 
-## Status
-
-- **Status:** Implemented
-
 For each agent run, Tyrum assembles a custom system prompt. The purpose is to provide the model with the minimum context and rules needed to act safely and effectively.
 
 ## Typical sections

--- a/docs/architecture/tenancy.md
+++ b/docs/architecture/tenancy.md
@@ -1,9 +1,5 @@
 # Tenancy
 
-## Status
-
-- **Status:** Implemented
-
 Tyrum is a multi-tenant system. A **tenant** is the isolation boundary for identity, policy, and durable state.
 
 Every request, event, and durable record is scoped to exactly one `tenant_id`.

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -1,9 +1,5 @@
 # Tools
 
-## Status
-
-- **Status:** Implemented
-
 Tools are the gateway's invocable operations used by the agent runtime. Tools can be built-in, provided by plugins, or exposed via MCP servers.
 
 ## Categories

--- a/docs/architecture/workboard.md
+++ b/docs/architecture/workboard.md
@@ -1,23 +1,13 @@
 # Work board and delegated execution
 
-The WorkBoard is Tyrum's workspace-scoped backlog and work-tracking system. It exists to keep interactive sessions (chat, and future low-latency audio) responsive while long-running work is planned and executed in the background.
-
-## Status
-
-- **Status:** Partially Implemented
-
-## Current State
-
-- The gateway persists WorkItems and related drilldown data and exposes WorkBoard APIs.
-- The desktop app exposes a WorkBoard UI (Kanban + drilldown).
-- The web operator UI, CLI, and TUI do not yet provide full WorkBoard management (planned).
+The WorkBoard is Tyrum's workspace-scoped backlog and work-tracking system. It keeps interactive sessions (chat and other low-latency interactions) responsive while long-running work is decomposed and executed in the background.
 
 The WorkBoard is a Kanban view over durable work state. A WorkItem can contain an internal task graph (a DAG) that the planning loop updates and the execution engine executes.
 
 ## Goals
 
 - Keep channel-facing interactions low-latency by delegating long-running work to background runs/subagents.
-- Make background work queryable from operator clients (desktop app today) and, over time, from channels (for example Telegram) without relying on a specific session transcript.
+- Make background work queryable from operator surfaces (clients and channels) without relying on a specific session transcript.
 - Prevent "one mega task" by sizing WorkItems, enforcing WIP limits, and making consolidation explicit.
 - Preserve Tyrum's safety model: approvals, postconditions, artifacts, idempotency, and policy enforcement remain the enforcement layer.
 
@@ -34,7 +24,7 @@ The WorkBoard is a Kanban view over durable work state. A WorkItem can contain a
 A WorkBoard is a durable backlog scoped to `(tenant_id, agent_id, workspace_id)`.
 
 - It tracks WorkItems and their current state (Backlog/Ready/Doing/Blocked/Done/Cancelled).
-- It enforces a WIP limit for `Doing` items (starting default: `2`).
+- It enforces a configurable WIP limit for `Doing` items (for example `2`).
 - It is the primary place the interactive agent loop consults to answer "what are you working on?" and "status?" from any channel.
 
 Kanban is a representation. The engine runs jobs/runs; planning tasks update task graphs; the board summarizes outcomes and blockers.
@@ -243,7 +233,7 @@ Operator overrides should exist (slash commands / UI actions) to force a mode fo
 
 ## Execution flow (fan-out, fan-in)
 
-"Figure out what to do" is implemented as explicit fan-out tasks (often with different models/execution profiles) followed by a synthesis task that proposes next steps.
+"Figure out what to do" can be expressed as explicit fan-out tasks (often with different models/execution profiles) followed by a synthesis task that proposes next steps.
 
 To keep planning inspectable and resilient under interruption, these tasks write durable WorkBoard state:
 
@@ -299,7 +289,7 @@ This supports "start work on desktop, ask for status on Telegram, receive comple
 
 Multiple long-running WorkItems are expected. The WorkBoard prevents overload and thrash:
 
-- **WIP limit (Doing):** default `2`. New items over the limit stay Ready/Backlog.
+- **WIP limit (Doing):** configurable (for example `2`). New items over the limit stay Ready/Backlog.
 - **Overlap detection:** compare WorkItem fingerprints to warn about resource contention.
 - **No auto-merge:** overlap produces an operator-visible choice (queue, link as dependency, or explicitly merge).
 - **Explicit linking:** prefer dependency links (WorkItem B depends on A) over merging content into a single "blob" item.
@@ -311,8 +301,8 @@ stateDiagram-v2
 
   [*] --> Backlog: created
   Backlog --> Ready: triaged
-  Ready --> Doing: lease acquired (WIP < 2)
-  Ready --> Ready: WIP limit reached (2)
+  Ready --> Doing: lease acquired (WIP < limit)
+  Ready --> Ready: WIP limit reached
   Ready --> Cancelled: operator cancels
 
   Doing --> Blocked: awaiting approval / external dependency
@@ -344,17 +334,16 @@ Spawning subagents and mutating the WorkBoard should be controlled by execution 
 
 ## Data model sketch (durable state)
 
-Exact schemas belong in `@tyrum/schemas`, but the durable record shapes are:
+Exact schemas belong in versioned contracts, but the durable entities are:
 
-- `work_items(id, tenant_id, agent_id, workspace_id, kind, title, status, priority, created_at, created_from_session_key, last_active_at, fingerprint, acceptance, budgets, parent_work_item_id?)`
-- `work_item_tasks(id, work_item_id, status, depends_on[], execution_profile, side_effect_class, run_id?, approval_id?, artifacts[], started_at, finished_at, result_summary)`
-- `work_item_events(id, work_item_id, created_at, kind, payload_json)` (append-only audit trail for board state changes)
-- `work_artifacts(id, tenant_id, agent_id, workspace_id, work_item_id?, kind, title, body_md?, refs[], confidence?, created_at, created_by_run_id?, created_by_subagent_id?)`
-- `work_decisions(id, tenant_id, agent_id, workspace_id, work_item_id?, question, chosen, alternatives[], rationale_md, input_artifact_ids[], created_at, created_by_run_id?, created_by_subagent_id?)`
-- `work_signals(id, tenant_id, agent_id, workspace_id, work_item_id?, trigger_kind, trigger_spec_json, payload_json, status, created_at, last_fired_at?)`
-- `work_item_state_kv(work_item_id, key, value_json, updated_at, updated_by_run_id?, provenance_json)`
-- `agent_state_kv(agent_id, key, value_json, updated_at, updated_by_run_id?, provenance_json)`
-- `subagents(id, agent_id, workspace_id, execution_profile, session_key, status, created_at, last_heartbeat_at)`
+- `WorkItem`: scoped to `(tenant_id, agent_id, workspace_id)` and includes kind/title/status/priority, acceptance criteria, budgets, timestamps, fingerprints, and optional parent linkage.
+- `WorkItemTask`: task graph nodes with status, dependencies, execution profile, side-effect class, links to runs/approvals/artifacts, timing, and result summary.
+- `WorkItemEvent`: append-only audit trail for WorkBoard state changes.
+- `WorkArtifact`: typed blackboard items with optional body/refs/confidence and provenance links.
+- `DecisionRecord`: question, chosen option, alternatives, rationale, and input artifact links.
+- `WorkSignal`: trigger kind/spec, payload, status, and firing metadata.
+- `StateKV`: authoritative key/value state for agents and work items with provenance.
+- `Subagent`: delegated execution unit with execution profile, session key, status, and heartbeats.
 
 ## Events and observability
 

--- a/docs/architecture/workspace.md
+++ b/docs/architecture/workspace.md
@@ -1,9 +1,5 @@
 # Workspace
 
-## Status
-
-- **Status:** Implemented
-
 A workspace is the agent's working directory boundary for tools that read and write files. Workspaces make file operations explicit, containable, and **durable across runs**.
 
 ## Properties
@@ -16,7 +12,7 @@ A workspace is the agent's working directory boundary for tools that read and wr
 ## Durability (hard requirement)
 
 - A workspace filesystem is **persistent**: files written during one run are available across runs.
-- In single-host deployments, `TYRUM_HOME` is a durable local directory on disk.
+- In single-host deployments, the workspace directory is a durable local directory on disk.
 - In clustered deployments, a workspace is backed by durable storage (for example a PVC) and must remain available across pod reschedules.
 
 ## HA semantics (RWO without RWX)


### PR DESCRIPTION
- Removes implementation-status/roadmap framing from `docs/architecture/`
- Rewords architecture notes to avoid repo-specific paths/env knobs
- Keeps contracts/protocols described as versioned interfaces

Test:
- `pnpm --filter @tyrum/docs build`