### PR TITLE
Desktop: show setup wizard on first run

### DIFF
--- a/apps/desktop/src/renderer/lib/desktop-operator-core.ts
+++ b/apps/desktop/src/renderer/lib/desktop-operator-core.ts
@@ -36,6 +36,7 @@ export type DesktopOperatorCoreState = {
   core: OperatorCore | null;
   busy: boolean;
   errorMessage: string | null;
+  needsConfiguration: boolean;
   retry: () => void;
 };
 
@@ -51,6 +52,7 @@ export function useDesktopOperatorCore(
   const [core, setCore] = useState<OperatorCore | null>(null);
   const [busy, setBusy] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [needsConfiguration, setNeedsConfiguration] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
   const managerRef = useRef<OperatorCoreManager | null>(null);
   const unsubManagerRef = useRef<(() => void) | null>(null);
@@ -65,6 +67,7 @@ export function useDesktopOperatorCore(
       setCore(null);
       setBusy(false);
       setErrorMessage(null);
+      setNeedsConfiguration(false);
       return;
     }
     let disposed = false;
@@ -73,6 +76,16 @@ export function useDesktopOperatorCore(
       setBusy(true);
       setErrorMessage(null);
       try {
+        const hasConfig = await api.configExists();
+        if (disposed) return;
+        if (!hasConfig) {
+          setNeedsConfiguration(true);
+          setCore(null);
+          setErrorMessage(null);
+          return;
+        }
+        setNeedsConfiguration(false);
+
         const connection = (await api.gateway.getOperatorConnection()) as OperatorConnectionInfo;
         if (disposed) return;
 
@@ -142,6 +155,7 @@ export function useDesktopOperatorCore(
         manager.getCore().connect();
       } catch (error) {
         if (disposed) return;
+        setNeedsConfiguration(false);
         setErrorMessage(toErrorMessage(error));
         setCore(null);
       } finally {
@@ -164,5 +178,5 @@ export function useDesktopOperatorCore(
     };
   }, [api, enabled, retryCount]);
 
-  return { core, busy, errorMessage, retry };
+  return { core, busy, errorMessage, needsConfiguration, retry };
 }

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -5,17 +5,144 @@ import {
   Card,
   CardContent,
   ErrorBoundary,
+  Input,
   OperatorUiApp,
   OperatorUiHostProvider,
   ThemeProvider,
   getDesktopApi,
 } from "@tyrum/operator-ui";
 import "@tyrum/operator-ui/globals.css";
+import { useState } from "react";
+import { toErrorMessage } from "./lib/errors.js";
 import { useDesktopOperatorCore } from "./lib/desktop-operator-core.js";
+
+function DesktopSetupWizard({ onConfigured }: { onConfigured: () => void }) {
+  const api = window.tyrumDesktop;
+  const [mode, setMode] = useState<"embedded" | "remote">("embedded");
+  const [remoteWsUrl, setRemoteWsUrl] = useState("ws://127.0.0.1:8788/ws");
+  const [remoteToken, setRemoteToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const saveConfig = async (): Promise<void> => {
+    if (!api || busy) return;
+
+    setBusy(true);
+    setErrorMessage(null);
+    try {
+      if (mode === "embedded") {
+        await api.setConfig({ mode: "embedded" });
+      } else {
+        const wsUrl = remoteWsUrl.trim();
+        const token = remoteToken.trim();
+
+        if (!wsUrl) {
+          setErrorMessage("Remote WebSocket URL is required.");
+          return;
+        }
+        try {
+          const parsed = new URL(wsUrl);
+          if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+            throw new Error("invalid protocol");
+          }
+        } catch {
+          setErrorMessage("Remote WebSocket URL must be a valid ws:// or wss:// URL.");
+          return;
+        }
+        if (!token) {
+          setErrorMessage("A gateway token is required for remote mode.");
+          return;
+        }
+
+        await api.setConfig({ mode: "remote", remote: { wsUrl, tokenRef: token } });
+      }
+
+      onConfigured();
+    } catch (error) {
+      setErrorMessage(toErrorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto mt-20 max-w-md w-full px-4" data-testid="desktop-setup-wizard">
+      <Card>
+        <CardContent className="grid gap-4 py-6">
+          <Alert
+            title="Set up Tyrum Desktop"
+            description="Choose Embedded or Remote mode to continue."
+          />
+
+          <div className="flex gap-2">
+            <Button
+              variant={mode === "embedded" ? "primary" : "secondary"}
+              disabled={busy}
+              onClick={() => setMode("embedded")}
+            >
+              Embedded
+            </Button>
+            <Button
+              variant={mode === "remote" ? "primary" : "secondary"}
+              disabled={busy}
+              onClick={() => setMode("remote")}
+            >
+              Remote
+            </Button>
+          </div>
+
+          {mode === "remote" ? (
+            <div className="grid gap-4">
+              <Input
+                label="Gateway WebSocket URL"
+                type="text"
+                value={remoteWsUrl}
+                onChange={(e) => setRemoteWsUrl(e.target.value)}
+                placeholder="wss://host:port/ws"
+                disabled={busy}
+                required
+              />
+              <Input
+                label="Gateway token"
+                type="password"
+                value={remoteToken}
+                onChange={(e) => setRemoteToken(e.target.value)}
+                placeholder="Bearer token"
+                disabled={busy}
+                required
+              />
+            </div>
+          ) : (
+            <div className="text-sm text-fg-muted">
+              Embedded mode runs an Operator gateway locally on this machine.
+            </div>
+          )}
+
+          {errorMessage ? (
+            <Alert variant="error" title="Setup error" description={errorMessage} />
+          ) : null}
+
+          <Button
+            isLoading={busy}
+            onClick={() => {
+              void saveConfig();
+            }}
+          >
+            Continue
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 function DesktopBootstrap() {
   const operatorCore = useDesktopOperatorCore();
   const hostApi = { kind: "desktop" as const, api: getDesktopApi() };
+
+  if (operatorCore.needsConfiguration) {
+    return <DesktopSetupWizard onConfigured={operatorCore.retry} />;
+  }
 
   if (operatorCore.busy && !operatorCore.core) {
     return (

--- a/apps/desktop/tests/renderer-main-operator-ui-bootstrap.test.ts
+++ b/apps/desktop/tests/renderer-main-operator-ui-bootstrap.test.ts
@@ -5,6 +5,7 @@ type DesktopOperatorCoreState = {
   core: unknown | null;
   busy: boolean;
   errorMessage: string | null;
+  needsConfiguration: boolean;
   retry: () => void;
 };
 
@@ -66,6 +67,7 @@ const {
   CardContentMock,
   CardMock,
   ErrorBoundaryMock,
+  InputMock,
   OperatorUiAppMock,
   OperatorUiHostProviderMock,
   ThemeProviderMock,
@@ -86,6 +88,7 @@ const {
     core: null,
     busy: false,
     errorMessage: null,
+    needsConfiguration: false,
     retry: vi.fn(),
   };
   const setDesktopOperatorCoreState = (next: DesktopOperatorCoreState): void => {
@@ -105,6 +108,7 @@ const {
   const ButtonMock = vi.fn(() => null);
   const CardMock = vi.fn(() => null);
   const CardContentMock = vi.fn(() => null);
+  const InputMock = vi.fn(() => null);
 
   return {
     AlertMock,
@@ -112,6 +116,7 @@ const {
     CardContentMock,
     CardMock,
     ErrorBoundaryMock,
+    InputMock,
     OperatorUiAppMock,
     OperatorUiHostProviderMock,
     ThemeProviderMock,
@@ -134,6 +139,7 @@ vi.mock("@tyrum/operator-ui", () => ({
   Card: CardMock,
   CardContent: CardContentMock,
   ErrorBoundary: ErrorBoundaryMock,
+  Input: InputMock,
   OperatorUiApp: OperatorUiAppMock,
   OperatorUiHostProvider: OperatorUiHostProviderMock,
   ThemeProvider: ThemeProviderMock,
@@ -175,7 +181,13 @@ describe("desktop renderer main bootstrap", () => {
   it("boots OperatorUiApp in desktop mode when operator core is available", async () => {
     const retry = vi.fn();
     const core = { name: "core" };
-    setDesktopOperatorCoreState({ core, busy: false, errorMessage: null, retry });
+    setDesktopOperatorCoreState({
+      core,
+      busy: false,
+      errorMessage: null,
+      needsConfiguration: false,
+      retry,
+    });
 
     await import("../src/renderer/main.tsx");
 
@@ -198,7 +210,13 @@ describe("desktop renderer main bootstrap", () => {
 
   it("shows an error state and wires Retry to operatorCore.retry", async () => {
     const retry = vi.fn();
-    setDesktopOperatorCoreState({ core: null, busy: false, errorMessage: "boom", retry });
+    setDesktopOperatorCoreState({
+      core: null,
+      busy: false,
+      errorMessage: "boom",
+      needsConfiguration: false,
+      retry,
+    });
 
     await import("../src/renderer/main.tsx");
 
@@ -222,5 +240,26 @@ describe("desktop renderer main bootstrap", () => {
 
     (onClick as () => void)();
     expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the desktop setup wizard when configuration is missing", async () => {
+    const retry = vi.fn();
+    setDesktopOperatorCoreState({
+      core: null,
+      busy: false,
+      errorMessage: null,
+      needsConfiguration: true,
+      retry,
+    });
+
+    await import("../src/renderer/main.tsx");
+
+    const DesktopBootstrap = loadDesktopBootstrap();
+    const tree = DesktopBootstrap();
+
+    expect(isReactElementLike(tree)).toBe(true);
+    expect(typeof (tree as ReactElementLike).type).toBe("function");
+    expect(((tree as ReactElementLike).type as { name?: unknown }).name).toBe("DesktopSetupWizard");
+    expect((tree as ReactElementLike).props.onConfigured).toBe(retry);
   });
 });


### PR DESCRIPTION
Closes #967.

- When `~/.tyrum/desktop-node.json` is missing, show a setup wizard (Embedded/Remote) instead of the operator-core bootstrap error.
- Wizard persists config via IPC and triggers a retry so the Operator UI can finish bootstrapping.

Tests:
- pnpm --filter tyrum-desktop test
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
