### PR TITLE
[Data model] Establish index tuning loop (measure → add indexes → verify) (#986)

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -123,7 +123,11 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Operations & Observability",
-          items: ["architecture/observability", "architecture/presence"],
+          items: [
+            "architecture/observability",
+            "architecture/index-tuning",
+            "architecture/presence",
+          ],
         },
         "architecture/glossary",
       ],

--- a/docs/architecture/index-tuning.md
+++ b/docs/architecture/index-tuning.md
@@ -1,0 +1,48 @@
+# Index tuning loop
+
+Tyrum’s v2 schema ships with a solid baseline index set, but real-world query patterns evolve. This runbook defines a lightweight loop for proposing and validating index changes.
+
+## Checklist
+
+1. **Capture the hot query**
+   - Record the exact SQL and the call site (file + function).
+   - Note cadence and cardinality (e.g., “runs every second”, “per session”, “per tenant”).
+
+2. **Measure the baseline**
+   - **SQLite:** run `EXPLAIN QUERY PLAN <SQL>` (and optionally time a representative query loop). For reproducible “explicit index” validation, temporarily set `PRAGMA automatic_index = OFF`.
+   - **Postgres:** run `EXPLAIN (ANALYZE, BUFFERS) <SQL>` on representative data.
+
+3. **Propose an index**
+   - Add a new numbered migration in both:
+     - `packages/gateway/migrations/sqlite/`
+     - `packages/gateway/migrations/postgres/`
+   - Keep index names consistent across dialects.
+   - Include a short justification comment tying the index to the measured query.
+
+4. **Verify improvement**
+   - Confirm the planner uses the new index and eliminates avoidable sorts/scans.
+   - Add a regression test when practical (for example: assert `EXPLAIN QUERY PLAN` uses the index on SQLite).
+
+5. **Rollout / rollback**
+   - Roll forward with an index-add migration.
+   - Roll back by adding a follow-up migration that drops the index (avoid editing applied migrations).
+
+## Example: `channel_outbox` inbox ordering
+
+`ChannelOutboxDal` frequently needs rows ordered by `(chunk_index, outbox_id)` for a single `inbox_id` (list + claim loops). Call sites include `packages/gateway/src/modules/channels/outbox-dal.ts` (`listForInbox`, `claimNextForInbox`). We added an index to avoid a full scan and temp sort.
+
+- Migration:
+  - `packages/gateway/migrations/sqlite/105_channel_outbox_inbox_chunk_order_idx.sql`
+  - `packages/gateway/migrations/postgres/105_channel_outbox_inbox_chunk_order_idx.sql`
+- Regression test: `packages/gateway/tests/contract/index-tuning-loop.test.ts`
+
+SQLite evidence (`EXPLAIN QUERY PLAN` for `WHERE inbox_id = ? ORDER BY chunk_index, outbox_id LIMIT 1`, collected with `PRAGMA automatic_index = OFF`):
+
+```text
+# Before (without 105_* migration)
+SCAN channel_outbox
+USE TEMP B-TREE FOR ORDER BY
+
+# After (with 105_* migration)
+SEARCH channel_outbox USING COVERING INDEX channel_outbox_inbox_chunk_outbox_idx (inbox_id=?)
+```

--- a/packages/gateway/migrations/postgres/105_channel_outbox_inbox_chunk_order_idx.sql
+++ b/packages/gateway/migrations/postgres/105_channel_outbox_inbox_chunk_order_idx.sql
@@ -1,0 +1,4 @@
+-- Indexes for channel_outbox claim/list queries.
+CREATE INDEX IF NOT EXISTS channel_outbox_inbox_chunk_outbox_idx
+ON channel_outbox (inbox_id, chunk_index, outbox_id);
+

--- a/packages/gateway/migrations/sqlite/105_channel_outbox_inbox_chunk_order_idx.sql
+++ b/packages/gateway/migrations/sqlite/105_channel_outbox_inbox_chunk_order_idx.sql
@@ -1,0 +1,4 @@
+-- Indexes for channel_outbox claim/list queries.
+CREATE INDEX IF NOT EXISTS channel_outbox_inbox_chunk_outbox_idx
+ON channel_outbox (inbox_id, chunk_index, outbox_id);
+

--- a/packages/gateway/tests/contract/index-tuning-loop.test.ts
+++ b/packages/gateway/tests/contract/index-tuning-loop.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+
+describe("index tuning loop", () => {
+  it("uses an index for outbox ordering by inbox_id (sqlite)", async () => {
+    const db = openTestSqliteDb();
+    try {
+      await db.exec("PRAGMA automatic_index = OFF");
+
+      const rows = await db.all<{ detail: string }>(
+        `EXPLAIN QUERY PLAN
+         SELECT outbox_id
+         FROM channel_outbox
+         WHERE inbox_id = ?
+         ORDER BY chunk_index ASC, outbox_id ASC
+         LIMIT 1`,
+        [1],
+      );
+
+      const details = rows.map((r) => r.detail).join("\n");
+      expect(details).toContain("channel_outbox_inbox_chunk_outbox_idx");
+    } finally {
+      await db.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #986

## Summary
- Added a short index tuning runbook (`docs/architecture/index-tuning.md`) and linked it in the docs sidebar.
- Added `channel_outbox_inbox_chunk_outbox_idx` to speed inbox-scoped outbox ordering used by claim/list loops.

## Evidence (SQLite)
`EXPLAIN QUERY PLAN` for `WHERE inbox_id = ? ORDER BY chunk_index, outbox_id LIMIT 1` (collected with `PRAGMA automatic_index = OFF`):
- Before (without 105_* migration): `SCAN channel_outbox` + `USE TEMP B-TREE FOR ORDER BY`
- After (with 105_* migration): `SEARCH channel_outbox USING COVERING INDEX channel_outbox_inbox_chunk_outbox_idx (inbox_id=?)`

## Verification
- `pnpm test` (Test Files: 498 passed | 1 skipped; Tests: 2969 passed | 2 skipped)
- `pnpm typecheck`
- `pnpm lint` (0 errors)
- `pnpm format:check`}