### PR TITLE
tests: align naming/location conventions for unit vs integration vs e2e (#998)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,26 @@ The repo-local hooks are:
 - `pre-commit`: runs `pnpm format:check-staged` and `pnpm lint` for fast checks on commit.
 - `pre-push`: runs `pnpm lint`, `pnpm typecheck`, and `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json` for stronger validation before pushing.
 
-## 4. Before Opening a PR
+## 4. Test Conventions
+
+Use the smallest test scope that proves the behavior you changed:
+
+- `tests/unit/` for single-module behavior and pure logic.
+- `tests/integration/` for wiring across modules or package boundaries with real in-process dependencies.
+- `tests/e2e/` for full user or gateway flows that boot real servers, WebSocket clients, browsers, containers, or other entry points end-to-end.
+- `tests/contract/` for durable schema, migration, and storage compatibility checks.
+- `tests/conformance/` for protocol behaviors that multiple implementations must satisfy the same way.
+
+If a package only has one test scope today, keeping those unit-style tests directly under `tests/` is acceptable until another scope is added.
+
+Name executable tests after the behavior under test and keep the scope in the folder, not the file name:
+
+- Prefer `tests/e2e/dispatch.test.ts` over `tests/integration/e2e-dispatch.test.ts`.
+- Keep `*.test.ts` for executable tests only.
+- Prefer `tests/helpers/` and `tests/fixtures/` for shared helpers and reusable data; small scope-local `*-utils.ts` files are fine when they stay adjacent to one test family.
+- Avoid repeating the scope in the file name when the folder already provides it.
+
+## 5. Before Opening a PR
 
 Run these commands and verify all pass:
 
@@ -101,7 +120,7 @@ To audit the whole repo (warnings only):
 pnpm lint:oxlint:report
 ```
 
-## 5. Branch Protections & Reviews
+## 6. Branch Protections & Reviews
 
 Pull requests must reference their GitHub Issue and pass all required checks:
 
@@ -111,7 +130,7 @@ Pull requests must reference their GitHub Issue and pass all required checks:
 
 Follow the 72-character imperative commit style (e.g. `Add policy gate scaffold`).
 
-## 6. Static Analysis (SAST)
+## 7. Static Analysis (SAST)
 
 The `sast` workflow runs Semgrep on every PR and on pushes to `main` when there are changes under `packages/` or `apps/`.
 

--- a/apps/desktop/tests/e2e/desktop-dispatch.test.ts
+++ b/apps/desktop/tests/e2e/desktop-dispatch.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration test: embedded gateway + desktop/cli node dispatch.
+ * End-to-end test: embedded gateway + desktop/cli node dispatch.
  *
  * Exercises the full round-trip:
  * 1. Start a real gateway (HTTP + WS) on a random port

--- a/apps/docs/tests/issue-998-test-conventions.test.ts
+++ b/apps/docs/tests/issue-998-test-conventions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { access, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+describe("Issue #998 test conventions", () => {
+  it("documents where each test scope belongs", async () => {
+    const contributing = await readFile(resolve(repoRoot, "CONTRIBUTING.md"), "utf8");
+
+    expect(contributing).toMatch(/^## (?:\d+\.\s+)?Test Conventions$/m);
+    expect(contributing).toMatch(/`tests\/unit\/`/);
+    expect(contributing).toMatch(/`tests\/integration\/`/);
+    expect(contributing).toMatch(/`tests\/e2e\/`/);
+    expect(contributing).toMatch(/`tests\/contract\/`/);
+    expect(contributing).toMatch(/`tests\/conformance\/`/);
+    expect(contributing).toMatch(/If a package only has one test scope.*`tests\/`/s);
+    expect(contributing).toMatch(/avoid repeating the scope in the file name/i);
+    expect(contributing).toMatch(/`tests\/e2e\/dispatch\.test\.ts`/);
+  });
+
+  it("moves representative end-to-end tests into tests/e2e", async () => {
+    const gatewayE2e = resolve(
+      repoRoot,
+      "packages/gateway/tests/e2e/client-dispatch-smoke.test.ts",
+    );
+    const oldGatewayLocation = resolve(
+      repoRoot,
+      "packages/gateway/tests/integration/e2e-smoke.test.ts",
+    );
+    const desktopE2e = resolve(repoRoot, "apps/desktop/tests/e2e/desktop-dispatch.test.ts");
+    const oldDesktopLocation = resolve(
+      repoRoot,
+      "apps/desktop/tests/integration/e2e-dispatch.test.ts",
+    );
+
+    expect(await pathExists(gatewayE2e)).toBe(true);
+    expect(await pathExists(oldGatewayLocation)).toBe(false);
+    expect(await pathExists(desktopE2e)).toBe(true);
+    expect(await pathExists(oldDesktopLocation)).toBe(false);
+  });
+});

--- a/packages/gateway/tests/e2e/client-dispatch-smoke.test.ts
+++ b/packages/gateway/tests/e2e/client-dispatch-smoke.test.ts
@@ -16,7 +16,7 @@ import { createServer } from "node:http";
 import type { Server } from "node:http";
 import { getRequestListener } from "@hono/node-server";
 import type { Hono } from "hono";
-import { createTestApp, minimalPlanRequest } from "./helpers.js";
+import { createTestApp, minimalPlanRequest } from "../integration/helpers.js";
 import { createWsHandler } from "../../src/routes/ws.js";
 import { ConnectionManager } from "../../src/ws/connection-manager.js";
 import { dispatchTask, type ProtocolDeps } from "../../src/ws/protocol.js";


### PR DESCRIPTION
## Summary
- document the repo test-scope convention in `CONTRIBUTING.md`
- move representative end-to-end tests into `tests/e2e/` with non-redundant names
- add a regression test that locks the convention and representative file locations

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

Closes #998