### PR TITLE
nit: Replace mutating sort/reverse with toSorted/toReversed in selected low-risk files (#1036)

### DIFF
--- a/apps/docs/scripts/publish-raw-docs-and-llms.mjs
+++ b/apps/docs/scripts/publish-raw-docs-and-llms.mjs
@@ -35,7 +35,7 @@ async function walkFiles(dir) {
 }
 
 function sortPaths(paths) {
-  return [...paths].sort((a, b) => a.localeCompare(b));
+  return paths.toSorted((a, b) => a.localeCompare(b));
 }
 
 function addSection(lines, header, urls) {

--- a/apps/docs/tests/markdown-utils.ts
+++ b/apps/docs/tests/markdown-utils.ts
@@ -16,5 +16,5 @@ export async function listMarkdownFiles(dir: string): Promise<string[]> {
     }
   }
 
-  return files.sort();
+  return files.toSorted();
 }

--- a/packages/operator-ui/src/components/pages/approvals-page.tsx
+++ b/packages/operator-ui/src/components/pages/approvals-page.tsx
@@ -139,7 +139,7 @@ export function ApprovalsPage({ core }: { core: OperatorCore }) {
       };
     })
     .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
-    .sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+    .toSorted((a, b) => a.nodeId.localeCompare(b.nodeId));
 
   const takeoverUrl = desktopTakeoverLinks.at(0)?.url;
 

--- a/packages/operator-ui/tests/a11y-config.ts
+++ b/packages/operator-ui/tests/a11y-config.ts
@@ -19,7 +19,7 @@ export function formatAxeIncompleteSummary({
 
   const summary = results.incomplete
     .map((result) => ({ id: result.id, nodes: result.nodes.length }))
-    .sort((a, b) => a.id.localeCompare(b.id))
+    .toSorted((a, b) => a.id.localeCompare(b.id))
     .map(({ id, nodes }) => `${id} (${nodes})`)
     .join(", ");
 

--- a/packages/schemas/src/postcondition.ts
+++ b/packages/schemas/src/postcondition.ts
@@ -131,7 +131,7 @@ function parseSpec(raw: unknown): ParsedSpec {
     if ("type" in obj) {
       return { assertions: [parseAssertion(raw)], metadata: undefined };
     }
-    const keys = Object.keys(obj).sort().join(",");
+    const keys = Object.keys(obj).toSorted().join(",");
     throw new PostconditionError("unsupported_postcondition", `object_with_fields:${keys}`);
   }
   throw new PostconditionError("invalid_postcondition", "postcondition must be an object or array");

--- a/packages/tui/src/runs-view.ts
+++ b/packages/tui/src/runs-view.ts
@@ -2,7 +2,7 @@ import type { ExecutionAttempt, ExecutionRun, ExecutionStep } from "@tyrum/opera
 import type { RunsState } from "@tyrum/operator-core";
 
 export function getRunList(state: RunsState): ExecutionRun[] {
-  return Object.values(state.runsById).sort((a, b) => {
+  return Object.values(state.runsById).toSorted((a, b) => {
     const aTime = Date.parse(a.created_at);
     const bTime = Date.parse(b.created_at);
     const aScore = Number.isFinite(aTime) ? aTime : 0;
@@ -16,7 +16,7 @@ export function getStepsForRun(state: RunsState, runId: string): ExecutionStep[]
   return (state.stepIdsByRunId[runId] ?? [])
     .map((stepId) => state.stepsById[stepId])
     .filter((step): step is ExecutionStep => step !== undefined)
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       if (a.step_index !== b.step_index) return a.step_index - b.step_index;
       return a.step_id.localeCompare(b.step_id);
     });
@@ -26,7 +26,7 @@ export function getAttemptsForStep(state: RunsState, stepId: string): ExecutionA
   return (state.attemptIdsByStepId[stepId] ?? [])
     .map((attemptId) => state.attemptsById[attemptId])
     .filter((attempt): attempt is ExecutionAttempt => attempt !== undefined)
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       if (a.attempt !== b.attempt) return a.attempt - b.attempt;
       return a.attempt_id.localeCompare(b.attempt_id);
     });


### PR DESCRIPTION
Closes #1036

## Summary
- replace mutating `sort()` usage with `toSorted()` in the six issue-scoped files
- preserve existing ordering behavior while avoiding in-place mutation
- keep the diff limited to the approved file list

## Verification
- `pnpm -s lint:oxlint:report | rg "^(apps/docs/|packages/schemas/src/postcondition\.ts|packages/tui/src/runs-view\.ts|packages/operator-ui/src/components/pages/approvals-page\.tsx|packages/operator-ui/tests/a11y-config\.ts)" | rg 'no-array-(sort|reverse)'`
- `pnpm exec vitest run apps/docs/tests/issue-568-docs.test.ts apps/docs/tests/issue-666-docs.test.ts packages/tui/tests/runs-view.test.ts packages/schemas/tests/postcondition.test.ts packages/operator-ui/tests/pages/approvals-page.desktop.test.ts packages/operator-ui/tests/operator-ui.a11y.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
