### PR TITLE
Admin hub (WS): WorkBoard drilldowns (links/artifacts/decisions) (#920)

### DIFF
--- a/packages/operator-ui/src/components/admin-workboard/admin-workboard-ws-hub.tsx
+++ b/packages/operator-ui/src/components/admin-workboard/admin-workboard-ws-hub.tsx
@@ -125,20 +125,20 @@ function WorkBoardLinkPanels({
       <WsJsonPanel
         scope={scope}
         onScopeErrors={onScopeErrors}
-        title="work.link.create"
-        payloadTestId="admin-ws-work-link-create-payload"
-        runTestId="admin-ws-work-link-create-run"
-        defaultPayload={{ work_item_id: "", linked_work_item_id: "", kind: "depends_on" }}
-        run={(payload) => core.ws.workLinkCreate(payload as WorkLinkCreatePayload)}
-      />
-      <WsJsonPanel
-        scope={scope}
-        onScopeErrors={onScopeErrors}
         title="work.link.list"
         payloadTestId="admin-ws-work-link-list-payload"
         runTestId="admin-ws-work-link-list-run"
         defaultPayload={{ work_item_id: "", limit: 50 }}
         run={(payload) => core.ws.workLinkList(payload as WorkLinkListPayload)}
+      />
+      <WsJsonPanel
+        scope={scope}
+        onScopeErrors={onScopeErrors}
+        title="work.link.create"
+        payloadTestId="admin-ws-work-link-create-payload"
+        runTestId="admin-ws-work-link-create-run"
+        defaultPayload={{ work_item_id: "", linked_work_item_id: "", kind: "depends_on" }}
+        run={(payload) => core.ws.workLinkCreate(payload as WorkLinkCreatePayload)}
       />
     </>
   );

--- a/packages/operator-ui/tests/pages/admin-page.workboard-ws.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.workboard-ws.test.ts
@@ -556,6 +556,25 @@ describe("AdminPage WorkBoard WS panels", () => {
       workspace_id: "ws-1",
     });
 
+    const workboard = testRoot.container.querySelector<HTMLDivElement>(
+      '[data-testid="admin-ws-workboard"]',
+    );
+    expect(workboard).not.toBeNull();
+
+    const linkListPanel = workboard!.querySelector<HTMLDivElement>(
+      '[data-testid="admin-ws-panel-work.link.list"]',
+    );
+    const linkCreatePanel = workboard!.querySelector<HTMLDivElement>(
+      '[data-testid="admin-ws-panel-work.link.create"]',
+    );
+    expect(linkListPanel).not.toBeNull();
+    expect(linkCreatePanel).not.toBeNull();
+
+    const allPanels = Array.from(
+      workboard!.querySelectorAll<HTMLDivElement>('[data-testid^="admin-ws-panel-"]'),
+    );
+    expect(allPanels.indexOf(linkListPanel!)).toBeLessThan(allPanels.indexOf(linkCreatePanel!));
+
     const linkCreatePayload = testRoot.container.querySelector<HTMLTextAreaElement>(
       '[data-testid="admin-ws-work-link-create-payload"]',
     );


### PR DESCRIPTION
Closes #920

**What**
- Add Admin WS WorkBoard drilldown panels for links, artifacts, and decisions.

**Verification**
- `pnpm format:check` (pass)
- `pnpm typecheck` (pass)
- `pnpm lint` (551 warnings, 0 errors)
- `pnpm test` (Test Files: 496 passed, 1 skipped; Tests: 2911 passed, 2 skipped)