### PR TITLE
[Data model] Define source-of-truth invariants: sessions.turns_json vs channel inbox/outbox (#982)

### DIFF
--- a/docs/architecture/messages-sessions.md
+++ b/docs/architecture/messages-sessions.md
@@ -38,6 +38,18 @@ Connectors treat inbound content as **data**, not instructions. Provenance is pr
 
 Sessions are durable conversation containers with stored transcripts and metadata. Session keys are stable and chosen by Tyrum, not by the model.
 
+### Transcript source of truth
+
+For channel-backed conversations, Tyrum keeps conversation content in more than one place on purpose, but those copies do not have equal authority:
+
+- `sessions.turns_json` plus `sessions.summary` are the authoritative session context used for future model turns.
+- `channel_inbox.payload_json` and `channel_inbox.reply_text` are transport/audit records for a specific inbound delivery.
+- `channel_outbox.text` / `response_json` are delivery-side artifacts and may be chunked, retried, failed, or deleted after send.
+
+Transport tables are therefore useful for debugging and best-effort repair, but they are not the canonical conversation state. Queue cleanup and outbox delivery may delete rows, so the runtime must continue to work even when transport logs are incomplete.
+
+When retained channel logs disagree with session context, repair should rebuild the bounded turn window from transport history without discarding authoritative summarized context. Tyrum exposes this as `/repair [max_turns]`, which reconstructs `sessions.turns_json` from completed `channel_inbox` rows, folds any repaired overflow into the existing `sessions.summary`, prefers `reply_text`, and falls back to ordered outbox chunks when needed.
+
 ### DM isolation (secure by default for multi-user inboxes)
 
 Tyrum isolates direct-message context by default when more than one distinct sender can reach an agent via DMs. This prevents cross-user context leakage.

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -18,6 +18,7 @@ Commands are handled by the gateway (not by the model). This keeps control-plane
 - `/reset` — reset the current session state (policy-defined).
 - `/stop` — cancel the active run and clear queued followups for the current session.
 - `/compact` — request compaction of older history into a summary.
+- `/repair [max_turns]` — rebuild session context from retained channel transport logs.
 
 ### Context and usage
 

--- a/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
@@ -8,7 +8,6 @@ import type {
 } from "@ai-sdk/provider";
 import type {
   AgentTurnRequest as AgentTurnRequestT,
-  NormalizedAttachment as NormalizedAttachmentT,
   NormalizedContainerKind,
   NormalizedMessageEnvelope as NormalizedMessageEnvelopeT,
 } from "@tyrum/schemas";
@@ -18,6 +17,7 @@ import { coerceRecord } from "../../util/coerce.js";
 import { buildAgentTurnKey } from "../turn-key.js";
 import type { PolicyService } from "../../policy/service.js";
 import { deriveElevatedExecutionAvailableFromPolicyBundle } from "../../sandbox/elevated-execution.js";
+import { renderEnvelopeMessageText } from "../session-message-text.js";
 import type { LaneQueueScope } from "./turn-engine-bridge.js";
 
 export function createStaticLanguageModelV3(text: string): LanguageModelV3 {
@@ -145,20 +145,6 @@ export type ResolvedAgentTurnInput = {
   metadata?: Record<string, unknown>;
 };
 
-function formatNormalizedAttachment(attachment: NormalizedAttachmentT): string {
-  const fields = [`kind=${attachment.kind}`];
-  if (attachment.mime_type) fields.push(`mime_type=${attachment.mime_type}`);
-  if (typeof attachment.size_bytes === "number")
-    fields.push(`size_bytes=${String(attachment.size_bytes)}`);
-  if (attachment.sha256) fields.push(`sha256=${attachment.sha256}`);
-  return `- ${fields.join(" ")}`;
-}
-
-function formatAttachmentSummary(attachments: NormalizedAttachmentT[]): string | undefined {
-  if (!attachments || attachments.length === 0) return undefined;
-  return `Attachments:\n${attachments.map(formatNormalizedAttachment).join("\n")}`;
-}
-
 export function resolveAgentTurnInput(input: AgentTurnRequestT): ResolvedAgentTurnInput {
   const envelope = input.envelope;
   const channel = envelope?.delivery.channel ?? input.channel;
@@ -171,14 +157,10 @@ export function resolveAgentTurnInput(input: AgentTurnRequestT): ResolvedAgentTu
     throw new Error("thread_id is required");
   }
 
-  const baseText = (input.message ?? envelope?.content.text ?? "").trim();
-  const attachmentsSummary = envelope
-    ? formatAttachmentSummary(envelope.content.attachments)
-    : undefined;
-  const message = [baseText, attachmentsSummary]
-    .filter((part) => part && part.trim().length > 0)
-    .join("\n\n")
-    .trim();
+  const message = renderEnvelopeMessageText({
+    envelope,
+    fallbackText: input.message ?? envelope?.content.text ?? "",
+  });
 
   if (message.length === 0) {
     throw new Error("message is required (either message text or envelope content)");

--- a/packages/gateway/src/modules/agent/session-dal.ts
+++ b/packages/gateway/src/modules/agent/session-dal.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { NormalizedThreadMessage as NormalizedThreadMessageSchema } from "@tyrum/schemas";
 import type { NormalizedContainerKind } from "@tyrum/schemas";
 import type { SqlDb } from "../../statestore/types.js";
+import { safeJsonParse } from "../../utils/json.js";
 import { buildAgentTurnKey } from "./turn-key.js";
 import type { IdentityScopeDal, ScopeKeys } from "../identity/scope.js";
 import { DEFAULT_TENANT_KEY, normalizeScopeKeys } from "../identity/scope.js";
@@ -10,6 +12,7 @@ import {
   normalizeAccountId,
   normalizeConnectorId,
 } from "../channels/interface.js";
+import { renderNormalizedThreadMessageText } from "./session-message-text.js";
 import { Logger } from "../observability/logger.js";
 
 const logger = new Logger({ base: { module: "agent.session_dal" } });
@@ -90,6 +93,20 @@ interface RawSessionWithDeliveryRow extends RawSessionRow {
   account_key: string;
   provider_thread_id: string;
   container_kind: string;
+}
+
+interface RawChannelTranscriptRow {
+  inbox_id: number;
+  payload_json: string;
+  reply_text: string | null;
+  processed_at: string | Date | null;
+}
+
+export interface SessionRepairResult {
+  source_rows: number;
+  rebuilt_messages: number;
+  kept_messages: number;
+  dropped_messages: number;
 }
 
 function normalizeTime(value: string | Date): string {
@@ -220,6 +237,34 @@ function compactSessionSummary(
   }
 
   return lines.join("\n");
+}
+
+function buildStoredTranscript(input: {
+  turns: readonly SessionMessage[];
+  keepLastMessages: number;
+  previousSummary?: string;
+}): { turns: SessionMessage[]; summary: string; droppedMessages: number } {
+  const keepLastMessages = Math.max(1, input.keepLastMessages);
+  const overflow = input.turns.length - keepLastMessages;
+  const dropped = overflow > 0 ? input.turns.slice(0, overflow) : [];
+  const turns = input.turns.slice(-keepLastMessages);
+  const previousSummary = input.previousSummary ?? "";
+  const summary =
+    dropped.length > 0 ? compactSessionSummary(previousSummary, dropped) : previousSummary;
+
+  return {
+    turns: turns.slice(),
+    summary,
+    droppedMessages: dropped.length,
+  };
+}
+
+function normalizeRepairTimestamp(
+  processedAt: string | Date | null,
+  fallbackTimestamp: string | undefined,
+): string {
+  if (processedAt) return normalizeTime(processedAt);
+  return fallbackTimestamp?.trim() || new Date().toISOString();
 }
 
 export class SessionDal {
@@ -567,19 +612,18 @@ export class SessionDal {
       timestamp: input.timestamp,
     });
 
-    const maxMessages = Math.max(1, input.maxTurns) * 2;
-    const overflow = turns.length - maxMessages;
-    const dropped = overflow > 0 ? turns.slice(0, overflow) : [];
-    const bounded = turns.slice(-maxMessages);
-    const summary =
-      dropped.length > 0 ? compactSessionSummary(session.summary, dropped) : session.summary;
+    const stored = buildStoredTranscript({
+      turns,
+      keepLastMessages: Math.max(1, input.maxTurns) * 2,
+      previousSummary: session.summary,
+    });
 
     const nowIso = new Date().toISOString();
     await this.db.run(
       `UPDATE sessions
        SET turns_json = ?, summary = ?, updated_at = ?
        WHERE tenant_id = ? AND session_id = ?`,
-      [JSON.stringify(bounded), summary, nowIso, input.tenantId, input.sessionId],
+      [JSON.stringify(stored.turns), stored.summary, nowIso, input.tenantId, input.sessionId],
     );
 
     const updated = await this.getById({ tenantId: input.tenantId, sessionId: input.sessionId });
@@ -600,21 +644,95 @@ export class SessionDal {
     }
 
     const keepLastMessages = Math.max(2, input.keepLastMessages);
-    const overflow = session.turns.length - keepLastMessages;
-    const dropped = overflow > 0 ? session.turns.slice(0, overflow) : [];
-    const bounded = session.turns.slice(-keepLastMessages);
-    const summary =
-      dropped.length > 0 ? compactSessionSummary(session.summary, dropped) : session.summary;
+    const stored = buildStoredTranscript({
+      turns: session.turns,
+      keepLastMessages,
+      previousSummary: session.summary,
+    });
 
     const nowIso = new Date().toISOString();
     await this.db.run(
       `UPDATE sessions
        SET turns_json = ?, summary = ?, updated_at = ?
        WHERE tenant_id = ? AND session_id = ?`,
-      [JSON.stringify(bounded), summary, nowIso, input.tenantId, input.sessionId],
+      [JSON.stringify(stored.turns), stored.summary, nowIso, input.tenantId, input.sessionId],
     );
 
-    return { droppedMessages: dropped.length, keptMessages: bounded.length };
+    return { droppedMessages: stored.droppedMessages, keptMessages: stored.turns.length };
+  }
+
+  async repairFromChannelLogs(input: {
+    tenantId: string;
+    sessionId: string;
+    maxTurns: number;
+  }): Promise<SessionRepairResult | null> {
+    const session = await this.getById({ tenantId: input.tenantId, sessionId: input.sessionId });
+    if (!session) {
+      throw new Error(`session '${input.sessionId}' not found`);
+    }
+
+    const rows = await this.db.all<RawChannelTranscriptRow>(
+      `SELECT inbox_id, payload_json, reply_text, processed_at
+       FROM channel_inbox
+       WHERE tenant_id = ?
+         AND session_id = ?
+         AND status = 'completed'
+       ORDER BY received_at_ms ASC, inbox_id ASC`,
+      [input.tenantId, input.sessionId],
+    );
+
+    const rebuiltTurns: SessionMessage[] = [];
+    let sourceRows = 0;
+
+    for (const row of rows) {
+      const parsed = NormalizedThreadMessageSchema.safeParse(safeJsonParse(row.payload_json, {}));
+      if (!parsed.success) continue;
+
+      const userMessage = renderNormalizedThreadMessageText(parsed.data);
+      if (userMessage.length === 0) continue;
+
+      const assistantMessage =
+        row.reply_text !== null
+          ? row.reply_text
+          : await this.loadOutboxReplyText({
+              tenantId: input.tenantId,
+              inboxId: row.inbox_id,
+            });
+      if (assistantMessage === undefined) continue;
+
+      const timestamp = normalizeRepairTimestamp(
+        row.processed_at,
+        parsed.data.message.envelope?.received_at ?? parsed.data.message.timestamp,
+      );
+      rebuiltTurns.push(
+        { role: "user", content: userMessage, timestamp },
+        { role: "assistant", content: assistantMessage, timestamp },
+      );
+      sourceRows += 1;
+    }
+
+    if (sourceRows === 0) return null;
+
+    const stored = buildStoredTranscript({
+      turns: rebuiltTurns,
+      keepLastMessages: Math.max(1, input.maxTurns) * 2,
+      previousSummary: session.summary,
+    });
+    const updatedAt = stored.turns.at(-1)?.timestamp ?? session.updated_at;
+
+    await this.db.run(
+      `UPDATE sessions
+       SET turns_json = ?, summary = ?, updated_at = ?
+       WHERE tenant_id = ? AND session_id = ?`,
+      [JSON.stringify(stored.turns), stored.summary, updatedAt, input.tenantId, input.sessionId],
+    );
+
+    return {
+      source_rows: sourceRows,
+      rebuilt_messages: rebuiltTurns.length,
+      kept_messages: stored.turns.length,
+      dropped_messages: stored.droppedMessages,
+    };
   }
 
   async deleteExpired(ttlDays: number, agentKey?: string): Promise<number> {
@@ -648,5 +766,20 @@ export class SessionDal {
       agentId ? [tenantId, agentId, cutoffIso] : [tenantId, cutoffIso],
     );
     return res.changes;
+  }
+
+  private async loadOutboxReplyText(input: {
+    tenantId: string;
+    inboxId: number;
+  }): Promise<string | undefined> {
+    const rows = await this.db.all<{ text: string }>(
+      `SELECT text
+       FROM channel_outbox
+       WHERE tenant_id = ? AND inbox_id = ?
+       ORDER BY chunk_index ASC, outbox_id ASC`,
+      [input.tenantId, input.inboxId],
+    );
+    if (rows.length === 0) return undefined;
+    return rows.map((row) => row.text).join("");
   }
 }

--- a/packages/gateway/src/modules/agent/session-message-text.ts
+++ b/packages/gateway/src/modules/agent/session-message-text.ts
@@ -1,0 +1,46 @@
+import type {
+  NormalizedAttachment as NormalizedAttachmentT,
+  NormalizedMessageEnvelope as NormalizedMessageEnvelopeT,
+  NormalizedThreadMessage as NormalizedThreadMessageT,
+} from "@tyrum/schemas";
+
+function formatNormalizedAttachment(attachment: NormalizedAttachmentT): string {
+  const fields = [`kind=${attachment.kind}`];
+  if (attachment.mime_type) fields.push(`mime_type=${attachment.mime_type}`);
+  if (typeof attachment.size_bytes === "number") {
+    fields.push(`size_bytes=${String(attachment.size_bytes)}`);
+  }
+  if (attachment.sha256) fields.push(`sha256=${attachment.sha256}`);
+  return `- ${fields.join(" ")}`;
+}
+
+function formatAttachmentSummary(attachments: NormalizedAttachmentT[]): string | undefined {
+  if (!attachments || attachments.length === 0) return undefined;
+  return `Attachments:\n${attachments.map(formatNormalizedAttachment).join("\n")}`;
+}
+
+export function renderEnvelopeMessageText(input: {
+  envelope?: NormalizedMessageEnvelopeT;
+  fallbackText?: string;
+}): string {
+  const baseText = (input.fallbackText ?? "").trim();
+  const attachmentsSummary = input.envelope
+    ? formatAttachmentSummary(input.envelope.content.attachments)
+    : undefined;
+
+  return [baseText, attachmentsSummary]
+    .filter((part) => part && part.trim().length > 0)
+    .join("\n\n")
+    .trim();
+}
+
+export function renderNormalizedThreadMessageText(input: NormalizedThreadMessageT): string {
+  const fallbackText =
+    input.message.content.kind === "text"
+      ? input.message.content.text
+      : (input.message.content.caption ?? "");
+  return renderEnvelopeMessageText({
+    envelope: input.message.envelope,
+    fallbackText,
+  });
+}

--- a/packages/gateway/src/modules/commands/dispatcher.ts
+++ b/packages/gateway/src/modules/commands/dispatcher.ts
@@ -104,6 +104,8 @@ type UsageTotals = {
   usd_micros: number;
 };
 
+const DEFAULT_REPAIR_MAX_TURNS = 20;
+
 async function resolveKeyLane(
   db: SqlDb,
   ctx: CommandDeps["commandContext"] | undefined,
@@ -257,6 +259,26 @@ async function resolveFallbackKeyLane(
     }),
     lane: "main",
   };
