### PR TITLE
tests(docs): rename issue-* tests to behavior-focused names (keep issue ref in description) (#999)

### DIFF
--- a/apps/docs/tests/api-reference-docs.test.ts
+++ b/apps/docs/tests/api-reference-docs.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 
-describe("Issue #842 API reference docs", () => {
+describe("API reference docs (Issue #842)", () => {
   it("adds docs/api-reference.md covering HTTP and WebSocket APIs", async () => {
     const doc = await readFile(resolve(repoRoot, "docs/api-reference.md"), "utf8");
 

--- a/apps/docs/tests/desktop-docs.test.ts
+++ b/apps/docs/tests/desktop-docs.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 
-describe("Issue #841 desktop docs", () => {
+describe("Desktop docs (Issue #841)", () => {
   it("adds desktop developer README", async () => {
     const readme = await readFile(resolve(repoRoot, "apps/desktop/README.md"), "utf8");
 

--- a/apps/docs/tests/memory-operator-workflows-docs.test.ts
+++ b/apps/docs/tests/memory-operator-workflows-docs.test.ts
@@ -7,7 +7,7 @@ import { listMarkdownFiles } from "./markdown-utils.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 
-describe("Issue #666 docs", () => {
+describe("Memory operator workflow docs (Issue #666)", () => {
   it("documents Memory v1 operator workflows (inspect/export/forget)", async () => {
     const memoryDoc = await readFile(resolve(repoRoot, "docs/architecture/memory.md"), "utf8");
 

--- a/apps/docs/tests/regression-test-naming.test.ts
+++ b/apps/docs/tests/regression-test-naming.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { readdir, readFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const renamedRegressionTests = [
+  { file: "api-reference-docs.test.ts", issue: "Issue #842" },
+  { file: "desktop-docs.test.ts", issue: "Issue #841" },
+  { file: "memory-operator-workflows-docs.test.ts", issue: "Issue #666" },
+  { file: "ui-bootstrap-and-auth-docs.test.ts", issue: "Issue #568" },
+];
+
+describe("Docs regression test naming (Issue #999)", () => {
+  it("uses behavior-based filenames while keeping issue references visible", async () => {
+    const testFiles = await readdir(__dirname);
+    const legacyIssueFiles = testFiles.filter((file) => /^issue-\d+.*\.test\.ts$/.test(file));
+
+    expect(legacyIssueFiles).toEqual([]);
+
+    for (const { file, issue } of renamedRegressionTests) {
+      expect(testFiles).toContain(file);
+
+      const source = await readFile(resolve(__dirname, file), "utf8");
+      expect(source).toMatch(
+        new RegExp(String.raw`describe\(\s*["'\`][^\n]*${escapeRegExp(issue)}`),
+      );
+      expect(basename(file, ".test.ts")).not.toMatch(/^issue-\d+/);
+    }
+  });
+});

--- a/apps/docs/tests/ui-bootstrap-and-auth-docs.test.ts
+++ b/apps/docs/tests/ui-bootstrap-and-auth-docs.test.ts
@@ -7,7 +7,7 @@ import { listMarkdownFiles } from "./markdown-utils.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 
-describe("Issue #568 docs", () => {
+describe("UI bootstrap and auth docs (Issue #568)", () => {
   it("updates install + getting started docs for /ui and /auth/session cookie bootstrap", async () => {
     const installDoc = await readFile(resolve(repoRoot, "docs/install.md"), "utf8");
     expect(installDoc).toMatch(/\/ui\b/);


### PR DESCRIPTION
Closes #999

## Summary
- rename the docs regression tests to behavior-based filenames
- keep the linked issue IDs visible in each `describe(...)` label
- add a regression test that prevents the suite from drifting back to `issue-*` filenames for these cases

## Verification
- `pnpm exec vitest run apps/docs/tests/*.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
