### PR TITLE
fix(operator-ui): reuse active auth for admin mode entry

### DIFF
--- a/packages/operator-ui/src/components/admin-mode/admin-mode-enter-dialog.tsx
+++ b/packages/operator-ui/src/components/admin-mode/admin-mode-enter-dialog.tsx
@@ -1,9 +1,6 @@
-import { createTyrumHttpClient } from "@tyrum/client";
 import { useEffect, useRef, useState } from "react";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
-import { Input } from "../ui/input.js";
-import { Label } from "../ui/label.js";
 import {
   Dialog,
   DialogContent,
@@ -14,7 +11,6 @@ import {
 } from "../ui/dialog.js";
 import { useAdminModeUiContext } from "./admin-mode-provider.js";
 import { formatErrorMessage } from "../../utils/format-error-message.js";
-import { resolveTyrumHttpFetch } from "../../utils/tyrum-http-fetch.js";
 
 export function AdminModeEnterDialog() {
   const { core, mode, isEnterOpen, requestEnter, closeEnter } = useAdminModeUiContext();
@@ -22,16 +18,10 @@ export function AdminModeEnterDialog() {
   const busyRef = useRef(busy);
   busyRef.current = busy;
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [revealToken, setRevealToken] = useState(false);
   const confirmRef = useRef<HTMLInputElement | null>(null);
-  const tokenRef = useRef<HTMLInputElement | null>(null);
 
   const resetForm = (): void => {
     setErrorMessage(null);
-    setRevealToken(false);
-    if (tokenRef.current) {
-      tokenRef.current.value = "";
-    }
     if (confirmRef.current) {
       confirmRef.current.checked = false;
     }
@@ -42,16 +32,10 @@ export function AdminModeEnterDialog() {
     resetForm();
   }, [isEnterOpen]);
 
-  const issueDeviceToken = async (adminToken: string): Promise<void> => {
-    const http = createTyrumHttpClient({
-      baseUrl: core.httpBaseUrl,
-      auth: { type: "bearer", token: adminToken },
-      fetch: resolveTyrumHttpFetch(mode),
-    });
-
-    const issued = await http.deviceTokens.issue({
+  const issueDeviceToken = async (): Promise<void> => {
+    const requestBody = {
       device_id: "operator-ui",
-      role: "client",
+      role: "client" as const,
       scopes: [
         "operator.read",
         "operator.write",
@@ -60,12 +44,15 @@ export function AdminModeEnterDialog() {
         "operator.admin",
       ],
       ttl_seconds: 60 * 10,
-    });
-
-    core.adminModeStore.enter({
-      elevatedToken: issued.token,
-      expiresAt: issued.expires_at,
-    });
+    };
+    const applyIssuedToken = (issued: { token: string; expires_at: string }): void => {
+      core.adminModeStore.enter({
+        elevatedToken: issued.token,
+        expiresAt: issued.expires_at,
+      });
+    };
+    const issued = await core.http.deviceTokens.issue(requestBody);
+    applyIssuedToken(issued);
   };
 
   const submit = async (): Promise<void> => {
@@ -77,16 +64,10 @@ export function AdminModeEnterDialog() {
       return;
     }
 
-    const adminToken = tokenRef.current?.value.trim() ?? "";
-    if (!adminToken) {
-      setErrorMessage("Admin token is required");
-      return;
-    }
-
     setBusy(true);
     setErrorMessage(null);
     try {
-      await issueDeviceToken(adminToken);
+      await issueDeviceToken();
       resetForm();
       closeEnter();
     } catch (error) {
@@ -128,7 +109,7 @@ export function AdminModeEnterDialog() {
         }}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
-          tokenRef.current?.focus();
+          confirmRef.current?.focus();
         }}
       >
         <DialogHeader>
@@ -145,36 +126,15 @@ export function AdminModeEnterDialog() {
             <span>I understand and want to proceed.</span>
           </label>
 
-          <div className="grid gap-2">
-            <Label htmlFor="admin-mode-token">Admin token</Label>
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <Input
-                  id="admin-mode-token"
-                  data-testid="admin-mode-token"
-                  ref={tokenRef}
-                  type={revealToken ? "text" : "password"}
-                  spellCheck={false}
-                  autoCapitalize="none"
-                  autoCorrect="off"
-                  autoComplete="off"
-                />
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                data-testid="admin-mode-token-toggle"
-                disabled={busy}
-                aria-pressed={revealToken}
-                onClick={() => {
-                  setRevealToken((prev) => !prev);
-                }}
-              >
-                {revealToken ? "Hide" : "Show"}
-              </Button>
-            </div>
-          </div>
+          {mode === "desktop" ? (
+            <p className="text-sm text-fg-muted">
+              Desktop connection auth is used automatically for Admin Mode.
+            </p>
+          ) : (
+            <p className="text-sm text-fg-muted">
+              Your authenticated web session is used automatically for Admin Mode.
+            </p>
+          )}
 
           {errorMessage ? (
             <Alert variant="error" title="Admin Mode error" description={errorMessage} />

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -3639,26 +3639,20 @@ describe("operator-ui", () => {
       "operator.admin",
     ];
 
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      expect(init?.method).toBe("POST");
-      expect(headers.get("authorization")).toBe("Bearer admin-token");
-
-      return new Response(
-        JSON.stringify({
-          token_kind: "device",
-          token: "elevated-device-token",
-          token_id: "token-1",
-          device_id: "operator-ui",
-          role: "client",
-          scopes: expectedScopes,
-          issued_at: issuedAt,
-          expires_at: expiresAt,
-        }),
-        { status: 201, headers: { "content-type": "application/json" } },
-      );
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const issueDeviceToken = vi.fn(async () => ({
+      token_kind: "device" as const,
+      token: "elevated-device-token",
+      token_id: "token-1",
+      device_id: "operator-ui",
+      role: "client" as const,
+      scopes: expectedScopes,
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+    }));
+    const revokeDeviceToken = vi.fn(async () => ({
+      revoked: true,
+      token_id: "token-1",
+    }));
 
     const ws = new FakeWsClient();
     const { http } = createFakeHttpClient();
@@ -3666,7 +3660,16 @@ describe("operator-ui", () => {
       wsUrl: "ws://example.test/ws",
       httpBaseUrl: "http://example.test",
       auth: createBearerTokenAuth("baseline"),
-      deps: { ws, http },
+      deps: {
+        ws,
+        http: {
+          ...http,
+          deviceTokens: {
+            issue: issueDeviceToken,
+            revoke: revokeDeviceToken,
+          },
+        },
+      },
     });
 
     const container = document.createElement("div");
@@ -3692,11 +3695,8 @@ describe("operator-ui", () => {
       enterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const tokenField = document.querySelector<HTMLInputElement>('[data-testid="admin-mode-token"]');
-    expect(tokenField).not.toBeNull();
-    act(() => {
-      tokenField!.value = "admin-token";
-    });
+    expect(document.querySelector('[data-testid="admin-mode-token"]')).toBeNull();
+    expect(document.querySelector('[data-testid="admin-mode-token-toggle"]')).toBeNull();
 
     const confirmCheckbox = document.querySelector<HTMLInputElement>(
       '[data-testid="admin-mode-confirm"]',
@@ -3717,15 +3717,13 @@ describe("operator-ui", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, callInit] = fetchMock.mock.calls[0] ?? [];
-    const bodyText = typeof callInit?.body === "string" ? callInit.body : "";
-    const body = JSON.parse(bodyText) as { scopes?: unknown; ttl_seconds?: unknown };
-    expect(body).toMatchObject({
-      ttl_seconds: 60 * 10,
-    });
-    expect(body.scopes).toEqual(expect.arrayContaining(expectedScopes));
-    expect(body.scopes).toHaveLength(expectedScopes.length);
+    expect(issueDeviceToken).toHaveBeenCalledTimes(1);
+    expect(issueDeviceToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ttl_seconds: 60 * 10,
+        scopes: expect.arrayContaining(expectedScopes),
+      }),
+    );
     expect(core.adminModeStore.getSnapshot()).toMatchObject({
       status: "active",
       elevatedToken: "elevated-device-token",
@@ -3763,32 +3761,138 @@ describe("operator-ui", () => {
     container.remove();
   });
 
+  it("uses desktop-managed auth without requiring token entry in desktop mode", async () => {
+    const issuedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 10 * 60_000).toISOString();
+
+    const ws = new FakeWsClient();
+    const { http } = createFakeHttpClient();
+    const fallbackIssue = vi.fn(async () => ({
+      token_kind: "device" as const,
+      token: "desktop-elevated-token",
+      token_id: "token-1",
+      device_id: "operator-ui",
+      role: "client" as const,
+      scopes: ["operator.admin"],
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+    }));
+    const fallbackRevoke = vi.fn(async () => ({ revoked: true, token_id: "token-1" }));
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("desktop-baseline-token"),
+      deps: {
+        ws,
+        http: {
+          ...http,
+          deviceTokens: {
+            issue: fallbackIssue,
+            revoke: fallbackRevoke,
+          },
+        },
+      },
+    });
+
+    const desktopHttpFetch = vi.fn(async () => ({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      bodyText: JSON.stringify({ status: "ok" }),
+    }));
+    (window as unknown as Record<string, unknown>)["tyrumDesktop"] = {
+      gateway: {
+        httpFetch: desktopHttpFetch,
+      },
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(AdminModeProvider, {
+          core,
+          mode: "desktop",
+          children: React.createElement(
+            AdminModeGate,
+            null,
+            React.createElement(
+              "button",
+              { type: "button", "data-testid": "danger-action" },
+              "Danger action",
+            ),
+          ),
+        }),
+      );
+    });
+
+    const enterButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="admin-mode-enter"]',
+    );
+    expect(enterButton).not.toBeNull();
+    act(() => {
+      enterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(document.querySelector('[data-testid="admin-mode-token"]')).toBeNull();
+    expect(document.querySelector('[data-testid="admin-mode-token-toggle"]')).toBeNull();
+
+    const confirmCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="admin-mode-confirm"]',
+    );
+    expect(confirmCheckbox).not.toBeNull();
+    act(() => {
+      confirmCheckbox!.checked = true;
+      confirmCheckbox!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const submitButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="admin-mode-submit"]',
+    );
+    expect(submitButton).not.toBeNull();
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(desktopHttpFetch).toHaveBeenCalledTimes(0);
+    expect(fallbackIssue).toHaveBeenCalledTimes(1);
+    expect(core.adminModeStore.getSnapshot()).toMatchObject({
+      status: "active",
+      elevatedToken: "desktop-elevated-token",
+      expiresAt,
+    });
+    expect(container.querySelector('[data-testid="danger-action"]')).not.toBeNull();
+
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    delete (window as unknown as Record<string, unknown>)["tyrumDesktop"];
+  });
+
   it("gates admin-only actions behind a shared Admin Mode flow", async () => {
     const issuedAt = "2026-02-27T00:00:00.000Z";
     const expiresAt = "2026-02-27T00:10:00.000Z";
     vi.useFakeTimers();
     vi.setSystemTime(new Date(issuedAt));
 
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      expect(init?.method).toBe("POST");
-      expect(headers.get("authorization")).toBe("Bearer admin-token");
-
-      return new Response(
-        JSON.stringify({
-          token_kind: "device",
-          token: "elevated-device-token",
-          token_id: "token-1",
-          device_id: "operator-ui",
-          role: "client",
-          scopes: ["operator.admin"],
-          issued_at: issuedAt,
-          expires_at: expiresAt,
-        }),
-        { status: 201, headers: { "content-type": "application/json" } },
-      );
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const issueDeviceToken = vi.fn(async () => ({
+      token_kind: "device" as const,
+      token: "elevated-device-token",
+      token_id: "token-1",
+      device_id: "operator-ui",
+      role: "client" as const,
+      scopes: ["operator.admin"],
+      issued_at: issuedAt,
+      expires_at: expiresAt,
+    }));
+    const revokeDeviceToken = vi.fn(async () => ({
+      revoked: true,
+      token_id: "token-1",
+    }));
 
     const ws = new FakeWsClient();
     const { http } = createFakeHttpClient();
@@ -3796,7 +3900,16 @@ describe("operator-ui", () => {
       wsUrl: "ws://example.test/ws",
       httpBaseUrl: "http://example.test",
       auth: createBearerTokenAuth("baseline"),
-      deps: { ws, http },
+      deps: {
+        ws,
+        http: {
+          ...http,
+          deviceTokens: {
+            issue: issueDeviceToken,
+            revoke: revokeDeviceToken,
+          },
+        },
+      },
     });
 
     const container = document.createElement("div");
@@ -3837,27 +3950,8 @@ describe("operator-ui", () => {
     const dialog = document.querySelector('[data-testid="admin-mode-dialog"]');
     expect(dialog).not.toBeNull();
 
-    const tokenField = document.querySelector<HTMLInputElement>('[data-testid="admin-mode-token"]');
-    expect(tokenField).not.toBeNull();
-    expect(tokenField!.type).toBe("password");
-    expect(tokenField!.getAttribute("autocomplete")).toBe("off");
-
-    const toggleTokenButton = document.querySelector<HTMLButtonElement>(
-      '[data-testid="admin-mode-token-toggle"]',
-    );
-    expect(toggleTokenButton).not.toBeNull();
-    act(() => {
-      toggleTokenButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    expect(tokenField!.type).toBe("text");
-    act(() => {
-      toggleTokenButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    expect(tokenField!.type).toBe("password");
-
-    act(() => {
-      tokenField!.value = "  admin-token  ";
-    });
+    expect(document.querySelector('[data-testid="admin-mode-token"]')).toBeNull();
+    expect(document.querySelector('[data-testid="admin-mode-token-toggle"]')).toBeNull();
 
     const confirmCheckbox = document.querySelector<HTMLInputElement>(
       '[data-testid="admin-mode-confirm"]',
@@ -3878,7 +3972,7 @@ describe("operator-ui", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(issueDeviceToken).toHaveBeenCalledTimes(1);
     expect(core.adminModeStore.getSnapshot()).toMatchObject({
       status: "active",
       elevatedToken: "elevated-device-token",
@@ -3943,12 +4037,16 @@ describe("operator-ui", () => {
     expect(dialog?.getAttribute("aria-modal")).toBe("true");
     expect(dialog?.getAttribute("aria-labelledby")).toBeTruthy();
 
-    const tokenField = document.querySelector<HTMLInputElement>('[data-testid="admin-mode-token"]');
-    expect(tokenField).not.toBeNull();
-    expect(tokenField!.type).toBe("password");
+    const confirmCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="admin-mode-confirm"]',
+    );
+    expect(confirmCheckbox).not.toBeNull();
+    expect(document.activeElement).toBe(confirmCheckbox);
 
     act(() => {
-      tokenField?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      confirmCheckbox?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
     });
 
     expect(document.querySelector('[data-testid="admin-mode-dialog"]')).toBeNull();


### PR DESCRIPTION
## Summary
- remove Admin Mode token re-entry and use the active authenticated connection in both web and desktop modes
- issue elevated admin device tokens through `core.http.deviceTokens.issue(...)` and keep confirmation gating in the dialog
- update operator UI tests to cover automatic auth usage, accessibility focus behavior, and shared admin-mode gating flows

## Test plan
- [x] `pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts`
- [x] `pnpm exec vitest run packages/operator-ui/tests`