### PR TITLE
[Data model] Fix Postgres/SQLite vector_metadata PK column mismatch (breaks Postgres VectorDal) (#972)

### DIFF
--- a/packages/gateway/migrations/postgres/102_vector_metadata_pk.sql
+++ b/packages/gateway/migrations/postgres/102_vector_metadata_pk.sql
@@ -1,0 +1,6 @@
+-- Rename Postgres PK column to match SQLite + DAL expectations.
+ALTER TABLE vector_metadata RENAME COLUMN id TO vector_metadata_id;
+-- pg-mem (used in tests) does not preserve SERIAL defaults on rename; re-assert explicitly.
+CREATE SEQUENCE IF NOT EXISTS vector_metadata_id_seq;
+ALTER TABLE vector_metadata
+  ALTER COLUMN vector_metadata_id SET DEFAULT nextval('vector_metadata_id_seq');

--- a/packages/gateway/migrations/sqlite/102_vector_metadata_pk.sql
+++ b/packages/gateway/migrations/sqlite/102_vector_metadata_pk.sql
@@ -1,0 +1,3 @@
+-- SQLite already uses `vector_metadata_id` for `vector_metadata` — no-op.
+SELECT 1;
+

--- a/packages/gateway/tests/contract/schema-contract.test.ts
+++ b/packages/gateway/tests/contract/schema-contract.test.ts
@@ -29,14 +29,6 @@ async function getPostgresColumns(
   return (res.rows as Array<{ column_name: string }>).map((r) => r.column_name);
 }
 
-function normalizeColumnsForContract(table: string, cols: string[]): string[] {
-  // SQLite keeps AUTOINCREMENT PK as `vector_metadata_id`; Postgres uses `id`.
-  if (table === "vector_metadata") {
-    return cols.map((c) => (c === "vector_metadata_id" ? "id" : c));
-  }
-  return cols;
-}
-
 describe("StateStore schema contract (sqlite vs postgres)", () => {
   it("keeps core table column sets aligned", async () => {
     // SQLite (real engine)
@@ -106,8 +98,8 @@ describe("StateStore schema contract (sqlite vs postgres)", () => {
       ] as const;
 
       for (const table of tables) {
-        const sqliteCols = normalizeColumnsForContract(table, getSqliteColumns(sqlite, table));
-        const pgCols = normalizeColumnsForContract(table, await getPostgresColumns(pg, table));
+        const sqliteCols = getSqliteColumns(sqlite, table);
+        const pgCols = await getPostgresColumns(pg, table);
         expect(sqliteCols.length, `sqlite columns for ${table}`).toBeGreaterThan(0);
         expect(pgCols.length, `postgres columns for ${table}`).toBeGreaterThan(0);
         sqliteCols.sort();

--- a/packages/gateway/tests/helpers/postgres-db.ts
+++ b/packages/gateway/tests/helpers/postgres-db.ts
@@ -1,0 +1,161 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DataType, newDb } from "pg-mem";
+import { migratePostgres } from "../../src/migrate-postgres.js";
+import type { SqlDb } from "../../src/statestore/types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const POSTGRES_MIGRATIONS_DIR = join(__dirname, "../../migrations/postgres");
+
+function translatePlaceholders(sql: string): string {
+  let out = "";
+  let count = 0;
+  let inSingle = false;
+  let inDouble = false;
+
+  for (let i = 0; i < sql.length; i += 1) {
+    const ch = sql[i]!;
+
+    if (ch === "'" && !inDouble) {
+      out += ch;
+      if (inSingle) {
+        const next = sql[i + 1];
+        if (next === "'") {
+          out += next;
+          i += 1;
+        } else {
+          inSingle = false;
+        }
+      } else {
+        inSingle = true;
+      }
+      continue;
+    }
+
+    if (ch === `"` && !inSingle) {
+      inDouble = !inDouble;
+      out += ch;
+      continue;
+    }
+
+    if (ch === "?" && !inSingle && !inDouble) {
+      count += 1;
+      out += `$${count}`;
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
+}
+
+function registerCommonPgFunctions(mem: ReturnType<typeof newDb>): void {
+  mem.public.registerFunction({
+    name: "strpos",
+    args: [DataType.text, DataType.text],
+    returns: DataType.integer,
+    implementation: (haystack: string, needle: string) => {
+      const idx = haystack.indexOf(needle);
+      return idx >= 0 ? idx + 1 : 0;
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "jsonb_array_length",
+    args: [DataType.jsonb],
+    returns: DataType.integer,
+    implementation: (value: unknown) => {
+      if (!Array.isArray(value)) {
+        throw new Error("cannot get array length of a scalar/object");
+      }
+      return value.length;
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "jsonb_typeof",
+    args: [DataType.jsonb],
+    returns: DataType.text,
+    implementation: (value: unknown) => {
+      if (value === null) return "null";
+      if (Array.isArray(value)) return "array";
+      if (typeof value === "object") return "object";
+      if (typeof value === "string") return "string";
+      if (typeof value === "number") return "number";
+      if (typeof value === "boolean") return "boolean";
+      return "unknown";
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "pg_input_is_valid",
+    args: [DataType.text, DataType.text],
+    returns: DataType.bool,
+    implementation: (value: string, targetType: string) => {
+      if (!targetType || !targetType.toLowerCase().includes("json")) return false;
+      try {
+        JSON.parse(value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}
+
+export async function openTestPostgresDb(): Promise<{ db: SqlDb; close: () => Promise<void> }> {
+  const mem = newDb();
+  registerCommonPgFunctions(mem);
+
+  const { Client } = mem.adapters.createPg();
+  const pg = new Client();
+  await pg.connect();
+  await migratePostgres(pg, POSTGRES_MIGRATIONS_DIR);
+
+  const db: SqlDb = {
+    kind: "postgres",
+    get: async (sql, params = []) => {
+      const translated = translatePlaceholders(sql);
+      const res = await pg.query(translated, params as unknown[]);
+      return (res.rows[0] as unknown) ?? undefined;
+    },
+    all: async (sql, params = []) => {
+      const translated = translatePlaceholders(sql);
+      const res = await pg.query(translated, params as unknown[]);
+      return res.rows as unknown[];
+    },
+    run: async (sql, params = []) => {
+      const translated = translatePlaceholders(sql);
+      const res = await pg.query(translated, params as unknown[]);
+      return { changes: res.rowCount ?? 0 };
+    },
+    exec: async (sql) => {
+      await pg.query(sql);
+    },
+    transaction: async (fn) => {
+      await pg.query("BEGIN");
+      try {
+        const result = await fn(db);
+        await pg.query("COMMIT");
+        return result;
+      } catch (err) {
+        try {
+          await pg.query("ROLLBACK");
+        } catch {
+          // ignore rollback errors; surface original failure
+        }
+        throw err;
+      }
+    },
+    close: async () => {},
+  };
+
+  return {
+    db,
+    close: async () => {
+      await pg.end();
+    },
+  };
+}

--- a/packages/gateway/tests/unit/memory-v1-dal.test.ts
+++ b/packages/gateway/tests/unit/memory-v1-dal.test.ts
@@ -1,123 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { openTestPostgresDb } from "../helpers/postgres-db.js";
 import { MemoryV1Dal } from "../../src/modules/memory/v1-dal.js";
 import type { SqlDb } from "../../src/statestore/types.js";
 import { IdentityScopeDal } from "../../src/modules/identity/scope.js";
-import { migratePostgres } from "../../src/migrate-postgres.js";
-import { DataType, newDb } from "pg-mem";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 
 type OpenDalResult = { dal: MemoryV1Dal; db: SqlDb; close: () => Promise<void> };
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const postgresMigrationsDir = join(__dirname, "../../migrations/postgres");
-
-function translatePlaceholders(sql: string): { sql: string; count: number } {
-  let out = "";
-  let count = 0;
-  let inSingle = false;
-  let inDouble = false;
-
-  for (let i = 0; i < sql.length; i += 1) {
-    const ch = sql[i]!;
-
-    if (ch === "'" && !inDouble) {
-      out += ch;
-      if (inSingle) {
-        const next = sql[i + 1];
-        if (next === "'") {
-          out += next;
-          i += 1;
-        } else {
-          inSingle = false;
-        }
-      } else {
-        inSingle = true;
-      }
-      continue;
-    }
-
-    if (ch === `"` && !inSingle) {
-      inDouble = !inDouble;
-      out += ch;
-      continue;
-    }
-
-    if (ch === "?" && !inSingle && !inDouble) {
-      count += 1;
-      out += `$${count}`;
-      continue;
-    }
-
-    out += ch;
-  }
-
-  return { sql: out, count };
-}
-
-async function openPgMemDal(): Promise<OpenDalResult> {
-  const mem = newDb();
-  mem.public.registerFunction({
-    name: "strpos",
-    args: [DataType.text, DataType.text],
-    returns: DataType.integer,
-    implementation: (haystack: string, needle: string) => {
-      const idx = haystack.indexOf(needle);
-      return idx >= 0 ? idx + 1 : 0;
-    },
-  });
-  const { Client } = mem.adapters.createPg();
-  const pg = new Client();
-  await pg.connect();
-  await migratePostgres(pg, postgresMigrationsDir);
-
-  const db: SqlDb = {
-    kind: "postgres",
-    get: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return (res.rows[0] as unknown) ?? undefined;
-    },
-    all: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return res.rows as unknown[];
-    },
-    run: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return { changes: res.rowCount ?? 0 };
-    },
-    exec: async (sql) => {
-      await pg.query(sql);
-    },
-    transaction: async (fn) => {
-      await pg.query("BEGIN");
-      try {
-        const result = await fn(db);
-        await pg.query("COMMIT");
-        return result;
-      } catch (err) {
-        try {
-          await pg.query("ROLLBACK");
-        } catch {
-          // ignore rollback errors; surface original failure
-        }
-        throw err;
-      }
-    },
-    close: async () => {},
-  };
-
-  return {
-    dal: new MemoryV1Dal(db),
-    db,
-    close: async () => {
-      await pg.end();
-    },
-  };
-}
 
 async function openSqliteDal(): Promise<OpenDalResult> {
   const db = openTestSqliteDb();
@@ -130,9 +18,14 @@ async function openSqliteDal(): Promise<OpenDalResult> {
   };
 }
 
+async function openPostgresDal(): Promise<OpenDalResult> {
+  const { db, close } = await openTestPostgresDb();
+  return { dal: new MemoryV1Dal(db), db, close };
+}
+
 const fixtures = [
   { name: "sqlite" as const, open: openSqliteDal },
-  { name: "postgres" as const, open: openPgMemDal },
+  { name: "postgres" as const, open: openPostgresDal },
 ];
 
 async function ensureAgentScopes(db: SqlDb): Promise<{

--- a/packages/gateway/tests/unit/memory-v1-semantic-index.test.ts
+++ b/packages/gateway/tests/unit/memory-v1-semantic-index.test.ts
@@ -1,115 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { openTestPostgresDb } from "../helpers/postgres-db.js";
 import { MemoryV1Dal } from "../../src/modules/memory/v1-dal.js";
 import { MemoryV1SemanticIndex } from "../../src/modules/memory/v1-semantic-index.js";
 import type { SqlDb } from "../../src/statestore/types.js";
-import { migratePostgres } from "../../src/migrate-postgres.js";
-import { newDb } from "pg-mem";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { DEFAULT_AGENT_ID, DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
 
 type OpenDbResult = { dal: MemoryV1Dal; db: SqlDb; close: () => Promise<void> };
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const postgresMigrationsDir = join(__dirname, "../../migrations/postgres");
-
-function translatePlaceholders(sql: string): { sql: string; count: number } {
-  let out = "";
-  let count = 0;
-  let inSingle = false;
-  let inDouble = false;
-
-  for (let i = 0; i < sql.length; i += 1) {
-    const ch = sql[i]!;
-
-    if (ch === "'" && !inDouble) {
-      out += ch;
-      if (inSingle) {
-        const next = sql[i + 1];
-        if (next === "'") {
-          out += next;
-          i += 1;
-        } else {
-          inSingle = false;
-        }
-      } else {
-        inSingle = true;
-      }
-      continue;
-    }
-
-    if (ch === `"` && !inSingle) {
-      inDouble = !inDouble;
-      out += ch;
-      continue;
-    }
-
-    if (ch === "?" && !inSingle && !inDouble) {
-      count += 1;
-      out += `$${count}`;
-      continue;
-    }
-
-    out += ch;
-  }
-
-  return { sql: out, count };
-}
-
-async function openPgMemDb(): Promise<OpenDbResult> {
-  const mem = newDb();
-  const { Client } = mem.adapters.createPg();
-  const pg = new Client();
-  await pg.connect();
-  await migratePostgres(pg, postgresMigrationsDir);
-
-  const db: SqlDb = {
-    kind: "postgres",
-    get: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return (res.rows[0] as unknown) ?? undefined;
-    },
-    all: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return res.rows as unknown[];
-    },
-    run: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return { changes: res.rowCount ?? 0 };
-    },
-    exec: async (sql) => {
-      await pg.query(sql);
-    },
-    transaction: async (fn) => {
-      await pg.query("BEGIN");
-      try {
-        const result = await fn(db);
-        await pg.query("COMMIT");
-        return result;
-      } catch (err) {
-        try {
-          await pg.query("ROLLBACK");
-        } catch {
-          // ignore rollback errors; surface original failure
-        }
-        throw err;
-      }
-    },
-    close: async () => {},
-  };
-
-  return {
-    dal: new MemoryV1Dal(db),
-    db,
-    close: async () => {
-      await pg.end();
-    },
-  };
-}
 
 async function openSqliteDb(): Promise<OpenDbResult> {
   const db = openTestSqliteDb();
@@ -120,6 +17,11 @@ async function openSqliteDb(): Promise<OpenDbResult> {
       await db.close();
     },
   };
+}
+
+async function openPostgresDb(): Promise<OpenDbResult> {
+  const { db, close } = await openTestPostgresDb();
+  return { dal: new MemoryV1Dal(db), db, close };
 }
 
 const EMBED_FEATURES = [
@@ -139,7 +41,7 @@ function embedDeterministic(text: string): number[] {
 
 const fixtures = [
   { name: "sqlite" as const, open: openSqliteDb },
-  { name: "postgres" as const, open: openPgMemDb },
+  { name: "postgres" as const, open: openPostgresDb },
 ];
 
 for (const fixture of fixtures) {

--- a/packages/gateway/tests/unit/session-dal.postgres-list.test.ts
+++ b/packages/gateway/tests/unit/session-dal.postgres-list.test.ts
@@ -1,146 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { DataType, newDb } from "pg-mem";
-import { migratePostgres } from "../../src/migrate-postgres.js";
-import type { SqlDb } from "../../src/statestore/types.js";
 import { SessionDal } from "../../src/modules/agent/session-dal.js";
 import { ChannelThreadDal } from "../../src/modules/channels/thread-dal.js";
 import { IdentityScopeDal } from "../../src/modules/identity/scope.js";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const postgresMigrationsDir = join(__dirname, "../../migrations/postgres");
-
-function translatePlaceholders(sql: string): { sql: string; count: number } {
-  let count = 0;
-  let out = "";
-  let inSingle = false;
-  let inDouble = false;
-
-  for (const ch of sql) {
-    if (ch === `'` && !inDouble) {
-      inSingle = !inSingle;
-      out += ch;
-      continue;
-    }
-
-    if (ch === `"` && !inSingle) {
-      inDouble = !inDouble;
-      out += ch;
-      continue;
-    }
-
-    if (ch === "?" && !inSingle && !inDouble) {
-      count += 1;
-      out += `$${count}`;
-      continue;
-    }
-
-    out += ch;
-  }
-
-  return { sql: out, count };
-}
-
-async function openPgMemDb(): Promise<{ db: SqlDb; close: () => Promise<void> }> {
-  const mem = newDb();
-
-  mem.public.registerFunction({
-    name: "jsonb_array_length",
-    args: [DataType.jsonb],
-    returns: DataType.integer,
-    implementation: (value: unknown) => {
-      if (!Array.isArray(value)) {
-        throw new Error("cannot get array length of a scalar/object");
-      }
-      return value.length;
-    },
-  });
-
-  mem.public.registerFunction({
-    name: "jsonb_typeof",
-    args: [DataType.jsonb],
-    returns: DataType.text,
-    implementation: (value: unknown) => {
-      if (value === null) return "null";
-      if (Array.isArray(value)) return "array";
-      if (typeof value === "object") return "object";
-      if (typeof value === "string") return "string";
-      if (typeof value === "number") return "number";
-      if (typeof value === "boolean") return "boolean";
-      return "unknown";
-    },
-  });
-
-  mem.public.registerFunction({
-    name: "pg_input_is_valid",
-    args: [DataType.text, DataType.text],
-    returns: DataType.bool,
-    implementation: (value: string, targetType: string) => {
-      if (!targetType || !targetType.toLowerCase().includes("json")) return false;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-  });
-
-  const { Client } = mem.adapters.createPg();
-  const pg = new Client();
-  await pg.connect();
-  await migratePostgres(pg, postgresMigrationsDir);
-
-  const db: SqlDb = {
-    kind: "postgres",
-    get: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return (res.rows[0] as unknown) ?? undefined;
-    },
-    all: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return res.rows as unknown[];
-    },
-    run: async (sql, params = []) => {
-      const translated = translatePlaceholders(sql);
-      const res = await pg.query(translated.sql, params as unknown[]);
-      return { changes: res.rowCount ?? 0 };
-    },
-    exec: async (sql) => {
-      await pg.query(sql);
-    },
-    transaction: async (fn) => {
-      await pg.query("BEGIN");
-      try {
-        const result = await fn(db);
-        await pg.query("COMMIT");
-        return result;
-      } catch (err) {
-        try {
-          await pg.query("ROLLBACK");
-        } catch {
-          // ignore rollback errors; surface original failure
-        }
-        throw err;
-      }
-    },
-    close: async () => {},
-  };
-
-  return {
-    db,
-    close: async () => {
-      await pg.end();
-    },
-  };
-}
+import { openTestPostgresDb } from "../helpers/postgres-db.js";
 
 describe("SessionDal.list (postgres)", () => {
   it("treats malformed turns_json as empty instead of failing the whole query", async () => {
-    const { db, close } = await openPgMemDb();
+    const { db, close } = await openTestPostgresDb();
     try {
       const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
       const channelThreadDal = new ChannelThreadDal(db);
@@ -176,7 +42,7 @@ describe("SessionDal.list (postgres)", () => {
   });
 
   it("treats non-array turns_json as empty instead of failing the whole query", async () => {
-    const { db, close } = await openPgMemDb();
+    const { db, close } = await openTestPostgresDb();
     try {
       const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
       const channelThreadDal = new ChannelThreadDal(db);

--- a/packages/gateway/tests/unit/vector-dal.postgres.test.ts
+++ b/packages/gateway/tests/unit/vector-dal.postgres.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SqlDb } from "../../src/statestore/types.js";
+import { VectorDal } from "../../src/modules/memory/vector-dal.js";
+import { openTestPostgresDb } from "../helpers/postgres-db.js";
+
+describe("VectorDal (postgres)", () => {
+  let db: SqlDb;
+  let closeDb: () => Promise<void> = async () => {};
+  let dal: VectorDal;
+
+  beforeEach(async () => {
+    const opened = await openTestPostgresDb();
+    db = opened.db;
+    closeDb = opened.close;
+    dal = new VectorDal(db);
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it("inserts and lists embeddings", async () => {
+    await dal.insertEmbedding("first", [1, 0], "model");
+    await dal.insertEmbedding("second", [0, 1], "model");
+
+    const rows = await dal.list();
+    expect(rows.map((r) => r.label)).toEqual(["second", "first"]);
+    expect(typeof rows[0]!.id).toBe("number");
+  });
+
+  it("searchByCosineSimilarity returns vectors with ids", async () => {
+    await dal.insertEmbedding("north", [1, 0, 0], "model");
+    await dal.insertEmbedding("east", [0, 1, 0], "model");
+
+    const results = await dal.searchByCosineSimilarity([1, 0, 0], 1);
+    expect(results[0]!.row.label).toBe("north");
+    expect(typeof results[0]!.row.id).toBe("number");
+  });
+});


### PR DESCRIPTION
Closes #972

**What**
- Add Postgres migration to rename `vector_metadata.id` -> `vector_metadata_id` to match SQLite + `VectorDal`.
- Add/extend tests to cover `VectorDal` on Postgres and enforce sqlite/postgres schema alignment.

**Verification**
- `pnpm format:check`
- `pnpm lint` (0 errors)
- `pnpm typecheck`
- `pnpm test` (2954 passed, 2 skipped)
