### PR TITLE
test(operator-ui): add coverage for platform and workboard pages

### DIFF
--- a/packages/operator-ui/tests/pages/platform-pages.test.ts
+++ b/packages/operator-ui/tests/pages/platform-pages.test.ts
@@ -1,0 +1,634 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import type { OperatorCore } from "../../../operator-core/src/index.js";
+import type { DesktopApi } from "../../src/desktop-api.js";
+import { OperatorUiHostProvider } from "../../src/host/host-api.js";
+import { BrowserCapabilitiesPage } from "../../src/components/pages/platform/browser-capabilities-page.js";
+import { PlatformConnectionPage } from "../../src/components/pages/platform/connection-page.js";
+import { PlatformDebugPage } from "../../src/components/pages/platform/debug-page.js";
+import { PlatformDiagnosticsPanel } from "../../src/components/pages/platform/diagnostics.js";
+import { PlatformLogsPanel } from "../../src/components/pages/platform/logs.js";
+import { PlatformPermissionsPage } from "../../src/components/pages/platform/permissions-page.js";
+import { cleanupTestRoot, renderIntoDocument, setNativeValue } from "../test-utils.js";
+
+type HostValue =
+  | {
+      kind: "web";
+    }
+  | {
+      kind: "desktop";
+      api: DesktopApi | null;
+    };
+
+function renderWithHost(host: HostValue, element: React.ReactElement) {
+  return renderIntoDocument(React.createElement(OperatorUiHostProvider, { value: host }, element));
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function clickTab(container: HTMLElement, label: string): void {
+  const tab = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]')).find((el) =>
+    el.textContent?.includes(label),
+  );
+  expect(tab).not.toBeUndefined();
+  tab?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+}
+
+function clickButton(container: HTMLElement, label: string): void {
+  const button = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((el) =>
+    el.textContent?.includes(label),
+  );
+  expect(button).not.toBeUndefined();
+  button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+function getInputByLabel(container: HTMLElement, labelText: string): HTMLInputElement {
+  const label = Array.from(container.querySelectorAll<HTMLLabelElement>("label")).find((el) =>
+    el.textContent?.includes(labelText),
+  );
+  expect(label).not.toBeUndefined();
+  const id = label?.getAttribute("for");
+  expect(id).toBeTruthy();
+  const input = id ? container.querySelector<HTMLInputElement>(`input[id="${id}"]`) : null;
+  expect(input).not.toBeNull();
+  return input!;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Platform pages", () => {
+  it("renders the browser capabilities placeholder", () => {
+    const testRoot = renderIntoDocument(React.createElement(BrowserCapabilitiesPage));
+    try {
+      expect(testRoot.container.textContent).toContain("Browser Capabilities");
+      expect(testRoot.container.textContent).toContain("Coming soon");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("renders debug tabs and switches from logs to diagnostics", async () => {
+    const testRoot = renderWithHost({ kind: "web" }, React.createElement(PlatformDebugPage));
+    try {
+      expect(testRoot.container.textContent).toContain("Debug");
+      expect(testRoot.container.textContent).toContain(
+        "Logs are only available in the desktop app.",
+      );
+
+      await act(async () => {
+        clickTab(testRoot.container, "Diagnostics");
+        await Promise.resolve();
+      });
+
+      expect(testRoot.container.textContent).toContain(
+        "Diagnostics are only available in the desktop app.",
+      );
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows connection-page fallback states for non-desktop and missing desktop api", () => {
+    const webRoot = renderWithHost(
+      { kind: "web" },
+      React.createElement(PlatformConnectionPage, { core: {} as OperatorCore }),
+    );
+    try {
+      expect(webRoot.container.textContent).toContain(
+        "Platform connection controls are only available in the desktop app.",
+      );
+    } finally {
+      cleanupTestRoot(webRoot);
+    }
+
+    const missingApiRoot = renderWithHost(
+      { kind: "desktop", api: null },
+      React.createElement(PlatformConnectionPage, { core: {} as OperatorCore }),
+    );
+    try {
+      expect(missingApiRoot.container.textContent).toContain("Desktop API not available.");
+    } finally {
+      cleanupTestRoot(missingApiRoot);
+    }
+  });
+
+  it("runs embedded and remote connection actions through desktop api", async () => {
+    const statusListeners: Array<(status: unknown) => void> = [];
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({
+        mode: "remote",
+        embedded: { port: 9001 },
+        remote: {
+          wsUrl: "wss://saved.example/ws",
+          tokenRef: "saved-token",
+          tlsCertFingerprint256: "AA:BB",
+        },
+      })),
+      setConfig: vi.fn(async () => {}),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "stopped", port: 9001 })),
+        start: vi.fn(async () => ({ status: "running", port: 9001 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((cb: (status: unknown) => void) => {
+        statusListeners.push(cb);
+        return () => {};
+      }),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformConnectionPage, { core: {} as OperatorCore }),
+    );
+
+    try {
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain(
+        "A token is already saved. Leave blank to reuse it, or enter a new token to replace it.",
+      );
+
+      const wsUrlInput = getInputByLabel(testRoot.container, "Gateway WebSocket URL");
+      const tokenInput = getInputByLabel(testRoot.container, "Token");
+      const fingerprintInput = getInputByLabel(
+        testRoot.container,
+        "TLS certificate fingerprint (SHA-256, optional)",
+      );
+
+      act(() => {
+        setNativeValue(wsUrlInput, "  wss://edge.example/ws  ");
+        setNativeValue(tokenInput, "  top-secret-token  ");
+        setNativeValue(fingerprintInput, "  AB:CD:EF  ");
+      });
+
+      await act(async () => {
+        clickButton(testRoot.container, "Connect");
+        await Promise.resolve();
+      });
+
+      expect(desktopApi.node.connect).toHaveBeenCalledTimes(1);
+      expect(desktopApi.setConfig).toHaveBeenCalledWith({
+        mode: "remote",
+        remote: {
+          wsUrl: "  wss://edge.example/ws  ",
+          tokenRef: "top-secret-token",
+          tlsCertFingerprint256: "AB:CD:EF",
+        },
+      });
+      expect(testRoot.container.textContent).toContain("Disconnect");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Disconnect");
+        await Promise.resolve();
+      });
+      expect(desktopApi.node.disconnect).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        clickTab(testRoot.container, "Embedded");
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        clickButton(testRoot.container, "Start Gateway");
+        await Promise.resolve();
+      });
+      expect(desktopApi.gateway.start).toHaveBeenCalledTimes(1);
+      expect(desktopApi.setConfig).toHaveBeenCalledWith({
+        mode: "embedded",
+        embedded: { port: 9001 },
+      });
+
+      await act(async () => {
+        clickButton(testRoot.container, "Stop Gateway");
+        await Promise.resolve();
+      });
+      expect(desktopApi.gateway.stop).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        statusListeners[0]?.({ gatewayStatus: "running", nodeStatus: "connected", port: 9010 });
+      });
+      expect(testRoot.container.textContent).toContain("Status: running");
+      await act(async () => {
+        clickTab(testRoot.container, "Remote");
+        await Promise.resolve();
+      });
+      expect(testRoot.container.textContent).toContain("Node status: connected");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows gateway errors when starting embedded mode fails", async () => {
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({ mode: "embedded", embedded: { port: 8788 } })),
+      setConfig: vi.fn(async () => {}),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "stopped", port: 8788 })),
+        start: vi.fn(async () => {
+          throw new Error("start failed");
+        }),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformConnectionPage, { core: {} as OperatorCore }),
+    );
+    try {
+      await flushEffects();
+      await act(async () => {
+        clickButton(testRoot.container, "Start Gateway");
+        await Promise.resolve();
+      });
+
+      expect(testRoot.container.textContent).toContain("Gateway error");
+      expect(testRoot.container.textContent).toContain("start failed");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows permission-page fallback states for non-desktop and missing desktop api", () => {
+    const webRoot = renderWithHost({ kind: "web" }, React.createElement(PlatformPermissionsPage));
+    try {
+      expect(webRoot.container.textContent).toContain(
+        "Platform permission controls are only available in the desktop app.",
+      );
+    } finally {
+      cleanupTestRoot(webRoot);
+    }
+
+    const missingApiRoot = renderWithHost(
+      { kind: "desktop", api: null },
+      React.createElement(PlatformPermissionsPage),
+    );
+    try {
+      expect(missingApiRoot.container.textContent).toContain("Desktop API not available.");
+    } finally {
+      cleanupTestRoot(missingApiRoot);
+    }
+  });
+
+  it("loads, edits, and saves platform permission settings", async () => {
+    const setConfig = vi.fn(async () => {});
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({
+        permissions: { profile: "balanced" },
+        capabilities: { desktop: true, playwright: true, cli: true, http: true },
+        cli: { allowedCommands: [], allowedWorkingDirs: [] },
+        web: { allowedDomains: [], headless: true },
+      })),
+      setConfig,
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "stopped", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformPermissionsPage),
+    );
+    try {
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain("CLI allowlist is active and empty");
+      expect(testRoot.container.textContent).toContain("Domain allowlist is active and empty");
+
+      const safeLabel = Array.from(testRoot.container.querySelectorAll("label")).find((el) =>
+        el.textContent?.includes("Safe"),
+      );
+      expect(safeLabel).not.toBeUndefined();
+      act(() => {
+        safeLabel?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await act(async () => {
+        clickButton(testRoot.container, "Save Permissions");
+        await Promise.resolve();
+      });
+
+      expect(desktopApi.setConfig).toHaveBeenCalledTimes(1);
+      const firstPayload = desktopApi.setConfig.mock.calls[0]?.[0] as any;
+      expect(firstPayload.permissions.profile).toBe("safe");
+      expect(firstPayload.capabilities).toEqual({
+        desktop: true,
+        playwright: false,
+        cli: false,
+        http: false,
+      });
+
+      setConfig.mockRejectedValueOnce(new Error("persist failed"));
+      await act(async () => {
+        clickButton(testRoot.container, "Save");
+        await Promise.resolve();
+      });
+      expect(testRoot.container.textContent).toContain("Save failed");
+      expect(testRoot.container.textContent).toContain("persist failed");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows log-panel fallback states for non-desktop, missing api, and missing stream", () => {
+    const webRoot = renderWithHost({ kind: "web" }, React.createElement(PlatformLogsPanel));
+    try {
+      expect(webRoot.container.textContent).toContain(
+        "Logs are only available in the desktop app.",
+      );
+    } finally {
+      cleanupTestRoot(webRoot);
+    }
+
+    const missingApiRoot = renderWithHost(
+      { kind: "desktop", api: null },
+      React.createElement(PlatformLogsPanel),
+    );
+    try {
+      expect(missingApiRoot.container.textContent).toContain("Desktop API not available.");
+    } finally {
+      cleanupTestRoot(missingApiRoot);
+    }
+
+    const noStreamApi = {
+      getConfig: vi.fn(async () => ({})),
+      setConfig: vi.fn(async () => ({})),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "stopped", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+    } satisfies DesktopApi;
+    const noStreamRoot = renderWithHost(
+      { kind: "desktop", api: noStreamApi },
+      React.createElement(PlatformLogsPanel),
+    );
+    try {
+      expect(noStreamRoot.container.textContent).toContain(
+        "This desktop build does not expose log streaming.",
+      );
+    } finally {
+      cleanupTestRoot(noStreamRoot);
+    }
+  });
+
+  it("renders desktop logs, filters by tab, and clears entries", async () => {
+    let logListener: ((entry: unknown) => void) | null = null;
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({})),
+      setConfig: vi.fn(async () => ({})),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "running", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+      onLog: vi.fn((cb: (entry: unknown) => void) => {
+        logListener = cb;
+        return () => {};
+      }),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformLogsPanel),
+    );
+    try {
+      expect(testRoot.container.textContent).toContain("No log entries yet");
+
+      act(() => {
+        logListener?.({
+          timestamp: "2026-01-01T00:00:00.000Z",
+          level: "info",
+          source: "gateway",
+          message: "gateway ready",
+        });
+        logListener?.({
+          timestamp: "2026-01-01T00:00:01.000Z",
+          level: "warn",
+          source: "node",
+          message: "node warning",
+        });
+      });
+
+      expect(testRoot.container.textContent).toContain("gateway ready");
+
+      await act(async () => {
+        clickTab(testRoot.container, "Node");
+        await Promise.resolve();
+      });
+      expect(testRoot.container.textContent).toContain("node warning");
+
+      act(() => {
+        clickButton(testRoot.container, "Clear");
+      });
+      expect(testRoot.container.textContent).toContain("No log entries yet");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows diagnostics fallback states for non-desktop and missing desktop api", () => {
+    const webRoot = renderWithHost({ kind: "web" }, React.createElement(PlatformDiagnosticsPanel));
+    try {
+      expect(webRoot.container.textContent).toContain(
+        "Diagnostics are only available in the desktop app.",
+      );
+    } finally {
+      cleanupTestRoot(webRoot);
+    }
+
+    const missingApiRoot = renderWithHost(
+      { kind: "desktop", api: null },
+      React.createElement(PlatformDiagnosticsPanel),
+    );
+    try {
+      expect(missingApiRoot.container.textContent).toContain("Desktop API not available.");
+    } finally {
+      cleanupTestRoot(missingApiRoot);
+    }
+  });
+
+  it("handles unavailable permission-request API in diagnostics panel", async () => {
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({ mode: "embedded" })),
+      setConfig: vi.fn(async () => {}),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "running", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+      checkMacPermissions: vi.fn(async () => null),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformDiagnosticsPanel),
+    );
+    try {
+      await flushEffects();
+      act(() => {
+        clickButton(testRoot.container, "Request Accessibility");
+      });
+      expect(testRoot.container.textContent).toContain(
+        "Permission requests are not available in this build.",
+      );
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("runs diagnostics checks, permission requests, and desktop update actions", async () => {
+    let updateStateListener: ((state: unknown) => void) | null = null;
+    const baseUpdateState = {
+      stage: "idle",
+      currentVersion: "1.0.0",
+      availableVersion: null,
+      downloadedVersion: null,
+      releaseDate: null,
+      releaseNotes: null,
+      progressPercent: null,
+      message: null,
+      checkedAt: null,
+    };
+
+    const desktopApi = {
+      getConfig: vi.fn(async () => ({ mode: "embedded" })),
+      setConfig: vi.fn(async () => {}),
+      gateway: {
+        getStatus: vi.fn(async () => ({ status: "running", port: 8788 })),
+        start: vi.fn(async () => ({ status: "running", port: 8788 })),
+        stop: vi.fn(async () => ({ status: "stopped" })),
+      },
+      node: {
+        connect: vi.fn(async () => ({ status: "connected" })),
+        disconnect: vi.fn(async () => ({ status: "disconnected" })),
+      },
+      onStatusChange: vi.fn((_cb: (status: unknown) => void) => () => {}),
+      checkMacPermissions: vi.fn(async () => ({
+        accessibility: false,
+        screenRecording: true,
+        instructions: "Open Settings",
+      })),
+      requestMacPermission: vi.fn(async () => ({
+        granted: false,
+        instructions: "Open Settings",
+      })),
+      updates: {
+        getState: vi.fn(async () => baseUpdateState),
+        check: vi.fn(async () => ({
+          ...baseUpdateState,
+          stage: "available",
+          availableVersion: "1.1.0",
+        })),
+        download: vi.fn(async () => ({
+          ...baseUpdateState,
+          stage: "downloading",
+          progressPercent: 25,
+        })),
+        install: vi.fn(async () => ({
+          ...baseUpdateState,
+          stage: "installing",
+        })),
+        openReleaseFile: vi.fn(async () => ({
+          opened: true,
+          path: "/tmp/release.zip",
+          message: null,
+        })),
+      },
+      onUpdateStateChange: vi.fn((cb: (state: unknown) => void) => {
+        updateStateListener = cb;
+        return () => {};
+      }),
+    } satisfies DesktopApi;
+
+    const testRoot = renderWithHost(
+      { kind: "desktop", api: desktopApi },
+      React.createElement(PlatformDiagnosticsPanel),
+    );
+    try {
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain("Missing: Accessibility");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Request Accessibility");
+        await Promise.resolve();
+      });
+      expect(desktopApi.requestMacPermission).toHaveBeenCalledWith("accessibility");
+      expect(testRoot.container.textContent).toContain("Open Settings");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Check for Updates");
+        await Promise.resolve();
+      });
+      expect(desktopApi.updates?.check).toHaveBeenCalledTimes(1);
+      expect(testRoot.container.textContent).toContain("Update check started.");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Download Update");
+        await Promise.resolve();
+      });
+      expect(desktopApi.updates?.download).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        updateStateListener?.({
+          ...baseUpdateState,
+          stage: "downloaded",
+          downloadedVersion: "1.1.0",
+        });
+      });
+
+      await act(async () => {
+        clickButton(testRoot.container, "Install Update");
+        await Promise.resolve();
+      });
+      expect(desktopApi.updates?.install).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        clickButton(testRoot.container, "Use Local Release File");
+        await Promise.resolve();
+      });
+      expect(desktopApi.updates?.openReleaseFile).toHaveBeenCalledTimes(1);
+      expect(testRoot.container.textContent).toContain("Installer opened.");
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+});

