### PR TITLE
refactor(gateway): Continue decomposing AgentRuntime long private methods (#1024)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
@@ -1,14 +1,13 @@
 import { randomUUID } from "node:crypto";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { generateText, stepCountIs, streamText } from "ai";
-import type { EmbeddingModel, LanguageModel, ModelMessage, ToolSet } from "ai";
+import type { LanguageModel, ModelMessage, ToolSet } from "ai";
 import type {
   AgentStatusResponse as AgentStatusResponseT,
   AgentTurnRequest as AgentTurnRequestT,
   AgentTurnResponse as AgentTurnResponseT,
   AgentConfig as AgentConfigT,
   McpServerSpec as McpServerSpecT,
-  IdentityPack as IdentityPackT,
   NormalizedContainerKind,
   SecretHandle as SecretHandleT,
   WorkScope,
@@ -17,7 +16,6 @@ import {
   AgentConfig,
   AgentKey,
   AgentStatusResponse,
-  AgentTurnResponse,
   ContextReport as ContextReportSchema,
   SubagentSessionKey,
   WorkspaceKey,
@@ -45,7 +43,6 @@ import {
   type ResolvedAgentTurnInput,
   resolveMainLaneSessionKey,
   resolveTurnRequestId,
-  shouldPromoteToCoreMemory,
   type StepPauseRequest,
 } from "./turn-helpers.js";
 import {
@@ -55,30 +52,16 @@ import {
   formatSkillsPrompt,
   formatToolPrompt,
 } from "./prompts.js";
-import {
-  buildProviderResolutionSetup,
-  listOrderedEligibleProfilesForProvider,
-  parseProviderModelId,
-  resolveProfileApiKey,
-  resolveProviderBaseURL,
-} from "./provider-resolution.js";
 import { resolveSessionModel as resolveSessionModelImpl } from "./session-model-resolution.js";
-import { looksLikeSecretText } from "./secrets.js";
-import type { AgentContextReport, AgentRuntimeOptions } from "./types.js";
+import { resolveEmbeddingPipeline } from "./embedding-pipeline-resolution.js";
+import { finalizeTurn } from "./turn-finalization.js";
+import { buildWorkFocusDigest } from "./work-focus-digest.js";
+import type { AgentContextReport, AgentLoadedContext, AgentRuntimeOptions } from "./types.js";
 import { ensureWorkspaceInitialized, resolveTyrumHome } from "../home.js";
-import {
-  decideCrossTurnLoopWarning,
-  detectWithinTurnToolLoop,
-  LOOP_WARNING_PREFIX,
-} from "../loop-detection.js";
+import { detectWithinTurnToolLoop } from "../loop-detection.js";
 import { MarkdownMemoryStore } from "../markdown-memory.js";
 import { SessionDal, type SessionRow } from "../session-dal.js";
-import {
-  loadEnabledMcpServers,
-  loadEnabledSkills,
-  loadIdentity,
-  type LoadedSkillManifest,
-} from "../workspace.js";
+import { loadEnabledMcpServers, loadEnabledSkills, loadIdentity } from "../workspace.js";
 import { AgentConfigDal } from "../../config/agent-config-dal.js";
 import { isToolAllowed, selectToolDirectory } from "../tools.js";
 import { getExecutionProfile, normalizeExecutionProfileId } from "../execution-profiles.js";
@@ -89,11 +72,8 @@ import { NodeDispatchService } from "../node-dispatch-service.js";
 import { ToolExecutor } from "../tool-executor.js";
 import { tagContent } from "../provenance.js";
 import { sanitizeForModel } from "../sanitizer.js";
-import { VectorDal } from "../../memory/vector-dal.js";
-import { EmbeddingPipeline } from "../../memory/embedding-pipeline.js";
 import { MemoryV1Dal } from "../../memory/v1-dal.js";
 import { buildMemoryV1Digest } from "../../memory/v1-digest.js";
-import { recordMemoryV1SystemEpisode } from "../../memory/v1-episode-recorder.js";
 import {
   MemoryV1SemanticIndex,
   type MemoryV1SemanticSearchHit,
@@ -102,7 +82,6 @@ import type { ApprovalNotifier } from "../../approval/notifier.js";
 import type { ApprovalDal } from "../../approval/dal.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import type { PolicyService } from "../../policy/service.js";
-import { createProviderFromNpm } from "../../models/provider-factory.js";
 import {
   appendToolApprovalResponseMessage,
   countAssistantMessages,
@@ -130,10 +109,6 @@ const WITHIN_TURN_LOOP_STOP_REPLY =
   "Loop detected (repeated tool calls); stopping to avoid runaway execution. " +
   "If you want me to continue, adjust the request/constraints or ask me to try a different approach.";
 
-const CROSS_TURN_LOOP_WARNING_TEXT =
-  `${LOOP_WARNING_PREFIX} I may be repeating myself. If this isn’t progressing, tell me what to change ` +
-  "(goal/constraints/example output) and I’ll take a different approach.";
-
 function makeEventfulAbortSignal(upstream: AbortSignal | undefined): AbortSignal | undefined {
   if (!upstream) return undefined;
   const controller = new AbortController();
@@ -150,14 +125,6 @@ function makeEventfulAbortSignal(upstream: AbortSignal | undefined): AbortSignal
   return controller.signal;
 }
 
-interface AgentLoadedContext {
-  config: AgentConfigT;
-  identity: IdentityPackT;
-  skills: LoadedSkillManifest[];
-  mcpServers: McpServerSpecT[];
-  memoryStore: MarkdownMemoryStore;
-}
-
 type TurnExecutionContext = {
   planId: string;
   runId: string;
@@ -170,11 +137,6 @@ type ResolvedExecutionProfile = {
   id: ExecutionProfileId;
   profile: ExecutionProfile;
   source: "interaction_default" | "subagent_record" | "subagent_fallback";
-};
-
-type EmbeddingModelProviderSdk = {
-  textEmbeddingModel?: (modelId: string) => EmbeddingModel;
-  embeddingModel?: (modelId: string) => EmbeddingModel;
 };
 
 const NOOP_APPROVAL_NOTIFIER: ApprovalNotifier = {
@@ -205,50 +167,6 @@ export class AgentRuntime {
   private readonly turnEngineWaitMs: number;
   private lastContextReport: AgentContextReport | undefined;
   private cleanupAtMs = 0;
-
-  private async buildWorkFocusDigest(scope: WorkScope): Promise<string> {
-    try {
-      const workboard = new WorkboardDal(
-        this.opts.container.db,
-        this.opts.container.redactionEngine,
-      );
-      const [{ items: doing }, { items: blocked }, { items: ready }] = await Promise.all([
-        workboard.listItems({ scope, statuses: ["doing"], limit: 3 }),
-        workboard.listItems({ scope, statuses: ["blocked"], limit: 3 }),
-        workboard.listItems({ scope, statuses: ["ready"], limit: 3 }),
-      ]);
-
-      if (doing.length === 0 && blocked.length === 0 && ready.length === 0) {
-        return "No active WorkItems.";
-      }
-
-      const lines: string[] = [];
-      if (doing.length > 0) {
-        lines.push("Doing:");
-        for (const item of doing) {
-          lines.push(`- ${item.work_item_id} — ${item.title}`);
-        }
-      }
-      if (blocked.length > 0) {
-        lines.push("Blocked:");
-        for (const item of blocked) {
-          lines.push(`- ${item.work_item_id} — ${item.title}`);
-        }
-      }
-      if (ready.length > 0) {
-        lines.push("Ready:");
-        for (const item of ready) {
-          lines.push(`- ${item.work_item_id} — ${item.title}`);
-        }
-      }
-
-      return lines.join("\n");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.opts.container.logger.warn("workboard.focus_digest_failed", { error: message });
-      return "Work focus digest unavailable.";
-    }
-  }
 
   constructor(private readonly opts: AgentRuntimeOptions) {
     this.home = opts.home ?? resolveTyrumHome();
@@ -538,14 +456,17 @@ export class AgentRuntime {
         },
         createdFromSessionKey: mainLaneSessionKey,
       });
-      const response = await this.finalizeTurn(
+      this.lastContextReport = contextReport;
+      const response = await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
         ctx,
         session,
         resolved,
-        delegation.reply,
+        reply: delegation.reply,
         usedTools,
         contextReport,
-      );
+      });
 
       const streamResult = streamText({
         model: createStaticLanguageModelV3(delegation.reply),
@@ -591,15 +512,25 @@ export class AgentRuntime {
       ],
       tools: toolSet,
       stopWhen,
-      prepareStep: ({ messages }) =>
-        this.prepareLaneQueueStep(laneQueue, messages, ctx.config.sessions.context_pruning),
+      prepareStep: ({ messages: stepMessages }) =>
+        this.prepareLaneQueueStep(laneQueue, stepMessages, ctx.config.sessions.context_pruning),
     });
 
     const finalize = async (): Promise<AgentTurnResponseT> => {
       const result = await streamResult;
       const rawReply = (await result.text) || "";
       const reply = this.resolveTurnReply(rawReply, withinTurnLoop.value);
-      return await this.finalizeTurn(ctx, session, resolved, reply, usedTools, contextReport);
+      this.lastContextReport = contextReport;
+      return await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
+        ctx,
+        session,
+        resolved,
+        reply,
+        usedTools,
+        contextReport,
+      });
     };
 
     return { streamResult, sessionId: session.session_id, finalize };
@@ -705,7 +636,17 @@ export class AgentRuntime {
         reply = "WorkBoard status is unavailable.";
       }
 
-      return await this.finalizeTurn(ctx, session, resolved, reply, usedTools, contextReport);
+      this.lastContextReport = contextReport;
+      return await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
+        ctx,
+        session,
+        resolved,
+        reply,
+        usedTools,
+        contextReport,
+      });
     }
 
     const intakeModeDecision = parseIntakeModeDecision(resolved.message);
@@ -782,7 +723,17 @@ export class AgentRuntime {
       }
 
       const reply = `Delegated work item created: ${item.work_item_id} (mode=${intakeModeDecision.mode}, reason=${intakeModeDecision.reason_code})`;
-      return await this.finalizeTurn(ctx, session, resolved, reply, usedTools, contextReport);
+      this.lastContextReport = contextReport;
+      return await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
+        ctx,
+        session,
+        resolved,
+        reply,
+        usedTools,
+        contextReport,
+      });
     }
 
     const intake = await this.resolveIntakeDecision({
@@ -800,14 +751,17 @@ export class AgentRuntime {
         scope: workScope,
         createdFromSessionKey: mainLaneSessionKey,
       });
-      return await this.finalizeTurn(
+      this.lastContextReport = contextReport;
+      return await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
         ctx,
         session,
         resolved,
-        delegation.reply,
+        reply: delegation.reply,
         usedTools,
         contextReport,
-      );
+      });
     }
 
     await maybeRunPreCompactionMemoryFlush(
@@ -869,7 +823,17 @@ export class AgentRuntime {
     const remainingSteps = this.maxSteps - stepsUsedSoFar;
     if (remainingSteps <= 0) {
       const reply = "No assistant response returned.";
-      return await this.finalizeTurn(ctx, session, resolved, reply, usedTools, contextReport);
+      this.lastContextReport = contextReport;
+      return await finalizeTurn({
+        container: this.opts.container,
+        sessionDal: this.sessionDal,
+        ctx,
+        session,
+        resolved,
+        reply,
+        usedTools,
+        contextReport,
+      });
     }
 
     const withinTurnCfg = ctx.config.sessions.loop_detection.within_turn;
@@ -887,8 +851,8 @@ export class AgentRuntime {
       messages,
       tools: toolSet,
       stopWhen,
-      prepareStep: ({ messages }) =>
-        this.prepareLaneQueueStep(laneQueue, messages, ctx.config.sessions.context_pruning),
+      prepareStep: ({ messages: stepMessages }) =>
+        this.prepareLaneQueueStep(laneQueue, stepMessages, ctx.config.sessions.context_pruning),
       abortSignal,
     });
     const stepsUsedAfterCall = stepsUsedSoFar + result.steps.length;
@@ -971,7 +935,17 @@ export class AgentRuntime {
 
     const rawReply = result.text || "";
     const reply = this.resolveTurnReply(rawReply, withinTurnLoop.value);
-    return await this.finalizeTurn(ctx, session, resolved, reply, usedTools, contextReport);
+    this.lastContextReport = contextReport;
+    return await finalizeTurn({
+      container: this.opts.container,
+      sessionDal: this.sessionDal,
+      ctx,
+      session,
+      resolved,
+      reply,
+      usedTools,
+      contextReport,
+    });
   }
 
   private async turnViaExecutionEngine(input: AgentTurnRequestT): Promise<AgentTurnResponseT> {
@@ -1007,12 +981,16 @@ export class AgentRuntime {
     agentId: string,
   ): Promise<MemoryV1SemanticSearchHit[]> {
     try {
-      const pipeline = await this.resolveEmbeddingPipeline(
+      const pipeline = await resolveEmbeddingPipeline({
+        container: this.opts.container,
+        secretProvider: this.opts.secretProvider,
+        instanceOwner: this.instanceOwner,
+        fetchImpl: this.fetchImpl,
         primaryModelId,
         sessionId,
         tenantId,
         agentId,
-      );
+      });
       if (!pipeline) return [];
       const index = new MemoryV1SemanticIndex({
         db: this.opts.container.db,
@@ -1027,204 +1005,6 @@ export class AgentRuntime {
     } catch {
       // Intentional: semantic search is best-effort; fall back to no hits on failure.
       return [];
-    }
-  }
-
-  private async resolveEmbeddingPipeline(
-    primaryModelId: string,
-    sessionId: string,
-    tenantId: string,
-    agentId: string,
-  ): Promise<EmbeddingPipeline | undefined> {
-    try {
-      const loaded = await this.opts.container.modelCatalog.getEffectiveCatalog({ tenantId });
-      const catalog = loaded.catalog;
-
-      type ProviderEntry = (typeof catalog)[string];
-      type ModelEntry = NonNullable<ProviderEntry["models"]>[string];
-      type ResolvedEmbeddingCandidate = {
-        providerId: string;
-        modelId: string;
-        provider: ProviderEntry;
-        model: ModelEntry;
-        npm: string;
-        api: string | undefined;
-      };
-
-      const isEmbeddingModel = (id: string, model: ModelEntry): boolean => {
-        if (/embedding/i.test(id)) return true;
-        const family = (model as { family?: unknown }).family;
-        if (typeof family === "string" && /embedding/i.test(family)) return true;
-        const name = (model as { name?: unknown }).name;
-        return typeof name === "string" && /embedding/i.test(name);
-      };
-
-      const resolveEmbeddingCandidate = (
-        providerId: string,
-      ): ResolvedEmbeddingCandidate | undefined => {
-        const provider = catalog[providerId];
-        if (!provider) return undefined;
-        const providerEnabled = (provider as { enabled?: boolean }).enabled ?? true;
-        if (!providerEnabled) return undefined;
-
-        const models = provider.models ?? {};
-        const preferredIds = ["text-embedding-3-small", "text-embedding-3-large"];
-        let embeddingModelId: string | undefined;
-        for (const id of preferredIds) {
-          const candidate = models[id];
-          const candidateEnabled = candidate
-            ? ((candidate as { enabled?: boolean }).enabled ?? true)
-            : false;
-          if (candidate && candidateEnabled) {
-            embeddingModelId = id;
-            break;
-          }
-        }
-        if (!embeddingModelId) {
-          const candidateIds = Object.entries(models)
-            .filter(
-              ([id, model]) =>
-                ((model as { enabled?: boolean }).enabled ?? true) && isEmbeddingModel(id, model),
-            )
-            .map(([id]) => id)
-            .sort((a, b) => a.localeCompare(b));
-          embeddingModelId = candidateIds[0];
-        }
-
-        if (!embeddingModelId) return undefined;
-        const model = models[embeddingModelId];
-        if (!model) return undefined;
-
-        const providerOverride = (model as { provider?: { npm?: string; api?: string } }).provider;
-        const npm = providerOverride?.npm ?? provider.npm;
-        const api = providerOverride?.api ?? provider.api;
-        if (!npm) return undefined;
-
-        return {
-          providerId,
-          modelId: embeddingModelId,
-          provider,
-          model,
-          npm,
-          api,
-        };
-      };
-
-      const primaryProviderId = (() => {
-        try {
-          return parseProviderModelId(primaryModelId).providerId;
-        } catch {
-          // Intentional: primary model id may not follow provider/model format; treat as unknown.
-          return undefined;
-        }
-      })();
-
-      const orderedProviderIds: string[] = [];
-      const seen = new Set<string>();
-      const addProvider = (id: string | undefined): void => {
-        const trimmed = id?.trim();
-        if (!trimmed) return;
-        const provider = catalog[trimmed];
-        if (!provider) return;
-        const enabled = (provider as { enabled?: boolean }).enabled ?? true;
-        if (!enabled) return;
-        if (seen.has(trimmed)) return;
-        seen.add(trimmed);
-        orderedProviderIds.push(trimmed);
-      };
-
-      addProvider(primaryProviderId);
-      addProvider("openai");
-      for (const id of Object.keys(catalog).sort((a, b) => a.localeCompare(b))) {
-        addProvider(id);
-      }
-
-      const {
-        secretProvider,
-        authProfileDal,
-        pinDal,
-        oauthProviderRegistry,
-        oauthRefreshLeaseDal,
-        logger,
-        oauthLeaseOwner,
-        fetchImpl,
-      } = buildProviderResolutionSetup({
-        container: this.opts.container,
-        secretProvider: this.opts.secretProvider,
-        oauthLeaseOwner: this.instanceOwner,
-        fetchImpl: this.fetchImpl,
-      });
-
-      const resolveProviderApiKey = async (providerId: string): Promise<string | undefined> => {
-        const orderedProfiles = await listOrderedEligibleProfilesForProvider({
-          tenantId,
-          sessionId,
-          providerKey: providerId,
-          authProfileDal,
-          pinDal,
-        });
-
-        for (const profile of orderedProfiles) {
-          const apiKey = await resolveProfileApiKey(profile, {
-            tenantId,
-            secretProvider,
-            oauthProviderRegistry,
-            oauthRefreshLeaseDal,
-            oauthLeaseOwner,
-            logger,
-            fetchImpl,
-          });
-          if (apiKey) return apiKey;
-        }
-
-        return undefined;
-      };
-
-      for (const providerId of orderedProviderIds) {
-        const candidate = resolveEmbeddingCandidate(providerId);
-        if (!candidate) continue;
-
-        const apiKey = await resolveProviderApiKey(candidate.providerId);
-        const providerEnv = (candidate.provider as { env?: unknown }).env;
-        const providerRequiresApiKey = Array.isArray(providerEnv)
-          ? providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
-          : true;
-        if (!apiKey && providerRequiresApiKey) continue;
-
-        const baseURL = resolveProviderBaseURL({
-          providerApi: candidate.api,
-        });
-
-        const sdk = createProviderFromNpm({
-          npm: candidate.npm,
-          providerId: candidate.providerId,
-          apiKey,
-          baseURL,
-          fetchImpl: this.fetchImpl,
-        });
-
-        const sdkAny = sdk as EmbeddingModelProviderSdk;
-        const embeddingModel =
-          typeof sdkAny.textEmbeddingModel === "function"
-            ? sdkAny.textEmbeddingModel(candidate.modelId)
-            : typeof sdkAny.embeddingModel === "function"
-              ? sdkAny.embeddingModel(candidate.modelId)
-              : undefined;
-        if (!embeddingModel) continue;
-
-        const vectorDal = new VectorDal(this.opts.container.db);
-        return new EmbeddingPipeline({
-          vectorDal,
-          scope: { tenantId, agentId },
-          embeddingModel,
-          embeddingModelId: `${candidate.providerId}/${candidate.modelId}`,
-        });
-      }
-
-      return undefined;
-    } catch {
-      // Intentional: embedding pipeline resolution is best-effort; fall back to other retrieval strategies.
-      return undefined;
     }
   }
 
@@ -1436,10 +1216,13 @@ export class AgentRuntime {
     const workFocusDigest =
       isStatusQuery(resolved.message) || parseIntakeModeDecision(resolved.message)
         ? "Skipped for command turns."
-        : await this.buildWorkFocusDigest({
-            tenant_id: session.tenant_id,
-            agent_id: session.agent_id,
-            workspace_id: session.workspace_id,
+        : await buildWorkFocusDigest({
+            container: this.opts.container,
+            scope: {
+              tenant_id: session.tenant_id,
+              agent_id: session.agent_id,
+              workspace_id: session.workspace_id,
+            },
           });
 
     const identityPrompt = formatIdentityPrompt(ctx.identity);
@@ -1477,10 +1260,7 @@ export class AgentRuntime {
       return { id: t.id, chars };
     });
     const toolSchemaTotalChars = toolSchemaParts.reduce((total, part) => total + part.chars, 0);
-    const toolSchemaTop = toolSchemaParts
-      .slice()
-      .sort((a, b) => b.chars - a.chars)
-      .slice(0, 5);
+    const toolSchemaTop = toolSchemaParts.toSorted((a, b) => b.chars - a.chars).slice(0, 5);
 
     const contextReportId = randomUUID();
     const report: AgentContextReport = {
@@ -1831,136 +1611,5 @@ export class AgentRuntime {
       work_item_id: workItem.work_item_id,
       subagent_id: subagent.subagent_id,
     };
-  }
-
-  private async finalizeTurn(
-    ctx: AgentLoadedContext,
-    session: SessionRow,
-    input: ResolvedAgentTurnInput,
-    reply: string,
-    usedTools: Set<string>,
-    contextReport: AgentContextReport,
-  ): Promise<AgentTurnResponseT> {
-    const nowIso = new Date().toISOString();
-
-    let finalizedReply = reply;
-    const crossTurnCfg = ctx.config.sessions.loop_detection.cross_turn;
-    if (crossTurnCfg.enabled && !finalizedReply.includes(LOOP_WARNING_PREFIX)) {
-      const previousAssistantMessages = session.turns
-        .filter((turn) => turn.role === "assistant")
-        .map((turn) => turn.content);
-
-      const decision = decideCrossTurnLoopWarning({
-        previousAssistantMessages,
-        reply: finalizedReply,
-        windowAssistantMessages: crossTurnCfg.window_assistant_messages,
-        similarityThreshold: crossTurnCfg.similarity_threshold,
-        minChars: crossTurnCfg.min_chars,
-        cooldownAssistantMessages: crossTurnCfg.cooldown_assistant_messages,
-      });
-      if (decision.warn) {
-        finalizedReply = `${finalizedReply.trimEnd()}\n\n${CROSS_TURN_LOOP_WARNING_TEXT}`;
-        this.opts.container.logger.info("agents.loop.cross_turn_warned", {
-          session_id: session.session_id,
-          channel: input.channel,
-          thread_id: input.thread_id,
-          similarity: decision.similarity,
-          matched_index: decision.matchedIndex,
-        });
-      }
-    }
-
-    this.lastContextReport = contextReport;
-    try {
-      await this.opts.container.contextReportDal.insert({
-        tenantId: session.tenant_id,
-        contextReportId: contextReport.context_report_id,
-        sessionId: session.session_id,
-        channel: input.channel,
-        threadId: input.thread_id,
-        agentId: contextReport.agent_id,
-        workspaceId: contextReport.workspace_id,
-        report: contextReport,
-        createdAtIso: contextReport.generated_at,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.opts.container.logger.warn("context_report.persist_failed", {
-        context_report_id: contextReport.context_report_id,
-        session_id: session.session_id,
-        error: message,
-      });
-    }
-
-    await this.sessionDal.appendTurn({
-      tenantId: session.tenant_id,
-      sessionId: session.session_id,
-      userMessage: input.message,
-      assistantMessage: finalizedReply,
-      maxTurns: ctx.config.sessions.max_turns,
-      timestamp: nowIso,
-    });
-
-    let memoryWritten = false;
-    if (ctx.config.memory.markdown_enabled) {
-      const entry = [
-        `Channel: ${input.channel}`,
-        `Thread: ${input.thread_id}`,
-        `User: ${input.message}`,
-        `Assistant: ${finalizedReply}`,
-      ].join("\n");
-      if (looksLikeSecretText(entry)) {
-        this.opts.container.logger.warn("memory.write_skipped_secret_like", {
-          session_id: session.session_id,
-          channel: input.channel,
-          thread_id: input.thread_id,
-        });
-      } else {
-        await ctx.memoryStore.appendDaily(entry);
-        memoryWritten = true;
-
-        if (shouldPromoteToCoreMemory(input.message)) {
-          await ctx.memoryStore.appendToCoreSection(
-            "Learned Preferences",
-            `- ${input.message.trim()}`,
-          );
-        }
-      }
-    }
-
-    try {
-      await recordMemoryV1SystemEpisode(
-        this.opts.container.memoryV1Dal,
-        {
-          occurred_at: nowIso,
-          channel: input.channel,
-          event_type: "agent_turn",
-          summary_md: `Agent turn: ${input.channel}`,
-          tags: ["agent", "turn"],
-          metadata: {
-            channel: input.channel,
-            thread_id: input.thread_id,
-            session_id: session.session_id,
-          },
-        },
-        session.agent_id,
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.opts.container.logger.warn("memory.v1.system_episode_record_failed", {
-        session_id: session.session_id,
-        channel: input.channel,
-        thread_id: input.thread_id,
-        error: message,
-      });
-    }
-
-    return AgentTurnResponse.parse({
-      reply: finalizedReply,
-      session_id: session.session_id,
-      session_key: session.session_key,
-      used_tools: Array.from(usedTools),
-      memory_written: memoryWritten,
-    });
   }
 }

--- a/packages/gateway/src/modules/agent/runtime/embedding-pipeline-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/embedding-pipeline-resolution.ts
@@ -1,0 +1,245 @@
+import type { EmbeddingModel } from "ai";
+import type { GatewayContainer } from "../../../container.js";
+import { EmbeddingPipeline } from "../../memory/embedding-pipeline.js";
+import { VectorDal } from "../../memory/vector-dal.js";
+import { createProviderFromNpm } from "../../models/provider-factory.js";
+import type { SecretProvider } from "../../secret/provider.js";
+import {
+  buildProviderResolutionSetup,
+  listOrderedEligibleProfilesForProvider,
+  parseProviderModelId,
+  resolveProfileApiKey,
+  resolveProviderBaseURL,
+} from "./provider-resolution.js";
+
+type ProviderCatalog = Awaited<
+  ReturnType<GatewayContainer["modelCatalog"]["getEffectiveCatalog"]>
+>["catalog"];
+type ProviderEntry = ProviderCatalog[string];
+type ModelEntry = NonNullable<ProviderEntry["models"]>[string];
+type ProviderResolutionDeps = ReturnType<typeof buildProviderResolutionSetup>;
+
+interface EmbeddingModelProviderSdk {
+  textEmbeddingModel?: (modelId: string) => EmbeddingModel;
+  embeddingModel?: (modelId: string) => EmbeddingModel;
+}
+
+interface ResolvedEmbeddingCandidate {
+  providerId: string;
+  modelId: string;
+  provider: ProviderEntry;
+  model: ModelEntry;
+  npm: string;
+  api: string | undefined;
+}
+
+function isEmbeddingModel(id: string, model: ModelEntry): boolean {
+  if (/embedding/i.test(id)) return true;
+
+  const family = (model as { family?: unknown }).family;
+  if (typeof family === "string" && /embedding/i.test(family)) return true;
+
+  const name = (model as { name?: unknown }).name;
+  return typeof name === "string" && /embedding/i.test(name);
+}
+
+function resolveEmbeddingCandidate(
+  catalog: ProviderCatalog,
+  providerId: string,
+): ResolvedEmbeddingCandidate | undefined {
+  const provider = catalog[providerId];
+  if (!provider) return undefined;
+
+  const providerEnabled = (provider as { enabled?: boolean }).enabled ?? true;
+  if (!providerEnabled) return undefined;
+
+  const models = provider.models ?? {};
+  const preferredIds = ["text-embedding-3-small", "text-embedding-3-large"];
+  const embeddingModelId =
+    preferredIds.find((id) => {
+      const candidate = models[id];
+      return candidate ? ((candidate as { enabled?: boolean }).enabled ?? true) : false;
+    }) ??
+    Object.entries(models)
+      .filter(
+        ([id, model]) =>
+          ((model as { enabled?: boolean }).enabled ?? true) && isEmbeddingModel(id, model),
+      )
+      .map(([id]) => id)
+      .toSorted((left, right) => left.localeCompare(right))[0];
+  if (!embeddingModelId) return undefined;
+
+  const model = models[embeddingModelId];
+  if (!model) return undefined;
+
+  const providerOverride = (model as { provider?: { npm?: string; api?: string } }).provider;
+  const npm = providerOverride?.npm ?? provider.npm;
+  if (!npm) return undefined;
+
+  return {
+    providerId,
+    modelId: embeddingModelId,
+    provider,
+    model,
+    npm,
+    api: providerOverride?.api ?? provider.api,
+  };
+}
+
+function buildOrderedProviderIds(catalog: ProviderCatalog, primaryModelId: string): string[] {
+  const primaryProviderId = (() => {
+    try {
+      return parseProviderModelId(primaryModelId).providerId;
+    } catch {
+      // Intentional: primary model id may not follow provider/model format; treat as unknown.
+      return undefined;
+    }
+  })();
+
+  const orderedProviderIds: string[] = [];
+  const seen = new Set<string>();
+  const addProvider = (id: string | undefined): void => {
+    const trimmed = id?.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+
+    const provider = catalog[trimmed];
+    const enabled = provider ? ((provider as { enabled?: boolean }).enabled ?? true) : false;
+    if (!enabled) return;
+
+    seen.add(trimmed);
+    orderedProviderIds.push(trimmed);
+  };
+
+  addProvider(primaryProviderId);
+  addProvider("openai");
+  for (const id of Object.keys(catalog).toSorted((left, right) => left.localeCompare(right))) {
+    addProvider(id);
+  }
+  return orderedProviderIds;
+}
+
+function resolveSdkEmbeddingModel(sdk: unknown, modelId: string): EmbeddingModel | undefined {
+  const providerSdk = sdk as EmbeddingModelProviderSdk;
+  if (typeof providerSdk.textEmbeddingModel === "function") {
+    return providerSdk.textEmbeddingModel(modelId);
+  }
+  if (typeof providerSdk.embeddingModel === "function") {
+    return providerSdk.embeddingModel(modelId);
+  }
+  return undefined;
+}
+
+async function resolveProviderApiKey(input: {
+  deps: ProviderResolutionDeps;
+  tenantId: string;
+  sessionId: string;
+  providerId: string;
+}): Promise<string | undefined> {
+  const orderedProfiles = await listOrderedEligibleProfilesForProvider({
+    tenantId: input.tenantId,
+    sessionId: input.sessionId,
+    providerKey: input.providerId,
+    authProfileDal: input.deps.authProfileDal,
+    pinDal: input.deps.pinDal,
+  });
+
+  for (const profile of orderedProfiles) {
+    const apiKey = await resolveProfileApiKey(profile, {
+      tenantId: input.tenantId,
+      secretProvider: input.deps.secretProvider,
+      oauthProviderRegistry: input.deps.oauthProviderRegistry,
+      oauthRefreshLeaseDal: input.deps.oauthRefreshLeaseDal,
+      oauthLeaseOwner: input.deps.oauthLeaseOwner,
+      logger: input.deps.logger,
+      fetchImpl: input.deps.fetchImpl,
+    });
+    if (apiKey) return apiKey;
+  }
+
+  return undefined;
+}
+
+function providerRequiresApiKey(provider: ProviderEntry): boolean {
+  const providerEnv = (provider as { env?: unknown }).env;
+  return Array.isArray(providerEnv)
+    ? providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
+    : true;
+}
+
+function buildEmbeddingPipeline(input: {
+  db: GatewayContainer["db"];
+  fetchImpl: typeof fetch;
+  candidate: ResolvedEmbeddingCandidate;
+  tenantId: string;
+  agentId: string;
+  apiKey: string | undefined;
+}): EmbeddingPipeline | undefined {
+  const sdk = createProviderFromNpm({
+    npm: input.candidate.npm,
+    providerId: input.candidate.providerId,
+    apiKey: input.apiKey,
+    baseURL: resolveProviderBaseURL({ providerApi: input.candidate.api }),
+    fetchImpl: input.fetchImpl,
+  });
+  const embeddingModel = resolveSdkEmbeddingModel(sdk, input.candidate.modelId);
+  if (!embeddingModel) return undefined;
+
+  return new EmbeddingPipeline({
+    vectorDal: new VectorDal(input.db),
+    scope: { tenantId: input.tenantId, agentId: input.agentId },
+    embeddingModel,
+    embeddingModelId: `${input.candidate.providerId}/${input.candidate.modelId}`,
+  });
+}
+
+export async function resolveEmbeddingPipeline(input: {
+  container: GatewayContainer;
+  secretProvider?: SecretProvider;
+  instanceOwner: string;
+  fetchImpl: typeof fetch;
+  primaryModelId: string;
+  sessionId: string;
+  tenantId: string;
+  agentId: string;
+}): Promise<EmbeddingPipeline | undefined> {
+  try {
+    const { catalog } = await input.container.modelCatalog.getEffectiveCatalog({
+      tenantId: input.tenantId,
+    });
+    const providerIds = buildOrderedProviderIds(catalog, input.primaryModelId);
+    const deps = buildProviderResolutionSetup({
+      container: input.container,
+      secretProvider: input.secretProvider,
+      oauthLeaseOwner: input.instanceOwner,
+      fetchImpl: input.fetchImpl,
+    });
+
+    for (const providerId of providerIds) {
+      const candidate = resolveEmbeddingCandidate(catalog, providerId);
+      if (!candidate) continue;
+
+      const apiKey = await resolveProviderApiKey({
+        deps,
+        tenantId: input.tenantId,
+        sessionId: input.sessionId,
+        providerId: candidate.providerId,
+      });
+      if (!apiKey && providerRequiresApiKey(candidate.provider)) continue;
+
+      const pipeline = buildEmbeddingPipeline({
+        db: input.container.db,
+        fetchImpl: input.fetchImpl,
+        candidate,
+        tenantId: input.tenantId,
+        agentId: input.agentId,
+        apiKey,
+      });
+      if (pipeline) return pipeline;
+    }
+
+    return undefined;
+  } catch {
+    // Intentional: embedding pipeline resolution is best-effort; fall back to other retrieval strategies.
+    return undefined;
+  }
+}

--- a/packages/gateway/src/modules/agent/runtime/turn-finalization.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-finalization.ts
@@ -1,0 +1,191 @@
+import type { AgentTurnResponse as AgentTurnResponseT } from "@tyrum/schemas";
+import { AgentTurnResponse } from "@tyrum/schemas";
+import type { GatewayContainer } from "../../../container.js";
+import { decideCrossTurnLoopWarning, LOOP_WARNING_PREFIX } from "../loop-detection.js";
+import type { SessionDal, SessionRow } from "../session-dal.js";
+import { recordMemoryV1SystemEpisode } from "../../memory/v1-episode-recorder.js";
+import { looksLikeSecretText } from "./secrets.js";
+import { shouldPromoteToCoreMemory, type ResolvedAgentTurnInput } from "./turn-helpers.js";
+import type { AgentContextReport, AgentLoadedContext } from "./types.js";
+
+type FinalizeContainer = Pick<GatewayContainer, "contextReportDal" | "logger" | "memoryV1Dal">;
+
+const CROSS_TURN_LOOP_WARNING_TEXT =
+  `${LOOP_WARNING_PREFIX} I may be repeating myself. If this isn't progressing, tell me what to change ` +
+  "(goal/constraints/example output) and I'll take a different approach.";
+
+function applyCrossTurnLoopWarning(input: {
+  container: FinalizeContainer;
+  ctx: AgentLoadedContext;
+  session: SessionRow;
+  resolved: ResolvedAgentTurnInput;
+  reply: string;
+}): string {
+  const crossTurnCfg = input.ctx.config.sessions.loop_detection.cross_turn;
+  if (!crossTurnCfg.enabled || input.reply.includes(LOOP_WARNING_PREFIX)) {
+    return input.reply;
+  }
+
+  const previousAssistantMessages = input.session.turns
+    .filter((turn) => turn.role === "assistant")
+    .map((turn) => turn.content);
+  const decision = decideCrossTurnLoopWarning({
+    previousAssistantMessages,
+    reply: input.reply,
+    windowAssistantMessages: crossTurnCfg.window_assistant_messages,
+    similarityThreshold: crossTurnCfg.similarity_threshold,
+    minChars: crossTurnCfg.min_chars,
+    cooldownAssistantMessages: crossTurnCfg.cooldown_assistant_messages,
+  });
+  if (!decision.warn) return input.reply;
+
+  input.container.logger.info("agents.loop.cross_turn_warned", {
+    session_id: input.session.session_id,
+    channel: input.resolved.channel,
+    thread_id: input.resolved.thread_id,
+    similarity: decision.similarity,
+    matched_index: decision.matchedIndex,
+  });
+  return `${input.reply.trimEnd()}\n\n${CROSS_TURN_LOOP_WARNING_TEXT}`;
+}
+
+async function persistContextReport(input: {
+  container: FinalizeContainer;
+  session: SessionRow;
+  resolved: ResolvedAgentTurnInput;
+  contextReport: AgentContextReport;
+}): Promise<void> {
+  try {
+    await input.container.contextReportDal.insert({
+      tenantId: input.session.tenant_id,
+      contextReportId: input.contextReport.context_report_id,
+      sessionId: input.session.session_id,
+      channel: input.resolved.channel,
+      threadId: input.resolved.thread_id,
+      agentId: input.contextReport.agent_id,
+      workspaceId: input.contextReport.workspace_id,
+      report: input.contextReport,
+      createdAtIso: input.contextReport.generated_at,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    input.container.logger.warn("context_report.persist_failed", {
+      context_report_id: input.contextReport.context_report_id,
+      session_id: input.session.session_id,
+      error: message,
+    });
+  }
+}
+
+async function appendMarkdownMemory(input: {
+  container: FinalizeContainer;
+  ctx: AgentLoadedContext;
+  session: SessionRow;
+  resolved: ResolvedAgentTurnInput;
+  reply: string;
+}): Promise<boolean> {
+  if (!input.ctx.config.memory.markdown_enabled) return false;
+
+  const entry = [
+    `Channel: ${input.resolved.channel}`,
+    `Thread: ${input.resolved.thread_id}`,
+    `User: ${input.resolved.message}`,
+    `Assistant: ${input.reply}`,
+  ].join("\n");
+  if (looksLikeSecretText(entry)) {
+    input.container.logger.warn("memory.write_skipped_secret_like", {
+      session_id: input.session.session_id,
+      channel: input.resolved.channel,
+      thread_id: input.resolved.thread_id,
+    });
+    return false;
+  }
+
+  await input.ctx.memoryStore.appendDaily(entry);
+  if (shouldPromoteToCoreMemory(input.resolved.message)) {
+    await input.ctx.memoryStore.appendToCoreSection(
+      "Learned Preferences",
+      `- ${input.resolved.message.trim()}`,
+    );
+  }
+  return true;
+}
+
+async function recordAgentTurnEpisode(input: {
+  container: FinalizeContainer;
+  session: SessionRow;
+  resolved: ResolvedAgentTurnInput;
+  nowIso: string;
+}): Promise<void> {
+  try {
+    await recordMemoryV1SystemEpisode(
+      input.container.memoryV1Dal,
+      {
+        occurred_at: input.nowIso,
+        channel: input.resolved.channel,
+        event_type: "agent_turn",
+        summary_md: `Agent turn: ${input.resolved.channel}`,
+        tags: ["agent", "turn"],
+        metadata: {
+          channel: input.resolved.channel,
+          thread_id: input.resolved.thread_id,
+          session_id: input.session.session_id,
+        },
+      },
+      input.session.agent_id,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    input.container.logger.warn("memory.v1.system_episode_record_failed", {
+      session_id: input.session.session_id,
+      channel: input.resolved.channel,
+      thread_id: input.resolved.thread_id,
+      error: message,
+    });
+  }
+}
+
+export async function finalizeTurn(input: {
+  container: FinalizeContainer;
+  sessionDal: SessionDal;
+  ctx: AgentLoadedContext;
+  session: SessionRow;
+  resolved: ResolvedAgentTurnInput;
+  reply: string;
+  usedTools: ReadonlySet<string>;
+  contextReport: AgentContextReport;
+}): Promise<AgentTurnResponseT> {
+  const nowIso = new Date().toISOString();
+  const finalizedReply = applyCrossTurnLoopWarning(input);
+
+  await persistContextReport(input);
+  await input.sessionDal.appendTurn({
+    tenantId: input.session.tenant_id,
+    sessionId: input.session.session_id,
+    userMessage: input.resolved.message,
+    assistantMessage: finalizedReply,
+    maxTurns: input.ctx.config.sessions.max_turns,
+    timestamp: nowIso,
+  });
+  const memoryWritten = await appendMarkdownMemory({
+    container: input.container,
+    ctx: input.ctx,
+    session: input.session,
+    resolved: input.resolved,
+    reply: finalizedReply,
+  });
+  await recordAgentTurnEpisode({
+    container: input.container,
+    session: input.session,
+    resolved: input.resolved,
+    nowIso,
+  });
+
+  return AgentTurnResponse.parse({
+    reply: finalizedReply,
+    session_id: input.session.session_id,
+    session_key: input.session.session_key,
+    used_tools: Array.from(input.usedTools),
+    memory_written: memoryWritten,
+  });
+}

--- a/packages/gateway/src/modules/agent/runtime/types.ts
+++ b/packages/gateway/src/modules/agent/runtime/types.ts
@@ -1,7 +1,14 @@
 import type { LanguageModel } from "ai";
+import type {
+  AgentConfig as AgentConfigT,
+  IdentityPack as IdentityPackT,
+  McpServerSpec as McpServerSpecT,
+} from "@tyrum/schemas";
 import type { GatewayContainer } from "../../../container.js";
 import type { McpManager } from "../mcp-manager.js";
+import { MarkdownMemoryStore } from "../markdown-memory.js";
 import type { SessionDal } from "../session-dal.js";
+import type { LoadedSkillManifest } from "../workspace.js";
 import type { ApprovalNotifier } from "../../approval/notifier.js";
 import type { ApprovalDal } from "../../approval/dal.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
@@ -41,6 +48,14 @@ export interface AgentRuntimeOptions {
   approvalPollMs?: number;
   /** Maximum duration for a single turn to complete via the execution engine. */
   turnEngineWaitMs?: number;
+}
+
+export interface AgentLoadedContext {
+  config: AgentConfigT;
+  identity: IdentityPackT;
+  skills: LoadedSkillManifest[];
+  mcpServers: McpServerSpecT[];
+  memoryStore: MarkdownMemoryStore;
 }
 
 export interface AgentContextPartReport {

--- a/packages/gateway/src/modules/agent/runtime/work-focus-digest.ts
+++ b/packages/gateway/src/modules/agent/runtime/work-focus-digest.ts
@@ -1,0 +1,41 @@
+import type { WorkScope } from "@tyrum/schemas";
+import type { GatewayContainer } from "../../../container.js";
+import { WorkboardDal } from "../../workboard/dal.js";
+
+export async function buildWorkFocusDigest(input: {
+  container: Pick<GatewayContainer, "db" | "redactionEngine" | "logger">;
+  scope: WorkScope;
+}): Promise<string> {
+  try {
+    const workboard = new WorkboardDal(input.container.db, input.container.redactionEngine);
+    const [{ items: doing }, { items: blocked }, { items: ready }] = await Promise.all([
+      workboard.listItems({ scope: input.scope, statuses: ["doing"], limit: 3 }),
+      workboard.listItems({ scope: input.scope, statuses: ["blocked"], limit: 3 }),
+      workboard.listItems({ scope: input.scope, statuses: ["ready"], limit: 3 }),
+    ]);
+
+    if (doing.length === 0 && blocked.length === 0 && ready.length === 0) {
+      return "No active WorkItems.";
+    }
+
+    const lines: string[] = [];
+    if (doing.length > 0) {
+      lines.push("Doing:");
+      for (const item of doing) lines.push(`- ${item.work_item_id} — ${item.title}`);
+    }
+    if (blocked.length > 0) {
+      lines.push("Blocked:");
+      for (const item of blocked) lines.push(`- ${item.work_item_id} — ${item.title}`);
+    }
+    if (ready.length > 0) {
+      lines.push("Ready:");
+      for (const item of ready) lines.push(`- ${item.work_item_id} — ${item.title}`);
+    }
+
+    return lines.join("\n");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    input.container.logger.warn("workboard.focus_digest_failed", { error: message });
+    return "Work focus digest unavailable.";
+  }
+}

--- a/packages/gateway/tests/unit/agent-runtime-embedding.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-embedding.test.ts
@@ -81,24 +81,23 @@ describe("AgentRuntime embedding pipeline selection", () => {
 
     const fetchImpl: typeof fetch = async () => new Response("not found", { status: 404 });
 
-    const { AgentRuntime } = await import("../../src/modules/agent/runtime.js");
-    const runtime = new AgentRuntime({
-      container,
-      agentId: "agent-1",
-      fetchImpl,
-    });
+    const { resolveEmbeddingPipeline } =
+      await import("../../src/modules/agent/runtime/embedding-pipeline-resolution.js");
 
     const ids = await new IdentityScopeDal(container.db).resolveScopeIds({
       tenantKey: "default",
       agentKey: "agent-1",
       workspaceKey: "default",
     });
-    const pipeline = await (runtime as any).resolveEmbeddingPipeline(
-      "local/chat",
-      randomUUID(),
-      ids.tenantId,
-      ids.agentId,
-    );
+    const pipeline = await resolveEmbeddingPipeline({
+      container,
+      fetchImpl,
+      primaryModelId: "local/chat",
+      sessionId: randomUUID(),
+      tenantId: ids.tenantId,
+      agentId: ids.agentId,
+      instanceOwner: "test-owner",
+    });
     expect(pipeline).toBeDefined();
 
     expect(seenProviderInputs[0]).toMatchObject({
@@ -175,20 +174,19 @@ describe("AgentRuntime embedding pipeline selection", () => {
 
     const fetchImpl: typeof fetch = async () => new Response("not found", { status: 404 });
 
-    const { AgentRuntime } = await import("../../src/modules/agent/runtime.js");
-    const runtime = new AgentRuntime({
+    const { resolveEmbeddingPipeline } =
+      await import("../../src/modules/agent/runtime/embedding-pipeline-resolution.js");
+
+    const pipeline = await resolveEmbeddingPipeline({
       container,
-      agentId: "agent-1",
       secretProvider,
       fetchImpl,
+      primaryModelId: "anthropic/claude-3.5-sonnet",
+      sessionId: randomUUID(),
+      tenantId: ids.tenantId,
+      agentId: ids.agentId,
+      instanceOwner: "test-owner",
     });
-
-    const pipeline = await (runtime as any).resolveEmbeddingPipeline(
-      "anthropic/claude-3.5-sonnet",
-      randomUUID(),
-      ids.tenantId,
-      ids.agentId,
-    );
     expect(pipeline).toBeDefined();
 
     expect(seenProviderInputs[0]).toMatchObject({


### PR DESCRIPTION
Closes #1024

## Summary
- extract embedding pipeline resolution from `AgentRuntime` into a dedicated runtime helper module
- extract turn finalization and work-focus digest assembly so `AgentRuntime` stays more orchestration-focused
- keep embedding selection coverage by moving the runtime embedding test to the new helper boundary

## Verification
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run packages/gateway/tests/unit/agent-runtime-embedding.test.ts packages/gateway/tests/unit/agent-runtime-loop-warning.test.ts packages/gateway/tests/unit/agent-runtime.test.ts`

## Notes
- no Playwright/UI flow changes in this refactor
- lint pressure is reduced, but `AgentRuntime` still has remaining `max-lines` warnings for future follow-up work