### PR TITLE
fix(client): remove TLS verification bypass

### DIFF
--- a/docs/advanced/remote-gateway.md
+++ b/docs/advanced/remote-gateway.md
@@ -63,7 +63,8 @@ Notes:
 
 - Pinning is enforced only for `wss://` URLs.
 - Browser-based clients cannot enforce certificate pinning.
-- When pinning is configured, clients use **trust-by-fingerprint** (the pinned cert is accepted even if it is not CA-trusted); hostname validation still applies.
+- When pinning is configured, Node clients still perform standard TLS verification (CA trust + hostname validation) and **also** verify the configured fingerprint.
+- For private PKI / self-signed deployments, add your CA to the OS/Node trust store, or pass `tlsCaCertPem` when constructing `TyrumClient`.
 
 ## Troubleshooting
 

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -214,9 +214,18 @@ export interface TyrumClientOptions {
    *
    * The value is the server certificate's SHA-256 fingerprint, as hex (with or
    * without `:`), case-insensitive. When set, the client will refuse to
-   * connect if the remote certificate does not match.
+   * connect if the remote certificate does not match. Standard TLS verification
+   * (CA trust + hostname) still applies.
    */
   tlsCertFingerprint256?: string;
+  /**
+   * Optional PEM-encoded CA certificate(s) used for Node.js `wss://` TLS
+   * verification when `tlsCertFingerprint256` is enabled.
+   *
+   * Use this for private PKI / self-signed deployments, or configure your OS /
+   * Node trust store instead.
+   */
+  tlsCaCertPem?: string;
   /** Capabilities to advertise in the hello handshake. */
   capabilities: ClientCapability[];
   /** Peer role for vNext handshake. Defaults to `client`. */
@@ -795,11 +804,16 @@ export class TyrumClient {
           callback(err, socket);
         };
 
