### PR TITLE
Fix Admin Mode elevated token scopes (superset) (#911)

### DIFF
--- a/packages/operator-ui/src/components/admin-mode/admin-mode-enter-dialog.tsx
+++ b/packages/operator-ui/src/components/admin-mode/admin-mode-enter-dialog.tsx
@@ -86,7 +86,13 @@ export function AdminModeEnterDialog() {
     const issued = await http.deviceTokens.issue({
       device_id: "operator-ui",
       role: "client",
-      scopes: ["operator.admin"],
+      scopes: [
+        "operator.read",
+        "operator.write",
+        "operator.approvals",
+        "operator.pairing",
+        "operator.admin",
+      ],
       ttl_seconds: 60 * 10,
     });
 

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -2562,6 +2562,14 @@ describe("operator-ui", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(issuedAt));
 
+    const expectedScopes = [
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+      "operator.admin",
+    ];
+
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       expect(init?.method).toBe("POST");
@@ -2574,7 +2582,7 @@ describe("operator-ui", () => {
           token_id: "token-1",
           device_id: "operator-ui",
           role: "client",
-          scopes: ["operator.admin"],
+          scopes: expectedScopes,
           issued_at: issuedAt,
           expires_at: expiresAt,
         }),
@@ -2641,6 +2649,14 @@ describe("operator-ui", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, callInit] = fetchMock.mock.calls[0] ?? [];
+    const bodyText = typeof callInit?.body === "string" ? callInit.body : "";
+    const body = JSON.parse(bodyText) as { scopes?: unknown; ttl_seconds?: unknown };
+    expect(body).toMatchObject({
+      ttl_seconds: 60 * 10,
+    });
+    expect(body.scopes).toEqual(expect.arrayContaining(expectedScopes));
+    expect(body.scopes).toHaveLength(expectedScopes.length);
     expect(core.adminModeStore.getSnapshot()).toMatchObject({
       status: "active",
       elevatedToken: "elevated-device-token",


### PR DESCRIPTION
Closes #911

## What
- Admin Mode device token issuance now requests an explicit operator scope superset (read/write/approvals/pairing) while adding operator.admin.
- Regression test asserts the issued scope set.

## Tests
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
