### PR TITLE
Admin hub (HTTP): Observability + Models panels (#914)

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-page.tsx
+++ b/packages/operator-ui/src/components/pages/admin-page.tsx
@@ -1,8 +1,14 @@
 import type { OperatorCore } from "@tyrum/operator-core";
+import * as React from "react";
 import { AdminModeGate } from "../../admin-mode.js";
+import { parseJsonInput } from "../../utils/parse-json-input.js";
 import { PageHeader } from "../layout/page-header.js";
+import { ApiResultCard } from "../ui/api-result-card.js";
 import { Button } from "../ui/button.js";
 import { Card, CardContent, CardHeader } from "../ui/card.js";
+import { ConfirmDangerDialog } from "../ui/confirm-danger-dialog.js";
+import { Input } from "../ui/input.js";
+import { JsonTextarea } from "../ui/json-textarea.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs.js";
 
 export interface AdminPageProps {
@@ -18,7 +24,456 @@ const QUICK_LINKS: ReadonlyArray<{ id: string; label: string }> = [
   { id: "settings", label: "Settings" },
 ] as const;
 
-export function AdminPage({ onNavigate }: AdminPageProps) {
+type ApiCallState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; value: unknown }
+  | { status: "error"; error: unknown };
+
+type UsageGetQuery = Parameters<OperatorCore["http"]["usage"]["get"]>[0];
+type UsageGetQueryValue = Exclude<UsageGetQuery, undefined>;
+
+type PairingsApproveInput = Parameters<OperatorCore["http"]["pairings"]["approve"]>[1];
+type PairingsDenyInput = Parameters<OperatorCore["http"]["pairings"]["deny"]>[1];
+type PairingsDenyBody = Exclude<PairingsDenyInput, undefined>;
+type PairingsRevokeInput = Parameters<OperatorCore["http"]["pairings"]["revoke"]>[1];
+type PairingsRevokeBody = Exclude<PairingsRevokeInput, undefined>;
+
+function useApiCallState(): {
+  state: ApiCallState;
+  run: (request: () => Promise<unknown>) => Promise<void>;
+  runAndThrow: <T>(request: () => Promise<T>) => Promise<T>;
+} {
+  const mountedRef = React.useRef(true);
+  const inFlightRef = React.useRef(false);
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const [state, setState] = React.useState<ApiCallState>({ status: "idle" });
+
+  const run = React.useCallback(async (request: () => Promise<unknown>): Promise<void> => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    setState({ status: "loading" });
+    try {
+      const value = await request();
+      if (!mountedRef.current) return;
+      setState({ status: "success", value });
+    } catch (error) {
+      if (!mountedRef.current) return;
+      setState({ status: "error", error });
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const runAndThrow = React.useCallback(async <T,>(request: () => Promise<T>): Promise<T> => {
+    if (inFlightRef.current) throw new Error("Request already in progress");
+    inFlightRef.current = true;
+    setState({ status: "loading" });
+    try {
+      const value = await request();
+      if (mountedRef.current) setState({ status: "success", value });
+      return value;
+    } catch (error) {
+      if (mountedRef.current) setState({ status: "error", error });
+      throw error;
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  return { state, run, runAndThrow };
+}
+
+function ApiResultSection({ state, heading }: { state: ApiCallState; heading: string }) {
+  const value = state.status === "success" ? state.value : undefined;
+  const error = state.status === "error" ? state.error : undefined;
+  return <ApiResultCard heading={heading} value={value} error={error} />;
+}
+
+function ObservabilityPanels({ core }: { core: OperatorCore }): React.ReactElement {
+  const status = useApiCallState();
+  const usage = useApiCallState();
+  const presence = useApiCallState();
+  const pairingsList = useApiCallState();
+  const pairingsMutate = useApiCallState();
+
+  const [usageQueryRaw, setUsageQueryRaw] = React.useState("");
+  const usageQuery = React.useMemo(() => parseJsonInput(usageQueryRaw), [usageQueryRaw]);
+
+  const [pairingIdRaw, setPairingIdRaw] = React.useState("");
+  const pairingId = (() => {
+    const trimmed = pairingIdRaw.trim();
+    if (!trimmed) return null;
+    const value = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return value;
+  })();
+
+  const [pairingBodyRaw, setPairingBodyRaw] = React.useState("");
+  const pairingBody = React.useMemo(() => parseJsonInput(pairingBodyRaw), [pairingBodyRaw]);
+
+  const [pairingsAction, setPairingsAction] = React.useState<null | "approve" | "deny" | "revoke">(
+    null,
+  );
+
+  const closePairingsDialog = (): void => {
+    setPairingsAction(null);
+  };
+
+  const submitPairingsAction = async (): Promise<void> => {
+    if (!pairingsAction) return;
+    if (pairingId === null) throw new Error("Pairing id is required");
+
+    if (pairingsAction === "approve") {
+      if (pairingBody.errorMessage) throw new Error(`Invalid JSON: ${pairingBody.errorMessage}`);
+      if (typeof pairingBody.value === "undefined") throw new Error("Approve body is required");
+      await pairingsMutate.runAndThrow(() =>
+        core.http.pairings.approve(pairingId, pairingBody.value as PairingsApproveInput),
+      );
+      return;
+    }
+
+    if (pairingBody.errorMessage) throw new Error(`Invalid JSON: ${pairingBody.errorMessage}`);
+    const bodyValue = pairingBody.value;
+    const denyBody: PairingsDenyInput =
+      typeof bodyValue === "undefined" ? undefined : (bodyValue as PairingsDenyBody);
+    const revokeBody: PairingsRevokeInput =
+      typeof bodyValue === "undefined" ? undefined : (bodyValue as PairingsRevokeBody);
+
+    if (pairingsAction === "deny") {
+      await pairingsMutate.runAndThrow(() => core.http.pairings.deny(pairingId, denyBody));
+      return;
+    }
+
+    await pairingsMutate.runAndThrow(() => core.http.pairings.revoke(pairingId, revokeBody));
+  };
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-4" aria-label="HTTP status, usage, and presence">
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">status.get()</div>
+            <Button
+              data-testid="admin-http-status-get"
+              size="sm"
+              variant="secondary"
+              isLoading={status.state.status === "loading"}
+              onClick={() => {
+                void status.run(() => core.http.status.get());
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <ApiResultSection state={status.state} heading="Status" />
+        </div>
+
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">usage.get()</div>
+            <Button
+              data-testid="admin-http-usage-get"
+              size="sm"
+              variant="secondary"
+              isLoading={usage.state.status === "loading"}
+              disabled={usageQuery.errorMessage !== null}
+              onClick={() => {
+                const query: UsageGetQuery =
+                  typeof usageQuery.value === "undefined"
+                    ? undefined
+                    : (usageQuery.value as UsageGetQueryValue);
+                void usage.run(() => core.http.usage.get(query));
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <JsonTextarea
+            value={usageQueryRaw}
+            rows={4}
+            placeholder='Optional query JSON. Example: {"run_id":"..."}'
+            helperText="Optional. Leave blank for deployment usage."
+            onChange={(event) => {
+              setUsageQueryRaw(event.currentTarget.value);
+            }}
+          />
+          <ApiResultSection state={usage.state} heading="Usage" />
+        </div>
+
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">presence.list()</div>
+            <Button
+              data-testid="admin-http-presence-list"
+              size="sm"
+              variant="secondary"
+              isLoading={presence.state.status === "loading"}
+              onClick={() => {
+                void presence.run(() => core.http.presence.list());
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <ApiResultSection state={presence.state} heading="Presence" />
+        </div>
+      </section>
+
+      <section className="grid gap-4" aria-label="HTTP pairing administration">
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">pairings.list()</div>
+            <Button
+              data-testid="admin-http-pairings-list"
+              size="sm"
+              variant="secondary"
+              isLoading={pairingsList.state.status === "loading"}
+              onClick={() => {
+                void pairingsList.run(() => core.http.pairings.list());
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <ApiResultSection state={pairingsList.state} heading="Pairings" />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className="text-sm font-medium text-fg">pairings.approve()/deny()/revoke()</div>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <Input
+              data-testid="admin-http-pairings-mutate-id"
+              label="Pairing id"
+              value={pairingIdRaw}
+              onChange={(event) => {
+                setPairingIdRaw(event.currentTarget.value);
+              }}
+              placeholder="123"
+              inputMode="numeric"
+              autoComplete="off"
+            />
+
+            <JsonTextarea
+              data-testid="admin-http-pairings-mutate-body"
+              label="Request body JSON"
+              value={pairingBodyRaw}
+              rows={6}
+              placeholder='For approve: {"trust_level":"local","capability_allowlist":[],"reason":"..."}'
+              helperText="Approve requires trust_level and capability_allowlist. Deny/revoke accept optional reason."
+              onChange={(event) => {
+                setPairingBodyRaw(event.currentTarget.value);
+              }}
+            />
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                data-testid="admin-http-pairings-approve"
+                size="sm"
+                variant="primary"
+                disabled={
+                  pairingId === null ||
+                  pairingBody.errorMessage !== null ||
+                  pairingBody.value === undefined
+                }
+                onClick={() => {
+                  setPairingsAction("approve");
+                }}
+              >
+                Approve (confirm)
+              </Button>
+              <Button
+                data-testid="admin-http-pairings-deny"
+                size="sm"
+                variant="secondary"
+                disabled={pairingId === null || pairingBody.errorMessage !== null}
+                onClick={() => {
+                  setPairingsAction("deny");
+                }}
+              >
+                Deny (confirm)
+              </Button>
+              <Button
+                data-testid="admin-http-pairings-revoke"
+                size="sm"
+                variant="danger"
+                disabled={pairingId === null || pairingBody.errorMessage !== null}
+                onClick={() => {
+                  setPairingsAction("revoke");
+                }}
+              >
+                Revoke (confirm)
+              </Button>
+            </div>
+
+            <ApiResultSection state={pairingsMutate.state} heading="Mutation result" />
+          </CardContent>
+        </Card>
+
+        <ConfirmDangerDialog
+          open={pairingsAction !== null}
+          onOpenChange={(open) => {
+            if (open) return;
+            closePairingsDialog();
+          }}
+          title={`Confirm ${pairingsAction ?? "pairing"} action`}
+          description={`This will ${pairingsAction ?? "mutate"} pairing ${
+            pairingId === null ? "(missing id)" : `#${String(pairingId)}`
+          }.`}
+          confirmLabel="Run mutation"
+          onConfirm={submitPairingsAction}
+          isLoading={pairingsMutate.state.status === "loading"}
+        />
+      </section>
+    </div>
+  );
+}
+
+function ModelsPanels({ core }: { core: OperatorCore }): React.ReactElement {
+  const status = useApiCallState();
+  const refresh = useApiCallState();
+  const listProviders = useApiCallState();
+  const getProvider = useApiCallState();
+  const listProviderModels = useApiCallState();
+
+  const [providerId, setProviderId] = React.useState("");
+  const trimmedProviderId = providerId.trim();
+
+  const [refreshOpen, setRefreshOpen] = React.useState(false);
+
+  return (
+    <div className="grid gap-6">
+      <section className="grid gap-4" aria-label="HTTP models status">
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">models.status()</div>
+            <Button
+              data-testid="admin-http-models-status"
+              size="sm"
+              variant="secondary"
+              isLoading={status.state.status === "loading"}
+              onClick={() => {
+                void status.run(() => core.http.models.status());
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <ApiResultSection state={status.state} heading="Models status" />
+        </div>
+
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">models.refresh() (dangerous)</div>
+            <Button
+              data-testid="admin-http-models-refresh"
+              size="sm"
+              variant="danger"
+              onClick={() => {
+                setRefreshOpen(true);
+              }}
+            >
+              Refresh (confirm)
+            </Button>
+          </div>
+          <ApiResultSection state={refresh.state} heading="Refresh result" />
+        </div>
+
+        <ConfirmDangerDialog
+          open={refreshOpen}
+          onOpenChange={setRefreshOpen}
+          title="Refresh model catalog"
+          description="This forces providers to refresh model availability. Admin-only and potentially disruptive."
+          confirmLabel="Refresh models"
+          onConfirm={async () => {
+            await refresh.runAndThrow(() => core.http.models.refresh());
+          }}
+          isLoading={refresh.state.status === "loading"}
+        />
+      </section>
+
+      <section className="grid gap-4" aria-label="HTTP models providers">
+        <div className="grid gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-sm font-medium text-fg">models.listProviders()</div>
+            <Button
+              data-testid="admin-http-models-providers-list"
+              size="sm"
+              variant="secondary"
+              isLoading={listProviders.state.status === "loading"}
+              onClick={() => {
+                void listProviders.run(() => core.http.models.listProviders());
+              }}
+            >
+              Fetch
+            </Button>
+          </div>
+          <ApiResultSection state={listProviders.state} heading="Providers" />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className="text-sm font-medium text-fg">Provider lookup</div>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            <Input
+              data-testid="admin-http-models-provider-id"
+              label="Provider id"
+              value={providerId}
+              onChange={(event) => {
+                setProviderId(event.currentTarget.value);
+              }}
+              placeholder="openai"
+              autoComplete="off"
+            />
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                data-testid="admin-http-models-provider-get"
+                size="sm"
+                variant="secondary"
+                disabled={!trimmedProviderId}
+                isLoading={getProvider.state.status === "loading"}
+                onClick={() => {
+                  void getProvider.run(() => core.http.models.getProvider(trimmedProviderId));
+                }}
+              >
+                Get provider
+              </Button>
+              <Button
+                data-testid="admin-http-models-provider-models-list"
+                size="sm"
+                variant="secondary"
+                disabled={!trimmedProviderId}
+                isLoading={listProviderModels.state.status === "loading"}
+                onClick={() => {
+                  void listProviderModels.run(() =>
+                    core.http.models.listProviderModels(trimmedProviderId),
+                  );
+                }}
+              >
+                List models
+              </Button>
+            </div>
+
+            <ApiResultSection state={getProvider.state} heading="Provider" />
+            <ApiResultSection state={listProviderModels.state} heading="Provider models" />
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+export function AdminPage({ core, onNavigate }: AdminPageProps) {
   return (
     <div className="grid gap-6" data-testid="admin-page">
       <PageHeader title="Admin" />
@@ -53,14 +508,24 @@ export function AdminPage({ onNavigate }: AdminPageProps) {
 
         <AdminModeGate>
           <TabsContent value="http">
-            <Card>
-              <CardHeader>
-                <div className="text-sm font-medium text-fg">HTTP</div>
-              </CardHeader>
-              <CardContent className="text-sm text-fg-muted">
-                Admin HTTP panels will appear here.
-              </CardContent>
-            </Card>
+            <Tabs defaultValue="observability" className="grid gap-3">
+              <TabsList aria-label="Admin HTTP API sections">
+                <TabsTrigger value="observability" data-testid="admin-http-tab-observability">
+                  Observability
+                </TabsTrigger>
+                <TabsTrigger value="models" data-testid="admin-http-tab-models">
+                  Models
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="observability">
+                <ObservabilityPanels core={core} />
+              </TabsContent>
+
+              <TabsContent value="models">
+                <ModelsPanels core={core} />
+              </TabsContent>
+            </Tabs>
           </TabsContent>
 
           <TabsContent value="ws">

--- a/packages/operator-ui/src/components/ui/json-textarea.tsx
+++ b/packages/operator-ui/src/components/ui/json-textarea.tsx
@@ -1,20 +1,6 @@
 import * as React from "react";
+import { parseJsonInput } from "../../utils/parse-json-input.js";
 import { Textarea, type TextareaProps } from "./textarea.js";
-
-function parseJsonInput(rawValue: string): {
-  value: unknown | undefined;
-  errorMessage: string | null;
-} {
-  const trimmed = rawValue.trim();
-  if (!trimmed) return { value: undefined, errorMessage: null };
-
-  try {
-    return { value: JSON.parse(trimmed) as unknown, errorMessage: null };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { value: undefined, errorMessage: message };
-  }
-}
 
 export interface JsonTextareaProps extends TextareaProps {
   onJsonChange?: (value: unknown | undefined, errorMessage: string | null) => void;

--- a/packages/operator-ui/src/utils/parse-json-input.ts
+++ b/packages/operator-ui/src/utils/parse-json-input.ts
@@ -1,0 +1,14 @@
+export function parseJsonInput(rawValue: string): {
+  value: unknown | undefined;
+  errorMessage: string | null;
+} {
+  const trimmed = rawValue.trim();
+  if (!trimmed) return { value: undefined, errorMessage: null };
+
+  try {
+    return { value: JSON.parse(trimmed) as unknown, errorMessage: null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { value: undefined, errorMessage: message };
+  }
+}

--- a/packages/operator-ui/tests/pages/admin-page.http-panels.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http-panels.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import type { OperatorCore } from "../../../operator-core/src/index.js";
+import { createAdminModeStore } from "../../../operator-core/src/stores/admin-mode-store.js";
+import { AdminModeProvider } from "../../src/admin-mode.js";
+import { AdminPage } from "../../src/components/pages/admin-page.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+function setNativeValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+  const proto =
+    element instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+  if (setter) {
+    setter.call(element, value);
+  }
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+describe("AdminPage (HTTP panels)", () => {
+  it("renders HTTP Observability + Models panels and wires actions", async () => {
+    const nowMs = Date.parse("2026-01-01T00:00:00.000Z");
+    const adminModeStore = createAdminModeStore({ tickIntervalMs: 0, now: () => nowMs });
+    adminModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2026-01-01T00:10:00.000Z",
+    });
+
+    const http = {
+      status: { get: vi.fn(async () => ({ status: "ok" })) },
+      usage: { get: vi.fn(async () => ({ status: "ok" })) },
+      presence: { list: vi.fn(async () => ({ status: "ok", entries: [] })) },
+      pairings: {
+        list: vi.fn(async () => ({ status: "ok", pairings: [] })),
+        approve: vi.fn(async () => ({ status: "ok", pairing: { pairing_id: 123 } })),
+        deny: vi.fn(async () => ({ status: "ok", pairing: { pairing_id: 123 } })),
+        revoke: vi.fn(async () => ({ status: "ok", pairing: { pairing_id: 123 } })),
+      },
+      models: {
+        status: vi.fn(async () => ({ status: "ok" })),
+        refresh: vi.fn(async () => ({ status: "ok" })),
+        listProviders: vi.fn(async () => ({ status: "ok", providers: [] })),
+        getProvider: vi.fn(async () => ({ status: "ok" })),
+        listProviderModels: vi.fn(async () => ({ status: "ok" })),
+      },
+    };
+
+    const core = {
+      httpBaseUrl: "http://example.test",
+      adminModeStore,
+      http,
+    } as unknown as OperatorCore;
+
+    const testRoot = renderIntoDocument(
+      React.createElement(
+        AdminModeProvider,
+        { core, mode: "web" },
+        React.createElement(AdminPage, { core }),
+      ),
+    );
+
+    try {
+      expect(testRoot.container.querySelector("[data-testid='admin-tab-http']")).not.toBeNull();
+
+      expect(
+        testRoot.container.querySelector("[data-testid='admin-http-tab-observability']"),
+      ).not.toBeNull();
+      expect(
+        testRoot.container.querySelector("[data-testid='admin-http-tab-models']"),
+      ).not.toBeNull();
+
+      const statusButton = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-status-get']",
+      );
+      expect(statusButton).not.toBeNull();
+      await act(async () => {
+        statusButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      expect(http.status.get).toHaveBeenCalledTimes(1);
+
+      const modelsTab = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-tab-models']",
+      );
+      expect(modelsTab).not.toBeNull();
+      await act(async () => {
+        modelsTab?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+        await Promise.resolve();
+      });
+
+      const listProvidersButton = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-models-providers-list']",
+      );
+      expect(listProvidersButton).not.toBeNull();
+      await act(async () => {
+        listProvidersButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      expect(http.models.listProviders).toHaveBeenCalledTimes(1);
+
+      const refreshButton = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-models-refresh']",
+      );
+      expect(refreshButton).not.toBeNull();
+
+      act(() => {
+        refreshButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(document.querySelector("[data-testid='confirm-danger-dialog']")).not.toBeNull();
+      expect(http.models.refresh).toHaveBeenCalledTimes(0);
+
+      const checkbox = document.querySelector<HTMLInputElement>(
+        "[data-testid='confirm-danger-checkbox']",
+      );
+      expect(checkbox).not.toBeNull();
+      act(() => {
+        checkbox?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      const confirmButton = document.querySelector<HTMLButtonElement>(
+        "[data-testid='confirm-danger-confirm']",
+      );
+      expect(confirmButton).not.toBeNull();
+      await act(async () => {
+        confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+      expect(http.models.refresh).toHaveBeenCalledTimes(1);
+
+      const obsTab = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-tab-observability']",
+      );
+      expect(obsTab).not.toBeNull();
+      await act(async () => {
+        obsTab?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+        await Promise.resolve();
+      });
+
+      const pairingId = testRoot.container.querySelector<HTMLInputElement>(
+        "[data-testid='admin-http-pairings-mutate-id']",
+      );
+      expect(pairingId).not.toBeNull();
+      act(() => {
+        if (!pairingId) return;
+        setNativeValue(pairingId, "123");
+      });
+
+      const pairingBody = testRoot.container.querySelector<HTMLTextAreaElement>(
+        "[data-testid='admin-http-pairings-mutate-body']",
+      );
+      expect(pairingBody).not.toBeNull();
+      act(() => {
+        if (!pairingBody) return;
+        setNativeValue(
+          pairingBody,
+          JSON.stringify({ trust_level: "local", capability_allowlist: [] }),
+        );
+      });
+
+      const approveButton = testRoot.container.querySelector<HTMLButtonElement>(
+        "[data-testid='admin-http-pairings-approve']",
+      );
+      expect(approveButton).not.toBeNull();
+      act(() => {
+        approveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(document.querySelector("[data-testid='confirm-danger-dialog']")).not.toBeNull();
+      expect(http.pairings.approve).toHaveBeenCalledTimes(0);
+
+      const approveCheckbox = document.querySelector<HTMLInputElement>(
+        "[data-testid='confirm-danger-checkbox']",
+      );
+      expect(approveCheckbox).not.toBeNull();
+      act(() => {
+        approveCheckbox?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      const approveConfirm = document.querySelector<HTMLButtonElement>(
+        "[data-testid='confirm-danger-confirm']",
+      );
+      expect(approveConfirm).not.toBeNull();
+      await act(async () => {
+        approveConfirm?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      expect(http.pairings.approve).toHaveBeenCalledTimes(1);
+      expect(http.pairings.approve).toHaveBeenCalledWith(123, {
+        trust_level: "local",
+        capability_allowlist: [],
+      });
+    } finally {
+      adminModeStore.dispose();
+      cleanupTestRoot(testRoot);
+    }
+  });
+});


### PR DESCRIPTION
Closes #914

## What
- Add Admin hub HTTP nested tabs for Observability and Models panels.
- Surface JSON-first results for status/usage/presence/pairings + models/providers APIs.
- Confirm-gate dangerous/admin-only actions (models.refresh + pairings approve/deny/revoke).

## Verification
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
