### PR TITLE
Exclude tests from max-lines-per-function

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -22,5 +22,13 @@
     "preserve-caught-error": "off",
     "unicorn/consistent-function-scoping": "off",
     "no-await-in-loop": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/tests/**", "**/__tests__/**", "**/*.test.*", "**/*.spec.*"],
+      "rules": {
+        "max-lines-per-function": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Closes #941

## Summary
- Disable `max-lines-per-function` for test files via Oxlint overrides.

## Test Plan
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- [x] pnpm test
- [x] pnpm format:check
