### PR TITLE
fix(gateway): enforce AES-GCM auth tag length

### DIFF
--- a/packages/gateway/src/modules/secret/provider.ts
+++ b/packages/gateway/src/modules/secret/provider.ts
@@ -204,6 +204,7 @@ const FILE_SECRET_PBKDF2_ITERATIONS = 100_000;
 const FILE_SECRET_PBKDF2_KEY_LENGTH_BYTES = 32;
 const FILE_SECRET_PBKDF2_DIGEST = "sha256";
 const FILE_SECRET_LEGACY_PBKDF2_SALT = "tyrum-secrets-v1";
+const FILE_SECRET_GCM_AUTH_TAG_LENGTH_BYTES = 16;
 
 function resolveFileSecretSaltPath(secretsPath: string): string {
   return join(dirname(secretsPath), ".salt");
@@ -228,7 +229,9 @@ function encryptWithKey(
   data: string,
 ): { iv: string; authTag: string; ciphertext: string } {
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const cipher = createCipheriv("aes-256-gcm", key, iv, {
+    authTagLength: FILE_SECRET_GCM_AUTH_TAG_LENGTH_BYTES,
+  });
   const encrypted = Buffer.concat([cipher.update(data, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
   return {
@@ -242,7 +245,9 @@ function decryptWithKey(
   key: Buffer,
   entry: Pick<EncryptedEntry, "iv" | "authTag" | "ciphertext">,
 ): string {
-  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(entry.iv, "hex"));
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(entry.iv, "hex"), {
+    authTagLength: FILE_SECRET_GCM_AUTH_TAG_LENGTH_BYTES,
+  });
   decipher.setAuthTag(Buffer.from(entry.authTag, "hex"));
   const decrypted = Buffer.concat([
     decipher.update(Buffer.from(entry.ciphertext, "hex")),

--- a/packages/gateway/tests/unit/secret-provider.test.ts
+++ b/packages/gateway/tests/unit/secret-provider.test.ts
@@ -286,6 +286,20 @@ describe("FileSecretProvider", () => {
     expect(await provider.list()).toHaveLength(2);
   });
 
+  it("rejects truncated GCM authentication tags (fail closed)", async () => {
+    const provider = await FileSecretProvider.create(secretsPath, adminToken);
+    const handle = await provider.store("SECRET", "classified");
+
+    const raw = readFileSync(secretsPath, "utf8");
+    const store = JSON.parse(raw) as {
+      handles: Record<string, { authTag: string }>;
+    };
+    store.handles[handle.handle_id].authTag = store.handles[handle.handle_id].authTag.slice(0, 16);
+    writeFileSync(secretsPath, JSON.stringify(store), { mode: 0o600 });
+
+    await expect(provider.resolve(handle)).rejects.toThrow();
+  });
+
   it("different admin tokens cannot decrypt", async () => {
     const provider1 = await FileSecretProvider.create(secretsPath, "token-alpha");
     const handle = await provider1.store("SECRET", "classified");


### PR DESCRIPTION
## Summary
- Enforce 16-byte (128-bit) AES-256-GCM auth tags for FileSecretProvider encryption/decryption (Semgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length)
- Add regression test that truncated tags fail closed

## Test Plan
- [x] pnpm test
- [x] pnpm typecheck
- [x] pnpm lint