+}
+
+function resolveContainerKindFromSessionKey(key: string | undefined): "dm" | "group" | "channel" {
+  if (!key) return "channel";
+
+  try {
+    const parsed = parseTyrumKey(key as never);
+    if (
+      parsed.kind === "agent" &&
+      (parsed.thread_kind === "dm" ||
+        parsed.thread_kind === "group" ||
+        parsed.thread_kind === "channel")
+    ) {
+      return parsed.thread_kind;
+    }
+  } catch {
+    // Intentional: fall back to channel-scoped sessions for legacy/unknown keys.
+  }
+
+  return "channel";
 }
 
 async function cancelRunsAndClearQueuedInbox(input: {
@@ -455,6 +477,7 @@ function helpText(): string {
     "- /reset",
     "- /stop",
     "- /compact",
+    "- /repair [max_turns]",
     "- /status",
     "- /presence",
     "- /approvals [pending|approved|denied|expired]",
@@ -583,6 +606,68 @@ export async function executeCommand(
     return { output: jsonBlock(payload), data: payload };
   }
 
+  if (cmd === "repair") {
+    if (!deps.db) {
+      return { output: "Sessions are not available on this gateway instance.", data: null };
+    }
+
+    const ctx = deps.commandContext;
+    const agentId = resolveAgentId(ctx);
+    const resolved = await resolveChannelThread(deps.db, ctx);
+    if (!resolved) {
+      return {
+        output: "Usage: /repair [max_turns] (requires key or channel/thread context)",
+        data: null,
+      };
+    }
+
+    const maxTurnsRaw = toks[1]?.trim();
+    let maxTurns = DEFAULT_REPAIR_MAX_TURNS;
+    if (maxTurnsRaw) {
+      if (!/^[0-9]+$/.test(maxTurnsRaw)) {
+        return {
+          output: "Usage: /repair [max_turns] (max_turns must be a positive integer)",
+          data: null,
+        };
+      }
+      maxTurns = Math.min(500, Math.max(1, Number(maxTurnsRaw)));
+    }
+
+    const { channel, accountKey, threadId } = resolved;
+    const keyLane =
+      (await resolveKeyLane(deps.db, ctx)) ?? (await resolveFallbackKeyLane(deps.db, ctx, agentId));
+    const sessionDal = new SessionDal(
+      deps.db,
+      new IdentityScopeDal(deps.db),
+      new ChannelThreadDal(deps.db),
+    );
+    const session = await sessionDal.getOrCreate({
+      scopeKeys: { agentKey: agentId, workspaceKey: resolveWorkspaceKey() },
+      connectorKey: channel,
+      accountKey,
+      providerThreadId: threadId,
+      containerKind: resolveContainerKindFromSessionKey(keyLane?.key),
+    });
+    const repaired = await sessionDal.repairFromChannelLogs({
+      tenantId: session.tenant_id,
+      sessionId: session.session_id,
+      maxTurns,
+    });
+    if (!repaired) {
+      return {
+        output: "No completed retained channel logs were found for this session.",
+        data: null,
+      };
+    }
+
+    const payload = {
+      agent_id: agentId,
+      session_id: session.session_id,
+      ...repaired,
+    };
+    return { output: jsonBlock(payload), data: payload };
+  }
+
   if (cmd === "stop") {
     if (!deps.db) {
       return { output: "Stop is not available on this gateway instance.", data: null };
@@ -635,22 +720,6 @@ export async function executeCommand(
         lane: "main",
       };
 
-    // Prefer the container kind from the resolved key (so /reset works for dm/group keys too).
-    let containerKind: "dm" | "group" | "channel" = "channel";
-    try {
-      const parsed = parseTyrumKey(keyLane.key as never);
-      if (
-        parsed.kind === "agent" &&
-        (parsed.thread_kind === "dm" ||
-          parsed.thread_kind === "group" ||
-          parsed.thread_kind === "channel")
-      ) {
-        containerKind = parsed.thread_kind;
-      }
-    } catch {
-      // Intentional: fall back to channel-scoped sessions.
-    }
-
     const sessionDal = new SessionDal(
       deps.db,
       new IdentityScopeDal(deps.db),
@@ -661,7 +730,7 @@ export async function executeCommand(
       connectorKey: channel,
       accountKey,
       providerThreadId: threadId,
-      containerKind,
+      containerKind: resolveContainerKindFromSessionKey(keyLane.key),
     });
 
     if (keyLane?.key) {

--- a/packages/gateway/tests/helpers/channel-session-repair.ts
+++ b/packages/gateway/tests/helpers/channel-session-repair.ts
@@ -1,0 +1,104 @@
+import type { NormalizedThreadMessage } from "@tyrum/schemas";
+import type { SessionRow } from "../../src/modules/agent/session-dal.js";
+import { ChannelInboxDal } from "../../src/modules/channels/inbox-dal.js";
+import { ChannelOutboxDal } from "../../src/modules/channels/outbox-dal.js";
+
+function containerKindFromThreadKind(
+  threadKind: "private" | "group" | "supergroup" | "channel" | "other",
+): "dm" | "group" | "channel" {
+  if (threadKind === "private") return "dm";
+  if (threadKind === "channel") return "channel";
+  return "group";
+}
+
+export function createTelegramNormalizedMessage(input: {
+  threadId: string;
+  messageId: string;
+  text: string;
+  receivedAt: string;
+  threadKind?: "private" | "group" | "supergroup" | "channel" | "other";
+}): NormalizedThreadMessage {
+  const threadKind = input.threadKind ?? "channel";
+  return {
+    thread: {
+      id: input.threadId,
+      kind: threadKind,
+      pii_fields: [],
+    },
+    message: {
+      id: input.messageId,
+      thread_id: input.threadId,
+      source: "telegram",
+      content: { kind: "text", text: input.text },
+      timestamp: input.receivedAt,
+      pii_fields: ["message_text"],
+      envelope: {
+        message_id: input.messageId,
+        received_at: input.receivedAt,
+        delivery: { channel: "telegram", account: "default" },
+        container: { kind: containerKindFromThreadKind(threadKind), id: input.threadId },
+        sender: { id: "user-1", display: "User 1" },
+        content: { text: input.text, attachments: [] },
+        provenance: ["user"],
+      },
+    },
+  };
+}
+
+export async function seedCompletedTelegramTurn(input: {
+  inboxDal: ChannelInboxDal;
+  outboxDal: ChannelOutboxDal;
+  session: SessionRow;
+  threadId: string;
+  messageId: string;
+  userText: string;
+  assistantText: string;
+  receivedAtMs: number;
+  threadKind?: "private" | "group" | "supergroup" | "channel" | "other";
+  owner?: string;
+}): Promise<void> {
+  const owner = input.owner ?? "worker-1";
+  const receivedAt = new Date(input.receivedAtMs).toISOString();
+  const { row } = await input.inboxDal.enqueue({
+    source: "telegram:default",
+    thread_id: input.threadId,
+    message_id: input.messageId,
+    key: input.session.session_key,
+    lane: "main",
+    received_at_ms: input.receivedAtMs,
+    payload: createTelegramNormalizedMessage({
+      threadId: input.threadId,
+      messageId: input.messageId,
+      text: input.userText,
+      receivedAt,
+      threadKind: input.threadKind,
+    }),
+  });
+
+  const claimed = await input.inboxDal.claimNext({
+    owner,
+    now_ms: input.receivedAtMs + 1,
+    lease_ttl_ms: 60_000,
+  });
+  if (!claimed || claimed.inbox_id !== row.inbox_id) {
+    throw new Error("failed to claim seeded channel inbox row");
+  }
+
+  await input.outboxDal.enqueue({
+    tenant_id: row.tenant_id,
+    inbox_id: row.inbox_id,
+    source: row.source,
+    thread_id: row.thread_id,
+    dedupe_key: `repair:${String(row.inbox_id)}:0`,
+    chunk_index: 0,
+    text: input.assistantText,
+    workspace_id: row.workspace_id,
+    session_id: row.session_id,
+    channel_thread_id: row.channel_thread_id,
+  });
+
+  const marked = await input.inboxDal.markCompleted(row.inbox_id, owner, input.assistantText);
+  if (!marked) {
+    throw new Error("failed to mark seeded channel inbox row as completed");
+  }
+}

--- a/packages/gateway/tests/unit/command-session-primitives.test.ts
+++ b/packages/gateway/tests/unit/command-session-primitives.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 import { executeCommand } from "../../src/modules/commands/dispatcher.js";
 import { SessionDal } from "../../src/modules/agent/session-dal.js";
@@ -9,7 +9,10 @@ import {
   IdentityScopeDal,
 } from "../../src/modules/identity/scope.js";
 import { ChannelThreadDal } from "../../src/modules/channels/thread-dal.js";
+import { ChannelInboxDal } from "../../src/modules/channels/inbox-dal.js";
+import { ChannelOutboxDal } from "../../src/modules/channels/outbox-dal.js";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { seedCompletedTelegramTurn } from "../helpers/channel-session-repair.js";
 
 describe("session command primitives", () => {
   let db: ReturnType<typeof openTestSqliteDb> | undefined;
@@ -243,6 +246,119 @@ describe("session command primitives", () => {
     );
     expect(defaultUpdated?.summary).toBe("default-summary");
     expect(defaultUpdated?.turns_json).toBe(JSON.stringify(defaultTurns));
+  });
+
+  it("supports /repair (rebuilds session context from retained channel logs)", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-17T00:10:00.000Z"));
+      db = openTestSqliteDb();
+
+      const session = await ensureSession({
+        agentKey: "default",
+        channel: "telegram",
+        threadId: "thread-repair",
+        containerKind: "channel",
+      });
+      const inboxDal = new ChannelInboxDal(db);
+      const outboxDal = new ChannelOutboxDal(db);
+
+      await seedCompletedTelegramTurn({
+        inboxDal,
+        outboxDal,
+        session,
+        threadId: "thread-repair",
+        messageId: "repair-1",
+        userText: "user-one",
+        assistantText: "assistant-one",
+        receivedAtMs: Date.parse("2026-02-17T00:00:00.000Z"),
+      });
+
+      await db.run(
+        `UPDATE sessions
+         SET turns_json = ?, summary = ?, updated_at = ?
+         WHERE tenant_id = ? AND session_id = ?`,
+        ["[]", "stale-summary", "2026-02-17T00:00:01.000Z", DEFAULT_TENANT_ID, session.session_id],
+      );
+
+      const result = await executeCommand("/repair", {
+        db,
+        commandContext: { agentId: "default", channel: "telegram", threadId: "thread-repair" },
+      });
+
+      expect(result.data).toMatchObject({
+        agent_id: "default",
+        session_id: session.session_id,
+        source_rows: 1,
+        rebuilt_messages: 2,
+        kept_messages: 2,
+        dropped_messages: 0,
+      });
+
+      const updated = await db.get<{ summary: string; turns_json: string }>(
+        `SELECT summary, turns_json
+         FROM sessions
+         WHERE tenant_id = ? AND session_id = ?`,
+        [DEFAULT_TENANT_ID, session.session_id],
+      );
+      expect(updated?.summary).toBe("stale-summary");
+      expect(updated?.turns_json).toContain("user-one");
+      expect(updated?.turns_json).toContain("assistant-one");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("supports /repair for dm sessions when the command is resolved from a dm key", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-17T00:10:00.000Z"));
+      db = openTestSqliteDb();
+
+      const session = await ensureSession({
+        agentKey: "default",
+        channel: "telegram",
+        threadId: "dm-repair",
+        containerKind: "dm",
+      });
+      const inboxDal = new ChannelInboxDal(db);
+      const outboxDal = new ChannelOutboxDal(db);
+
+      await seedCompletedTelegramTurn({
+        inboxDal,
+        outboxDal,
+        session,
+        threadId: "dm-repair",
+        messageId: "repair-dm-1",
+        userText: "dm-user",
+        assistantText: "dm-assistant",
+        receivedAtMs: Date.parse("2026-02-17T00:00:00.000Z"),
+        threadKind: "private",
+      });
+
+      await db.run(
+        `UPDATE sessions
+         SET turns_json = ?, summary = ?
+         WHERE tenant_id = ? AND session_id = ?`,
+        ["[]", "", DEFAULT_TENANT_ID, session.session_id],
+      );
+
+      const result = await executeCommand("/repair", {
+        db,
+        commandContext: { agentId: "default", key: session.session_key },
+      });
+
+      expect(result.data).toMatchObject({
+        agent_id: "default",
+        session_id: session.session_id,
+        source_rows: 1,
+        rebuilt_messages: 2,
+        kept_messages: 2,
+        dropped_messages: 0,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("supports /stop (cancels active run + clears queued inbox)", async () => {

--- a/packages/gateway/tests/unit/session-dal.test.ts
+++ b/packages/gateway/tests/unit/session-dal.test.ts
@@ -4,6 +4,9 @@ import { openTestSqliteDb } from "../helpers/sqlite-db.js";
 import type { SqliteDb } from "../../src/statestore/sqlite.js";
 import { ChannelThreadDal } from "../../src/modules/channels/thread-dal.js";
 import { IdentityScopeDal } from "../../src/modules/identity/scope.js";
+import { ChannelInboxDal } from "../../src/modules/channels/inbox-dal.js";
+import { ChannelOutboxDal } from "../../src/modules/channels/outbox-dal.js";
+import { seedCompletedTelegramTurn } from "../helpers/channel-session-repair.js";
 
 describe("SessionDal", () => {
   let db: SqliteDb | undefined;
@@ -156,6 +159,86 @@ describe("SessionDal", () => {
     expect(third.summary).toContain("u1");
     expect(third.summary).toContain("u2");
     expect(third.summary).not.toContain("u3");
+  });
+
+  it("repairs bounded session turns and summary from retained channel logs", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-17T00:10:00.000Z"));
+
+      const dal = createDal();
+      const session = await dal.getOrCreate({
+        connectorKey: "telegram",
+        providerThreadId: "thread-repair",
+        containerKind: "channel",
+      });
+      const inboxDal = new ChannelInboxDal(db!, dal);
+      const outboxDal = new ChannelOutboxDal(db!);
+
+      await seedCompletedTelegramTurn({
+        inboxDal,
+        outboxDal,
+        session,
+        threadId: "thread-repair",
+        messageId: "msg-1",
+        userText: "u1",
+        assistantText: "a1",
+        receivedAtMs: Date.parse("2026-02-17T00:00:00.000Z"),
+      });
+      await seedCompletedTelegramTurn({
+        inboxDal,
+        outboxDal,
+        session,
+        threadId: "thread-repair",
+        messageId: "msg-2",
+        userText: "u2",
+        assistantText: "a2",
+        receivedAtMs: Date.parse("2026-02-17T00:01:00.000Z"),
+      });
+
+      await db!.run(
+        `UPDATE sessions
+         SET turns_json = ?, summary = ?, updated_at = ?
+         WHERE tenant_id = ? AND session_id = ?`,
+        [
+          JSON.stringify([
+            { role: "user", content: "stale", timestamp: "2026-02-17T00:00:00.000Z" },
+          ]),
+          "stale-summary",
+          "2026-02-17T00:02:00.000Z",
+          session.tenant_id,
+          session.session_id,
+        ],
+      );
+
+      const repaired = await dal.repairFromChannelLogs({
+        tenantId: session.tenant_id,
+        sessionId: session.session_id,
+        maxTurns: 1,
+      });
+
+      expect(repaired).toEqual({
+        source_rows: 2,
+        rebuilt_messages: 4,
+        kept_messages: 2,
+        dropped_messages: 2,
+      });
+
+      const updated = await dal.getById({
+        tenantId: session.tenant_id,
+        sessionId: session.session_id,
+      });
+      expect(updated?.summary).toContain("stale-summary");
+      expect(updated?.summary).toContain("u1");
+      expect(updated?.summary).toContain("a1");
+      expect(updated?.summary).not.toContain("u2");
+      expect(updated?.turns).toEqual([
+        { role: "user", content: "u2", timestamp: "2026-02-17T00:10:00.000Z" },
+        { role: "assistant", content: "a2", timestamp: "2026-02-17T00:10:00.000Z" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("deletes expired sessions using ttl days", async () => {


### PR DESCRIPTION
Closes #982

## Summary
- document the session/channel source-of-truth invariants and repair semantics
- add session transcript repair from retained channel logs, including `/repair [max_turns]`
- share message text rendering logic and add regression coverage for channel and DM repair flows

## Verification
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm exec vitest run packages/gateway/tests/unit/session-dal.test.ts packages/gateway/tests/unit/command-session-primitives.test.ts
