### PR TITLE
lint(gateway): Clear non-structural oxlint warnings in packages/gateway/src/** (excluding hotspot files) (#1035)

### DIFF
--- a/packages/gateway/src/migrate-postgres.ts
+++ b/packages/gateway/src/migrate-postgres.ts
@@ -21,7 +21,7 @@ export async function migratePostgres(client: ClientBase, migrationsDir: string)
 
   const files = readdirSync(migrationsDir)
     .filter((f) => f.endsWith(".sql"))
-    .sort();
+    .toSorted();
 
   for (const file of files) {
     if (applied.has(file)) continue;

--- a/packages/gateway/src/migrate.ts
+++ b/packages/gateway/src/migrate.ts
@@ -37,7 +37,7 @@ export function migrate(db: Database.Database, migrationsDir: string): void {
 
   const files = readdirSync(migrationsDir)
     .filter((f) => f.endsWith(".sql"))
-    .sort();
+    .toSorted();
 
   for (const file of files) {
     if (applied.has(file)) continue;

--- a/packages/gateway/src/modules/agent/loop-detection.ts
+++ b/packages/gateway/src/modules/agent/loop-detection.ts
@@ -53,7 +53,7 @@ export function signatureForToolStep(
   const callSigs = toolCalls
     .map(safeToolCallSignature)
     .filter((sig): sig is string => typeof sig === "string" && sig.length > 0)
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    .toSorted((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 
   if (callSigs.length === 0) return undefined;
   return { signature: callSigs.join("|"), toolNames };

--- a/packages/gateway/src/modules/agent/markdown-memory.ts
+++ b/packages/gateway/src/modules/agent/markdown-memory.ts
@@ -172,8 +172,8 @@ export class MarkdownMemoryStore {
       .filter((entry) => entry.isFile())
       .map((entry) => entry.name)
       .filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))
-      .sort()
-      .reverse();
+      .toSorted()
+      .toReversed();
 
     for (const name of dailyFiles) {
       if (hits.length >= limit) break;

--- a/packages/gateway/src/modules/agent/mcp-manager.ts
+++ b/packages/gateway/src/modules/agent/mcp-manager.ts
@@ -78,7 +78,7 @@ function stableFingerprint(spec: McpServerSpecT): string {
       transport: remote.transport,
       url: remote.url,
       headers: remote.headers
-        ? Object.entries(remote.headers).sort((a, b) => a[0].localeCompare(b[0]))
+        ? Object.entries(remote.headers).toSorted((a, b) => a[0].localeCompare(b[0]))
         : [],
       timeout_ms: remote.timeout_ms ?? null,
       scopes: remote.scopes ?? [],
@@ -87,7 +87,7 @@ function stableFingerprint(spec: McpServerSpecT): string {
 
   const stdio = asStdio(spec);
   const envEntries = stdio.env
-    ? Object.entries(stdio.env).sort((a, b) => a[0].localeCompare(b[0]))
+    ? Object.entries(stdio.env).toSorted((a, b) => a[0].localeCompare(b[0]))
     : [];
 
   return JSON.stringify({

--- a/packages/gateway/src/modules/agent/runtime/provider-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/provider-resolution.ts
@@ -101,7 +101,7 @@ export async function listOrderedEligibleProfilesForProvider(input: {
   const pinnedId = pin?.auth_profile_id;
 
   return pinnedId
-    ? [...eligibleProfiles].sort((a, b) =>
+    ? [...eligibleProfiles].toSorted((a, b) =>
         a.auth_profile_id === pinnedId ? -1 : b.auth_profile_id === pinnedId ? 1 : 0,
       )
     : eligibleProfiles;

--- a/packages/gateway/src/modules/agent/runtime/turn-engine-bridge.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-engine-bridge.ts
@@ -334,7 +334,7 @@ export async function turnViaExecutionEngine(
   let laneQueueInterruptReason: string | undefined;
 
   const executor: StepExecutor = {
-    execute: async (action, planId, stepIndex, timeoutMs, _context) => {
+    execute: async (action, stepPlanId, stepIndex, timeoutMs, _context) => {
       if (action.type !== "Decide") {
         return { success: false, error: `unsupported action type: ${action.type}` };
       }
@@ -372,7 +372,7 @@ export async function turnViaExecutionEngine(
           abortSignal: controller.signal,
           timeoutMs: effectiveTimeoutMs,
           execution: {
-            planId,
+            planId: stepPlanId,
             runId,
             stepIndex,
             stepId: stepRow.step_id,

--- a/packages/gateway/src/modules/agent/tools.ts
+++ b/packages/gateway/src/modules/agent/tools.ts
@@ -179,7 +179,7 @@ export function selectToolDirectory(
   const normalizedPrompt = userPrompt.toLowerCase();
   return available
     .map((tool) => ({ tool, score: scoreTool(tool, normalizedPrompt) }))
-    .sort((a, b) => b.score - a.score || a.tool.id.localeCompare(b.tool.id))
+    .toSorted((a, b) => b.score - a.score || a.tool.id.localeCompare(b.tool.id))
     .slice(0, limit)
     .map((entry) => entry.tool);
 }

--- a/packages/gateway/src/modules/channels/telegram.ts
+++ b/packages/gateway/src/modules/channels/telegram.ts
@@ -438,9 +438,9 @@ export class TelegramChannelQueue {
             : {}),
         },
       };
-      const parsed = WsChannelQueueOverflowEvent.safeParse(candidate);
-      if (parsed.success) {
-        this.emitWsEvent(row.tenant_id, parsed.data);
+      const overflowEvent = WsChannelQueueOverflowEvent.safeParse(candidate);
+      if (overflowEvent.success) {
+        this.emitWsEvent(row.tenant_id, overflowEvent.data);
       }
     }
 
@@ -1069,8 +1069,8 @@ export class TelegramChannelProcessor {
             text: "Sorry, something went wrong. Please try again later.",
             parseMode: "HTML",
           })
-          .catch((err) => {
-            const message2 = err instanceof Error ? err.message : String(err);
+          .catch((sendErr) => {
+            const message2 = sendErr instanceof Error ? sendErr.message : String(sendErr);
             this.logger?.warn("channels.telegram.send_error_reply_failed", {
               channel_id: connectorId,
               message_id: leader.message_id,

--- a/packages/gateway/src/modules/commands/dispatcher.ts
+++ b/packages/gateway/src/modules/commands/dispatcher.ts
@@ -1086,7 +1086,7 @@ export async function executeCommand(
 
     const row = await deps.db.transaction(async (tx) => {
       const modelOverrideDal = new SessionModelOverrideDal(tx);
-      const row = await modelOverrideDal.upsert({
+      const overrideRow = await modelOverrideDal.upsert({
         tenantId: session.tenant_id,
         sessionId: session.session_id,
         modelId: modelIdRaw,
@@ -1097,7 +1097,7 @@ export async function executeCommand(
         sessionId: session.session_id,
         providerKey: providerId,
       });
-      return row;
+      return overrideRow;
     });
 
     const payload = {

--- a/packages/gateway/src/modules/discovery/strategies/capability-memory.ts
+++ b/packages/gateway/src/modules/discovery/strategies/capability-memory.ts
@@ -38,13 +38,12 @@ function recencyWeight(lastSuccessAt: string | null): number {
 }
 
 function normalizeUrl(identifier: string): string {
-  try {
-    new URL(identifier);
+  if (URL.canParse(identifier)) {
     return identifier;
-  } catch {
-    // Intentional: bare domain or path — assume https.
-    return `https://${identifier}`;
   }
+
+  // Intentional: bare domain or path — assume https.
+  return `https://${identifier}`;
 }
 
 function matchesQuery(row: CapabilityMemoryRow, query: string): boolean {

--- a/packages/gateway/src/modules/execution/worker-loop.ts
+++ b/packages/gateway/src/modules/execution/worker-loop.ts
@@ -35,7 +35,8 @@ export function startExecutionWorkerLoop(opts: ExecutionWorkerLoopOptions): Exec
       max_ticks_per_cycle: maxTicksPerCycle,
     });
 
-    while (!stopping) {
+    for (;;) {
+      if (stopping) break;
       try {
         let didWork = false;
         for (let i = 0; i < maxTicksPerCycle; i += 1) {

--- a/packages/gateway/src/modules/markdown/telegram.ts
+++ b/packages/gateway/src/modules/markdown/telegram.ts
@@ -179,7 +179,7 @@ function renderInlineRangeToTelegramHtml(
       (span): span is InlineSpan =>
         (span.kind === "style" || span.kind === "link") && span.start >= start && span.end <= end,
     )
-    .map((span) => ({ ...span }));
+    .map((span) => Object.assign({}, span) as InlineSpan);
 
   const suffixes = new Map<number, string[]>();
   const filtered: InlineSpan[] = [];
@@ -216,8 +216,8 @@ function renderInlineRangeToTelegramHtml(
     closesByIndex.set(span.end, closes);
   }
 
-  for (const [idx, spans] of opensByIndex) {
-    spans.sort((a, b) => {
+  for (const [idx, openSpans] of opensByIndex) {
+    openSpans.sort((a, b) => {
       if (a.end !== b.end) return b.end - a.end;
 
       const kindCmp = inlineKindRank(a) - inlineKindRank(b);
@@ -235,11 +235,11 @@ function renderInlineRangeToTelegramHtml(
 
       return 0;
     });
-    opensByIndex.set(idx, spans);
+    opensByIndex.set(idx, openSpans);
   }
 
-  for (const [idx, spans] of closesByIndex) {
-    spans.sort((a, b) => {
+  for (const [idx, closeSpans] of closesByIndex) {
+    closeSpans.sort((a, b) => {
       if (a.start !== b.start) return b.start - a.start;
 
       const kindCmp = inlineKindRank(b) - inlineKindRank(a);
@@ -257,7 +257,7 @@ function renderInlineRangeToTelegramHtml(
 
       return 0;
     });
-    closesByIndex.set(idx, spans);
+    closesByIndex.set(idx, closeSpans);
   }
 
   let out = "";

--- a/packages/gateway/src/modules/memory/v1-dal.ts
+++ b/packages/gateway/src/modules/memory/v1-dal.ts
@@ -119,7 +119,7 @@ function decodeCursor(raw: string): Cursor {
 }
 
 function uniqSortedStrings(values: readonly string[]): string[] {
-  return [...new Set(values.map((v) => v.trim()).filter((v) => v.length > 0))].sort();
+  return [...new Set(values.map((v) => v.trim()).filter((v) => v.length > 0))].toSorted();
 }
 
 type MemoryV1BudgetLimits = {
@@ -1315,14 +1315,26 @@ export class MemoryV1Dal {
     const scored = rows.map((row) => {
       const provenance: MemoryProvenance = {
         source_kind: row.source_kind,
-        ...(row.channel ? { channel: row.channel } : {}),
-        ...(row.thread_id ? { thread_id: row.thread_id } : {}),
-        ...(row.session_id ? { session_id: row.session_id } : {}),
-        ...(row.message_id ? { message_id: row.message_id } : {}),
-        ...(row.tool_call_id ? { tool_call_id: row.tool_call_id } : {}),
         refs: parseJson<string[]>(row.refs_json),
-        ...(row.metadata_json ? { metadata: parseJson<unknown>(row.metadata_json) } : {}),
       };
+      if (row.channel) {
+        provenance.channel = row.channel;
+      }
+      if (row.thread_id) {
+        provenance.thread_id = row.thread_id;
+      }
+      if (row.session_id) {
+        provenance.session_id = row.session_id;
+      }
+      if (row.message_id) {
+        provenance.message_id = row.message_id;
+      }
+      if (row.tool_call_id) {
+        provenance.tool_call_id = row.tool_call_id;
+      }
+      if (row.metadata_json) {
+        provenance.metadata = parseJson<unknown>(row.metadata_json);
+      }
 
       const title = row.title ?? "";
       const key = row.key ?? "";
@@ -1360,14 +1372,24 @@ export class MemoryV1Dal {
       const snippet =
         snippetSource.length > 0 ? buildSnippet(snippetSource, terms, 240) : undefined;
 
-      return {
+      const hit: {
+        memory_item_id: string;
+        kind: MemoryItemKind;
+        score: number;
+        provenance: MemoryProvenance;
+        _created_at: string;
+        snippet?: string;
+      } = {
         memory_item_id: row.memory_item_id,
         kind: row.kind,
         score: Math.max(0, score),
-        ...(snippet ? { snippet } : {}),
         provenance,
         _created_at: normalizeTime(row.created_at),
       };
+      if (snippet) {
+        hit.snippet = snippet;
+      }
+      return hit;
     });
 
     scored.sort((a, b) => {
@@ -1605,7 +1627,7 @@ export class MemoryV1Dal {
     if (rows.some((row) => row.kind === "episode") && overBudget(usage, limits)) {
       const episodes = rows
         .filter((row) => row.kind === "episode" && row.summary_md && row.occurred_at)
-        .sort((a, b) => {
+        .toSorted((a, b) => {
           const oa = a.occurred_at ?? "";
           const ob = b.occurred_at ?? "";
           if (oa !== ob) return oa.localeCompare(ob);
@@ -1768,7 +1790,7 @@ export class MemoryV1Dal {
         usage.total.chars > limits.max_total_chars ||
         usage.per_kind[kind].chars > limits.per_kind[kind].max_chars;
 
-      const sorted = candidates.slice().sort((a, b) => {
+      const sorted = candidates.toSorted((a, b) => {
         const charsA = memoryItemCharCount(a);
         const charsB = memoryItemCharCount(b);
 

--- a/packages/gateway/src/modules/memory/v1-digest.ts
+++ b/packages/gateway/src/modules/memory/v1-digest.ts
@@ -322,11 +322,9 @@ export async function buildMemoryV1Digest(params: {
     });
   }
 
-  const semanticSorted = semanticHits
-    .slice()
-    .sort((a, b) =>
-      b.score !== a.score ? b.score - a.score : a.memory_item_id.localeCompare(b.memory_item_id),
-    );
+  const semanticSorted = semanticHits.toSorted((a, b) =>
+    b.score !== a.score ? b.score - a.score : a.memory_item_id.localeCompare(b.memory_item_id),
+  );
   for (const hit of semanticSorted) {
     candidates.push({
       memory_item_id: hit.memory_item_id,

--- a/packages/gateway/src/modules/memory/v1-semantic-index.ts
+++ b/packages/gateway/src/modules/memory/v1-semantic-index.ts
@@ -267,13 +267,23 @@ export class MemoryV1SemanticIndex {
     }
 
     return [...bestByItem.values()]
-      .sort((a, b) => b.similarity - a.similarity)
+      .toSorted((a, b) => b.similarity - a.similarity)
       .slice(0, topK)
-      .map((hit) => ({
-        memory_item_id: hit.memory_item_id,
-        kind: hit.kind,
-        score: Math.max(0, hit.similarity),
-        ...(hit.snippet ? { snippet: hit.snippet } : {}),
-      }));
+      .map((hit) => {
+        const normalizedHit: {
+          memory_item_id: string;
+          kind: MemoryItemKind;
+          score: number;
+          snippet?: string;
+        } = {
+          memory_item_id: hit.memory_item_id,
+          kind: hit.kind,
+          score: Math.max(0, hit.similarity),
+        };
+        if (hit.snippet) {
+          normalizedHit.snippet = hit.snippet;
+        }
+        return normalizedHit;
+      });
   }
 }

--- a/packages/gateway/src/modules/models/model-catalog-service.ts
+++ b/packages/gateway/src/modules/models/model-catalog-service.ts
@@ -119,7 +119,7 @@ export class ModelCatalogService {
 
     const effectiveCatalog: Record<string, unknown> = {};
 
-    const sortedProviderIds = Array.from(providerIds).sort((a, b) => a.localeCompare(b));
+    const sortedProviderIds = Array.from(providerIds).toSorted((a, b) => a.localeCompare(b));
     for (const providerId of sortedProviderIds) {
       const baseProvider = base.catalog[providerId];
       const providerOverride = providerOverrideById.get(providerId);
@@ -197,7 +197,7 @@ export class ModelCatalogService {
       const modelIds = new Set<string>([...Object.keys(baseModels), ...overrideModels.keys()]);
 
       const models: Record<string, unknown> = {};
-      const sortedModelIds = Array.from(modelIds).sort((a, b) => a.localeCompare(b));
+      const sortedModelIds = Array.from(modelIds).toSorted((a, b) => a.localeCompare(b));
       for (const modelId of sortedModelIds) {
         const baseModel = baseModels[modelId] as Record<string, unknown> | undefined;
         const modelOverride = overrideModels.get(modelId);

--- a/packages/gateway/src/modules/observability/status-details.ts
+++ b/packages/gateway/src/modules/observability/status-details.ts
@@ -269,7 +269,7 @@ async function loadAuthProfileHealth(
   const disabled = profiles.filter((p) => p.status === "disabled").length;
   const providers = [...new Set(profiles.map((p) => p.provider_key))]
     .filter((provider) => provider.trim().length > 0)
-    .sort();
+    .toSorted();
 
   return {
     enabled: isAuthProfilesEnabled(),
@@ -487,7 +487,7 @@ async function loadSessionLanes(
     });
   }
 
-  return lanes.sort((a, b) => {
+  return lanes.toSorted((a, b) => {
     const keyCmp = a.key.localeCompare(b.key);
     if (keyCmp !== 0) return keyCmp;
     return a.lane.localeCompare(b.lane);

--- a/packages/gateway/src/modules/playbook/runtime.ts
+++ b/packages/gateway/src/modules/playbook/runtime.ts
@@ -11,7 +11,7 @@ import type { PlaybookRunner } from "./runner.js";
 import { DEFAULT_TENANT_ID } from "../identity/scope.js";
 
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
 function isValidationError(err: unknown): boolean {
@@ -232,188 +232,259 @@ export interface PlaybookRuntimeDeps {
   runner: PlaybookRunner;
 }
 
+type PlaybookRunInput = {
+  action: "run";
+  pipeline: string;
+  argsJson?: string;
+  cwd?: string;
+  maxOutputBytes?: number;
+  timeoutMs?: number;
+};
+
+type PlaybookResumeInput = {
+  action: "resume";
+  token: string;
+  approve: boolean;
+  reason?: string;
+  timeoutMs?: number;
+};
+
+type PlaybookRuntimeInput = PlaybookRunInput | PlaybookResumeInput;
+
+type PlaybookStep = ReturnType<PlaybookRunner["run"]>["steps"][number];
+
+function parseRuntimeArgs(argsJson: string | undefined): {
+  runtimeArgs: unknown | undefined;
+  error?: PlaybookRuntimeEnvelopeT;
+} {
+  if (argsJson === undefined) {
+    return { runtimeArgs: undefined };
+  }
+
+  try {
+    return { runtimeArgs: JSON.parse(argsJson) as unknown };
+  } catch (err) {
+    void err;
+    return {
+      runtimeArgs: undefined,
+      error: {
+        ok: false,
+        status: "error",
+        output: [],
+        error: { message: "argsJson must be valid JSON", code: "invalid_request" },
+      },
+    };
+  }
+}
+
+function validateWorkspaceRelativeCwd(
+  cwd: string | undefined,
+): PlaybookRuntimeEnvelopeT | undefined {
+  if (!cwd) return undefined;
+
+  const trimmed = cwd.trim();
+  if (trimmed.length === 0 || isAbsolute(trimmed) || trimmed.split(/[\\/]+/).includes("..")) {
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message: "cwd must be a workspace-relative path", code: "invalid_request" },
+    };
+  }
+
+  return undefined;
+}
+
+function applyRuntimeStepOverrides(
+  steps: readonly PlaybookStep[],
+  input: PlaybookRunInput,
+  runtimeArgs: unknown | undefined,
+): PlaybookStep[] {
+  return steps.map((step) => {
+    if (!input.cwd && input.maxOutputBytes === undefined && runtimeArgs === undefined) {
+      return step;
+    }
+
+    const nextArgs: Record<string, unknown> = { ...step.args };
+    if (runtimeArgs !== undefined) {
+      nextArgs["__playbook_runtime_args"] = runtimeArgs;
+    }
+    if (input.cwd) {
+      nextArgs["cwd"] = input.cwd;
+    }
+    if (typeof input.maxOutputBytes === "number" && Number.isFinite(input.maxOutputBytes)) {
+      nextArgs["max_output_bytes"] = Math.floor(input.maxOutputBytes);
+    }
+
+    return Object.assign({}, step, { args: nextArgs });
+  });
+}
+
+function buildTriggerMetadata(
+  playbook: Playbook,
+  input: PlaybookRunInput,
+  runtimeArgs: unknown | undefined,
+): Record<string, unknown> {
+  const triggerMetadata: Record<string, unknown> = {
+    source: "playbook-runtime",
+    playbook_id: playbook.manifest.id,
+  };
+  if (runtimeArgs !== undefined) {
+    triggerMetadata["args"] = runtimeArgs;
+  }
+  if (input.cwd) {
+    triggerMetadata["cwd"] = input.cwd;
+  }
+  if (typeof input.maxOutputBytes === "number" && Number.isFinite(input.maxOutputBytes)) {
+    triggerMetadata["max_output_bytes"] = Math.floor(input.maxOutputBytes);
+  }
+  return triggerMetadata;
+}
+
+async function runPlaybookRuntimeAction(
+  deps: PlaybookRuntimeDeps,
+  input: PlaybookRunInput,
+  timeoutMs: number,
+): Promise<PlaybookRuntimeEnvelopeT> {
+  const parsedArgs = parseRuntimeArgs(input.argsJson);
+  if (parsedArgs.error) {
+    return parsedArgs.error;
+  }
+
+  const cwdError = validateWorkspaceRelativeCwd(input.cwd);
+  if (cwdError) {
+    return cwdError;
+  }
+
+  const playbook = resolvePlaybookFromPipeline(input.pipeline, deps.playbooks);
+  const compiled = deps.runner.run(playbook);
+  const steps = applyRuntimeStepOverrides(compiled.steps, input, parsedArgs.runtimeArgs);
+  const planId = `playbook-${playbook.manifest.id}-${randomUUID()}`;
+  const requestId = `req-${randomUUID()}`;
+  const key = `playbook:${playbook.manifest.id}`;
+  const lane = "main";
+
+  const playbookBundle = resolvePlaybookPolicyBundle(playbook);
+  const effectivePolicy = await deps.policyService.loadEffectiveBundle({ playbookBundle });
+  const snapshot = await deps.policyService.getOrCreateSnapshot(
+    DEFAULT_TENANT_ID,
+    effectivePolicy.bundle,
+  );
+
+  const res = await deps.engine.enqueuePlan({
+    tenantId: DEFAULT_TENANT_ID,
+    key,
+    lane,
+    planId,
+    requestId,
+    steps,
+    policySnapshotId: snapshot.policy_snapshot_id,
+    trigger: {
+      kind: "api",
+      key,
+      lane,
+      metadata: buildTriggerMetadata(playbook, input, parsedArgs.runtimeArgs),
+    },
+  });
+
+  return envelopeForRunStatus(deps.db, res.runId, timeoutMs);
+}
+
+function resolveApprovalRunId(row: ApprovalRow): string | undefined {
+  const id = row.run_id?.trim();
+  return id && id.length > 0 ? id : undefined;
+}
+
+async function runPlaybookResumeAction(
+  deps: PlaybookRuntimeDeps,
+  input: PlaybookResumeInput,
+  timeoutMs: number,
+): Promise<PlaybookRuntimeEnvelopeT> {
+  const approval = await deps.approvalDal.getByResumeToken({
+    tenantId: DEFAULT_TENANT_ID,
+    resumeToken: input.token,
+  });
+  if (!approval) {
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message: "resume token not found", code: "not_found" },
+    };
+  }
+
+  const runId = resolveApprovalRunId(approval);
+  if (!runId) {
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message: "approval is missing run_id", code: "invalid_state" },
+    };
+  }
+
+  const resolvedApproval =
+    approval.status === "pending"
+      ? (
+          await deps.approvalDal.resolveWithEngineAction({
+            tenantId: DEFAULT_TENANT_ID,
+            approvalId: approval.approval_id,
+            decision: input.approve ? "approved" : "denied",
+            reason: input.reason,
+            resolvedBy: { kind: "playbook" },
+          })
+        )?.approval
+      : approval;
+  if (!resolvedApproval) {
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message: "resume token not found", code: "not_found" },
+    };
+  }
+
+  const matches =
+    (input.approve && resolvedApproval.status === "approved") ||
+    (!input.approve && resolvedApproval.status === "denied");
+  if (!matches) {
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message: "approval already resolved", code: "conflict" },
+    };
+  }
+
+  const deadline = Date.now() + Math.max(1, timeoutMs);
+  const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
+
+  try {
+    await waitForRunToResumeOrCancel(deps.db, runId, remainingTimeoutMs());
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: "error",
+      output: [],
+      error: { message, code: "timeout" },
+    };
+  }
+
+  return envelopeForRunStatus(deps.db, runId, remainingTimeoutMs());
+}
+
 export async function runPlaybookRuntimeEnvelope(
   deps: PlaybookRuntimeDeps,
-  input:
-    | {
-        action: "run";
-        pipeline: string;
-        argsJson?: string;
-        cwd?: string;
-        maxOutputBytes?: number;
-        timeoutMs?: number;
-      }
-    | { action: "resume"; token: string; approve: boolean; reason?: string; timeoutMs?: number },
+  input: PlaybookRuntimeInput,
 ): Promise<PlaybookRuntimeEnvelopeT> {
   const timeoutMs = input.timeoutMs ?? 30_000;
 
   try {
     if (input.action === "run") {
-      let runtimeArgs: unknown | undefined;
-      if (input.argsJson !== undefined) {
-        try {
-          runtimeArgs = JSON.parse(input.argsJson) as unknown;
-        } catch {
-          // Intentional: surface invalid JSON as a structured invalid_request error.
-          return {
-            ok: false,
-            status: "error",
-            output: [],
-            error: { message: "argsJson must be valid JSON", code: "invalid_request" },
-          };
-        }
-      }
-
-      if (input.cwd) {
-        const trimmed = input.cwd.trim();
-        if (trimmed.length === 0 || isAbsolute(trimmed) || trimmed.split(/[\\/]+/).includes("..")) {
-          return {
-            ok: false,
-            status: "error",
-            output: [],
-            error: { message: "cwd must be a workspace-relative path", code: "invalid_request" },
-          };
-        }
-      }
-
-      const playbook = resolvePlaybookFromPipeline(input.pipeline, deps.playbooks);
-      const compiled = deps.runner.run(playbook);
-      const steps = compiled.steps.map((step) => {
-        if (!input.cwd && input.maxOutputBytes === undefined && runtimeArgs === undefined) {
-          return step;
-        }
-
-        const nextArgs: Record<string, unknown> = { ...step.args };
-        if (runtimeArgs !== undefined) {
-          nextArgs["__playbook_runtime_args"] = runtimeArgs;
-        }
-        if (input.cwd) {
-          nextArgs["cwd"] = input.cwd;
-        }
-        if (typeof input.maxOutputBytes === "number" && Number.isFinite(input.maxOutputBytes)) {
-          nextArgs["max_output_bytes"] = Math.floor(input.maxOutputBytes);
-        }
-
-        return { ...step, args: nextArgs };
-      });
-
-      const planId = `playbook-${playbook.manifest.id}-${randomUUID()}`;
-      const requestId = `req-${randomUUID()}`;
-      const key = `playbook:${playbook.manifest.id}`;
-      const lane = "main";
-
-      const playbookBundle = resolvePlaybookPolicyBundle(playbook);
-      const effectivePolicy = await deps.policyService.loadEffectiveBundle({ playbookBundle });
-      const snapshot = await deps.policyService.getOrCreateSnapshot(
-        DEFAULT_TENANT_ID,
-        effectivePolicy.bundle,
-      );
-
-      const triggerMetadata: Record<string, unknown> = {
-        source: "playbook-runtime",
-        playbook_id: playbook.manifest.id,
-      };
-      if (runtimeArgs !== undefined) {
-        triggerMetadata["args"] = runtimeArgs;
-      }
-      if (input.cwd) {
-        triggerMetadata["cwd"] = input.cwd;
-      }
-      if (typeof input.maxOutputBytes === "number" && Number.isFinite(input.maxOutputBytes)) {
-        triggerMetadata["max_output_bytes"] = Math.floor(input.maxOutputBytes);
-      }
-
-      const res = await deps.engine.enqueuePlan({
-        tenantId: DEFAULT_TENANT_ID,
-        key,
-        lane,
-        planId,
-        requestId,
-        steps,
-        policySnapshotId: snapshot.policy_snapshot_id,
-        trigger: { kind: "api", key, lane, metadata: triggerMetadata },
-      });
-
-      return await envelopeForRunStatus(deps.db, res.runId, timeoutMs);
+      return await runPlaybookRuntimeAction(deps, input, timeoutMs);
     }
-
-    const approval = await deps.approvalDal.getByResumeToken({
-      tenantId: DEFAULT_TENANT_ID,
-      resumeToken: input.token,
-    });
-    if (!approval) {
-      return {
-        ok: false,
-        status: "error",
-        output: [],
-        error: { message: "resume token not found", code: "not_found" },
-      };
-    }
-
-    const resolveRunId = (row: ApprovalRow): string | undefined => {
-      const id = row.run_id?.trim();
-      return id && id.length > 0 ? id : undefined;
-    };
-
-    const runId = resolveRunId(approval);
-    if (!runId) {
-      return {
-        ok: false,
-        status: "error",
-        output: [],
-        error: { message: "approval is missing run_id", code: "invalid_state" },
-      };
-    }
-
-    const resolvedApproval =
-      approval.status === "pending"
-        ? (
-            await deps.approvalDal.resolveWithEngineAction({
-              tenantId: DEFAULT_TENANT_ID,
-              approvalId: approval.approval_id,
-              decision: input.approve ? "approved" : "denied",
-              reason: input.reason,
-              resolvedBy: { kind: "playbook" },
-            })
-          )?.approval
-        : approval;
-    if (!resolvedApproval) {
-      return {
-        ok: false,
-        status: "error",
-        output: [],
-        error: { message: "resume token not found", code: "not_found" },
-      };
-    }
-
-    const matches =
-      (input.approve && resolvedApproval.status === "approved") ||
-      (!input.approve && resolvedApproval.status === "denied");
-    if (!matches) {
-      return {
-        ok: false,
-        status: "error",
-        output: [],
-        error: { message: "approval already resolved", code: "conflict" },
-      };
-    }
-
-    const deadline = Date.now() + Math.max(1, timeoutMs);
-    const remainingTimeoutMs = () => Math.max(1, deadline - Date.now());
-
-    try {
-      await waitForRunToResumeOrCancel(deps.db, runId, remainingTimeoutMs());
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        ok: false,
-        status: "error",
-        output: [],
-        error: { message, code: "timeout" },
-      };
-    }
-
-    return await envelopeForRunStatus(deps.db, runId, remainingTimeoutMs());
+    return await runPlaybookResumeAction(deps, input, timeoutMs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const code =

--- a/packages/gateway/src/modules/plugins/registry.ts
+++ b/packages/gateway/src/modules/plugins/registry.ts
@@ -160,9 +160,9 @@ function collectAllOfInternalRefTargets(root: unknown): WeakSet<object> {
     if (Array.isArray(allOf)) {
       for (const entry of allOf) {
         if (!isRecord(entry)) continue;
-        const ref = entry["$ref"];
-        if (typeof ref !== "string") continue;
-        const resolved = resolveInternalJsonSchemaRef(root, ref);
+        const entryRef = entry["$ref"];
+        if (typeof entryRef !== "string") continue;
+        const resolved = resolveInternalJsonSchemaRef(root, entryRef);
         if (resolved !== null && typeof resolved === "object") {
           targets.add(resolved as object);
         }
@@ -602,7 +602,7 @@ export class PluginRegistry {
         loaded_at: p.loaded_at,
         source_dir: p.source_dir,
       }))
-      .sort((a, b) => a.id.localeCompare(b.id));
+      .toSorted((a, b) => a.id.localeCompare(b.id));
   }
 
   getManifest(pluginId: string): PluginManifestT | undefined {

--- a/packages/gateway/src/modules/policy/canonical-json.ts
+++ b/packages/gateway/src/modules/policy/canonical-json.ts
@@ -18,7 +18,7 @@ function sortValue(value: unknown): unknown {
     return value.map(sortValue);
   }
   if (isPlainObject(value)) {
-    const sortedKeys = Object.keys(value).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const sortedKeys = Object.keys(value).toSorted((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     const out: Record<string, unknown> = {};
     for (const key of sortedKeys) {
       out[key] = sortValue(value[key]);

--- a/packages/gateway/src/modules/policy/service.ts
+++ b/packages/gateway/src/modules/policy/service.ts
@@ -672,14 +672,12 @@ function mergePolicyBundles(bundles: Array<PolicyBundleT | undefined>): PolicyBu
   const maxBytesDefaultValue =
     maxBytesDefault.length > 0 ? Math.min(...maxBytesDefault) : undefined;
 
-  const provenanceValues = bundles
-    .map((b) => b?.provenance?.untrusted_shell_requires_approval)
-    .filter((v): v is boolean => typeof v === "boolean");
-  const provenanceShellApproval = provenanceValues.includes(true)
-    ? true
-    : provenanceValues.includes(false)
-      ? false
-      : true;
+  const provenanceValues = new Set(
+    bundles
+      .map((b) => b?.provenance?.untrusted_shell_requires_approval)
+      .filter((v): v is boolean => typeof v === "boolean"),
+  );
+  const provenanceShellApproval = provenanceValues.has(true) || !provenanceValues.has(false);
 
   return PolicyBundle.parse({
     v: 1,

--- a/packages/gateway/src/modules/redaction/engine.ts
+++ b/packages/gateway/src/modules/redaction/engine.ts
@@ -14,7 +14,7 @@ function normalizedSecrets(input: readonly string[]): string[] {
     const s = typeof raw === "string" ? raw : "";
     if (s.length > 0) unique.add(s);
   }
-  return Array.from(unique).sort((a, b) => {
+  return Array.from(unique).toSorted((a, b) => {
     const len = b.length - a.length;
     if (len !== 0) return len;
     return a.localeCompare(b);

--- a/packages/gateway/src/routes/agent.ts
+++ b/packages/gateway/src/routes/agent.ts
@@ -30,7 +30,7 @@ export function createAgentRoutes(agents: AgentRegistry): Hono {
         .map((entry) => entry.name)
         .filter((name) => name !== "default")
         .filter((name) => AgentKey.safeParse(name).success)
-        .sort((a, b) => a.localeCompare(b));
+        .toSorted((a, b) => a.localeCompare(b));
     } catch (err) {
       const code =
         err && typeof err === "object" && "code" in err

--- a/packages/gateway/src/routes/auth-profiles.ts
+++ b/packages/gateway/src/routes/auth-profiles.ts
@@ -37,9 +37,7 @@ function toContractPin(row: SessionProviderPinRow) {
   return SessionProviderPin.parse(rest);
 }
 
-export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
-  const app = new Hono();
-
+function registerProfileListRoute(app: Hono, deps: AuthProfileRouteDeps): void {
   app.get("/auth/profiles", async (c) => {
     const tenantId = requireTenantId(c);
     const providerKey = c.req.query("provider_key")?.trim() || undefined;
@@ -54,7 +52,9 @@ export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
     const profiles = rows.map(toContractProfile);
     return c.json(AuthProfileListResponse.parse({ profiles }));
   });
+}
 
+function registerProfileCreateAndUpdateRoutes(app: Hono, deps: AuthProfileRouteDeps): void {
   app.post("/auth/profiles", async (c) => {
     const tenantId = requireTenantId(c);
     const body = (await c.req.json()) as unknown;
@@ -97,7 +97,9 @@ export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
 
     return c.json({ status: "ok", profile: toContractProfile(updated) });
   });
+}
 
+function registerProfileStatusRoutes(app: Hono, deps: AuthProfileRouteDeps): void {
   app.post("/auth/profiles/:key/disable", async (c) => {
     const tenantId = requireTenantId(c);
     const authProfileKey = c.req.param("key");
@@ -139,7 +141,9 @@ export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
 
     return c.json({ status: "ok", profile: toContractProfile(updated) });
   });
+}
 
+function registerPinRoutes(app: Hono, deps: AuthProfileRouteDeps): void {
   app.get("/auth/pins", async (c) => {
     const tenantId = requireTenantId(c);
     const sessionId = c.req.query("session_id")?.trim() || undefined;
@@ -185,6 +189,14 @@ export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
     });
     return c.json({ status: "ok", pin: toContractPin(pin) }, 201);
   });
+}
+
+export function createAuthProfileRoutes(deps: AuthProfileRouteDeps): Hono {
+  const app = new Hono();
+  registerProfileListRoute(app, deps);
+  registerProfileCreateAndUpdateRoutes(app, deps);
+  registerProfileStatusRoutes(app, deps);
+  registerPinRoutes(app, deps);
 
   return app;
 }

--- a/packages/gateway/src/routes/contracts.ts
+++ b/packages/gateway/src/routes/contracts.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { readFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -62,126 +62,129 @@ async function readJsonFile(
   throw lastError;
 }
 
-export function createContractRoutes(): Hono {
-  const contracts = new Hono();
-  let jsonSchemaDir: string | undefined;
-  let jsonSchemaDirResolved: string | undefined;
+function resolveSchemaDirState(): {
+  jsonSchemaDir: string | undefined;
+  jsonSchemaDirResolved: string | undefined;
+} {
   try {
-    jsonSchemaDir = resolveSchemasJsonSchemaDir();
-    jsonSchemaDirResolved = resolve(jsonSchemaDir);
+    const jsonSchemaDir = resolveSchemasJsonSchemaDir();
+    return {
+      jsonSchemaDir,
+      jsonSchemaDirResolved: resolve(jsonSchemaDir),
+    };
   } catch (err) {
     void err;
-    jsonSchemaDir = undefined;
-    jsonSchemaDirResolved = undefined;
+    return {
+      jsonSchemaDir: undefined,
+      jsonSchemaDirResolved: undefined,
+    };
+  }
+}
+
+function unavailableResponse(c: Context, message: string): Response {
+  return c.json(
+    {
+      error: "contracts_unavailable",
+      message,
+    },
+    500,
+  );
+}
+
+function notFoundResponse(c: Context): Response {
+  return c.json(
+    {
+      error: "not_found",
+      message: "Contract schema not found.",
+    },
+    404,
+  );
+}
+
+function sanitizeCatalogEntry(entry: unknown): unknown {
+  if (!entry || typeof entry !== "object") return entry;
+  const file =
+    "file" in entry && typeof (entry as { file?: unknown }).file === "string"
+      ? basename(String((entry as { file: string }).file))
+      : undefined;
+  if (!file) return entry;
+  return Object.assign({}, entry, { file });
+}
+
+function sanitizeCatalogPayload(parsed: unknown): unknown {
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !("schemas" in parsed) ||
+    !Array.isArray((parsed as { schemas?: unknown }).schemas)
+  ) {
+    return parsed;
   }
 
-  contracts.get("/contracts/jsonschema/catalog.json", async (c) => {
-    if (!jsonSchemaDir) {
-      return c.json(
-        {
-          error: "contracts_unavailable",
-          message: "JSON Schema catalog unavailable.",
-        },
-        500,
-      );
+  const schemas = (parsed as { schemas: unknown[] }).schemas.map(sanitizeCatalogEntry);
+  return { ...(parsed as Record<string, unknown>), schemas };
+}
+
+async function handleCatalogRequest(
+  c: Context,
+  jsonSchemaDir: string | undefined,
+): Promise<Response> {
+  if (!jsonSchemaDir) {
+    return unavailableResponse(c, "JSON Schema catalog unavailable.");
+  }
+
+  try {
+    const parsed: unknown = await readJsonFile(join(jsonSchemaDir, "catalog.json"), {
+      transientNotFound: true,
+    });
+    return c.json(sanitizeCatalogPayload(parsed));
+  } catch (err) {
+    void err;
+    return unavailableResponse(c, "JSON Schema catalog unavailable.");
+  }
+}
+
+async function handleSchemaRequest(
+  c: Context,
+  jsonSchemaDirResolved: string | undefined,
+): Promise<Response> {
+  if (!jsonSchemaDirResolved) {
+    return unavailableResponse(c, "Contract schema unavailable.");
+  }
+
+  const file = c.req.param("file")?.trim() || "";
+  if (!isSafeContractFilename(file) || file === "catalog.json") {
+    return notFoundResponse(c);
+  }
+
+  const fullPath = resolve(jsonSchemaDirResolved, file);
+  const rel = relative(jsonSchemaDirResolved, fullPath);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    return notFoundResponse(c);
+  }
+
+  try {
+    const parsed = await readJsonFile(fullPath);
+    return c.json(parsed);
+  } catch (err) {
+    if (errorCode(err) === "ENOENT") {
+      return notFoundResponse(c);
     }
 
-    try {
-      const parsed: unknown = await readJsonFile(join(jsonSchemaDir, "catalog.json"), {
-        transientNotFound: true,
-      });
+    return unavailableResponse(c, "Contract schema unavailable.");
+  }
+}
 
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        "schemas" in parsed &&
-        Array.isArray((parsed as { schemas?: unknown }).schemas)
-      ) {
-        const schemas = (parsed as { schemas: unknown[] }).schemas.map((entry) => {
-          if (!entry || typeof entry !== "object") return entry;
-          const file =
-            "file" in entry && typeof (entry as { file?: unknown }).file === "string"
-              ? basename(String((entry as { file: string }).file))
-              : undefined;
-          if (!file) return entry;
-          return { ...entry, file };
-        });
+export function createContractRoutes(): Hono {
+  const contracts = new Hono();
+  const { jsonSchemaDir, jsonSchemaDirResolved } = resolveSchemaDirState();
 
-        return c.json({ ...(parsed as Record<string, unknown>), schemas });
-      }
-
-      return c.json(parsed);
-    } catch (err) {
-      void err;
-      return c.json(
-        {
-          error: "contracts_unavailable",
-          message: "JSON Schema catalog unavailable.",
-        },
-        500,
-      );
-    }
-  });
-
-  contracts.get("/contracts/jsonschema/:file", async (c) => {
-    if (!jsonSchemaDirResolved) {
-      return c.json(
-        {
-          error: "contracts_unavailable",
-          message: "Contract schema unavailable.",
-        },
-        500,
-      );
-    }
-
-    const file = c.req.param("file")?.trim() || "";
-    if (!isSafeContractFilename(file) || file === "catalog.json") {
-      return c.json(
-        {
-          error: "not_found",
-          message: "Contract schema not found.",
-        },
-        404,
-      );
-    }
-
-    const fullPath = resolve(jsonSchemaDirResolved, file);
-    const rel = relative(jsonSchemaDirResolved, fullPath);
-    if (rel.startsWith("..") || isAbsolute(rel)) {
-      return c.json(
-        {
-          error: "not_found",
-          message: "Contract schema not found.",
-        },
-        404,
-      );
-    }
-
-    try {
-      const parsed = await readJsonFile(fullPath);
-      return c.json(parsed);
-    } catch (err) {
-      const code = errorCode(err);
-
-      if (code === "ENOENT") {
-        return c.json(
-          {
-            error: "not_found",
-            message: "Contract schema not found.",
-          },
-          404,
-        );
-      }
-
-      return c.json(
-        {
-          error: "contracts_unavailable",
-          message: "Contract schema unavailable.",
-        },
-        500,
-      );
-    }
-  });
+  contracts.get("/contracts/jsonschema/catalog.json", (c) =>
+    handleCatalogRequest(c, jsonSchemaDir),
+  );
+  contracts.get("/contracts/jsonschema/:file", (c) =>
+    handleSchemaRequest(c, jsonSchemaDirResolved),
+  );
 
   return contracts;
 }

--- a/packages/gateway/src/routes/models-dev.ts
+++ b/packages/gateway/src/routes/models-dev.ts
@@ -84,7 +84,7 @@ export function createModelsDevRoutes(deps: ModelsDevRouteDeps): Hono {
           model_count: modelCount,
         };
       })
-      .sort((a, b) => a.id.localeCompare(b.id));
+      .toSorted((a, b) => a.id.localeCompare(b.id));
 
     return c.json({
       status: "ok",
@@ -132,7 +132,7 @@ export function createModelsDevRoutes(deps: ModelsDevRouteDeps): Hono {
         modalities: model.modalities ?? null,
         limit: model.limit ?? null,
       }))
-      .sort((a, b) => a.id.localeCompare(b.id));
+      .toSorted((a, b) => a.id.localeCompare(b.id));
 
     return c.json({
       status: "ok",

--- a/packages/gateway/src/routes/snapshot.ts
+++ b/packages/gateway/src/routes/snapshot.ts
@@ -154,7 +154,7 @@ async function listPrimaryKeyColumns(db: SqlDb, table: string): Promise<string[]
     );
     return rows
       .filter((r) => typeof r.pk === "number" && r.pk > 0)
-      .sort((a, b) => a.pk - b.pk)
+      .toSorted((a, b) => a.pk - b.pk)
       .map((r) => r.name);
   }
 

--- a/packages/gateway/src/ws/protocol/approvals.ts
+++ b/packages/gateway/src/ws/protocol/approvals.ts
@@ -64,10 +64,10 @@ export function requestApproval(
           audience: APPROVAL_WS_AUDIENCE,
         })
         .catch((err) => {
-          const message = err instanceof Error ? err.message : String(err);
+          const errorMessage = err instanceof Error ? err.message : String(err);
           deps.logger?.error("outbox.enqueue_failed", {
             topic: "ws.broadcast",
-            error: message,
+            error: errorMessage,
           });
         });
     }
@@ -82,10 +82,10 @@ export function requestApproval(
         audience: APPROVAL_WS_AUDIENCE,
       })
       .catch((err) => {
-        const message = err instanceof Error ? err.message : String(err);
+        const errorMessage = err instanceof Error ? err.message : String(err);
         deps.logger?.error("outbox.enqueue_failed", {
           topic: "ws.broadcast",
-          error: message,
+          error: errorMessage,
         });
       });
   }

--- a/packages/gateway/src/ws/protocol/subagent-handlers.ts
+++ b/packages/gateway/src/ws/protocol/subagent-handlers.ts
@@ -327,8 +327,8 @@ export async function handleSubagentMessage(
               WORKBOARD_WS_AUDIENCE,
             );
           }
-        } catch (err) {
-          const updateMessage = err instanceof Error ? err.message : String(err);
+        } catch (updateErr) {
+          const updateMessage = updateErr instanceof Error ? updateErr.message : String(updateErr);
           deps.logger?.warn("ws.subagent_failure_update_failed", {
             request_id: msg.request_id,
             client_id: client.id,


### PR DESCRIPTION
Closes #1035
Follow-up: #1089

## What changed
- cleared the non-structural oxlint warnings in `packages/gateway/src/**` outside the excluded hotspot files
- applied low-risk mechanical fixes (`no-shadow`, `no-array-sort`, `no-array-reverse`, `no-map-spread`, boolean/set preference warnings, and related small helper extractions)
- refactored a few route/runtime functions into helpers where needed to keep the cleanup behavior-preserving
- updated #1035 to match this delivered scope and moved the remaining structural `max-lines` / `max-lines-per-function` work into #1089

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

## Notes
- `pnpm lint` still reports warning-level oxlint findings repo-wide; the remaining gateway structural warnings targeted by the original broader issue are now tracked in #1089.
- Reviewer pass found no code-review findings.