+        const caCertPemRaw =
+          typeof this.opts.tlsCaCertPem === "string" ? this.opts.tlsCaCertPem : "";
+        const caCertPemTrimmed = caCertPemRaw.trim();
+        const caCertPem = caCertPemTrimmed.length ? caCertPemTrimmed : undefined;
+
         const socket = tls.connect({
           host: hostname,
           port,
           servername,
-          rejectUnauthorized: false,
+          ca: caCertPem,
         }) as import("node:tls").TLSSocket;
 
         socket.once("error", (err: Error) => {

--- a/packages/client/tests/tls-pinning.test.ts
+++ b/packages/client/tests/tls-pinning.test.ts
@@ -51,57 +51,58 @@ async function acceptConnect(ws: WsWebSocket, clientId = "client-1"): Promise<vo
 }
 
 const LOCALHOST_KEY_PEM = `-----BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDGT2L8H2cSqKyR
-ffeHuggcEaEkSai7P+WZ2aGADGrElyWuDKOf7u4YtABVsSlAA4i3JK5d8WlP7vy4
-1BC2bc2Pw4yJmqhy3M0tfHv9oy/6kTGYKB7TdJT0oov3Me70/Gx6wq+HRuCu6Zho
-exNp+jJ8bPl9+1o/Oa3ZX8INNSV7mKlbemdK0V00TtHKVSmF7AZhG9SnUKchhQ2J
-T27rQ7QiwwOYNy0NPi2Za7OlSvTSiaBAAn6PP0spCFrivTro963jfYpfpyUyRjxS
-vq0CdkbUQCdJBjuQ/3wKRSTG8JAb823gE9fMqAALH1t07LmUXScktmMtZEmnpQZT
-7DbLqbkrAgMBAAECggEAQ0snHMUPNf606H4lZBJVtCirVOQF9Nye7hEyw3/zLxjX
-OXOihqAOfaV/Q5TlmYpZd0RkQw6rnOtNKO8VaMJj8ff6las8pBWXLmtCq/QXUOC6
-QpbCtyCld0o9UrnIC6wop5Ou+qmrjs9H35R8Jwc24JAeLYkAu9m3y76527+AI6s1
-nPswjGXN7W/yLPzLbcnNz67mizBEuojM7ITNdAL2xFflsg1ujgXoBpJz1Dn8h4PS
-HPUOGlT1jXrgMxmZrHXZC7dTF5C3jgLGtC6pCRIiFEJkWdviEBGPqR3HUmAk1OEc
-UDt5eHiVLhhtfrQYwiRKFNIk7KaI1prMga37eyV92QKBgQD3hv3IsSVzh+LMb4bH
-8IwUAnXA2Ph/ir3GPh0Q1X+vdOI/awq4/CR8dR64gSom4cAw10GVvcdaXSK+aIWv
-lZpbXcTT1a42lDs/1ovuJTfEt5kyttWoWV9LuxqWJZaj+HiqdxQl69MT2JGimZ50
-gWJY7IB/CV4E28jhgRORKUm0HQKBgQDNGR6WzOSOYtTktZuTtWKTcR2/DwpCMaJM
-hCV2ssZwLgaXjygMkDnXrRh5K66C8Emv3RLJ5+o0BHhWi+aQleq7oxsLe2+Q9ugK
-jW0sqYWcpBa8EhbWMM3JwjptG4nXc9c1W02Dw7sDw8vadOfk+ZjC20zWDaE0kFPf
-JtPAuvyP5wKBgQCLG3s+sYeJoQFtwPOvI9mlWSiSI52sF+3FHp05G7MxiO+pkl+p
-TFK4+x0ztatZxJ89E4wROmFxwEvJVHZlEh94X39BSaIpnC6cFtf3E0V/MWtQW/5B
-KVDr/4/Wd/Nr3TT7IAbbtOegDKL0DX9GnHwH24nvWvVSp64CRYcYmmqIZQKBgAWC
-1EiXDtkonLHck2afrBtsIbF9lPf8X3EQ5/TNjvl6syClbx0PTw6Vjx/KZbENBd3c
-4eFdAvUM3bLtpW9jJ+CM3HAti+zoRYnrDPDzSSzRV+8LyWNOAmmWd31xDP4mFbVQ
-U7/jpYXPYA3psEV903YA8Iqb6SYBbs+DOpNmMt0nAoGBAOyy+SOZJ1cmaPUb3hGQ
-g8nWAnrGBkGnekwC8M0xoSbOVmIEQ6I5dPm9CjJYGGKAnEeMZPmBdoPbPsIZd9Iw
-H0WvcIrHBT758SPAzeqN18TtU1Z2jvqsfdfxNoC26kgWj2iX0bszlqHClqQi348Q
-OODWsR61F6ETxDc5mB7Fcg3s
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDKmma998uRhHdY
+KadWw/v/nxsKMrMhXYBLy+QVAAUan8lurGZCLJ03ePnEjTu6eDxeTIcnzX5BOzyS
+QQ88qV/L+NBIT0Hpb3LtCGXTs4LmC7PrdkMsiRbgZAev8JiOPLLFw8Vf3SFNdkrO
+jqsr8Dv/n1lYuPj0oC0tQ4rtpaHJ7X6+S1he4HWR7R2xU9vQs0TXFnFG8bWIfT5x
+tnizygNyXY7OHT+k4eVmq32ggZ5nd3ewNGurPShA7Gf+4f9b+p34opcK5SEvJ1ZT
+DyTUZ4y2rTWAMWUoqEIbf+tG6e8ih5m8R3O4la6MM20eq1NMGZu4GDf8QhvdZUJI
+RVVHK5ixAgMBAAECggEAA4nt8+ZoqXnQOVZJ6wMDle04zvqVedEs+7XxHbjz6IlZ
+s/uM0jNUCtXhEUuGZhfcoGjds/vmgdvCZODAHsHBGk+WDhXx+2fepftUxv1j0reU
+h2R34NFjWJzwAZpWLybU2GLhNyRQ784lA/Bb7EmsYfHDNmCNuv0eE47dAHtkBOzq
+GTLZLDK0vQK0DF8HPsEN+WeyxifNuYkZ5JotNNKLmppAVCNP8KvrXbAlNFqZwMvJ
+qyY8vO/x8o1Zr5Ki93m4BbUtpT6lGIXHe1tOXto3nofZRoyd9cFR2GseIkafRYF6
+39gOpznIT6+VnHTFN9GJfm1oaRD/ENc/izmqPSmC+QKBgQD2neZCR22aD1WxH8PG
+pCnk1L60qsQWD4wkiI0XcQOyYzFkDN1yhjDVbzgX2ypzHiVQnJCN3z1NsrdiYvCh
+Nc/re0xKFUUBH9E7bWYAwsJm0EF5AwL7bnkeJBKdoyS/ZgmokymH5dr99dGWkBZo
+bHN3OltagBTkHbnmuYtdB8L3qQKBgQDST8yho/eGsZPqpXfUSwrw0HX7IYE+YARl
+ienmeYAVOMOmf3fcZ8mR/OiivYKa/RasRF4bdpWyut45pmtCmRM5ntjkLKjHwDJQ
+DiPUdwuSNzxb7aE/uKY5R6yxYMVQzlrNQnDFMRJ6XMNL37RwfJOJ6NXrwc4C/07V
+rdJAcmEdyQKBgD+pp0U41yxMBR0CTDG9MytlWA2ff5sKTG0p6vJANGoafSeMwqXL
+ylNusJZH939cKtnScOaO2G50Ui7Nx7x1/cSWQa1mLDgMFKE4rnpHzJNp81zf0CdD
+73Q+b6fN87CNELU5uCDiz1N736z0aTRvuqbuo6KLKdlxawoKn9VWKZhxAoGBAMZN
+rjKfq87adBGlcia/l5JXzVc9UWNiH+MqNl02JVpdSsYcnQU666p24VhJ/vNrPsyy
+LlYQ67g6UT3kuHB0a9dB+1qy7XZjuE0Z+BjnIwb8hDJeD1RJJJsQBTq/d23pFV9D
+jZex3K15+D/7sGT8YhWAcO06sajL2SbMHlrcPsxZAoGAFYdpulnFUL7fAL/Zqx1A
+QbA+vsFULQTK5K8yELWOrg0jUW6gUEV0LKCWBHeREqIjl48wCgshF//1UpZ/V0K+
+g49I3BaJXeyYFS7YErqKZiMHH5dOBeX+KcxIeON1h8TSKDNtfltdrzzWG38RLtWU
+/aVwWykHXK0bXg8SKqZG2Ec=
 -----END PRIVATE KEY-----`;
 
 const LOCALHOST_CERT_PEM = `-----BEGIN CERTIFICATE-----
-MIIDHzCCAgegAwIBAgIUM4BVx2jDYxcHca4h5xmcdRphQXgwDQYJKoZIhvcNAQEL
-BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDIyNDE5NDcwNVoXDTI2MDIy
-NTE5NDcwNVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAxk9i/B9nEqiskX33h7oIHBGhJEmouz/lmdmhgAxqxJcl
-rgyjn+7uGLQAVbEpQAOItySuXfFpT+78uNQQtm3Nj8OMiZqoctzNLXx7/aMv+pEx
-mCge03SU9KKL9zHu9PxsesKvh0bgrumYaHsTafoyfGz5fftaPzmt2V/CDTUle5ip
-W3pnStFdNE7RylUphewGYRvUp1CnIYUNiU9u60O0IsMDmDctDT4tmWuzpUr00omg
-QAJ+jz9LKQha4r066Pet432KX6clMkY8Ur6tAnZG1EAnSQY7kP98CkUkxvCQG/Nt
-4BPXzKgACx9bdOy5lF0nJLZjLWRJp6UGU+w2y6m5KwIDAQABo2kwZzAdBgNVHQ4E
-FgQUgSFOb6AmgUThMGy7H01E3gwrApAwHwYDVR0jBBgwFoAUgSFOb6AmgUThMGy7
-H01E3gwrApAwDwYDVR0TAQH/BAUwAwEB/zAUBgNVHREEDTALgglsb2NhbGhvc3Qw
-DQYJKoZIhvcNAQELBQADggEBADOnfHYjiFYL2aFXLTTNoTPjmkcllvFSrRCFmWLQ
-wpDV5ZhHF8tFjZYlItsb9tZDklFrK+6SGRckKifrgeNOO26Joy7Jbx7DZ2Cw7lcD
-7uJZh8o4Ez+zMGFzKmxbu7i2LL+Snjs3QVF3k9hEJuJhofhxvi3oYf6tYlvZSYaI
-EaGVxsgV26FYq7U2ufaE8C1W1Yx6VJmsXmeh0H6aK7/hJpWB5S8PwBYelwJWQsj9
-1Elt886dGoTX3u8GWXYf4WN/9X9jmTjkRuIdLcjNwJODWlXKh6oq7n/VyBVadNUb
-seIrpr4hBpDBDCtxGBv8QuqGXXNVr7IZXv+rAagxCIrQ3jo=
+MIIDHzCCAgegAwIBAgIUHmOQAn2wXqSFYKsp73om7L+Bh4cwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDMwMjE0NTU1MFoXDTM2MDIy
+ODE0NTU1MFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAyppmvffLkYR3WCmnVsP7/58bCjKzIV2AS8vkFQAFGp/J
+bqxmQiydN3j5xI07ung8XkyHJ81+QTs8kkEPPKlfy/jQSE9B6W9y7Qhl07OC5guz
+63ZDLIkW4GQHr/CYjjyyxcPFX90hTXZKzo6rK/A7/59ZWLj49KAtLUOK7aWhye1+
+vktYXuB1ke0dsVPb0LNE1xZxRvG1iH0+cbZ4s8oDcl2Ozh0/pOHlZqt9oIGeZ3d3
+sDRrqz0oQOxn/uH/W/qd+KKXCuUhLydWUw8k1GeMtq01gDFlKKhCG3/rRunvIoeZ
+vEdzuJWujDNtHqtTTBmbuBg3/EIb3WVCSEVVRyuYsQIDAQABo2kwZzAdBgNVHQ4E
+FgQUu7d333Rp08IsecJUURlk+hW8zGEwHwYDVR0jBBgwFoAUu7d333Rp08IsecJU
+URlk+hW8zGEwDwYDVR0TAQH/BAUwAwEB/zAUBgNVHREEDTALgglsb2NhbGhvc3Qw
+DQYJKoZIhvcNAQELBQADggEBADZ2EEJ2XbtRzTS5BLh/kzD4/z7EzHjcovq/thTv
+JqBmqyioO69wyL1P1Axo7s1LLRFSFgIVpBcYgVwgm5KvwzXaUR6HBuLpLcK5iGeU
+TtBFmy13s/7YW+wKa9v74qN4QEQEGZWAP8Hs61nuRmejt898mSY2+I2SK/5Wsbgf
+7Xgr7vepf9MBV+Mc5OI0s5Ik4qJr4jOkIOf1FS94LTaUGK86dFMR2KiPdX0VTKiw
+ZUgdgr+jG3//EQG2CgZrofePBs20poQx1Sf/b6vpcR5u2oMY5YaEOk4TwqNi6TiR
+Ynb0ZZ9vCVyxnwC5aLw3DDYzEsuAd9JTDEbNfbR8qd26hMk=
 -----END CERTIFICATE-----`;
 
 async function createSecureTestServer(): Promise<{
   url: string;
   fingerprint256: string;
+  caCertPem: string;
   close: () => Promise<void>;
   waitForClient: () => Promise<WsWebSocket>;
 }> {
@@ -137,7 +138,7 @@ async function createSecureTestServer(): Promise<{
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 
-  return { url, fingerprint256, close, waitForClient };
+  return { url, fingerprint256, caCertPem: LOCALHOST_CERT_PEM, close, waitForClient };
 }
 
 describe("TLS certificate pinning", () => {
@@ -154,7 +155,7 @@ describe("TLS certificate pinning", () => {
     vi.restoreAllMocks();
   });
 
-  it("connects when the configured fingerprint matches", async () => {
+  it("rejects untrusted TLS certificates even when the fingerprint matches", async () => {
     server = await createSecureTestServer();
     client = new TyrumClient({
       url: server.url,
@@ -162,6 +163,33 @@ describe("TLS certificate pinning", () => {
       capabilities: [],
       reconnect: false,
       tlsCertFingerprint256: server.fingerprint256,
+    });
+
+    const connectedSpy = vi.fn();
+    client.on("connected", connectedSpy);
+
+    const transportError = new Promise<{ message: string }>((resolve) => {
+      client!.on("transport_error", resolve);
+    });
+
+    client.connect();
+
+    const err = await withTimeout(transportError, 2_000, "transport_error");
+    expect(err.message.toLowerCase()).toMatch(
+      /self\s*signed|unable to verify|local issuer|certificate/,
+    );
+    expect(connectedSpy).not.toHaveBeenCalled();
+  });
+
+  it("connects when the configured fingerprint matches and the CA is trusted", async () => {
+    server = await createSecureTestServer();
+    client = new TyrumClient({
+      url: server.url,
+      token: "test-token",
+      capabilities: [],
+      reconnect: false,
+      tlsCertFingerprint256: server.fingerprint256,
+      tlsCaCertPem: server.caCertPem,
     });
 
     const connected = new Promise<void>((resolve) => {
@@ -186,6 +214,7 @@ describe("TLS certificate pinning", () => {
       tlsCertFingerprint256: server.fingerprint256.replace(/[0-9A-F]/, (c) =>
         c === "A" ? "B" : "A",
       ),
+      tlsCaCertPem: server.caCertPem,
     });
 
     const connectedSpy = vi.fn();
@@ -212,6 +241,7 @@ describe("TLS certificate pinning", () => {
       tlsCertFingerprint256: server.fingerprint256.replace(/[0-9A-F]/, (c) =>
         c === "A" ? "B" : "A",
       ),
+      tlsCaCertPem: server.caCertPem,
     });
 
     const scheduleSpy = vi.spyOn(


### PR DESCRIPTION
## Summary
- Remove the `rejectUnauthorized: false` TLS verification bypass from Node `tlsCertFingerprint256` pinning.
- Add `tlsCaCertPem` to allow private PKI / self-signed deployments without disabling verification.
- Update docs and TLS pinning tests to match the new behavior.

## Test Plan
- [x] pnpm test
- [x] pnpm typecheck
- [x] pnpm lint