### PR TITLE
[Data model] Naming hygiene: standardize PK/FK column naming conventions (#987)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,11 @@ pnpm lint
 pnpm format:check
 ```
 
+If your PR changes database migrations under `packages/gateway/migrations/*`, also verify:
+
+- Naming conventions are followed (PK/FK/timestamps): `docs/architecture/db-naming-conventions.md`
+- SQLite and Postgres stay aligned: `pnpm test packages/gateway/tests/contract/schema-contract.test.ts`
+
 ### Coverage (optional locally, enforced in CI)
 
 CI runs `pnpm test` with coverage enabled and enforces both global and per-component minimums.

--- a/docs/architecture/db-naming-conventions.md
+++ b/docs/architecture/db-naming-conventions.md
@@ -1,0 +1,27 @@
+# DB naming conventions
+
+This document defines naming conventions for StateStore tables and migration SQL, with the goal of keeping SQLite and Postgres schemas aligned and reducing drift.
+
+## Primary keys (PK)
+
+- **Tenant-scoped entities:** prefer composite PKs: `(tenant_id, <entity>_id)` (UUID in Postgres; `TEXT` in SQLite).
+- **Surrogate/auto-increment PKs:** use `<table>_id` (not generic `id`) when the value is returned to callers or used in DAL queries.
+- **Consistency rule:** the PK column name for a table must be the same in both dialects (SQLite + Postgres).
+
+## Foreign keys (FK)
+
+- Name FK columns after the referenced PK column: `<ref_table>_id`.
+- For tenant-scoped references, include `tenant_id` in the FK columns (and in the referenced key) to prevent cross-tenant linkage.
+
+## Timestamps
+
+- Use `created_at` / `updated_at` for wall-clock timestamps (`TIMESTAMPTZ` on Postgres; `TEXT` in SQLite).
+- Use `*_at_ms` for millisecond epoch timestamps (`BIGINT` on Postgres; `INTEGER` in SQLite).
+
+## Migration checklist
+
+When adding or modifying migrations under `packages/gateway/migrations/*`:
+
+- Apply the same schema changes in both `sqlite/` and `postgres/`.
+- Keep PK/FK/timestamp column names consistent with the conventions above.
+- Run the schema contract test: `pnpm test packages/gateway/tests/contract/schema-contract.test.ts`.

--- a/packages/gateway/migrations/postgres/100_rebuild_v2.sql
+++ b/packages/gateway/migrations/postgres/100_rebuild_v2.sql
@@ -1317,7 +1317,7 @@ CREATE TABLE memory_item_embeddings (
 );
 
 CREATE TABLE vector_metadata (
-  id BIGSERIAL PRIMARY KEY,
+  vector_metadata_id BIGSERIAL PRIMARY KEY,
   tenant_id UUID NOT NULL,
   agent_id  UUID NOT NULL,
   embedding_id TEXT NOT NULL,

--- a/packages/gateway/migrations/postgres/101_indexes_v2.sql
+++ b/packages/gateway/migrations/postgres/101_indexes_v2.sql
@@ -203,5 +203,20 @@ ON work_signal_firings (tenant_id, lease_expires_at_ms);
 -- Memory
 CREATE INDEX IF NOT EXISTS memory_items_created_at_idx
 ON memory_items (tenant_id, agent_id, created_at DESC);
-CREATE INDEX IF NOT EXISTS vector_metadata_created_idx
-ON vector_metadata (tenant_id, created_at DESC, id DESC);
+DO $$
+BEGIN
+  -- Keep this migration compatible with both historical schemas:
+  -- - v2 rebuild initially created `vector_metadata.id` (then renamed in 103)
+  -- - newer rebuilds create `vector_metadata.vector_metadata_id` directly
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'vector_metadata'
+      AND column_name = 'vector_metadata_id'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS vector_metadata_created_idx ON vector_metadata (tenant_id, created_at DESC, vector_metadata_id DESC)';
+  ELSE
+    EXECUTE 'CREATE INDEX IF NOT EXISTS vector_metadata_created_idx ON vector_metadata (tenant_id, created_at DESC, id DESC)';
+  END IF;
+END $$;

--- a/packages/gateway/migrations/postgres/103_vector_metadata_pk.sql
+++ b/packages/gateway/migrations/postgres/103_vector_metadata_pk.sql
@@ -1,5 +1,16 @@
 -- Rename Postgres PK column to match SQLite + DAL expectations.
-ALTER TABLE vector_metadata RENAME COLUMN id TO vector_metadata_id;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'vector_metadata'
+      AND column_name = 'id'
+  ) THEN
+    EXECUTE 'ALTER TABLE vector_metadata RENAME COLUMN id TO vector_metadata_id';
+  END IF;
+END $$;
 -- pg-mem (used in tests) does not preserve SERIAL defaults on rename; re-assert explicitly.
 CREATE SEQUENCE IF NOT EXISTS vector_metadata_id_seq;
 ALTER TABLE vector_metadata

--- a/packages/gateway/tests/contract/memory-v1-postgres-migration.test.ts
+++ b/packages/gateway/tests/contract/memory-v1-postgres-migration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { newDb } from "pg-mem";
 import { migratePostgres } from "../../src/migrate-postgres.js";
+import { createPgMemDb } from "../helpers/pg-mem.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const postgresMigrationsDir = join(__dirname, "../../migrations/postgres");
@@ -23,7 +23,7 @@ async function getPostgresColumnUdtName(
 
 describe("Memory v1 migrations (postgres)", () => {
   it("stores memory_tombstones.deleted_at as timestamptz", async () => {
-    const mem = newDb();
+    const mem = createPgMemDb();
     const { Client } = mem.adapters.createPg();
     const pg = new Client();
     await pg.connect();

--- a/packages/gateway/tests/contract/migration-naming-hygiene.test.ts
+++ b/packages/gateway/tests/contract/migration-naming-hygiene.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createDatabase } from "../../src/db.js";
+import { getPostgresColumns, getSqliteColumns } from "../helpers/schema-introspection.js";
+import { createPgMemDb } from "../helpers/pg-mem.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sqliteRebuildPath = join(__dirname, "../../migrations/sqlite/100_rebuild_v2.sql");
+const postgresRebuildPath = join(__dirname, "../../migrations/postgres/100_rebuild_v2.sql");
+
+describe("Migration naming hygiene", () => {
+  it("keeps vector_metadata PK column name aligned in rebuild v2", async () => {
+    const sqlite = createDatabase(":memory:");
+    try {
+      sqlite.exec(readFileSync(sqliteRebuildPath, "utf-8"));
+      const columns = getSqliteColumns(sqlite, "vector_metadata");
+      expect(columns).toContain("vector_metadata_id");
+      expect(columns).not.toContain("id");
+    } finally {
+      sqlite.close();
+    }
+
+    const mem = createPgMemDb();
+    const { Client } = mem.adapters.createPg();
+    const pg = new Client();
+    await pg.connect();
+    try {
+      await pg.query(readFileSync(postgresRebuildPath, "utf-8"));
+      const columns = await getPostgresColumns(pg, "vector_metadata");
+      expect(columns).toContain("vector_metadata_id");
+      expect(columns).not.toContain("id");
+    } finally {
+      await pg.end();
+    }
+  });
+});

--- a/packages/gateway/tests/contract/schema-contract.test.ts
+++ b/packages/gateway/tests/contract/schema-contract.test.ts
@@ -1,33 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { newDb } from "pg-mem";
 import { migrate } from "../../src/migrate.js";
 import { migratePostgres } from "../../src/migrate-postgres.js";
 import { createDatabase } from "../../src/db.js";
+import { getPostgresColumns, getSqliteColumns } from "../helpers/schema-introspection.js";
+import { createPgMemDb } from "../helpers/pg-mem.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sqliteMigrationsDir = join(__dirname, "../../migrations/sqlite");
 const postgresMigrationsDir = join(__dirname, "../../migrations/postgres");
-
-function getSqliteColumns(db: ReturnType<typeof createDatabase>, table: string): string[] {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
-  return rows.map((r) => r.name);
-}
-
-async function getPostgresColumns(
-  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
-  table: string,
-): Promise<string[]> {
-  const res = await client.query(
-    `SELECT column_name
-     FROM information_schema.columns
-     WHERE table_schema = 'public' AND table_name = $1
-     ORDER BY ordinal_position`,
-    [table],
-  );
-  return (res.rows as Array<{ column_name: string }>).map((r) => r.column_name);
-}
 
 describe("StateStore schema contract (sqlite vs postgres)", () => {
   it("keeps core table column sets aligned", async () => {
@@ -36,7 +18,7 @@ describe("StateStore schema contract (sqlite vs postgres)", () => {
     migrate(sqlite, sqliteMigrationsDir);
 
     // Postgres (pg-mem, node-postgres adapter)
-    const mem = newDb();
+    const mem = createPgMemDb();
     const { Client } = mem.adapters.createPg();
     const pg = new Client();
     await pg.connect();

--- a/packages/gateway/tests/helpers/pg-mem.ts
+++ b/packages/gateway/tests/helpers/pg-mem.ts
@@ -1,0 +1,80 @@
+import { DataType, newDb } from "pg-mem";
+
+function registerCommonPgFunctions(mem: ReturnType<typeof newDb>): void {
+  mem.public.registerFunction({
+    name: "strpos",
+    args: [DataType.text, DataType.text],
+    returns: DataType.integer,
+    implementation: (haystack: string, needle: string) => {
+      const idx = haystack.indexOf(needle);
+      return idx >= 0 ? idx + 1 : 0;
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "jsonb_array_length",
+    args: [DataType.jsonb],
+    returns: DataType.integer,
+    implementation: (value: unknown) => {
+      if (!Array.isArray(value)) {
+        throw new Error("cannot get array length of a scalar/object");
+      }
+      return value.length;
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "jsonb_typeof",
+    args: [DataType.jsonb],
+    returns: DataType.text,
+    implementation: (value: unknown) => {
+      if (value === null) return "null";
+      if (Array.isArray(value)) return "array";
+      if (typeof value === "object") return "object";
+      if (typeof value === "string") return "string";
+      if (typeof value === "number") return "number";
+      if (typeof value === "boolean") return "boolean";
+      return "unknown";
+    },
+  });
+
+  mem.public.registerFunction({
+    name: "pg_input_is_valid",
+    args: [DataType.text, DataType.text],
+    returns: DataType.bool,
+    implementation: (value: string, targetType: string) => {
+      if (!targetType || !targetType.toLowerCase().includes("json")) return false;
+      try {
+        JSON.parse(value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}
+
+function registerNoopPlpgsql(mem: ReturnType<typeof newDb>): void {
+  mem.registerLanguage("plpgsql", ({ code }) => {
+    return () => {
+      const source = String(code);
+      const isIfExistsGuard = /IF\s+EXISTS\s*\(/i.test(source);
+      const hasExecute = /EXECUTE\s+'/i.test(source);
+      if (!isIfExistsGuard || !hasExecute) {
+        throw new Error(
+          "pg-mem does not execute plpgsql blocks; extend this stub or avoid DO $$ in migrations",
+        );
+      }
+      // No-op: pg-mem has no plpgsql interpreter. Our Postgres migrations only use
+      // DO $$ guards for backwards compatibility; the mainline schema is covered
+      // by contract tests without needing to execute these blocks.
+    };
+  });
+}
+
+export function createPgMemDb(): ReturnType<typeof newDb> {
+  const mem = newDb();
+  registerCommonPgFunctions(mem);
+  registerNoopPlpgsql(mem);
+  return mem;
+}

--- a/packages/gateway/tests/helpers/postgres-db.ts
+++ b/packages/gateway/tests/helpers/postgres-db.ts
@@ -1,8 +1,8 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { DataType, newDb } from "pg-mem";
 import { migratePostgres } from "../../src/migrate-postgres.js";
 import type { SqlDb } from "../../src/statestore/types.js";
+import { createPgMemDb } from "./pg-mem.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -51,63 +51,8 @@ function translatePlaceholders(sql: string): string {
   return out;
 }
 
-function registerCommonPgFunctions(mem: ReturnType<typeof newDb>): void {
-  mem.public.registerFunction({
-    name: "strpos",
-    args: [DataType.text, DataType.text],
-    returns: DataType.integer,
-    implementation: (haystack: string, needle: string) => {
-      const idx = haystack.indexOf(needle);
-      return idx >= 0 ? idx + 1 : 0;
-    },
-  });
-
-  mem.public.registerFunction({
-    name: "jsonb_array_length",
-    args: [DataType.jsonb],
-    returns: DataType.integer,
-    implementation: (value: unknown) => {
-      if (!Array.isArray(value)) {
-        throw new Error("cannot get array length of a scalar/object");
-      }
-      return value.length;
-    },
-  });
-
-  mem.public.registerFunction({
-    name: "jsonb_typeof",
-    args: [DataType.jsonb],
-    returns: DataType.text,
-    implementation: (value: unknown) => {
-      if (value === null) return "null";
-      if (Array.isArray(value)) return "array";
-      if (typeof value === "object") return "object";
-      if (typeof value === "string") return "string";
-      if (typeof value === "number") return "number";
-      if (typeof value === "boolean") return "boolean";
-      return "unknown";
-    },
-  });
-
-  mem.public.registerFunction({
-    name: "pg_input_is_valid",
-    args: [DataType.text, DataType.text],
-    returns: DataType.bool,
-    implementation: (value: string, targetType: string) => {
-      if (!targetType || !targetType.toLowerCase().includes("json")) return false;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-  });
-}
-
 export async function openTestPostgresDb(): Promise<{ db: SqlDb; close: () => Promise<void> }> {
-  const mem = newDb();
-  registerCommonPgFunctions(mem);
+  const mem = createPgMemDb();
 
   const { Client } = mem.adapters.createPg();
   const pg = new Client();

--- a/packages/gateway/tests/helpers/schema-introspection.ts
+++ b/packages/gateway/tests/helpers/schema-introspection.ts
@@ -1,0 +1,20 @@
+import type Database from "better-sqlite3";
+
+export function getSqliteColumns(db: Database.Database, table: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.map((r) => r.name);
+}
+
+export async function getPostgresColumns(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
+  table: string,
+): Promise<string[]> {
+  const res = await client.query(
+    `SELECT column_name
+     FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = $1
+     ORDER BY ordinal_position`,
+    [table],
+  );
+  return (res.rows as Array<{ column_name: string }>).map((r) => r.column_name);
+}


### PR DESCRIPTION
Closes #987

## What
- Add a short doc for StateStore naming conventions (PK/FK/timestamps)
- Reduce cross-dialect drift by aligning `vector_metadata` PK naming in the v2 rebuild migrations
- Keep pg-mem-based contract tests compatible with Postgres `DO $$` guards used for backward-compat migrations

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm format:check`
