### PR TITLE
[Data model] Standardize enum constraints for status/kind columns (#979)

### DIFF
--- a/docs/architecture/db-enum-constraints.md
+++ b/docs/architecture/db-enum-constraints.md
@@ -1,0 +1,29 @@
+# DB enum constraints
+
+This document records which DB columns are treated as enums (and constrained at the database layer) vs intentionally open-ended.
+
+## Constrained (CHECK)
+
+### Plans (`plans`)
+
+- `plans.kind`: `audit | planner`
+- `plans.status`: `active | success | escalate | failure`
+
+Enforced in:
+
+- SQLite: `packages/gateway/migrations/sqlite/102_enum_constraints_v2.sql`
+- Postgres: `packages/gateway/migrations/postgres/102_enum_constraints_v2.sql`
+
+### Approvals (`approvals`)
+
+- `approvals.kind`: `@tyrum/schemas` `ApprovalKind`
+- `approvals.status`: `@tyrum/schemas` `ApprovalStatus`
+
+Enforced in:
+
+- SQLite: `packages/gateway/migrations/sqlite/102_enum_constraints_v2.sql`
+- Postgres: `packages/gateway/migrations/postgres/102_enum_constraints_v2.sql`
+
+## Intentionally unconstrained
+
+None documented yet (add rows here when we intentionally keep a `status`/`kind` column open-ended).

--- a/packages/gateway/migrations/postgres/102_enum_constraints_v2.sql
+++ b/packages/gateway/migrations/postgres/102_enum_constraints_v2.sql
@@ -1,0 +1,65 @@
+-- Tyrum Gateway schema v2 (Postgres) — enum constraints for stable status/kind columns.
+--
+-- Goal: align DB-level integrity with gateway-owned enums (and protect state machines
+-- from typo values). This migration is written to be rolling-upgrade safe by
+-- normalizing legacy/invalid stored values before applying CHECK constraints.
+
+-- ---------------------------------------------------------------------------
+-- Plans / planner
+-- ---------------------------------------------------------------------------
+
+UPDATE plans
+SET kind = 'audit'
+WHERE kind NOT IN ('audit', 'planner');
+
+UPDATE plans
+SET status = 'active'
+WHERE status NOT IN ('active', 'success', 'escalate', 'failure');
+
+ALTER TABLE plans
+  ADD CONSTRAINT plans_kind_check CHECK (kind IN ('audit', 'planner')),
+  ADD CONSTRAINT plans_status_check CHECK (status IN ('active', 'success', 'escalate', 'failure'));
+
+-- ---------------------------------------------------------------------------
+-- Approvals
+-- ---------------------------------------------------------------------------
+
+UPDATE approvals
+SET kind = 'other'
+WHERE kind NOT IN (
+  'spend',
+  'pii',
+  'workflow_step',
+  'policy',
+  'budget',
+  'pairing',
+  'takeover',
+  'intent',
+  'retry',
+  'connector.send',
+  'other'
+);
+
+UPDATE approvals
+SET status = 'pending'
+WHERE status NOT IN ('pending', 'approved', 'denied', 'expired', 'cancelled');
+
+ALTER TABLE approvals
+  ADD CONSTRAINT approvals_kind_check CHECK (
+    kind IN (
+      'spend',
+      'pii',
+      'workflow_step',
+      'policy',
+      'budget',
+      'pairing',
+      'takeover',
+      'intent',
+      'retry',
+      'connector.send',
+      'other'
+    )
+  ),
+  ADD CONSTRAINT approvals_status_check CHECK (
+    status IN ('pending', 'approved', 'denied', 'expired', 'cancelled')
+  );

--- a/packages/gateway/migrations/sqlite/102_enum_constraints_v2.sql
+++ b/packages/gateway/migrations/sqlite/102_enum_constraints_v2.sql
@@ -1,0 +1,186 @@
+-- tyrum:disable_foreign_keys
+--
+-- Tyrum Gateway schema v2 (SQLite) — enum constraints for stable status/kind columns.
+--
+-- Goal: align DB-level integrity with gateway-owned enums (and protect state machines
+-- from typo values). This migration is written to be rolling-upgrade safe by
+-- normalizing legacy/invalid stored values during the table rebuild.
+
+-- ---------------------------------------------------------------------------
+-- Plans / planner
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE plans_next (
+  tenant_id    TEXT NOT NULL,
+  plan_id      TEXT NOT NULL,
+  plan_key     TEXT NOT NULL,
+  agent_id     TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  session_id   TEXT,
+  kind         TEXT NOT NULL CHECK (kind IN ('audit','planner')),
+  status       TEXT NOT NULL CHECK (status IN ('active','success','escalate','failure')),
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, plan_id),
+  UNIQUE (tenant_id, plan_key),
+  FOREIGN KEY (tenant_id, agent_id, workspace_id)
+    REFERENCES agent_workspaces(tenant_id, agent_id, workspace_id) ON DELETE CASCADE,
+  FOREIGN KEY (tenant_id, session_id) REFERENCES sessions(tenant_id, session_id) ON DELETE SET NULL
+);
+
+INSERT INTO plans_next (
+  tenant_id,
+  plan_id,
+  plan_key,
+  agent_id,
+  workspace_id,
+  session_id,
+  kind,
+  status,
+  created_at,
+  updated_at
+)
+SELECT
+  tenant_id,
+  plan_id,
+  plan_key,
+  agent_id,
+  workspace_id,
+  session_id,
+  CASE
+    WHEN kind IN ('audit','planner') THEN kind
+    ELSE 'audit'
+  END AS kind,
+  CASE
+    WHEN status IN ('active','success','escalate','failure') THEN status
+    ELSE 'active'
+  END AS status,
+  created_at,
+  updated_at
+FROM plans;
+
+DROP TABLE plans;
+ALTER TABLE plans_next RENAME TO plans;
+
+CREATE INDEX IF NOT EXISTS plans_tenant_plan_key_idx ON plans (tenant_id, plan_key);
+
+-- ---------------------------------------------------------------------------
+-- Approvals
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE approvals_next (
+  tenant_id    TEXT NOT NULL,
+  approval_id  TEXT NOT NULL,
+  approval_key TEXT NOT NULL,
+  agent_id     TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  kind         TEXT NOT NULL CHECK (
+    kind IN (
+      'spend',
+      'pii',
+      'workflow_step',
+      'policy',
+      'budget',
+      'pairing',
+      'takeover',
+      'intent',
+      'retry',
+      'connector.send',
+      'other'
+    )
+  ),
+  status       TEXT NOT NULL CHECK (status IN ('pending','approved','denied','expired','cancelled')),
+  prompt       TEXT NOT NULL,
+  context_json TEXT NOT NULL DEFAULT '{}',
+  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at   TEXT,
+  resolved_at  TEXT,
+  resolution_json TEXT,
+  session_id   TEXT,
+  plan_id      TEXT,
+  run_id       TEXT,
+  step_id      TEXT,
+  attempt_id   TEXT,
+  work_item_id TEXT,
+  work_item_task_id TEXT,
+  resume_token TEXT,
+  PRIMARY KEY (tenant_id, approval_id),
+  UNIQUE (tenant_id, approval_key),
+  FOREIGN KEY (tenant_id, agent_id, workspace_id)
+    REFERENCES agent_workspaces(tenant_id, agent_id, workspace_id) ON DELETE CASCADE,
+  FOREIGN KEY (tenant_id, session_id) REFERENCES sessions(tenant_id, session_id) ON DELETE SET NULL,
+  FOREIGN KEY (tenant_id, plan_id) REFERENCES plans(tenant_id, plan_id) ON DELETE SET NULL
+);
+
+INSERT INTO approvals_next (
+  tenant_id,
+  approval_id,
+  approval_key,
+  agent_id,
+  workspace_id,
+  kind,
+  status,
+  prompt,
+  context_json,
+  created_at,
+  expires_at,
+  resolved_at,
+  resolution_json,
+  session_id,
+  plan_id,
+  run_id,
+  step_id,
+  attempt_id,
+  work_item_id,
+  work_item_task_id,
+  resume_token
+)
+SELECT
+  tenant_id,
+  approval_id,
+  approval_key,
+  agent_id,
+  workspace_id,
+  CASE
+    WHEN kind IN (
+      'spend',
+      'pii',
+      'workflow_step',
+      'policy',
+      'budget',
+      'pairing',
+      'takeover',
+      'intent',
+      'retry',
+      'connector.send',
+      'other'
+    ) THEN kind
+    ELSE 'other'
+  END AS kind,
+  CASE
+    WHEN status IN ('pending','approved','denied','expired','cancelled') THEN status
+    ELSE 'pending'
+  END AS status,
+  prompt,
+  context_json,
+  created_at,
+  expires_at,
+  resolved_at,
+  resolution_json,
+  session_id,
+  plan_id,
+  run_id,
+  step_id,
+  attempt_id,
+  work_item_id,
+  work_item_task_id,
+  resume_token
+FROM approvals;
+
+DROP TABLE approvals;
+ALTER TABLE approvals_next RENAME TO approvals;
+
+CREATE INDEX IF NOT EXISTS approvals_status_idx ON approvals (tenant_id, status);
+CREATE INDEX IF NOT EXISTS approvals_expires_at_idx ON approvals (tenant_id, expires_at);
+CREATE INDEX IF NOT EXISTS approvals_session_id_idx ON approvals (tenant_id, session_id);
+CREATE INDEX IF NOT EXISTS approvals_plan_id_idx ON approvals (tenant_id, plan_id);

