### PR TITLE
refactor(operator-ui): Clear oxlint warnings in RunsPage component (#1033)

### DIFF
--- a/packages/operator-ui/src/components/pages/runs-page-card.tsx
+++ b/packages/operator-ui/src/components/pages/runs-page-card.tsx
@@ -1,0 +1,296 @@
+import type { ExecutionAttempt, ExecutionRun, ExecutionStep } from "@tyrum/client";
+import type { OperatorCore } from "@tyrum/operator-core";
+import { ChevronDown } from "lucide-react";
+import { toast } from "sonner";
+import { AttemptArtifactsDialog } from "../artifacts/attempt-artifacts-dialog.js";
+import { Badge, type BadgeVariant } from "../ui/badge.js";
+import { Button } from "../ui/button.js";
+import { Card } from "../ui/card.js";
+import { StatusDot, type StatusDotVariant } from "../ui/status-dot.js";
+import { cn } from "../../lib/cn.js";
+import { formatRelativeTime } from "../../utils/format-relative-time.js";
+import type { RunTimelineEntry } from "./runs-page.lib.js";
+
+const TRUNCATED_ID_CHARS = 8;
+
+function truncateId(id: string): string {
+  if (id.length <= TRUNCATED_ID_CHARS) return id;
+  return id.slice(-TRUNCATED_ID_CHARS);
+}
+
+function formatDurationMs(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return "-";
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  if (durationMs < 60_000) {
+    const seconds = durationMs / 1000;
+    const text = seconds < 10 ? seconds.toFixed(1) : String(Math.round(seconds));
+    return `${text.replace(/\.0$/, "")}s`;
+  }
+  const minutes = Math.floor(durationMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h`;
+}
+
+function resolveRunStatusLabel(status: ExecutionRun["status"]): string {
+  if (status === "succeeded") return "completed";
+  return status;
+}
+
+function resolveRunBadgeVariant(status: ExecutionRun["status"]): BadgeVariant {
+  switch (status) {
+    case "running":
+      return "default";
+    case "succeeded":
+      return "success";
+    case "failed":
+      return "danger";
+    case "paused":
+      return "warning";
+    case "queued":
+    case "cancelled":
+    default:
+      return "outline";
+  }
+}
+
+function resolveStepStatusDotVariant(status: ExecutionStep["status"]): StatusDotVariant {
+  switch (status) {
+    case "running":
+      return "primary";
+    case "succeeded":
+      return "success";
+    case "failed":
+      return "danger";
+    case "paused":
+      return "warning";
+    case "cancelled":
+    case "skipped":
+    case "queued":
+    default:
+      return "neutral";
+  }
+}
+
+function resolveStepStatusLabel(status: ExecutionStep["status"]): string {
+  if (status === "succeeded") return "completed";
+  return status;
+}
+
+function resolveAttemptStatusDotVariant(status: ExecutionAttempt["status"]): StatusDotVariant {
+  switch (status) {
+    case "running":
+      return "primary";
+    case "succeeded":
+      return "success";
+    case "failed":
+    case "timed_out":
+      return "danger";
+    case "cancelled":
+    default:
+      return "neutral";
+  }
+}
+
+function resolveAttemptStatusLabel(status: ExecutionAttempt["status"]): string {
+  if (status === "succeeded") return "completed";
+  if (status === "timed_out") return "timed out";
+  return status;
+}
+
+function CopyableId({ id }: { id: string }) {
+  const copy = async (): Promise<void> => {
+    try {
+      await globalThis.navigator.clipboard.writeText(id);
+      toast.success("Copied to clipboard");
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      data-testid={`copy-id-${id}`}
+      aria-label={`Copy ID ${id}`}
+      title={id}
+      className={cn(
+        "font-mono text-xs text-fg-muted hover:text-fg",
+        "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+      )}
+      onClick={() => {
+        void copy();
+      }}
+    >
+      {truncateId(id)}
+    </button>
+  );
+}
+
+interface RunsPageCardProps {
+  core: OperatorCore;
+  run: ExecutionRun;
+  isExpanded: boolean;
+  onToggleRun: (runId: string) => void;
+  timeline: RunTimelineEntry[];
+}
+
+export function RunsPageCard({ core, run, isExpanded, onToggleRun, timeline }: RunsPageCardProps) {
+  const statusLabel = resolveRunStatusLabel(run.status);
+  const badgeVariant = resolveRunBadgeVariant(run.status);
+  const relativeTime = formatRelativeTime(run.started_at ?? run.created_at);
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-4 p-4">
+        <div className="flex min-w-0 flex-wrap items-center gap-3">
+          <Badge
+            data-testid={`run-status-${run.run_id}`}
+            variant={badgeVariant}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {statusLabel}
+          </Badge>
+          <CopyableId id={run.run_id} />
+          <span className="text-xs text-fg-muted">{relativeTime}</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          data-testid={`run-toggle-${run.run_id}`}
+          aria-expanded={isExpanded}
+          aria-label={isExpanded ? "Collapse run" : "Expand run"}
+          onClick={() => {
+            onToggleRun(run.run_id);
+          }}
+        >
+          <ChevronDown
+            aria-hidden={true}
+            className={cn("h-4 w-4 transition-transform", isExpanded ? "rotate-0" : "-rotate-90")}
+          />
+        </Button>
+      </div>
+
+      {isExpanded ? <RunTimeline core={core} runId={run.run_id} timeline={timeline} /> : null}
+    </Card>
+  );
+}
+
+function RunTimeline({
+  core,
+  runId,
+  timeline,
+}: {
+  core: OperatorCore;
+  runId: string;
+  timeline: RunTimelineEntry[];
+}) {
+  return (
+    <div className="grid gap-4 border-t border-border p-4">
+      {timeline.length === 0 ? (
+        <div className="text-sm text-fg-muted">No steps yet.</div>
+      ) : (
+        timeline.map(({ step, attempts }) => {
+          return (
+            <RunTimelineStep
+              key={step.step_id}
+              core={core}
+              runId={runId}
+              step={step}
+              attempts={attempts}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function RunTimelineStep({
+  core,
+  runId,
+  step,
+  attempts,
+}: {
+  core: OperatorCore;
+  runId: string;
+  step: ExecutionStep;
+  attempts: ExecutionAttempt[];
+}) {
+  const attemptCount = attempts.length;
+  const stepDotVariant = resolveStepStatusDotVariant(step.status);
+  const stepStatusLabel = resolveStepStatusLabel(step.status);
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <StatusDot
+            variant={stepDotVariant}
+            pulse={step.status === "running"}
+            aria-hidden={true}
+          />
+          <div className="truncate text-sm font-medium text-fg">
+            Step {step.step_index} • {step.action.type}
+          </div>
+          <div className="text-xs text-fg-muted">
+            {stepStatusLabel} • {attemptCount} attempt
+            {attemptCount === 1 ? "" : "s"}
+          </div>
+        </div>
+        <CopyableId id={step.step_id} />
+      </div>
+
+      {attemptCount > 0 ? (
+        <div className="ml-4 grid gap-1">
+          {attempts.map((attempt) => {
+            return (
+              <RunAttemptRow key={attempt.attempt_id} core={core} runId={runId} attempt={attempt} />
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RunAttemptRow({
+  core,
+  runId,
+  attempt,
+}: {
+  core: OperatorCore;
+  runId: string;
+  attempt: ExecutionAttempt;
+}) {
+  const timing =
+    attempt.finished_at && attempt.started_at
+      ? formatDurationMs(Date.parse(attempt.finished_at) - Date.parse(attempt.started_at))
+      : `started ${formatRelativeTime(attempt.started_at)}`;
+
+  return (
+    <div key={attempt.attempt_id} className="flex items-center justify-between gap-3 text-sm">
+      <div className="flex min-w-0 items-center gap-2">
+        <StatusDot
+          variant={resolveAttemptStatusDotVariant(attempt.status)}
+          pulse={attempt.status === "running"}
+          aria-hidden={true}
+        />
+        <div className="text-fg">Attempt {attempt.attempt}</div>
+        <div className="truncate text-xs text-fg-muted">
+          {resolveAttemptStatusLabel(attempt.status)} • {timing}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <AttemptArtifactsDialog
+          core={core}
+          runId={runId}
+          attemptId={attempt.attempt_id}
+          artifacts={attempt.artifacts}
+        />
+        <CopyableId id={attempt.attempt_id} />
+      </div>
+    </div>
+  );
+}

--- a/packages/operator-ui/src/components/pages/runs-page.lib.ts
+++ b/packages/operator-ui/src/components/pages/runs-page.lib.ts
@@ -1,0 +1,29 @@
+import type { ExecutionAttempt, ExecutionRun, ExecutionStep } from "@tyrum/client";
+import type { RunsState } from "@tyrum/operator-core";
+
+export interface RunTimelineEntry {
+  step: ExecutionStep;
+  attempts: ExecutionAttempt[];
+}
+
+export function sortRunsByCreatedAt(runs: ExecutionRun[]): ExecutionRun[] {
+  return runs.toSorted((left, right) => {
+    return Date.parse(right.created_at) - Date.parse(left.created_at);
+  });
+}
+
+export function buildRunTimeline(run: ExecutionRun, state: RunsState): RunTimelineEntry[] {
+  const steps = (state.stepIdsByRunId[run.run_id] ?? [])
+    .map((stepId) => state.stepsById[stepId])
+    .filter((step): step is ExecutionStep => step !== undefined)
+    .toSorted((left, right) => left.step_index - right.step_index);
+
+  return steps.map((step) => {
+    const attempts = (state.attemptIdsByStepId[step.step_id] ?? [])
+      .map((attemptId) => state.attemptsById[attemptId])
+      .filter((attempt): attempt is ExecutionAttempt => attempt !== undefined)
+      .toSorted((left, right) => left.attempt - right.attempt);
+
+    return { step, attempts };
+  });
+}

--- a/packages/operator-ui/src/components/pages/runs-page.tsx
+++ b/packages/operator-ui/src/components/pages/runs-page.tsx
@@ -1,162 +1,19 @@
-import type { ExecutionAttempt, ExecutionRun, ExecutionStep } from "@tyrum/client";
-import type { OperatorCore, RunsState } from "@tyrum/operator-core";
-import { ChevronDown, Play } from "lucide-react";
+import type { OperatorCore } from "@tyrum/operator-core";
+import { Play } from "lucide-react";
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
-import { AttemptArtifactsDialog } from "../artifacts/attempt-artifacts-dialog.js";
-import { Badge, type BadgeVariant } from "../ui/badge.js";
-import { Button } from "../ui/button.js";
-import { Card } from "../ui/card.js";
 import { EmptyState } from "../ui/empty-state.js";
-import { StatusDot, type StatusDotVariant } from "../ui/status-dot.js";
-import { cn } from "../../lib/cn.js";
 import { useOperatorStore } from "../../use-operator-store.js";
-import { formatRelativeTime } from "../../utils/format-relative-time.js";
-
-const TRUNCATED_ID_CHARS = 8;
-
-function truncateId(id: string): string {
-  if (id.length <= TRUNCATED_ID_CHARS) return id;
-  return id.slice(-TRUNCATED_ID_CHARS);
-}
-
-function formatDurationMs(durationMs: number): string {
-  if (!Number.isFinite(durationMs) || durationMs < 0) return "-";
-  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
-  if (durationMs < 60_000) {
-    const seconds = durationMs / 1000;
-    const text = seconds < 10 ? seconds.toFixed(1) : String(Math.round(seconds));
-    return `${text.replace(/\.0$/, "")}s`;
-  }
-  const minutes = Math.floor(durationMs / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  return `${hours}h`;
-}
-
-function resolveRunStatusLabel(status: ExecutionRun["status"]): string {
-  if (status === "succeeded") return "completed";
-  return status;
-}
-
-function resolveRunBadgeVariant(status: ExecutionRun["status"]): BadgeVariant {
-  switch (status) {
-    case "running":
-      return "default";
-    case "succeeded":
-      return "success";
-    case "failed":
-      return "danger";
-    case "paused":
-      return "warning";
-    case "queued":
-    case "cancelled":
-    default:
-      return "outline";
-  }
-}
-
-function resolveStepStatusDotVariant(status: ExecutionStep["status"]): StatusDotVariant {
-  switch (status) {
-    case "running":
-      return "primary";
-    case "succeeded":
-      return "success";
-    case "failed":
-      return "danger";
-    case "paused":
-      return "warning";
-    case "cancelled":
-    case "skipped":
-    case "queued":
-    default:
-      return "neutral";
-  }
-}
-
-function resolveStepStatusLabel(status: ExecutionStep["status"]): string {
-  if (status === "succeeded") return "completed";
-  return status;
-}
-
-function resolveAttemptStatusDotVariant(status: ExecutionAttempt["status"]): StatusDotVariant {
-  switch (status) {
-    case "running":
-      return "primary";
-    case "succeeded":
-      return "success";
-    case "failed":
-    case "timed_out":
-      return "danger";
-    case "cancelled":
-    default:
-      return "neutral";
-  }
-}
-
-function resolveAttemptStatusLabel(status: ExecutionAttempt["status"]): string {
-  if (status === "succeeded") return "completed";
-  if (status === "timed_out") return "timed out";
-  return status;
-}
-
-function CopyableId({ id }: { id: string }) {
-  const copy = async (): Promise<void> => {
-    try {
-      await globalThis.navigator.clipboard.writeText(id);
-      toast.success("Copied to clipboard");
-    } catch {
-      toast.error("Failed to copy to clipboard");
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      data-testid={`copy-id-${id}`}
-      aria-label={`Copy ID ${id}`}
-      title={id}
-      className={cn(
-        "font-mono text-xs text-fg-muted hover:text-fg",
-        "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-      )}
-      onClick={() => {
-        void copy();
-      }}
-    >
-      {truncateId(id)}
-    </button>
-  );
-}
-
-function buildRunTimeline(
-  run: ExecutionRun,
-  state: RunsState,
-): Array<{ step: ExecutionStep; attempts: ExecutionAttempt[] }> {
-  const steps = (state.stepIdsByRunId[run.run_id] ?? [])
-    .map((stepId) => state.stepsById[stepId])
-    .filter((step): step is ExecutionStep => step !== undefined)
-    .sort((a, b) => a.step_index - b.step_index);
-
-  return steps.map((step) => {
-    const attempts = (state.attemptIdsByStepId[step.step_id] ?? [])
-      .map((attemptId) => state.attemptsById[attemptId])
-      .filter((attempt): attempt is ExecutionAttempt => attempt !== undefined)
-      .sort((a, b) => a.attempt - b.attempt);
-
-    return { step, attempts };
-  });
-}
+import { buildRunTimeline, sortRunsByCreatedAt } from "./runs-page.lib.js";
+import { RunsPageCard } from "./runs-page-card.js";
 
 export function RunsPage({ core }: { core: OperatorCore }) {
   const runsState = useOperatorStore(core.runsStore);
   const [expandedRunIds, setExpandedRunIds] = useState<Set<string>>(() => new Set());
 
-  const runs = useMemo(() => {
-    return Object.values(runsState.runsById).sort((a, b) => {
-      return Date.parse(b.created_at) - Date.parse(a.created_at);
-    });
-  }, [runsState.runsById]);
+  const runs = useMemo(
+    () => sortRunsByCreatedAt(Object.values(runsState.runsById)),
+    [runsState.runsById],
+  );
 
   const toggleRun = (runId: string): void => {
     setExpandedRunIds((prev) => {
@@ -184,132 +41,16 @@ export function RunsPage({ core }: { core: OperatorCore }) {
         <div className="grid gap-4">
           {runs.map((run) => {
             const isExpanded = expandedRunIds.has(run.run_id);
-            const statusLabel = resolveRunStatusLabel(run.status);
-            const badgeVariant = resolveRunBadgeVariant(run.status);
-            const relativeTime = formatRelativeTime(run.started_at ?? run.created_at);
-            const timeline = isExpanded ? buildRunTimeline(run, runsState) : [];
 
             return (
-              <Card key={run.run_id}>
-                <div className="flex items-center justify-between gap-4 p-4">
-                  <div className="flex min-w-0 flex-wrap items-center gap-3">
-                    <Badge
-                      data-testid={`run-status-${run.run_id}`}
-                      variant={badgeVariant}
-                      aria-live="polite"
-                      aria-atomic="true"
-                    >
-                      {statusLabel}
-                    </Badge>
-                    <CopyableId id={run.run_id} />
-                    <span className="text-xs text-fg-muted">{relativeTime}</span>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    data-testid={`run-toggle-${run.run_id}`}
-                    aria-expanded={isExpanded}
-                    aria-label={isExpanded ? "Collapse run" : "Expand run"}
-                    onClick={() => {
-                      toggleRun(run.run_id);
-                    }}
-                  >
-                    <ChevronDown
-                      aria-hidden={true}
-                      className={cn(
-                        "h-4 w-4 transition-transform",
-                        isExpanded ? "rotate-0" : "-rotate-90",
-                      )}
-                    />
-                  </Button>
-                </div>
-
-                {isExpanded ? (
-                  <div className="grid gap-4 border-t border-border p-4">
-                    {timeline.length === 0 ? (
-                      <div className="text-sm text-fg-muted">No steps yet.</div>
-                    ) : (
-                      timeline.map(({ step, attempts }) => {
-                        const attemptCount = attempts.length;
-                        const stepDotVariant = resolveStepStatusDotVariant(step.status);
-                        const stepDotPulse = step.status === "running";
-                        const stepStatusLabel = resolveStepStatusLabel(step.status);
-
-                        return (
-                          <div key={step.step_id} className="grid gap-2">
-                            <div className="flex items-center justify-between gap-3">
-                              <div className="flex min-w-0 items-center gap-2">
-                                <StatusDot
-                                  variant={stepDotVariant}
-                                  pulse={stepDotPulse}
-                                  aria-hidden={true}
-                                />
-                                <div className="truncate text-sm font-medium text-fg">
-                                  Step {step.step_index} • {step.action.type}
-                                </div>
-                                <div className="text-xs text-fg-muted">
-                                  {stepStatusLabel} • {attemptCount} attempt
-                                  {attemptCount === 1 ? "" : "s"}
-                                </div>
-                              </div>
-                              <CopyableId id={step.step_id} />
-                            </div>
-
-                            {attemptCount > 0 ? (
-                              <div className="ml-4 grid gap-1">
-                                {attempts.map((attempt) => {
-                                  const attemptDotVariant = resolveAttemptStatusDotVariant(
-                                    attempt.status,
-                                  );
-                                  const attemptDotPulse = attempt.status === "running";
-                                  const attemptStatusLabel = resolveAttemptStatusLabel(
-                                    attempt.status,
-                                  );
-                                  const timing =
-                                    attempt.finished_at && attempt.started_at
-                                      ? formatDurationMs(
-                                          Date.parse(attempt.finished_at) -
-                                            Date.parse(attempt.started_at),
-                                        )
-                                      : `started ${formatRelativeTime(attempt.started_at)}`;
-
-                                  return (
-                                    <div
-                                      key={attempt.attempt_id}
-                                      className="flex items-center justify-between gap-3 text-sm"
-                                    >
-                                      <div className="flex min-w-0 items-center gap-2">
-                                        <StatusDot
-                                          variant={attemptDotVariant}
-                                          pulse={attemptDotPulse}
-                                          aria-hidden={true}
-                                        />
-                                        <div className="text-fg">Attempt {attempt.attempt}</div>
-                                        <div className="truncate text-xs text-fg-muted">
-                                          {attemptStatusLabel} • {timing}
-                                        </div>
-                                      </div>
-                                      <div className="flex items-center gap-2">
-                                        <AttemptArtifactsDialog
-                                          core={core}
-                                          runId={run.run_id}
-                                          attemptId={attempt.attempt_id}
-                                          artifacts={attempt.artifacts}
-                                        />
-                                        <CopyableId id={attempt.attempt_id} />
-                                      </div>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            ) : null}
-                          </div>
-                        );
-                      })
-                    )}
-                  </div>
-                ) : null}
-              </Card>
+              <RunsPageCard
+                key={run.run_id}
+                core={core}
+                run={run}
+                isExpanded={isExpanded}
+                onToggleRun={toggleRun}
+                timeline={isExpanded ? buildRunTimeline(run, runsState) : []}
+              />
             );
           })}
         </div>

--- a/packages/operator-ui/tests/pages/runs-page.test.ts
+++ b/packages/operator-ui/tests/pages/runs-page.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { RunsState } from "../../../operator-core/src/stores/runs-store.js";
+import { buildRunTimeline, sortRunsByCreatedAt } from "../../src/components/pages/runs-page.lib.js";
+
+describe("runs-page.lib", () => {
+  it("sorts runs newest-first without mutating the input array", () => {
+    const olderRun = {
+      run_id: "11111111-1111-1111-1111-111111111111",
+      job_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      key: "older-run",
+      lane: "main",
+      status: "queued",
+      attempt: 1,
+      created_at: "2026-01-01T00:00:00.000Z",
+      started_at: null,
+      finished_at: null,
+    } as const;
+    const newerRun = {
+      run_id: "22222222-2222-2222-2222-222222222222",
+      job_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      key: "newer-run",
+      lane: "main",
+      status: "running",
+      attempt: 1,
+      created_at: "2026-01-02T00:00:00.000Z",
+      started_at: "2026-01-02T00:00:01.000Z",
+      finished_at: null,
+    } as const;
+
+    const runs = [olderRun, newerRun];
+
+    expect(sortRunsByCreatedAt(runs).map((run) => run.run_id)).toEqual([
+      newerRun.run_id,
+      olderRun.run_id,
+    ]);
+    expect(runs.map((run) => run.run_id)).toEqual([olderRun.run_id, newerRun.run_id]);
+  });
+
+  it("builds timelines with steps and attempts sorted by index", () => {
+    const run = {
+      run_id: "33333333-3333-3333-3333-333333333333",
+      job_id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+      key: "sorted-run",
+      lane: "main",
+      status: "running",
+      attempt: 1,
+      created_at: "2026-01-03T00:00:00.000Z",
+      started_at: "2026-01-03T00:00:01.000Z",
+      finished_at: null,
+    } as const;
+    const firstStep = {
+      step_id: "44444444-4444-4444-4444-444444444444",
+      run_id: run.run_id,
+      step_index: 1,
+      status: "succeeded",
+      action: { type: "Desktop", args: {} },
+      created_at: "2026-01-03T00:00:02.000Z",
+    } as const;
+    const secondStep = {
+      step_id: "55555555-5555-5555-5555-555555555555",
+      run_id: run.run_id,
+      step_index: 2,
+      status: "running",
+      action: { type: "Desktop", args: {} },
+      created_at: "2026-01-03T00:00:03.000Z",
+    } as const;
+    const firstAttempt = {
+      attempt_id: "66666666-6666-6666-6666-666666666666",
+      step_id: secondStep.step_id,
+      attempt: 1,
+      status: "failed",
+      started_at: "2026-01-03T00:00:04.000Z",
+      finished_at: "2026-01-03T00:00:05.000Z",
+      error: "boom",
+      artifacts: [],
+    } as const;
+    const secondAttempt = {
+      attempt_id: "77777777-7777-7777-7777-777777777777",
+      step_id: secondStep.step_id,
+      attempt: 2,
+      status: "running",
+      started_at: "2026-01-03T00:00:06.000Z",
+      finished_at: null,
+      error: null,
+      artifacts: [],
+    } as const;
+
+    const state = {
+      runsById: { [run.run_id]: run },
+      stepsById: {
+        [firstStep.step_id]: firstStep,
+        [secondStep.step_id]: secondStep,
+      },
+      attemptsById: {
+        [firstAttempt.attempt_id]: firstAttempt,
+        [secondAttempt.attempt_id]: secondAttempt,
+      },
+      stepIdsByRunId: {
+        [run.run_id]: [secondStep.step_id, "missing-step", firstStep.step_id],
+      },
+      attemptIdsByStepId: {
+        [firstStep.step_id]: [],
+        [secondStep.step_id]: [
+          secondAttempt.attempt_id,
+          "missing-attempt",
+          firstAttempt.attempt_id,
+        ],
+      },
+    } satisfies RunsState;
+
+    const timeline = buildRunTimeline(run, state);
+
+    expect(timeline.map(({ step }) => step.step_id)).toEqual([
+      firstStep.step_id,
+      secondStep.step_id,
+    ]);
+    expect(timeline[0]?.attempts).toEqual([]);
+    expect(timeline[1]?.attempts.map((attempt) => attempt.attempt_id)).toEqual([
+      firstAttempt.attempt_id,
+      secondAttempt.attempt_id,
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #1033

## Summary
- split `RunsPage` into a smaller page shell plus extracted run-card/timeline components
- moved run sorting and timeline-building logic into a sibling helper module using `toSorted()`
- added regression coverage for run/step/attempt ordering in the new helper layer

## Verification
- `pnpm -s lint:oxlint:report | rg 'packages/operator-ui/src/components/pages/runs-page.tsx'` (no output)\n- `pnpm format:check`\n- `pnpm typecheck`\n- `pnpm lint`\n- `pnpm test`\n\n## Notes\n- Existing RunsPage artifact/expansion tests remain green.\n- Ordering is covered by the new helper test rather than a DOM-order assertion on `RunsPage` itself.