--- a/packages/operator-ui/tests/pages/workboard-page.test.ts
+++ b/packages/operator-ui/tests/pages/workboard-page.test.ts
@@ -1,0 +1,380 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import type { OperatorCore } from "../../../operator-core/src/index.js";
+import { WorkBoardPage } from "../../src/components/pages/workboard-page.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+function createConnectionStore(status: ConnectionStatus) {
+  const snapshot = { status, recovering: false };
+  return {
+    subscribe: (_listener: () => void) => () => {},
+    getSnapshot: () => snapshot,
+  };
+}
+
+function createWsStub(overrides?: Partial<Record<string, unknown>>) {
+  const handlers = new Map<string, Set<(event: any) => void>>();
+
+  const ws = {
+    on: vi.fn((event: string, handler: (payload: any) => void) => {
+      const existing = handlers.get(event) ?? new Set();
+      existing.add(handler);
+      handlers.set(event, existing);
+    }),
+    off: vi.fn((event: string, handler: (payload: any) => void) => {
+      const existing = handlers.get(event);
+      if (!existing) return;
+      existing.delete(handler);
+      if (existing.size === 0) handlers.delete(event);
+    }),
+    emit(event: string, payload: any) {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(payload);
+      }
+    },
+    workList: vi.fn(async () => ({ items: [] })),
+    workTransition: vi.fn(async ({ work_item_id, status }: any) => ({
+      item: makeWorkItem({ work_item_id, status }),
+    })),
+    workGet: vi.fn(async ({ work_item_id }: any) => ({ item: makeWorkItem({ work_item_id }) })),
+    workArtifactList: vi.fn(async () => ({ artifacts: [] })),
+    workDecisionList: vi.fn(async () => ({ decisions: [] })),
+    workSignalList: vi.fn(async () => ({ signals: [] })),
+    workStateKvList: vi.fn(async () => ({ entries: [] })),
+    workSignalGet: vi.fn(async ({ signal_id }: any) => ({
+      signal: {
+        signal_id,
+        work_item_id: "wi-1",
+        trigger_kind: "manual",
+        status: "fired",
+        created_at: "2026-01-01T00:00:00.000Z",
+        last_fired_at: "2026-01-01T00:00:01.000Z",
+        trigger_spec_json: { source: "event" },
+      },
+    })),
+    workStateKvGet: vi.fn(async ({ key, scope }: any) => ({
+      entry: {
+        scope,
+        key,
+        value_json: { value: key },
+      },
+    })),
+    ...overrides,
+  };
+
+  return ws;
+}
+
+function makeWorkItem(partial: Partial<Record<string, unknown>> & { work_item_id: string }) {
+  return {
+    work_item_id: partial.work_item_id,
+    title: "Ship regression tests",
+    kind: "task",
+    priority: 2,
+    status: "backlog",
+    acceptance: { done: true },
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:05:00.000Z",
+    last_active_at: "2026-01-01T00:10:00.000Z",
+    ...partial,
+  } as any;
+}
+
+function createCore(status: ConnectionStatus, wsOverrides?: Partial<Record<string, unknown>>) {
+  const ws = createWsStub(wsOverrides);
+  const core = {
+    connectionStore: createConnectionStore(status),
+    ws,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  } as unknown as OperatorCore;
+  return { core, ws };
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function clickButton(container: HTMLElement, label: string): void {
+  const button = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((el) =>
+    el.textContent?.includes(label),
+  );
+  expect(button).not.toBeUndefined();
+  button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("WorkBoardPage", () => {
+  it("shows disconnected state and reconnects", () => {
+    const { core } = createCore("disconnected");
+    const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
+
+    try {
+      expect(testRoot.container.textContent).toContain("Not connected");
+      const refreshButton = Array.from(
+        testRoot.container.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((el) => el.textContent?.includes("Refresh"));
+      expect(refreshButton?.disabled).toBe(true);
+
+      act(() => {
+        clickButton(testRoot.container, "Reconnect");
+      });
+
+      expect(core.disconnect).toHaveBeenCalledTimes(1);
+      expect(core.connect).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("loads work items, drills down, processes events, and transitions selected item", async () => {
+    const workItem = makeWorkItem({ work_item_id: "wi-1", status: "backlog" });
+    const { core, ws } = createCore("connected", {
+      workList: vi.fn(async () => ({ items: [workItem] })),
+      workGet: vi.fn(async () => ({ item: workItem })),
+      workArtifactList: vi.fn(async () => ({
+        artifacts: [
+          {
+            artifact_id: "artifact-1",
+            work_item_id: "wi-1",
+            kind: "note",
+            title: "Artifact title",
+            body_md: "Artifact body",
+            refs: [],
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      })),
+      workDecisionList: vi.fn(async () => ({
+        decisions: [
+          {
+            decision_id: "decision-1",
+            work_item_id: "wi-1",
+            question: "Ship?",
+            chosen: "yes",
+            rationale_md: "Looks good",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      })),
+      workSignalList: vi.fn(async () => ({
+        signals: [
+          {
+            signal_id: "signal-1",
+            work_item_id: "wi-1",
+            trigger_kind: "manual",
+            status: "pending",
+            trigger_spec_json: { source: "manual" },
+            created_at: "2026-01-01T00:00:00.000Z",
+            last_fired_at: null,
+          },
+        ],
+      })),
+      workStateKvList: vi.fn(async ({ scope }: any) => {
+        if (scope.kind === "agent") {
+          return {
+            entries: [
+              {
+                scope,
+                key: "agent.key",
+                value_json: { value: "agent" },
+              },
+            ],
+          };
+        }
+        return {
+          entries: [
+            {
+              scope,
+              key: "work.key",
+              value_json: { value: "work-item" },
+            },
+          ],
+        };
+      }),
+      workTransition: vi.fn(async ({ work_item_id, status }: any) => ({
+        item: makeWorkItem({ work_item_id, status }),
+      })),
+    });
+
+    const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
+    try {
+      await flushEffects();
+      expect(ws.workList).toHaveBeenCalledTimes(1);
+      expect(testRoot.container.textContent).toContain("Ship regression tests");
+
+      const workItemCard = Array.from(
+        testRoot.container.querySelectorAll<HTMLElement>('[role="button"]'),
+      ).find((el) => el.textContent?.includes("Ship regression tests"));
+      expect(workItemCard).not.toBeUndefined();
+
+      await act(async () => {
+        workItemCard?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      expect(ws.workGet).toHaveBeenCalledTimes(1);
+      expect(testRoot.container.textContent).toContain("Artifact title");
+      expect(testRoot.container.textContent).toContain("Looks good");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Mark Ready");
+        await Promise.resolve();
+      });
+      expect(ws.workTransition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          work_item_id: "wi-1",
+          status: "ready",
+          reason: "operator triaged",
+        }),
+      );
+
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => false),
+      );
+      await act(async () => {
+        clickButton(testRoot.container, "Cancel");
+        await Promise.resolve();
+      });
+      expect(ws.workTransition).toHaveBeenCalledTimes(1);
+
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => true),
+      );
+      await act(async () => {
+        clickButton(testRoot.container, "Cancel");
+        await Promise.resolve();
+      });
+      expect(ws.workTransition).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        ws.emit("work.task.paused", {
+          type: "work.task.paused",
+          occurred_at: "2026-01-01T00:01:00.000Z",
+          payload: {
+            work_item_id: "wi-1",
+            task_id: "task-1",
+            approval_id: 42,
+          },
+        });
+      });
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain("approval 42");
+
+      act(() => {
+        ws.emit("work.artifact.created", {
+          payload: {
+            artifact: {
+              artifact_id: "artifact-2",
+              work_item_id: "wi-1",
+              kind: "note",
+              title: "Live artifact",
+              body_md: "Created by event",
+              refs: [],
+              created_at: "2026-01-01T00:02:00.000Z",
+            },
+          },
+        });
+        ws.emit("work.decision.created", {
+          payload: {
+            decision: {
+              decision_id: "decision-2",
+              work_item_id: "wi-1",
+              question: "Proceed?",
+              chosen: "yes",
+              rationale_md: "Event decision",
+              created_at: "2026-01-01T00:02:00.000Z",
+            },
+          },
+        });
+        ws.emit("work.signal.updated", {
+          payload: {
+            signal: {
+              signal_id: "signal-2",
+              work_item_id: "wi-1",
+              trigger_kind: "manual",
+              status: "pending",
+              trigger_spec_json: { source: "event" },
+              created_at: "2026-01-01T00:02:00.000Z",
+              last_fired_at: null,
+            },
+          },
+        });
+      });
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain("Live artifact");
+      expect(testRoot.container.textContent).toContain("Event decision");
+
+      act(() => {
+        ws.emit("work.signal.fired", { payload: { signal_id: "signal-fired-1" } });
+        ws.emit("work.state_kv.updated", {
+          payload: {
+            scope: {
+              kind: "agent",
+              tenant_id: "default",
+              agent_id: "default",
+              workspace_id: "default",
+            },
+            key: "agent.from-event",
+          },
+        });
+        ws.emit("work.state_kv.updated", {
+          payload: {
+            scope: {
+              kind: "work_item",
+              tenant_id: "default",
+              agent_id: "default",
+              workspace_id: "default",
+              work_item_id: "wi-1",
+            },
+            key: "work.from-event",
+          },
+        });
+      });
+      await flushEffects();
+      expect(ws.workSignalGet).toHaveBeenCalledTimes(1);
+      expect(ws.workStateKvGet).toHaveBeenCalledTimes(2);
+      expect(testRoot.container.textContent).toContain("agent.from-event");
+      expect(testRoot.container.textContent).toContain("work.from-event");
+
+      await act(async () => {
+        clickButton(testRoot.container, "Refresh");
+        await Promise.resolve();
+      });
+      expect(ws.workList).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        clickButton(testRoot.container, "Reconnect");
+      });
+      expect(core.disconnect).toHaveBeenCalledTimes(1);
+      expect(core.connect).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("shows unsupported-request message when work.list is not available", async () => {
+    const { core } = createCore("connected", {
+      workList: vi.fn(async () => {
+        throw new Error("work.list failed: unsupported_request");
+      }),
+    });
+
+    const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
+    try {
+      await flushEffects();
+      expect(testRoot.container.textContent).toContain(
+        "WorkBoard is not supported by this gateway (database not configured).",
+      );
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+});

--- a/packages/operator-ui/tests/workboard-store.test.ts
+++ b/packages/operator-ui/tests/workboard-store.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORK_ITEM_STATUSES,
+  applyWorkTaskEvent,
+  groupWorkItemsByStatus,
+  selectTasksForSelectedWorkItem,
+  shouldProcessWorkStateKvUpdate,
+  upsertWorkArtifact,
+  upsertWorkDecision,
+  upsertWorkItem,
+  upsertWorkSignal,
+  upsertWorkStateKvEntry,
+  type WorkTaskEvent,
+} from "../src/components/workboard/workboard-store.js";
+
+function makeWorkItem(partial: Partial<Record<string, unknown>> & { work_item_id: string }) {
+  return {
+    work_item_id: partial.work_item_id,
+    status: "backlog",
+    title: "Work item",
+    kind: "task",
+    priority: 1,
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...partial,
+  } as any;
+}
+
+describe("workboard-store helpers", () => {
+  it("upserts work items by id and keeps newest insert first", () => {
+    const first = makeWorkItem({ work_item_id: "wi-1", title: "First" });
+    const second = makeWorkItem({ work_item_id: "wi-2", title: "Second" });
+    const updatedFirst = makeWorkItem({ work_item_id: "wi-1", title: "First updated" });
+
+    const inserted = upsertWorkItem([first], second);
+    expect(inserted.map((item) => item.work_item_id)).toEqual(["wi-2", "wi-1"]);
+
+    const updated = upsertWorkItem(inserted, updatedFirst);
+    expect(updated.map((item) => item.work_item_id)).toEqual(["wi-2", "wi-1"]);
+    expect(updated[1]?.title).toBe("First updated");
+  });
+
+  it("groups work items by status and ignores unknown statuses", () => {
+    const items = [
+      makeWorkItem({ work_item_id: "wi-backlog", status: "backlog" }),
+      makeWorkItem({ work_item_id: "wi-ready", status: "ready" }),
+      makeWorkItem({ work_item_id: "wi-done", status: "done" }),
+      makeWorkItem({ work_item_id: "wi-unknown", status: "mystery" }),
+    ];
+
+    const grouped = groupWorkItemsByStatus(items as any);
+    expect(Object.keys(grouped)).toEqual([...WORK_ITEM_STATUSES]);
+    expect(grouped.backlog.map((item) => item.work_item_id)).toEqual(["wi-backlog"]);
+    expect(grouped.ready.map((item) => item.work_item_id)).toEqual(["wi-ready"]);
+    expect(grouped.done.map((item) => item.work_item_id)).toEqual(["wi-done"]);
+  });
+
+  it("upserts artifacts, decisions, signals, and state kv entries by id/key", () => {
+    const artifacts = upsertWorkArtifact([{ artifact_id: "a-1", title: "old" } as any], {
+      artifact_id: "a-1",
+      title: "new",
+    } as any);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.title).toBe("new");
+
+    const decisions = upsertWorkDecision([{ decision_id: "d-1", chosen: "old" } as any], {
+      decision_id: "d-1",
+      chosen: "new",
+    } as any);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.chosen).toBe("new");
+
+    const signals = upsertWorkSignal([{ signal_id: "s-1", status: "pending" } as any], {
+      signal_id: "s-1",
+      status: "fired",
+    } as any);
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.status).toBe("fired");
+
+    const kvEntries = upsertWorkStateKvEntry([{ key: "foo", value_json: { value: 1 } } as any], {
+      key: "foo",
+      value_json: { value: 2 },
+    } as any);
+    expect(kvEntries).toHaveLength(1);
+    expect(kvEntries[0]?.value_json).toEqual({ value: 2 });
+  });
+
+  it("checks work-state-kv event applicability for selected work item", () => {
+    expect(
+      shouldProcessWorkStateKvUpdate(
+        {
+          kind: "agent",
+          tenant_id: "default",
+          agent_id: "default",
+          workspace_id: "default",
+        } as any,
+        null,
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldProcessWorkStateKvUpdate(
+        {
+          kind: "agent",
+          tenant_id: "default",
+          agent_id: "default",
+          workspace_id: "default",
+        } as any,
+        "wi-1",
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldProcessWorkStateKvUpdate(
+        {
+          kind: "work_item",
+          tenant_id: "default",
+          agent_id: "default",
+          workspace_id: "default",
+          work_item_id: "wi-1",
+        } as any,
+        "wi-1",
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldProcessWorkStateKvUpdate(
+        {
+          kind: "work_item",
+          tenant_id: "default",
+          agent_id: "default",
+          workspace_id: "default",
+          work_item_id: "wi-2",
+        } as any,
+        "wi-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns selected work item tasks and empty object for no selection", () => {
+    const tasksByWorkItemId = {
+      "wi-1": {
+        "task-1": {
+          task_id: "task-1",
+          status: "running",
+          last_event_at: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    };
+
+    expect(selectTasksForSelectedWorkItem(tasksByWorkItemId as any, "wi-1")).toEqual(
+      tasksByWorkItemId["wi-1"],
+    );
+    expect(selectTasksForSelectedWorkItem(tasksByWorkItemId as any, null)).toEqual({});
+    expect(selectTasksForSelectedWorkItem(tasksByWorkItemId as any, "missing")).toEqual({});
+  });
+
+  it("applies all work task event variants", () => {
+    const initial = {};
+
+    const leasedEvent: WorkTaskEvent = {
+      type: "work.task.leased",
+      occurred_at: "2026-01-01T00:00:00.000Z",
+      payload: {
+        work_item_id: "wi-1",
+        task_id: "task-1",
+        lease_expires_at_ms: 123,
+      },
+    };
+    const leased = applyWorkTaskEvent(initial, leasedEvent);
+    expect(leased["wi-1"]?.["task-1"]).toEqual({
+      task_id: "task-1",
+      status: "leased",
+      last_event_at: "2026-01-01T00:00:00.000Z",
+      lease_expires_at_ms: 123,
+    });
+
+    const started = applyWorkTaskEvent(leased, {
+      type: "work.task.started",
+      occurred_at: "2026-01-01T00:00:01.000Z",
+      payload: {
+        work_item_id: "wi-1",
+        task_id: "task-1",
+        run_id: "run-1",
+      },
+    });
+    expect(started["wi-1"]?.["task-1"]?.status).toBe("running");
+    expect(started["wi-1"]?.["task-1"]?.run_id).toBe("run-1");
+
+    const paused = applyWorkTaskEvent(started, {
+      type: "work.task.paused",
+      occurred_at: "2026-01-01T00:00:02.000Z",
+      payload: {
+        work_item_id: "wi-1",
+        task_id: "task-1",
+        approval_id: 7,
+      },
+    });
+    expect(paused["wi-1"]?.["task-1"]?.status).toBe("paused");
+    expect(paused["wi-1"]?.["task-1"]?.approval_id).toBe(7);
+
+    const completed = applyWorkTaskEvent(paused, {
+      type: "work.task.completed",
+      occurred_at: "2026-01-01T00:00:03.000Z",
+      payload: {
+        work_item_id: "wi-1",
+        task_id: "task-1",
+        result_summary: "ok",
+      },
+    });
+    expect(completed["wi-1"]?.["task-1"]?.status).toBe("completed");
+    expect(completed["wi-1"]?.["task-1"]?.result_summary).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary
- add platform page tests covering desktop/web host branches and desktop API action paths
- add workboard page tests for connected/disconnected flows, drilldown loading, transitions, and websocket event handling
- add workboard-store unit tests for upsert/group/select/event helpers, lifting `packages/operator-ui/src/**` coverage above enforced thresholds

## Test plan
- [x] `pnpm vitest run packages/operator-ui/tests/workboard-store.test.ts packages/operator-ui/tests/pages/platform-pages.test.ts packages/operator-ui/tests/pages/workboard-page.test.ts`
- [x] `VITEST_SHARD_RUN=1 pnpm vitest run packages/operator-ui/tests --coverage.enabled --coverage.include=\"packages/operator-ui/src/**\" --coverage.reporter=text-summary --coverage.reporter=json`