### PR TITLE
[Data model] JSON hygiene: standardize *_json default shapes and expectations (#988)

### DIFF
--- a/docs/architecture/db-json-hygiene.md
+++ b/docs/architecture/db-json-hygiene.md
@@ -1,0 +1,28 @@
+# DB JSON hygiene
+
+Tyrum stores many `*_json` columns as **JSON text** (cross-database, simple migrations).
+
+## Canonical shapes + NULLability
+
+The canonical expectations for every `*_json` column (shape, whether `NULL` is allowed, and the DB default when present) live in:
+
+- `packages/gateway/src/statestore/json-columns.json`
+
+This spec is enforced by contract tests:
+
+- `packages/gateway/tests/contract/json-column-specs.test.ts` (SQLite schema vs spec)
+- `packages/gateway/tests/contract/json-column-defaults-aligned.test.ts` (Postgres rebuild migration vs spec defaults)
+
+## Conventions
+
+- **shape = `object`**: JSON object (`{...}`), default (when present) is `{}`.
+- **shape = `array`**: JSON array (`[...]`), default (when present) is `[]`.
+- **shape = `any`**: any JSON value; callers must validate as needed.
+
+## When changing the schema
+
+When adding/changing a `*_json` column:
+
+1. Update the SQLite + Postgres migrations.
+2. Update `packages/gateway/src/statestore/json-columns.json`.
+3. Run `pnpm test` (or at least the relevant contract tests).

--- a/packages/gateway/src/statestore/json-columns.json
+++ b/packages/gateway/src/statestore/json-columns.json
@@ -1,0 +1,429 @@
+[
+  {
+    "table": "agent_state_kv",
+    "column": "provenance_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "agent_state_kv",
+    "column": "value_json",
+    "shape": "any",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "approvals",
+    "column": "context_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "approvals",
+    "column": "resolution_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "auth_profiles",
+    "column": "labels_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "canvas_artifacts",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "channel_inbox",
+    "column": "payload_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "channel_outbox",
+    "column": "response_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "connections",
+    "column": "capabilities_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "connections",
+    "column": "ready_capabilities_json",
+    "shape": "array",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "context_reports",
+    "column": "report_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "execution_artifacts",
+    "column": "labels_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "execution_artifacts",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "execution_attempts",
+    "column": "artifacts_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "execution_attempts",
+    "column": "cost_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_attempts",
+    "column": "metadata_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_attempts",
+    "column": "policy_applied_override_ids_json",
+    "shape": "array",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_attempts",
+    "column": "policy_decision_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_attempts",
+    "column": "postcondition_report_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_attempts",
+    "column": "result_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_jobs",
+    "column": "input_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_jobs",
+    "column": "trigger_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "execution_runs",
+    "column": "budgets_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "execution_steps",
+    "column": "action_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "execution_steps",
+    "column": "postcondition_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "idempotency_records",
+    "column": "result_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "memory_item_provenance",
+    "column": "metadata_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "memory_item_provenance",
+    "column": "refs_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "memory_items",
+    "column": "value_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "node_pairings",
+    "column": "capabilities_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "node_pairings",
+    "column": "capability_allowlist_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "node_pairings",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "node_pairings",
+    "column": "resolved_by_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "oauth_pending",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "outbox",
+    "column": "payload_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "planner_events",
+    "column": "action_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "policy_overrides",
+    "column": "created_by_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "policy_overrides",
+    "column": "revoked_by_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "policy_snapshots",
+    "column": "bundle_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "presence_entries",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "principals",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "routing_configs",
+    "column": "config_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "routing_configs",
+    "column": "created_by_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "sessions",
+    "column": "turns_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "vector_metadata",
+    "column": "metadata_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "watchers",
+    "column": "trigger_config_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "work_artifacts",
+    "column": "provenance_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_artifacts",
+    "column": "refs_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "work_decisions",
+    "column": "alternatives_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "work_decisions",
+    "column": "input_artifact_ids_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "work_item_events",
+    "column": "payload_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "work_item_links",
+    "column": "meta_json",
+    "shape": "object",
+    "nullable": false,
+    "default": "{}"
+  },
+  {
+    "table": "work_item_state_kv",
+    "column": "provenance_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_item_state_kv",
+    "column": "value_json",
+    "shape": "any",
+    "nullable": false,
+    "default": null
+  },
+  {
+    "table": "work_item_tasks",
+    "column": "artifacts_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "work_item_tasks",
+    "column": "depends_on_json",
+    "shape": "array",
+    "nullable": false,
+    "default": "[]"
+  },
+  {
+    "table": "work_items",
+    "column": "acceptance_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_items",
+    "column": "budgets_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_items",
+    "column": "fingerprint_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_signals",
+    "column": "payload_json",
+    "shape": "any",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "work_signals",
+    "column": "trigger_spec_json",
+    "shape": "any",
+    "nullable": false,
+    "default": null
+  }
+]

--- a/packages/gateway/src/utils/json.ts
+++ b/packages/gateway/src/utils/json.ts
@@ -1,7 +1,20 @@
 export function safeJsonParse<T>(raw: string | null | undefined, fallback: T): T {
   if (!raw) return fallback;
   try {
-    return JSON.parse(raw) as T;
+    const parsed = JSON.parse(raw) as unknown;
+    if (fallback == null) return parsed as T;
+
+    if (Array.isArray(fallback)) {
+      return Array.isArray(parsed) ? (parsed as T) : fallback;
+    }
+
+    if (typeof fallback === "object") {
+      return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as T)
+        : fallback;
+    }
+
+    return typeof parsed === typeof fallback ? (parsed as T) : fallback;
   } catch {
     return fallback;
   }

--- a/packages/gateway/tests/contract/json-column-defaults-aligned.test.ts
+++ b/packages/gateway/tests/contract/json-column-defaults-aligned.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type JsonColumnShape = "array" | "object" | "any";
+
+type JsonColumnSpec = {
+  table: string;
+  column: string;
+  shape: JsonColumnShape;
+  nullable: boolean;
+  default: "{}" | "[]" | null;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const specsPath = join(__dirname, "../../src/statestore/json-columns.json");
+const postgresRebuildPath = join(__dirname, "../../migrations/postgres/100_rebuild_v2.sql");
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readSpecs(): JsonColumnSpec[] {
+  return JSON.parse(readFileSync(specsPath, "utf8")) as JsonColumnSpec[];
+}
+
+function findCreateTableBlock(sql: string, table: string): string | null {
+  const pattern = new RegExp(
+    `CREATE\\s+TABLE(?:\\s+IF\\s+NOT\\s+EXISTS)?\\s+${escapeRegex(table)}\\s*\\(([\\s\\S]*?)\\);`,
+    "m",
+  );
+  const match = sql.match(pattern);
+  return match ? (match[1] ?? null) : null;
+}
+
+describe("Postgres migrations", () => {
+  it("keeps *_json column defaults aligned with canonical spec", () => {
+    const specs = readSpecs().filter((s) => s.default !== null);
+    expect(specs.length, "specs with defaults").toBeGreaterThan(0);
+
+    const sql = readFileSync(postgresRebuildPath, "utf8");
+    for (const spec of specs) {
+      const block = findCreateTableBlock(sql, spec.table);
+      expect(block, `missing CREATE TABLE block for ${spec.table}`).toBeTruthy();
+      if (!block) continue;
+
+      const defaultValue = spec.default;
+      const colPattern = new RegExp(
+        `\\b${escapeRegex(spec.column)}\\b[\\s\\S]{0,200}?DEFAULT\\s+'${escapeRegex(defaultValue)}'`,
+        "m",
+      );
+      expect(block, `${spec.table}.${spec.column} default`).toMatch(colPattern);
+    }
+  });
+});

--- a/packages/gateway/tests/contract/json-column-specs.test.ts
+++ b/packages/gateway/tests/contract/json-column-specs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createDatabase } from "../../src/db.js";
+import { migrate } from "../../src/migrate.js";
+
+type JsonColumnShape = "array" | "object" | "any";
+
+type JsonColumnSpec = {
+  table: string;
+  column: string;
+  shape: JsonColumnShape;
+  nullable: boolean;
+  default: "{}" | "[]" | null;
+};
+
+type SqliteColumnInfo = {
+  name: string;
+  notnull: 0 | 1;
+  dflt_value: string | null;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sqliteMigrationsDir = join(__dirname, "../../migrations/sqlite");
+const specsPath = join(__dirname, "../../src/statestore/json-columns.json");
+
+function listSqliteJsonColumns(db: ReturnType<typeof createDatabase>) {
+  const tables = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+    .all()
+    .map((r) => (r as { name: string }).name)
+    .filter((t) => !t.startsWith("sqlite_") && t !== "_migrations");
+
+  const columns: Array<{ table: string; column: string; info: SqliteColumnInfo }> = [];
+  for (const table of tables) {
+    const infos = db.prepare(`PRAGMA table_info(${table})`).all() as SqliteColumnInfo[];
+    for (const info of infos) {
+      if (info.name.endsWith("_json")) {
+        columns.push({ table, column: info.name, info });
+      }
+    }
+  }
+  columns.sort((a, b) => a.table.localeCompare(b.table) || a.column.localeCompare(b.column));
+  return columns;
+}
+
+describe("StateStore JSON column specs", () => {
+  it("documents canonical shapes/defaults for all *_json columns", () => {
+    const sqlite = createDatabase(":memory:");
+    try {
+      migrate(sqlite, sqliteMigrationsDir);
+
+      let rawSpecs: string | null = null;
+      try {
+        rawSpecs = readFileSync(specsPath, "utf8");
+      } catch {
+        // assertion below
+      }
+
+      expect(rawSpecs, `Missing JSON column specs file: ${specsPath}`).toBeTruthy();
+      if (!rawSpecs) return;
+
+      const specs = JSON.parse(rawSpecs) as JsonColumnSpec[];
+      expect(Array.isArray(specs), "specs is an array").toBe(true);
+      expect(specs.length, "specs has entries").toBeGreaterThan(0);
+
+      const specKeys = new Set<string>();
+      const specByKey = new Map<string, JsonColumnSpec>();
+      for (const spec of specs) {
+        const key = `${spec.table}.${spec.column}`;
+        expect(specKeys.has(key), `duplicate spec entry for ${key}`).toBe(false);
+        specKeys.add(key);
+        specByKey.set(key, spec);
+
+        expect(spec.column.endsWith("_json"), `${key} is a *_json column`).toBe(true);
+        expect(spec.shape === "array" || spec.shape === "object" || spec.shape === "any").toBe(
+          true,
+        );
+        expect(typeof spec.nullable).toBe("boolean");
+        expect(spec.default === null || spec.default === "{}" || spec.default === "[]").toBe(true);
+        if (spec.default !== null) {
+          if (spec.shape === "array") expect(spec.default).toBe("[]");
+          if (spec.shape === "object") expect(spec.default).toBe("{}");
+        }
+      }
+
+      const sqliteJsonCols = listSqliteJsonColumns(sqlite);
+      expect(sqliteJsonCols.length, "sqlite has *_json columns").toBeGreaterThan(0);
+      for (const { table, column, info } of sqliteJsonCols) {
+        const key = `${table}.${column}`;
+        const spec = specByKey.get(key);
+        expect(spec, `missing spec entry for ${key}`).toBeTruthy();
+        if (!spec) continue;
+
+        expect(info.notnull === 1, `${key} nullability`).toBe(!spec.nullable);
+        const expectedDefault = spec.default === null ? null : `'${spec.default}'`;
+        expect(info.dflt_value, `${key} default`).toBe(expectedDefault);
+      }
+
+      for (const spec of specs) {
+        const key = `${spec.table}.${spec.column}`;
+        const match = sqliteJsonCols.find((c) => `${c.table}.${c.column}` === key);
+        expect(match, `spec entry ${key} must exist in sqlite schema`).toBeTruthy();
+      }
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/packages/gateway/tests/unit/json.test.ts
+++ b/packages/gateway/tests/unit/json.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { safeJsonParse } from "../../src/utils/json.js";
+
+describe("safeJsonParse", () => {
+  it("returns fallback when JSON is malformed", () => {
+    expect(safeJsonParse("{", { ok: true })).toEqual({ ok: true });
+  });
+
+  it("returns fallback when JSON parses to the wrong shape", () => {
+    expect(safeJsonParse("{}", [] as unknown[])).toEqual([]);
+    expect(safeJsonParse("[]", {} as Record<string, unknown>)).toEqual({});
+  });
+});


### PR DESCRIPTION
Closes #988

## What changed
- Added canonical spec for every `*_json` column (shape, NULLability, defaults) and enforced it via contract tests.
- Hardened `safeJsonParse()` to return the fallback when JSON parses to the wrong shape.

## Verification
- `pnpm test` (509 files passed; 2992 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`