### PR TITLE
fix(operator-core): ignore reconnect schedule after terminal disconnect

### DIFF
--- a/packages/operator-core/src/stores/connection-store.ts
+++ b/packages/operator-core/src/stores/connection-store.ts
@@ -173,7 +173,16 @@ export function createConnectionStore(ws: OperatorWsClient): {
   }
 
   function handleReconnectScheduled(nextRetryAtMs: number): void {
-    setState((prev) => ({ ...prev, nextRetryAtMs }));
+    setState((prev) => {
+      if (
+        prev.status === "disconnected" &&
+        prev.lastDisconnect !== null &&
+        TERMINAL_CLOSE_CODES.has(prev.lastDisconnect.code)
+      ) {
+        return prev.nextRetryAtMs === null ? prev : { ...prev, nextRetryAtMs: null };
+      }
+      return { ...prev, nextRetryAtMs };
+    });
   }
 
   function handleTransportError(message: string): void {

--- a/packages/operator-core/tests/connection-recovery.test.ts
+++ b/packages/operator-core/tests/connection-recovery.test.ts
@@ -139,6 +139,37 @@ describe("connection recovery grace", () => {
     }
   });
 
+  it("does not record reconnect schedule after terminal disconnect", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      const ws = new FakeWsClient();
+      const http = createFakeHttpClient();
+      const core = createOperatorCore({
+        wsUrl: "ws://example.test/ws",
+        httpBaseUrl: "http://example.test",
+        auth: createBearerTokenAuth("test-token"),
+        deps: { ws: ws as any, http },
+      });
+
+      core.connect();
+      ws.emit("connected", { clientId: "client-123" });
+
+      ws.emit("disconnected", { code: 4001, reason: "unauthorized" });
+      const nextRetryAtMs = Date.now() + 12_000;
+      ws.emit("reconnect_scheduled", { delayMs: 12_000, nextRetryAtMs, attempt: 1 });
+
+      expect(core.connectionStore.getSnapshot()).toMatchObject({
+        status: "disconnected",
+        recovering: false,
+        nextRetryAtMs: null,
+        lastDisconnect: { code: 4001, reason: "unauthorized" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not re-enter recovering after grace has finalized to disconnected", () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary
- Prevents `reconnect_scheduled` from re-populating `nextRetryAtMs` after a terminal WS close (e.g. 4001), keeping the Connect page actionable.
- Adds a regression test covering `disconnected(4001)` followed by `reconnect_scheduled`.

## Test plan
- [x] `pnpm exec vitest packages/operator-core/tests/connection-recovery.test.ts`