### PR TITLE
tests(gateway): make integration harness hermetic (temp TYRUM_HOME by default) (#991)

### DIFF
--- a/packages/gateway/tests/integration/agent.test.ts
+++ b/packages/gateway/tests/integration/agent.test.ts
@@ -111,7 +111,7 @@ describe("agent routes", () => {
   });
 
   it("returns singleton status from local workspace", async () => {
-    const { app, agents, container } = await createTestApp();
+    const { app, agents, container } = await createTestApp({ tyrumHome: homeDir });
     const res = await app.request("/agent/status");
 
     expect(res.status).toBe(200);
@@ -143,7 +143,7 @@ describe("agent routes", () => {
     await mkdir(join(homeDir!, "agents/agent-1"), { recursive: true });
     await writeWorkspace(join(homeDir!, "agents/agent-1"));
 
-    const { app, agents, container } = await createTestApp();
+    const { app, agents, container } = await createTestApp({ tyrumHome: homeDir });
 
     const res = await app.request("/agent/list");
     expect(res.status).toBe(200);
@@ -165,7 +165,7 @@ describe("agent routes", () => {
     await mkdir(join(homeDir!, "agents/agent-2"), { recursive: true });
     await writeWorkspace(join(homeDir!, "agents/agent-2"));
 
-    const { app, agents, container } = await createTestApp();
+    const { app, agents, container } = await createTestApp({ tyrumHome: homeDir });
     const getRuntimeSpy = vi.spyOn(agents!, "getRuntime");
     const res = await app.request("/agent/status?agent_key=agent-2");
     expect(res.status).toBe(200);
@@ -185,6 +185,7 @@ describe("agent routes", () => {
 
   it("separates short-term session context per channel/thread and writes memory files", async () => {
     const { app, container, agents } = await createTestApp({
+      tyrumHome: homeDir,
       languageModel: createStubLanguageModel("ok"),
     });
 
@@ -264,6 +265,7 @@ describe("agent routes", () => {
 
   it("accepts envelope-only turns with attachments", async () => {
     const { app, container, agents } = await createTestApp({
+      tyrumHome: homeDir,
       languageModel: createStubLanguageModel("ok"),
     });
 

--- a/packages/gateway/tests/integration/context.test.ts
+++ b/packages/gateway/tests/integration/context.test.ts
@@ -130,6 +130,7 @@ describe("/context", () => {
 
   it("returns last-known context report metadata after an agent turn", async () => {
     const { app, container, agents } = await createTestApp({
+      tyrumHome: homeDir,
       languageModel: createToolCallLanguageModel({
         toolCalls: [
           {

--- a/packages/gateway/tests/integration/helpers.ts
+++ b/packages/gateway/tests/integration/helpers.ts
@@ -4,6 +4,9 @@
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { afterEach } from "vitest";
 import { createContainer } from "../../src/container.js";
 import { createApp } from "../../src/app.js";
 import type { GatewayContainer } from "../../src/container.js";
@@ -12,7 +15,6 @@ import { isAgentEnabled } from "../../src/modules/agent/enabled.js";
 import type { AgentRegistry } from "../../src/modules/agent/registry.js";
 import { AgentRegistry as AgentRegistryImpl } from "../../src/modules/agent/registry.js";
 import { createDbSecretProvider } from "../../src/modules/secret/create-secret-provider.js";
-import { resolveTyrumHome } from "../../src/modules/agent/home.js";
 import { VERSION } from "../../src/version.js";
 import type { TokenStore } from "../../src/modules/auth/token-store.js";
 import type { SlidingWindowRateLimiter } from "../../src/modules/auth/rate-limiter.js";
@@ -22,15 +24,55 @@ import type { LanguageModel } from "ai";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
 
-export async function createTestContainer(): Promise<GatewayContainer> {
-  return await createTestContainerWith({ dbPath: ":memory:" });
+const tempHomesToCleanup: string[] = [];
+
+function isRejected<T>(res: PromiseSettledResult<T>): res is PromiseRejectedResult {
+  return res.status === "rejected";
 }
 
-function createTestContainerWith(opts: { dbPath: string; tyrumHome?: string }): GatewayContainer {
+afterEach(async () => {
+  if (tempHomesToCleanup.length === 0) return;
+
+  const homes = tempHomesToCleanup.splice(0);
+  const results = await Promise.allSettled(
+    homes.map(async (home) => {
+      await rm(home, { recursive: true, force: true });
+    }),
+  );
+
+  const failures = results.filter(isRejected);
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      `failed to cleanup ${String(failures.length)} tyrum test home(s)`,
+    );
+  }
+});
+
+async function createTempTyrumHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "tyrum-test-home-"));
+  tempHomesToCleanup.push(home);
+  return home;
+}
+
+function normalizeOptionalTyrumHome(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+export async function createTestContainer(
+  opts: { tyrumHome?: string } = {},
+): Promise<GatewayContainer> {
+  const baseHome = normalizeOptionalTyrumHome(opts.tyrumHome) ?? (await createTempTyrumHome());
+  return createTestContainerWith({ dbPath: ":memory:", tyrumHome: baseHome });
+}
+
+function createTestContainerWith(opts: { dbPath: string; tyrumHome: string }): GatewayContainer {
   const gatewayConfig = loadConfig({
     ...process.env,
     GATEWAY_TOKEN: "test-token",
-    TYRUM_HOME: opts.tyrumHome ?? process.env["TYRUM_HOME"],
+    TYRUM_HOME: opts.tyrumHome,
   });
   return createContainer(
     {
@@ -55,7 +97,7 @@ export async function createTestApp(opts: TestAppOptions = {}): Promise<{
   container: GatewayContainer;
   agents?: AgentRegistry;
 }> {
-  const baseHome = opts.tyrumHome ?? resolveTyrumHome();
+  const baseHome = normalizeOptionalTyrumHome(opts.tyrumHome) ?? (await createTempTyrumHome());
   const container = createTestContainerWith({ dbPath: ":memory:", tyrumHome: baseHome });
   const agents = isAgentEnabled()
     ? new AgentRegistryImpl({

--- a/packages/gateway/tests/integration/hermetic-home.test.ts
+++ b/packages/gateway/tests/integration/hermetic-home.test.ts
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { createTestApp } from "./helpers.js";
+
+describe("integration helpers", () => {
+  const createdHomes: string[] = [];
+
+  afterAll(() => {
+    for (const home of createdHomes) {
+      expect(existsSync(home)).toBe(false);
+    }
+  });
+
+  it("does not create/use $HOME/.tyrum when TYRUM_HOME is unset", async () => {
+    const isolatedHome = await mkdtemp(join(tmpdir(), "tyrum-integration-home-"));
+    const priorHome = process.env["HOME"];
+    const priorTyrumHome = process.env["TYRUM_HOME"];
+
+    try {
+      process.env["HOME"] = isolatedHome;
+      process.env["TYRUM_HOME"] = "";
+
+      const { container } = await createTestApp();
+      expect(container.config.tyrumHome).toBeTruthy();
+      if (container.config.tyrumHome) createdHomes.push(container.config.tyrumHome);
+
+      await container.artifactStore.put({ kind: "log", body: Buffer.from("hello") });
+      await container.db.close();
+
+      expect(existsSync(join(isolatedHome, ".tyrum"))).toBe(false);
+    } finally {
+      if (priorHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = priorHome;
+
+      if (priorTyrumHome === undefined) delete process.env["TYRUM_HOME"];
+      else process.env["TYRUM_HOME"] = priorTyrumHome;
+
+      await rm(isolatedHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #991

## Summary
- Gateway integration test harness uses a fresh temp `TYRUM_HOME` by default and cleans it up automatically.
- Tests that need a specific workspace now pass `tyrumHome` explicitly.

## Verification
- `pnpm test -- packages/gateway/tests/integration`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`