--- a/packages/gateway/src/migrate.ts
+++ b/packages/gateway/src/migrate.ts
@@ -2,6 +2,8 @@ import type Database from "better-sqlite3";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+const DISABLE_FOREIGN_KEYS_MARKER = "-- tyrum:disable_foreign_keys";
+
 /**
  * Applies SQL migration files in filename order from the given directory.
  * Tracks applied migrations in a `_migrations` table to ensure idempotency.
@@ -39,7 +41,16 @@ export function migrate(db: Database.Database, migrationsDir: string): void {
   for (const file of files) {
     if (applied.has(file)) continue;
     const sql = readFileSync(join(migrationsDir, file), "utf-8");
-    applyMigration(file, sql);
+    if (sql.includes(DISABLE_FOREIGN_KEYS_MARKER)) {
+      db.exec("PRAGMA foreign_keys = OFF");
+      try {
+        applyMigration(file, sql);
+      } finally {
+        db.exec("PRAGMA foreign_keys = ON");
+      }
+    } else {
+      applyMigration(file, sql);
+    }
     applied.add(file);
   }
 }

--- a/packages/gateway/tests/unit/db-enum-constraints.test.ts
+++ b/packages/gateway/tests/unit/db-enum-constraints.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import type { SqliteDb } from "../../src/statestore/sqlite.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+} from "../../src/modules/identity/scope.js";
+
+describe("DB enum constraints", () => {
+  let db: SqliteDb | undefined;
+
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  async function insertPlan(kind: string, status: string): Promise<void> {
+    if (!db) throw new Error("test db not initialized");
+    await db.run(
+      `INSERT INTO plans (tenant_id, plan_id, plan_key, agent_id, workspace_id, kind, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        DEFAULT_TENANT_ID,
+        randomUUID(),
+        `plan-${randomUUID()}`,
+        DEFAULT_AGENT_ID,
+        DEFAULT_WORKSPACE_ID,
+        kind,
+        status,
+      ],
+    );
+  }
+
+  async function insertApproval(kind: string, status: string): Promise<void> {
+    if (!db) throw new Error("test db not initialized");
+    await db.run(
+      `INSERT INTO approvals (
+         tenant_id,
+         approval_id,
+         approval_key,
+         agent_id,
+         workspace_id,
+         kind,
+         status,
+         prompt
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        DEFAULT_TENANT_ID,
+        randomUUID(),
+        `approval-${randomUUID()}`,
+        DEFAULT_AGENT_ID,
+        DEFAULT_WORKSPACE_ID,
+        kind,
+        status,
+        "test prompt",
+      ],
+    );
+  }
+
+  it("rejects invalid plans.kind values", async () => {
+    db = openTestSqliteDb();
+    await expect(insertPlan("not_a_kind", "active")).rejects.toThrow();
+  });
+
+  it("rejects invalid plans.status values", async () => {
+    db = openTestSqliteDb();
+    await expect(insertPlan("audit", "not_a_status")).rejects.toThrow();
+  });
+
+  it("rejects invalid approvals.kind values", async () => {
+    db = openTestSqliteDb();
+    await expect(insertApproval("not_a_kind", "pending")).rejects.toThrow();
+  });
+
+  it("rejects invalid approvals.status values", async () => {
+    db = openTestSqliteDb();
+    await expect(insertApproval("workflow_step", "not_a_status")).rejects.toThrow();
+  });
+});

--- a/packages/gateway/tests/unit/execution-engine.test.ts
+++ b/packages/gateway/tests/unit/execution-engine.test.ts
@@ -1380,7 +1380,7 @@ describe("ExecutionEngine (normalized)", () => {
     expect(run?.paused_reason).toBe("policy");
 
     const policyApproval = await db.get<{ kind: string }>(
-      "SELECT kind FROM approvals WHERE tenant_id = ? AND run_id = ? ORDER BY created_at DESC, approval_id DESC LIMIT 1",
+      "SELECT kind FROM approvals WHERE tenant_id = ? AND run_id = ? AND kind = 'policy' ORDER BY created_at DESC, approval_id DESC LIMIT 1",
       [DEFAULT_TENANT_ID, runId],
     );
     expect(policyApproval?.kind).toBe("policy");

--- a/packages/gateway/tests/unit/planner-events-append-next.test.ts
+++ b/packages/gateway/tests/unit/planner-events-append-next.test.ts
@@ -57,7 +57,7 @@ describe("planner event append-next helpers", () => {
           "plan-1",
           DEFAULT_AGENT_ID,
           DEFAULT_WORKSPACE_ID,
-          "test",
+          "audit",
           "active",
         ],
       );

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -16,10 +16,13 @@ export const ApprovalKind = z.enum([
   "spend",
   "pii",
   "workflow_step",
+  "intent",
+  "retry",
   "policy",
   "budget",
   "pairing",
   "takeover",
+  "connector.send",
   "other",
 ]);
 export type ApprovalKind = z.infer<typeof ApprovalKind>;

--- a/packages/schemas/tests/approval.test.ts
+++ b/packages/schemas/tests/approval.test.ts
@@ -95,7 +95,10 @@ describe("Approval contracts", () => {
   it("exports stable enums", () => {
     expect(ApprovalStatus.options).toContain("pending");
     expect(ApprovalKind.options).toContain("workflow_step");
+    expect(ApprovalKind.options).toContain("intent");
+    expect(ApprovalKind.options).toContain("retry");
     expect(ApprovalKind.options).toContain("budget");
     expect(ApprovalKind.options).toContain("policy");
+    expect(ApprovalKind.options).toContain("connector.send");
   });
 });


### PR DESCRIPTION
Closes #979

## What
- Add DB CHECK constraints for `plans.kind/status` and `approvals.kind/status` (SQLite + Postgres).
- Normalize legacy/invalid values during migration (rolling-upgrade safe).
- SQLite: support table-rebuild migrations via `-- tyrum:disable_foreign_keys` marker (applied with `PRAGMA foreign_keys=OFF`, then re-enabled).
- Extend `@tyrum/schemas` `ApprovalKind` with `intent`, `retry`, and `connector.send`.
- Add regression tests asserting invalid enum values are rejected.
- Document enum decisions in `docs/architecture/db-enum-constraints.md`.

## Test evidence
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
