### PR TITLE
Add max-lines gate and remove diff coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,20 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Max lines gate (PR)
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+            base="$(git rev-parse HEAD^1)"
+          fi
+          node scripts/lint/max-lines-diff.mjs --base "$base"
+
       - name: Typecheck (packages)
         if: matrix.os == 'ubuntu-latest'
         run: pnpm typecheck
@@ -197,20 +211,6 @@ jobs:
           --coverage.reporter=html
           --coverage.reporter=clover
           --coverage.reporter=json
-
-      - name: Diff line coverage (PR)
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-            git fetch --no-tags --prune --unshallow
-          fi
-          base="${{ github.event.pull_request.base.sha }}"
-          if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
-            base="$(git rev-parse HEAD^1)"
-          fi
-          node scripts/coverage/diff-lines.mjs --base "$base" --min 70
 
       - name: Test desktop suite
         if: matrix.os != 'ubuntu-latest'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,17 @@ BASE_SHA="$(git merge-base HEAD origin/main)"
 node scripts/coverage/diff-lines.mjs --base "$BASE_SHA" --min 80
 ```
 
+Note: this diff-coverage check is optional and not enforced in CI.
+
+### Max lines (enforced in CI for PRs)
+
+CI enforces file/function length limits for changed TypeScript files only.
+
+```bash
+BASE_SHA="$(git merge-base HEAD origin/main)"
+node scripts/lint/max-lines-diff.mjs --base "$BASE_SHA"
+```
+
 ## 5. Branch Protections & Reviews
 
 Pull requests must reference their GitHub Issue and pass all required checks:

--- a/scripts/lint/max-lines-diff.mjs
+++ b/scripts/lint/max-lines-diff.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = { base: undefined, verbose: false };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--base" && argv[i + 1]) {
+      args.base = argv[++i];
+      continue;
+    }
+    if (token === "--verbose") {
+      args.verbose = true;
+      continue;
+    }
+  }
+  return args;
+}
+
+function runGit(args, options = {}) {
+  return execFileSync("git", args, { encoding: "utf8", ...options });
+}
+
+function getRepoRoot() {
+  return runGit(["rev-parse", "--show-toplevel"]).trim();
+}
+
+function resolveBaseCommit(explicitBase) {
+  if (explicitBase) return explicitBase;
+
+  // Prefer origin/main when available, otherwise fall back to main.
+  for (const candidate of ["origin/main", "main"]) {
+    try {
+      return runGit(["merge-base", "HEAD", candidate]).trim();
+    } catch {
+      // try next candidate
+    }
+  }
+
+  throw new Error("unable to resolve base commit (use --base <sha>)");
+}
+
+function listChangedFiles(base) {
+  const diff = runGit([
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMRT",
+    `${base}...HEAD`,
+  ]).trim();
+
+  return diff.length === 0 ? [] : diff.split("\n").map((l) => l.trim());
+}
+
+function isTypeScriptSourceFile(filePath) {
+  if (!(filePath.endsWith(".ts") || filePath.endsWith(".tsx"))) return false;
+  if (filePath.endsWith(".d.ts")) return false;
+  return true;
+}
+
+function runMaxLinesGate({ repoRoot, files, verbose }) {
+  const configPath = path.join(repoRoot, "scripts/oxlint-max-lines.json");
+
+  const args = ["exec", "oxlint", "-c", configPath, ...files];
+
+  if (verbose) {
+    console.log(
+      `[max-lines] checking ${files.length} file(s) (max 500 lines, max 80 lines/function)`
+    );
+  }
+
+  const result = spawnSync("pnpm", args, { stdio: "inherit", cwd: repoRoot });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const repoRoot = getRepoRoot();
+const base = resolveBaseCommit(args.base);
+
+const files = listChangedFiles(base).filter(isTypeScriptSourceFile);
+if (files.length === 0) {
+  if (args.verbose) console.log("[max-lines] no changed TypeScript files");
+  process.exit(0);
+}
+
+process.exit(runMaxLinesGate({ repoRoot, files, verbose: args.verbose }));

--- a/scripts/oxlint-max-lines.json
+++ b/scripts/oxlint-max-lines.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "off",
+    "suspicious": "off",
+    "pedantic": "off",
+    "perf": "off",
+    "style": "off",
+    "restriction": "off",
+    "nursery": "off"
+  },
+  "rules": {
+    "max-lines": [
+      "error",
+      { "max": 500, "skipBlankLines": true, "skipComments": true }
+    ],
+    "max-lines-per-function": [
+      "error",
+      { "max": 80, "skipBlankLines": true, "skipComments": true }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Enforce `max-lines` (500) and `max-lines-per-function` (80) on changed TS/TSX files in PRs.
- Remove the diff-line coverage CI gate; rely on Vitest per-package thresholds.
- Update contributing docs to match.

## Test Plan
- [x] pnpm format:check
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test