### PR TITLE
[Data model] Revisit work_item_tasks dependency modeling (depends_on_json) (#981)

### DIFF
--- a/docs/architecture/workboard.md
+++ b/docs/architecture/workboard.md
@@ -149,6 +149,22 @@ Each WorkItem may have an internal task graph: nodes represent tasks, and edges 
   - Doing if one or more tasks are leased/running.
   - Done only when acceptance checks pass and required evidence exists.
 
+#### Task dependency storage (`work_item_tasks`)
+
+Task-to-task dependencies are stored on each task row as `work_item_tasks.depends_on_json` (a JSON array of `task_id` strings). This JSON representation is the canonical model for now because it is cross-database and keeps migrations simple.
+
+Encoding and invariants:
+
+- Dependencies are normalized (trimmed, de-duplicated, no empty strings).
+- Writes validate: referenced tasks exist, belong to the same `work_item_id`, and never include the task itself.
+- Updates additionally reject dependency cycles.
+
+Scheduling:
+
+- A task is runnable when all dependencies are terminal (`completed`, `skipped`, `cancelled`, `failed`).
+
+If/when dependency graph queries become a bottleneck (critical path, reverse edges, large DAGs), we can introduce a normalized edge table (for example `work_item_task_dependencies`) and treat `depends_on_json` as a denormalized cache.
+
 ### Subagent (delegated execution context)
 
 A subagent is a delegated execution context that shares the parent agent's identity boundary but has its own runtime context and transcript.

--- a/packages/gateway/src/modules/workboard/dal-helpers.ts
+++ b/packages/gateway/src/modules/workboard/dal-helpers.ts
@@ -340,7 +340,7 @@ export function toWorkItemTask(raw: RawWorkItemTaskRow): WorkItemTask {
     task_id: raw.task_id,
     work_item_id: raw.work_item_id,
     status: raw.status as WorkItemTaskState,
-    depends_on: parseJsonOr(raw.depends_on_json, []) as string[],
+    depends_on: parseTaskDepsJson(raw.depends_on_json),
     execution_profile: raw.execution_profile,
     side_effect_class: raw.side_effect_class,
     run_id: raw.run_id ?? undefined,
@@ -350,6 +350,17 @@ export function toWorkItemTask(raw: RawWorkItemTaskRow): WorkItemTask {
     finished_at: normalizeMaybeTime(raw.finished_at),
     result_summary: raw.result_summary ?? undefined,
   } as WorkItemTask;
+}
+
+export function parseTaskDepsJson(raw: string | null): string[] {
+  const parsed = parseJsonOr(raw, []);
+  if (!Array.isArray(parsed)) return [];
+  const deps: string[] = [];
+  for (const value of parsed) {
+    if (typeof value !== "string") continue;
+    deps.push(value);
+  }
+  return normalizeTaskDeps(deps);
 }
 
 export function normalizeTaskDeps(input: readonly string[] | undefined): string[] {

--- a/packages/gateway/src/modules/workboard/dal.ts
+++ b/packages/gateway/src/modules/workboard/dal.ts
@@ -1618,8 +1618,7 @@ export class WorkboardDal {
 
         const adj = new Map<string, string[]>();
         for (const row of allTasks) {
-          const deps = dalHelpers.parseJsonOr(row.depends_on_json, []) as string[];
-          adj.set(row.task_id, dalHelpers.normalizeTaskDeps(deps));
+          adj.set(row.task_id, dalHelpers.parseTaskDepsJson(row.depends_on_json));
         }
         adj.set(params.task_id, normalizedDependsOn);
 
@@ -1792,10 +1791,7 @@ export class WorkboardDal {
       const depsById = new Map<string, string[]>();
       for (const row of rows) {
         statusById.set(row.task_id, row.status as WorkItemTaskState);
-        depsById.set(
-          row.task_id,
-          dalHelpers.normalizeTaskDeps(dalHelpers.parseJsonOr(row.depends_on_json, []) as string[]),
-        );
+        depsById.set(row.task_id, dalHelpers.parseTaskDepsJson(row.depends_on_json));
       }
 
       const isTerminal = (s: WorkItemTaskState | undefined): boolean => {

--- a/packages/gateway/tests/unit/workboard-dal.test.ts
+++ b/packages/gateway/tests/unit/workboard-dal.test.ts
@@ -1144,6 +1144,64 @@ describe("WorkboardDal", () => {
     ).rejects.toThrow(/depends_on|work item|scope/i);
   });
 
+  it("rejects depends_on task ids that do not exist", async () => {
+    const dal = createDal();
+    const scope = await resolveScope();
+
+    const item = await dal.createItem({
+      scope,
+      item: {
+        kind: "action",
+        title: "Missing depends_on",
+        created_from_session_key: "agent:default:main",
+      },
+      createdAtIso: "2026-02-27T00:00:00.000Z",
+    });
+
+    await expect(
+      dal.createTask({
+        scope,
+        task: {
+          work_item_id: item.work_item_id,
+          depends_on: ["00000000-0000-0000-0000-000000000099"],
+          execution_profile: "planner",
+          side_effect_class: "none",
+        },
+        createdAtIso: "2026-02-27T00:00:01.000Z",
+      }),
+    ).rejects.toThrow(/depends_on.*not found/i);
+  });
+
+  it("rejects depends_on that includes the task id itself", async () => {
+    const dal = createDal();
+    const scope = await resolveScope();
+
+    const item = await dal.createItem({
+      scope,
+      item: {
+        kind: "action",
+        title: "Self depends_on",
+        created_from_session_key: "agent:default:main",
+      },
+      createdAtIso: "2026-02-27T00:00:00.000Z",
+    });
+
+    const taskId = "00000000-0000-0000-0000-000000000001";
+    await expect(
+      dal.createTask({
+        scope,
+        task: {
+          work_item_id: item.work_item_id,
+          depends_on: [taskId],
+          execution_profile: "planner",
+          side_effect_class: "none",
+        },
+        taskId,
+        createdAtIso: "2026-02-27T00:00:01.000Z",
+      }),
+    ).rejects.toThrow(/depends_on.*itself/i);
+  });
+
   it("rejects task dependency cycles", async () => {
     const dal = createDal();
     const scope = await resolveScope();
@@ -1188,6 +1246,77 @@ describe("WorkboardDal", () => {
         updatedAtIso: "2026-02-27T00:00:04.000Z",
       }),
     ).rejects.toThrow(/cycle/i);
+  });
+
+  it("normalizes task depends_on entries on read", async () => {
+    const dal = createDal();
+    const scope = await resolveScope();
+
+    const item = await dal.createItem({
+      scope,
+      item: {
+        kind: "action",
+        title: "Read normalization",
+        created_from_session_key: "agent:default:main",
+      },
+      createdAtIso: "2026-02-27T00:00:00.000Z",
+    });
+
+    const root = await dal.createTask({
+      scope,
+      task: {
+        work_item_id: item.work_item_id,
+        execution_profile: "planner",
+        side_effect_class: "none",
+      },
+      taskId: "00000000-0000-0000-0000-000000000001",
+      createdAtIso: "2026-02-27T00:00:01.000Z",
+    });
+
+    const rawTaskId = "00000000-0000-0000-0000-000000000002";
+    const createdAtIso = "2026-02-27T00:00:02.000Z";
+    await db!.run(
+      `INSERT INTO work_item_tasks (
+         tenant_id,
+         task_id,
+         work_item_id,
+         status,
+         depends_on_json,
+         execution_profile,
+         side_effect_class,
+         run_id,
+         approval_id,
+         artifacts_json,
+         started_at,
+         finished_at,
+         result_summary,
+         created_at,
+         updated_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        scope.tenant_id,
+        rawTaskId,
+        item.work_item_id,
+        "queued",
+        JSON.stringify([`  ${root.task_id}  `, root.task_id, "", "   ", root.task_id]),
+        "planner",
+        "none",
+        null,
+        null,
+        "[]",
+        null,
+        null,
+        null,
+        createdAtIso,
+        createdAtIso,
+      ],
+    );
+
+    const tasks = await dal.listTasks({ scope, work_item_id: item.work_item_id });
+    const raw = tasks.find((t) => t.task_id === rawTaskId);
+    expect(raw).toBeDefined();
+    expect(raw!.depends_on).toEqual([root.task_id]);
   });
 
   it("leases runnable tasks respecting fan-out/fan-in dependencies", async () => {


### PR DESCRIPTION
Closes #981

## Summary
- Recorded the decision to keep task-to-task dependencies stored as JSON (`work_item_tasks.depends_on_json`) and documented encoding/invariants.
- Normalized `depends_on` on read and reused the shared helper in dependency-cycle detection + runnable leasing.
- Added unit tests for missing dependency IDs, self-dependencies, and normalization-on-read.

## Verification
- `pnpm format:check`
- `pnpm lint` (0 errors)
- `pnpm typecheck`
- `pnpm test` (2955 passed, 2 skipped)