### PR TITLE
lint(desktop-tests): Clear oxlint warnings in apps/desktop/tests/** (#1027)

### DIFF
--- a/apps/desktop/tests/gateway-ipc-handlers.test.ts
+++ b/apps/desktop/tests/gateway-ipc-handlers.test.ts
@@ -44,10 +44,6 @@ vi.mock("electron", () => ({
 vi.mock("undici", () => {
   class Agent {
     destroy = vi.fn(async () => {});
-
-    constructor(_opts: unknown) {
-      // no-op
-    }
   }
 
   return { Agent, fetch: undiciFetchMock };

--- a/apps/desktop/tests/main-context-menu.test.ts
+++ b/apps/desktop/tests/main-context-menu.test.ts
@@ -20,7 +20,7 @@ const {
   loadConfigMock,
   startEmbeddedGatewayFromConfigMock,
 } = vi.hoisted(() => {
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
       loadURL: vi.fn(),
       loadFile: vi.fn(),
@@ -34,44 +34,44 @@ const {
     };
   });
 
-  const appWhenReadyMock = vi.fn(() => new Promise<void>(() => {}));
-  const appOnMock = vi.fn();
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const shellOpenExternalMock = vi.fn(async () => {});
-  const menuBuildFromTemplateMock = vi.fn(() => ({}) as never);
-  const menuSetApplicationMenuMock = vi.fn();
+  const appWhenReadyMockInner = vi.fn(() => new Promise<void>(() => {}));
+  const appOnMockInner = vi.fn();
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const shellOpenExternalMockInner = vi.fn(async () => {});
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}) as never);
+  const menuSetApplicationMenuMockInner = vi.fn();
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
 
   return {
-    appRequestSingleInstanceLockMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    appOnMock,
-    appQuitMock,
-    browserWindowMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    shellOpenExternalMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    configExistsMock,
-    loadConfigMock,
-    startEmbeddedGatewayFromConfigMock,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    browserWindowMock: browserWindowMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    shellOpenExternalMock: shellOpenExternalMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-deep-links.test.ts
+++ b/apps/desktop/tests/main-deep-links.test.ts
@@ -30,94 +30,96 @@ const {
   captureWindowStateMock,
   ensureVisibleBoundsMock,
 } = vi.hoisted(() => {
-  const appHandlers = new Map<string, (...args: unknown[]) => void>();
-  const ipcMainHandlers = new Map<string, (...args: unknown[]) => unknown>();
-  const readyToShowHandlers: Array<() => void> = [];
+  const appHandlersInner = new Map<string, (...args: unknown[]) => void>();
+  const ipcMainHandlersInner = new Map<string, (...args: unknown[]) => unknown>();
+  const readyToShowHandlersInner: Array<() => void> = [];
 
-  const appOnMock = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-    appHandlers.set(event, handler);
+  const appOnMockInner = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    appHandlersInner.set(event, handler);
   });
-  const appWhenReadyMock = vi.fn(() => Promise.resolve());
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appGetPathMock = vi.fn(() => "/tmp/tyrum-desktop-tests");
-  const appSetAppUserModelIdMock = vi.fn();
+  const appWhenReadyMockInner = vi.fn(() => Promise.resolve());
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appGetPathMockInner = vi.fn(() => "/tmp/tyrum-desktop-tests");
+  const appSetAppUserModelIdMockInner = vi.fn();
 
-  const webContentsSendMock = vi.fn();
-  const browserWindowFocusMock = vi.fn();
-  const browserWindowOnceMock = vi.fn((event: string, handler: () => void) => {
+  const webContentsSendMockInner = vi.fn();
+  const browserWindowFocusMockInner = vi.fn();
+  const browserWindowOnceMockInner = vi.fn((event: string, handler: () => void) => {
     if (event === "ready-to-show") {
-      readyToShowHandlers.push(handler);
+      readyToShowHandlersInner.push(handler);
     }
   });
 
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
       loadURL: vi.fn(),
       loadFile: vi.fn(),
       on: vi.fn(),
       isMinimized: vi.fn(() => false),
       restore: vi.fn(),
-      once: browserWindowOnceMock,
+      once: browserWindowOnceMockInner,
       show: vi.fn(),
-      focus: browserWindowFocusMock,
+      focus: browserWindowFocusMockInner,
       isDestroyed: vi.fn(() => false),
       webContents: {
         on: vi.fn(),
         isDestroyed: vi.fn(() => false),
-        send: webContentsSendMock,
+        send: webContentsSendMockInner,
         setWindowOpenHandler: vi.fn(),
       },
     };
   });
 
-  const ipcMainHandleMock = vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
-    ipcMainHandlers.set(channel, handler);
-  });
+  const ipcMainHandleMockInner = vi.fn(
+    (channel: string, handler: (...args: unknown[]) => unknown) => {
+      ipcMainHandlersInner.set(channel, handler);
+    },
+  );
 
-  const menuBuildFromTemplateMock = vi.fn(() => ({}));
-  const menuSetApplicationMenuMock = vi.fn();
-  const nativeThemeOnMock = vi.fn();
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}));
+  const menuSetApplicationMenuMockInner = vi.fn();
+  const nativeThemeOnMockInner = vi.fn();
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
 
-  const loadWindowStateMock = vi.fn(() => null);
-  const saveWindowStateMock = vi.fn();
-  const captureWindowStateMock = vi.fn();
-  const ensureVisibleBoundsMock = vi.fn((bounds: unknown) => bounds);
+  const loadWindowStateMockInner = vi.fn(() => null);
+  const saveWindowStateMockInner = vi.fn();
+  const captureWindowStateMockInner = vi.fn();
+  const ensureVisibleBoundsMockInner = vi.fn((bounds: unknown) => bounds);
 
   return {
-    appHandlers,
-    appOnMock,
-    appWhenReadyMock,
-    appRequestSingleInstanceLockMock,
-    appGetPathMock,
-    appSetAppUserModelIdMock,
-    browserWindowMock,
-    browserWindowOnceMock,
-    browserWindowFocusMock,
-    ipcMainHandlers,
-    ipcMainHandleMock,
-    readyToShowHandlers,
-    webContentsSendMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    nativeThemeOnMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    configExistsMock,
-    loadConfigMock,
-    loadWindowStateMock,
-    saveWindowStateMock,
-    captureWindowStateMock,
-    ensureVisibleBoundsMock,
+    appHandlers: appHandlersInner,
+    appOnMock: appOnMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appGetPathMock: appGetPathMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    browserWindowMock: browserWindowMockInner,
+    browserWindowOnceMock: browserWindowOnceMockInner,
+    browserWindowFocusMock: browserWindowFocusMockInner,
+    ipcMainHandlers: ipcMainHandlersInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    readyToShowHandlers: readyToShowHandlersInner,
+    webContentsSendMock: webContentsSendMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    loadWindowStateMock: loadWindowStateMockInner,
+    saveWindowStateMock: saveWindowStateMockInner,
+    captureWindowStateMock: captureWindowStateMockInner,
+    ensureVisibleBoundsMock: ensureVisibleBoundsMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-lifecycle.test.ts
+++ b/apps/desktop/tests/main-lifecycle.test.ts
@@ -21,51 +21,51 @@ const {
   registerUpdateIpcMock,
   shutdownNodeResourcesMock,
 } = vi.hoisted(() => {
-  const appHandlers = new Map<string, (...args: unknown[]) => void>();
-  const ipcMainHandleMock = vi.fn();
-  const nativeThemeOnMock = vi.fn();
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const appOnMock = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-    appHandlers.set(event, handler);
+  const appHandlersInner = new Map<string, (...args: unknown[]) => void>();
+  const ipcMainHandleMockInner = vi.fn();
+  const nativeThemeOnMockInner = vi.fn();
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const appOnMockInner = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    appHandlersInner.set(event, handler);
   });
-  const appWhenReadyMock = vi.fn(() => new Promise<void>(() => {}));
-  const browserWindowMock = vi.fn(() => ({
+  const appWhenReadyMockInner = vi.fn(() => new Promise<void>(() => {}));
+  const browserWindowMockInner = vi.fn(() => ({
     loadURL: vi.fn(),
     loadFile: vi.fn(),
     on: vi.fn(),
   }));
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "embedded" }));
-  const registerNodeIpcMock = vi.fn();
-  const registerConfigIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
-  const shutdownNodeResourcesMock = vi.fn(async () => {});
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "embedded" }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
+  const shutdownNodeResourcesMockInner = vi.fn(async () => {});
 
   return {
-    appHandlers,
-    appOnMock,
-    appQuitMock,
-    appRequestSingleInstanceLockMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    browserWindowMock,
-    ipcMainHandleMock,
-    nativeThemeOnMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    startEmbeddedGatewayFromConfigMock,
-    configExistsMock,
-    loadConfigMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    shutdownNodeResourcesMock,
+    appHandlers: appHandlersInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    browserWindowMock: browserWindowMockInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    shutdownNodeResourcesMock: shutdownNodeResourcesMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-navigation-guard.test.ts
+++ b/apps/desktop/tests/main-navigation-guard.test.ts
@@ -31,12 +31,12 @@ const {
   screenGetAllDisplaysMock,
   screenGetPrimaryDisplayMock,
 } = vi.hoisted(() => {
-  const ipcMainHandleMock = vi.fn();
-  const nativeThemeOnMock = vi.fn();
+  const ipcMainHandleMockInner = vi.fn();
+  const nativeThemeOnMockInner = vi.fn();
 
-  const webContentsOnMock = vi.fn();
-  const setWindowOpenHandlerMock = vi.fn();
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const webContentsOnMockInner = vi.fn();
+  const setWindowOpenHandlerMockInner = vi.fn();
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
       loadURL: vi.fn(),
       loadFile: vi.fn(),
@@ -44,77 +44,77 @@ const {
       once: vi.fn(),
       show: vi.fn(),
       webContents: {
-        on: webContentsOnMock,
-        setWindowOpenHandler: setWindowOpenHandlerMock,
+        on: webContentsOnMockInner,
+        setWindowOpenHandler: setWindowOpenHandlerMockInner,
       },
     };
   });
-  const appWhenReadyMock = vi.fn(() => Promise.resolve());
-  const appOnMock = vi.fn();
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const appGetPathMock = vi.fn(() => "/tmp/tyrum-desktop-tests");
-  const shellOpenExternalMock = vi.fn(async () => {});
-  const menuBuildFromTemplateMock = vi.fn(() => ({}) as never);
-  const menuSetApplicationMenuMock = vi.fn();
+  const appWhenReadyMockInner = vi.fn(() => Promise.resolve());
+  const appOnMockInner = vi.fn();
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const appGetPathMockInner = vi.fn(() => "/tmp/tyrum-desktop-tests");
+  const shellOpenExternalMockInner = vi.fn(async () => {});
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}) as never);
+  const menuSetApplicationMenuMockInner = vi.fn();
 
-  const screenGetPrimaryDisplayMock = vi.fn(() => ({
+  const screenGetPrimaryDisplayMockInner = vi.fn(() => ({
     id: 1,
     workArea: { x: 0, y: 0, width: 1920, height: 1080 },
   }));
-  const screenGetAllDisplaysMock = vi.fn(() => [
+  const screenGetAllDisplaysMockInner = vi.fn(() => [
     {
       id: 1,
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },
     },
   ]);
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
 
-  const loadWindowStateMock = vi.fn(() => null);
-  const saveWindowStateMock = vi.fn();
-  const captureWindowStateMock = vi.fn();
-  const ensureVisibleBoundsMock = vi.fn((bounds: unknown) => bounds);
+  const loadWindowStateMockInner = vi.fn(() => null);
+  const saveWindowStateMockInner = vi.fn();
+  const captureWindowStateMockInner = vi.fn();
+  const ensureVisibleBoundsMockInner = vi.fn((bounds: unknown) => bounds);
 
   return {
-    appRequestSingleInstanceLockMock,
-    appGetPathMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    appOnMock,
-    appQuitMock,
-    browserWindowMock,
-    ipcMainHandleMock,
-    nativeThemeOnMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    shellOpenExternalMock,
-    webContentsOnMock,
-    setWindowOpenHandlerMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    configExistsMock,
-    loadConfigMock,
-    startEmbeddedGatewayFromConfigMock,
-    captureWindowStateMock,
-    ensureVisibleBoundsMock,
-    loadWindowStateMock,
-    saveWindowStateMock,
-    screenGetAllDisplaysMock,
-    screenGetPrimaryDisplayMock,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appGetPathMock: appGetPathMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    browserWindowMock: browserWindowMockInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    shellOpenExternalMock: shellOpenExternalMockInner,
+    webContentsOnMock: webContentsOnMockInner,
+    setWindowOpenHandlerMock: setWindowOpenHandlerMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
+    captureWindowStateMock: captureWindowStateMockInner,
+    ensureVisibleBoundsMock: ensureVisibleBoundsMockInner,
+    loadWindowStateMock: loadWindowStateMockInner,
+    saveWindowStateMock: saveWindowStateMockInner,
+    screenGetAllDisplaysMock: screenGetAllDisplaysMockInner,
+    screenGetPrimaryDisplayMock: screenGetPrimaryDisplayMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-ready-to-show.test.ts
+++ b/apps/desktop/tests/main-ready-to-show.test.ts
@@ -34,110 +34,110 @@ const {
   screenGetAllDisplaysMock,
   screenGetPrimaryDisplayMock,
 } = vi.hoisted(() => {
-  const appHandlers = new Map<string, (...args: unknown[]) => void>();
-  const readyToShowHandlers: Array<() => void> = [];
-  const browserWindowShowMock = vi.fn();
-  const browserWindowOnceMock = vi.fn((event: string, handler: () => void) => {
+  const appHandlersInner = new Map<string, (...args: unknown[]) => void>();
+  const readyToShowHandlersInner: Array<() => void> = [];
+  const browserWindowShowMockInner = vi.fn();
+  const browserWindowOnceMockInner = vi.fn((event: string, handler: () => void) => {
     if (event === "ready-to-show") {
-      readyToShowHandlers.push(handler);
+      readyToShowHandlersInner.push(handler);
     }
   });
-  const webContentsOnMock = vi.fn();
-  const setWindowOpenHandlerMock = vi.fn();
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const webContentsOnMockInner = vi.fn();
+  const setWindowOpenHandlerMockInner = vi.fn();
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
       loadURL: vi.fn(),
       loadFile: vi.fn(),
       on: vi.fn(),
       isMinimized: vi.fn(() => false),
       restore: vi.fn(),
-      once: browserWindowOnceMock,
-      show: browserWindowShowMock,
+      once: browserWindowOnceMockInner,
+      show: browserWindowShowMockInner,
       focus: vi.fn(),
       isDestroyed: vi.fn(() => false),
       webContents: {
-        on: webContentsOnMock,
+        on: webContentsOnMockInner,
         isDestroyed: vi.fn(() => false),
         send: vi.fn(),
-        setWindowOpenHandler: setWindowOpenHandlerMock,
+        setWindowOpenHandler: setWindowOpenHandlerMockInner,
       },
     };
   });
 
-  const appWhenReadyMock = vi.fn(() => Promise.resolve());
-  const appOnMock = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-    appHandlers.set(event, handler);
+  const appWhenReadyMockInner = vi.fn(() => Promise.resolve());
+  const appOnMockInner = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    appHandlersInner.set(event, handler);
   });
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const appGetPathMock = vi.fn(() => "/tmp/tyrum-desktop-tests");
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const appGetPathMockInner = vi.fn(() => "/tmp/tyrum-desktop-tests");
 
-  const screenGetPrimaryDisplayMock = vi.fn(() => ({
+  const screenGetPrimaryDisplayMockInner = vi.fn(() => ({
     id: 1,
     workArea: { x: 0, y: 0, width: 1920, height: 1080 },
   }));
-  const screenGetAllDisplaysMock = vi.fn(() => [
+  const screenGetAllDisplaysMockInner = vi.fn(() => [
     {
       id: 1,
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },
     },
   ]);
 
-  const ipcMainHandleMock = vi.fn();
-  const nativeThemeOnMock = vi.fn();
+  const ipcMainHandleMockInner = vi.fn();
+  const nativeThemeOnMockInner = vi.fn();
 
-  const menuBuildFromTemplateMock = vi.fn(() => ({}));
-  const menuSetApplicationMenuMock = vi.fn();
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}));
+  const menuSetApplicationMenuMockInner = vi.fn();
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
 
-  const loadWindowStateMock = vi.fn(() => null);
-  const saveWindowStateMock = vi.fn();
-  const captureWindowStateMock = vi.fn();
-  const ensureVisibleBoundsMock = vi.fn((bounds: unknown) => bounds);
+  const loadWindowStateMockInner = vi.fn(() => null);
+  const saveWindowStateMockInner = vi.fn();
+  const captureWindowStateMockInner = vi.fn();
+  const ensureVisibleBoundsMockInner = vi.fn((bounds: unknown) => bounds);
 
   return {
-    appRequestSingleInstanceLockMock,
-    appGetPathMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    appHandlers,
-    appOnMock,
-    appQuitMock,
-    browserWindowMock,
-    browserWindowOnceMock,
-    browserWindowShowMock,
-    ipcMainHandleMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    nativeThemeOnMock,
-    readyToShowHandlers,
-    webContentsOnMock,
-    setWindowOpenHandlerMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    configExistsMock,
-    loadConfigMock,
-    startEmbeddedGatewayFromConfigMock,
-    captureWindowStateMock,
-    ensureVisibleBoundsMock,
-    loadWindowStateMock,
-    saveWindowStateMock,
-    screenGetAllDisplaysMock,
-    screenGetPrimaryDisplayMock,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appGetPathMock: appGetPathMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    appHandlers: appHandlersInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    browserWindowMock: browserWindowMockInner,
+    browserWindowOnceMock: browserWindowOnceMockInner,
+    browserWindowShowMock: browserWindowShowMockInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    readyToShowHandlers: readyToShowHandlersInner,
+    webContentsOnMock: webContentsOnMockInner,
+    setWindowOpenHandlerMock: setWindowOpenHandlerMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
+    captureWindowStateMock: captureWindowStateMockInner,
+    ensureVisibleBoundsMock: ensureVisibleBoundsMockInner,
+    loadWindowStateMock: loadWindowStateMockInner,
+    saveWindowStateMock: saveWindowStateMockInner,
+    screenGetAllDisplaysMock: screenGetAllDisplaysMockInner,
+    screenGetPrimaryDisplayMock: screenGetPrimaryDisplayMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-theme-ipc.test.ts
+++ b/apps/desktop/tests/main-theme-ipc.test.ts
@@ -24,23 +24,23 @@ const {
   loadConfigMock,
   startEmbeddedGatewayFromConfigMock,
 } = vi.hoisted(() => {
-  const ipcMainHandleMock = vi.fn();
+  const ipcMainHandleMockInner = vi.fn();
 
   let nativeThemeUpdatedCallback: (() => void) | undefined;
-  const nativeThemeOnMock = vi.fn((event: string, cb: () => void) => {
+  const nativeThemeOnMockInner = vi.fn((event: string, cb: () => void) => {
     if (event === "updated") {
       nativeThemeUpdatedCallback = cb;
     }
   });
 
-  const menuBuildFromTemplateMock = vi.fn(() => ({}) as never);
-  const menuSetApplicationMenuMock = vi.fn();
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}) as never);
+  const menuSetApplicationMenuMockInner = vi.fn();
 
   const webContentsOnMock = vi.fn();
   const setWindowOpenHandlerMock = vi.fn();
-  const webContentsSendMock = vi.fn();
+  const webContentsSendMockInner = vi.fn();
 
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
       loadURL: vi.fn(),
       loadFile: vi.fn(),
@@ -50,7 +50,7 @@ const {
       focus: vi.fn(),
       isDestroyed: vi.fn(() => false),
       webContents: {
-        send: webContentsSendMock,
+        send: webContentsSendMockInner,
         isDestroyed: vi.fn(() => false),
         on: webContentsOnMock,
         setWindowOpenHandler: setWindowOpenHandlerMock,
@@ -58,46 +58,46 @@ const {
     };
   });
 
-  const appWhenReadyMock = vi.fn(() => Promise.resolve());
-  const appOnMock = vi.fn();
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const appGetPathMock = vi.fn(() => "/tmp/tyrum-desktop-tests");
+  const appWhenReadyMockInner = vi.fn(() => Promise.resolve());
+  const appOnMockInner = vi.fn();
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const appGetPathMockInner = vi.fn(() => "/tmp/tyrum-desktop-tests");
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
 
   return {
-    appGetPathMock,
-    appOnMock,
-    appQuitMock,
-    appRequestSingleInstanceLockMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    browserWindowMock,
-    ipcMainHandleMock,
-    nativeThemeOnMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    webContentsSendMock,
+    appGetPathMock: appGetPathMockInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    browserWindowMock: browserWindowMockInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    webContentsSendMock: webContentsSendMockInner,
     getNativeThemeUpdatedCallback: () => nativeThemeUpdatedCallback,
-    configExistsMock,
-    loadConfigMock,
-    startEmbeddedGatewayFromConfigMock,
+    configExistsMock: configExistsMockInner,
+    loadConfigMock: loadConfigMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
   };
 });
 

--- a/apps/desktop/tests/main-window-state-persistence.test.ts
+++ b/apps/desktop/tests/main-window-state-persistence.test.ts
@@ -32,24 +32,24 @@ const {
   startEmbeddedGatewayFromConfigMock,
   windowHandlers,
 } = vi.hoisted(() => {
-  const appWhenReadyMock = vi.fn(() => Promise.resolve());
-  const appOnMock = vi.fn();
-  const appQuitMock = vi.fn();
-  const appRequestSingleInstanceLockMock = vi.fn(() => true);
-  const appSetAppUserModelIdMock = vi.fn();
-  const appGetPathMock = vi.fn(() => "/tmp/tyrum-desktop-tests");
+  const appWhenReadyMockInner = vi.fn(() => Promise.resolve());
+  const appOnMockInner = vi.fn();
+  const appQuitMockInner = vi.fn();
+  const appRequestSingleInstanceLockMockInner = vi.fn(() => true);
+  const appSetAppUserModelIdMockInner = vi.fn();
+  const appGetPathMockInner = vi.fn(() => "/tmp/tyrum-desktop-tests");
 
-  const windowHandlers = new Map<string, (...args: unknown[]) => void>();
-  const browserWindowOnMock = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-    windowHandlers.set(event, handler);
+  const windowHandlersInner = new Map<string, (...args: unknown[]) => void>();
+  const browserWindowOnMockInner = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    windowHandlersInner.set(event, handler);
   });
-  const browserWindowMaximizeMock = vi.fn();
-  const browserWindowMock = vi.fn(function MockBrowserWindow() {
+  const browserWindowMaximizeMockInner = vi.fn();
+  const browserWindowMockInner = vi.fn(function MockBrowserWindow() {
     return {
-      maximize: browserWindowMaximizeMock,
+      maximize: browserWindowMaximizeMockInner,
       loadURL: vi.fn(),
       loadFile: vi.fn(),
-      on: browserWindowOnMock,
+      on: browserWindowOnMockInner,
       once: vi.fn(),
       show: vi.fn(),
       focus: vi.fn(),
@@ -63,48 +63,48 @@ const {
     };
   });
 
-  const screenGetPrimaryDisplayMock = vi.fn(() => ({
+  const screenGetPrimaryDisplayMockInner = vi.fn(() => ({
     id: 1,
     workArea: { x: 0, y: 0, width: 1920, height: 1080 },
   }));
-  const screenGetAllDisplaysMock = vi.fn(() => [
+  const screenGetAllDisplaysMockInner = vi.fn(() => [
     {
       id: 1,
       workArea: { x: 0, y: 0, width: 1920, height: 1080 },
     },
   ]);
 
-  const menuBuildFromTemplateMock = vi.fn(() => ({}));
-  const menuSetApplicationMenuMock = vi.fn();
-  const dialogShowMessageBoxMock = vi.fn(async () => ({ response: 0 }));
+  const menuBuildFromTemplateMockInner = vi.fn(() => ({}));
+  const menuSetApplicationMenuMockInner = vi.fn();
+  const dialogShowMessageBoxMockInner = vi.fn(async () => ({ response: 0 }));
 
-  const ipcMainHandleMock = vi.fn();
-  const nativeThemeOnMock = vi.fn();
+  const ipcMainHandleMockInner = vi.fn();
+  const nativeThemeOnMockInner = vi.fn();
 
-  const registerConfigIpcMock = vi.fn();
-  const registerGatewayIpcMock = vi.fn(() => ({ stop: vi.fn() }));
-  const registerNodeIpcMock = vi.fn();
-  const registerUpdateIpcMock = vi.fn();
+  const registerConfigIpcMockInner = vi.fn();
+  const registerGatewayIpcMockInner = vi.fn(() => ({ stop: vi.fn() }));
+  const registerNodeIpcMockInner = vi.fn();
+  const registerUpdateIpcMockInner = vi.fn();
 
-  const configExistsMock = vi.fn(() => true);
-  const loadConfigMock = vi.fn(() => ({ mode: "remote" }));
-  const startEmbeddedGatewayFromConfigMock = vi.fn(async () => ({
+  const configExistsMockInner = vi.fn(() => true);
+  const loadConfigMockInner = vi.fn(() => ({ mode: "remote" }));
+  const startEmbeddedGatewayFromConfigMockInner = vi.fn(async () => ({
     status: "running",
     port: 8788,
   }));
 
-  const loadWindowStateMock = vi.fn(() => ({
+  const loadWindowStateMockInner = vi.fn(() => ({
     bounds: { x: 2000, y: 100, width: 800, height: 600 },
     isMaximized: true,
   }));
-  const ensureVisibleBoundsMock = vi.fn((_bounds: unknown, _workAreas: unknown) => ({
+  const ensureVisibleBoundsMockInner = vi.fn((_bounds: unknown, _workAreas: unknown) => ({
     x: 1120,
     y: 100,
     width: 800,
     height: 600,
   }));
-  const saveWindowStateMock = vi.fn();
-  const captureWindowStateMock = vi.fn(
+  const saveWindowStateMockInner = vi.fn();
+  const captureWindowStateMockInner = vi.fn(
     (_window: unknown, options?: { isMaximized?: boolean }) =>
       ({
         bounds: { x: 100, y: 120, width: 800, height: 600 },
@@ -113,34 +113,34 @@ const {
   );
 
   return {
-    appGetPathMock,
-    appOnMock,
-    appQuitMock,
-    appRequestSingleInstanceLockMock,
-    appSetAppUserModelIdMock,
-    appWhenReadyMock,
-    browserWindowMock,
-    captureWindowStateMock,
-    browserWindowMaximizeMock,
-    browserWindowOnMock,
-    configExistsMock,
-    dialogShowMessageBoxMock,
-    ensureVisibleBoundsMock,
-    ipcMainHandleMock,
-    loadConfigMock,
-    loadWindowStateMock,
-    menuBuildFromTemplateMock,
-    menuSetApplicationMenuMock,
-    nativeThemeOnMock,
-    registerConfigIpcMock,
-    registerGatewayIpcMock,
-    registerNodeIpcMock,
-    registerUpdateIpcMock,
-    screenGetAllDisplaysMock,
-    screenGetPrimaryDisplayMock,
-    saveWindowStateMock,
-    startEmbeddedGatewayFromConfigMock,
-    windowHandlers,
+    appGetPathMock: appGetPathMockInner,
+    appOnMock: appOnMockInner,
+    appQuitMock: appQuitMockInner,
+    appRequestSingleInstanceLockMock: appRequestSingleInstanceLockMockInner,
+    appSetAppUserModelIdMock: appSetAppUserModelIdMockInner,
+    appWhenReadyMock: appWhenReadyMockInner,
+    browserWindowMock: browserWindowMockInner,
+    captureWindowStateMock: captureWindowStateMockInner,
+    browserWindowMaximizeMock: browserWindowMaximizeMockInner,
+    browserWindowOnMock: browserWindowOnMockInner,
+    configExistsMock: configExistsMockInner,
+    dialogShowMessageBoxMock: dialogShowMessageBoxMockInner,
+    ensureVisibleBoundsMock: ensureVisibleBoundsMockInner,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    loadConfigMock: loadConfigMockInner,
+    loadWindowStateMock: loadWindowStateMockInner,
+    menuBuildFromTemplateMock: menuBuildFromTemplateMockInner,
+    menuSetApplicationMenuMock: menuSetApplicationMenuMockInner,
+    nativeThemeOnMock: nativeThemeOnMockInner,
+    registerConfigIpcMock: registerConfigIpcMockInner,
+    registerGatewayIpcMock: registerGatewayIpcMockInner,
+    registerNodeIpcMock: registerNodeIpcMockInner,
+    registerUpdateIpcMock: registerUpdateIpcMockInner,
+    screenGetAllDisplaysMock: screenGetAllDisplaysMockInner,
+    screenGetPrimaryDisplayMock: screenGetPrimaryDisplayMockInner,
+    saveWindowStateMock: saveWindowStateMockInner,
+    startEmbeddedGatewayFromConfigMock: startEmbeddedGatewayFromConfigMockInner,
+    windowHandlers: windowHandlersInner,
   };
 });
 

--- a/apps/desktop/tests/renderer-main-operator-ui-bootstrap.test.ts
+++ b/apps/desktop/tests/renderer-main-operator-ui-bootstrap.test.ts
@@ -78,11 +78,11 @@ const {
   setDesktopOperatorCoreState,
   useDesktopOperatorCoreMock,
 } = vi.hoisted(() => {
-  const renderMock = vi.fn();
-  const createRootMock = vi.fn(() => ({ render: renderMock }));
+  const renderMockInner = vi.fn();
+  const createRootMockInner = vi.fn(() => ({ render: renderMockInner }));
 
-  const desktopApi = { kind: "desktop-api" as const };
-  const getDesktopApiMock = vi.fn(() => desktopApi);
+  const desktopApiInner = { kind: "desktop-api" as const };
+  const getDesktopApiMockInner = vi.fn(() => desktopApiInner);
 
   let operatorCoreState: DesktopOperatorCoreState = {
     core: null,
@@ -91,41 +91,41 @@ const {
     needsConfiguration: false,
     retry: vi.fn(),
   };
-  const setDesktopOperatorCoreState = (next: DesktopOperatorCoreState): void => {
+  const setDesktopOperatorCoreStateInner = (next: DesktopOperatorCoreState): void => {
     operatorCoreState = next;
   };
-  const useDesktopOperatorCoreMock = vi.fn(() => operatorCoreState);
+  const useDesktopOperatorCoreMockInner = vi.fn(() => operatorCoreState);
 
-  const ThemeProviderMock = vi.fn(({ children }: { children: unknown }) => children ?? null);
-  const ErrorBoundaryMock = vi.fn(({ children }: { children: unknown }) => children ?? null);
+  const ThemeProviderMockInner = vi.fn(({ children }: { children: unknown }) => children ?? null);
+  const ErrorBoundaryMockInner = vi.fn(({ children }: { children: unknown }) => children ?? null);
 
-  const OperatorUiHostProviderMock = vi.fn(
+  const OperatorUiHostProviderMockInner = vi.fn(
     ({ children }: { children: unknown }) => children ?? null,
   );
-  const OperatorUiAppMock = vi.fn(() => null);
+  const OperatorUiAppMockInner = vi.fn(() => null);
 
-  const AlertMock = vi.fn(() => null);
-  const ButtonMock = vi.fn(() => null);
-  const CardMock = vi.fn(() => null);
-  const CardContentMock = vi.fn(() => null);
-  const InputMock = vi.fn(() => null);
+  const AlertMockInner = vi.fn(() => null);
+  const ButtonMockInner = vi.fn(() => null);
+  const CardMockInner = vi.fn(() => null);
+  const CardContentMockInner = vi.fn(() => null);
+  const InputMockInner = vi.fn(() => null);
 
   return {
-    AlertMock,
-    ButtonMock,
-    CardContentMock,
-    CardMock,
-    ErrorBoundaryMock,
-    InputMock,
-    OperatorUiAppMock,
-    OperatorUiHostProviderMock,
-    ThemeProviderMock,
-    createRootMock,
-    desktopApi,
-    getDesktopApiMock,
-    renderMock,
-    setDesktopOperatorCoreState,
-    useDesktopOperatorCoreMock,
+    AlertMock: AlertMockInner,
+    ButtonMock: ButtonMockInner,
+    CardContentMock: CardContentMockInner,
+    CardMock: CardMockInner,
+    ErrorBoundaryMock: ErrorBoundaryMockInner,
+    InputMock: InputMockInner,
+    OperatorUiAppMock: OperatorUiAppMockInner,
+    OperatorUiHostProviderMock: OperatorUiHostProviderMockInner,
+    ThemeProviderMock: ThemeProviderMockInner,
+    createRootMock: createRootMockInner,
+    desktopApi: desktopApiInner,
+    getDesktopApiMock: getDesktopApiMockInner,
+    renderMock: renderMockInner,
+    setDesktopOperatorCoreState: setDesktopOperatorCoreStateInner,
+    useDesktopOperatorCoreMock: useDesktopOperatorCoreMockInner,
   };
 });
 

--- a/apps/desktop/tests/update-ipc-handlers.test.ts
+++ b/apps/desktop/tests/update-ipc-handlers.test.ts
@@ -14,39 +14,37 @@ const {
   NotificationMock,
   listeners,
 } = vi.hoisted(() => {
-  const ipcMainHandleMock = vi.fn();
-  const registeredHandlers = new Map<string, (...args: unknown[]) => unknown>();
-  const showOpenDialogMock = vi.fn();
-  const openPathMock = vi.fn();
-  const appGetVersionMock = vi.fn(() => "1.0.0");
-  const notificationShowMock = vi.fn();
-  const checkForUpdatesMock = vi.fn(async () => undefined);
-  const downloadUpdateMock = vi.fn(async () => undefined);
-  const quitAndInstallMock = vi.fn();
-  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const ipcMainHandleMockInner = vi.fn();
+  const registeredHandlersInner = new Map<string, (...args: unknown[]) => unknown>();
+  const showOpenDialogMockInner = vi.fn();
+  const openPathMockInner = vi.fn();
+  const appGetVersionMockInner = vi.fn(() => "1.0.0");
+  const notificationShowMockInner = vi.fn();
+  const checkForUpdatesMockInner = vi.fn(async () => undefined);
+  const downloadUpdateMockInner = vi.fn(async () => undefined);
+  const quitAndInstallMockInner = vi.fn();
+  const listenersInner = new Map<string, Array<(...args: unknown[]) => void>>();
 
-  class NotificationMock {
+  class NotificationMockInner {
     static isSupported = vi.fn(() => true);
 
-    constructor(_options: { title: string; body?: string }) {}
-
-    show = notificationShowMock;
+    show = notificationShowMockInner;
   }
 
-  const autoUpdaterMock = {
+  const autoUpdaterMockInner = {
     autoDownload: true,
     autoInstallOnAppQuit: true,
-    checkForUpdates: checkForUpdatesMock,
-    downloadUpdate: downloadUpdateMock,
-    quitAndInstall: quitAndInstallMock,
+    checkForUpdates: checkForUpdatesMockInner,
+    downloadUpdate: downloadUpdateMockInner,
+    quitAndInstall: quitAndInstallMockInner,
     on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
-      const handlers = listeners.get(event) ?? [];
+      const handlers = listenersInner.get(event) ?? [];
       handlers.push(listener);
-      listeners.set(event, handlers);
-      return autoUpdaterMock;
+      listenersInner.set(event, handlers);
+      return autoUpdaterMockInner;
     }),
     emit: (event: string, ...args: unknown[]) => {
-      const handlers = listeners.get(event) ?? [];
+      const handlers = listenersInner.get(event) ?? [];
       for (const handler of handlers) {
         handler(...args);
       }
@@ -54,18 +52,18 @@ const {
   };
 
   return {
-    ipcMainHandleMock,
-    registeredHandlers,
-    showOpenDialogMock,
-    openPathMock,
-    appGetVersionMock,
-    notificationShowMock,
-    autoUpdaterMock,
-    checkForUpdatesMock,
-    downloadUpdateMock,
-    quitAndInstallMock,
-    NotificationMock,
-    listeners,
+    ipcMainHandleMock: ipcMainHandleMockInner,
+    registeredHandlers: registeredHandlersInner,
+    showOpenDialogMock: showOpenDialogMockInner,
+    openPathMock: openPathMockInner,
+    appGetVersionMock: appGetVersionMockInner,
+    notificationShowMock: notificationShowMockInner,
+    autoUpdaterMock: autoUpdaterMockInner,
+    checkForUpdatesMock: checkForUpdatesMockInner,
+    downloadUpdateMock: downloadUpdateMockInner,
+    quitAndInstallMock: quitAndInstallMockInner,
+    NotificationMock: NotificationMockInner,
+    listeners: listenersInner,
   };
 });
 

--- a/apps/desktop/tests/work-item-notification-service.test.ts
+++ b/apps/desktop/tests/work-item-notification-service.test.ts
@@ -21,7 +21,6 @@ const {
 vi.mock("electron", () => ({
   Notification: class NotificationMock {
     static isSupported = vi.fn(() => false);
-    constructor(_options: { title: string; body?: string }) {}
     on = vi.fn();
     show = vi.fn();
   },

--- a/apps/desktop/tests/work-item-notifications.mock.ts
+++ b/apps/desktop/tests/work-item-notifications.mock.ts
@@ -2,8 +2,6 @@ import { vi } from "vitest";
 
 vi.mock("../src/main/work-item-notifications.js", () => ({
   WorkItemNotificationService: class WorkItemNotificationService {
-    constructor(_openDeepLink: unknown) {}
-
     start(): Promise<void> {
       return Promise.resolve();
     }


### PR DESCRIPTION
Closes #1027

## Verification
- `pnpm -s lint:oxlint:report | rg "^apps/desktop/tests/"` (empty)
- `pnpm exec vitest run apps/desktop/tests` (56 passed, 1 skipped; 313 passed, 2 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm format:check`
