### PR TITLE
fix(gateway): preserve agent model option precedence

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/session-model-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/session-model-resolution.ts
@@ -250,8 +250,8 @@ export async function resolveSessionModel(
         providerOptions,
         modelOptions,
         variantOptions,
-        input.config.model.options,
         chosen.optionsOverride ?? {},
+        input.config.model.options,
       );
     })();
 

--- a/packages/gateway/tests/unit/agent-runtime-baseurl-resolution.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-baseurl-resolution.test.ts
@@ -13,12 +13,25 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
 
-const seenBaseUrls: Array<string | undefined> = [];
+const seenProviderInputs: Array<{
+  baseURL?: string;
+  headers?: Record<string, string>;
+  options?: Record<string, unknown>;
+}> = [];
 
 vi.mock("../../src/modules/models/provider-factory.js", () => {
   return {
-    createProviderFromNpm: (input: { providerId: string; baseURL?: string }) => {
-      seenBaseUrls.push(input.baseURL);
+    createProviderFromNpm: (input: {
+      providerId: string;
+      baseURL?: string;
+      headers?: Record<string, string>;
+      options?: Record<string, unknown>;
+    }) => {
+      seenProviderInputs.push({
+        baseURL: input.baseURL,
+        headers: input.headers,
+        options: input.options,
+      });
 
       return {
         languageModel(modelId: string) {
@@ -50,7 +63,7 @@ describe("AgentRuntime baseURL resolution", () => {
   afterEach(async () => {
     await container?.db.close();
     container = undefined;
-    seenBaseUrls.length = 0;
+    seenProviderInputs.length = 0;
     if (tempDir) {
       const { rmSync } = await import("node:fs");
       rmSync(tempDir, { recursive: true, force: true });
@@ -127,8 +140,10 @@ describe("AgentRuntime baseURL resolution", () => {
 
     await model.doGenerate({} as any);
 
-    expect(seenBaseUrls.length).toBeGreaterThan(0);
-    expect(seenBaseUrls.every((x) => x === "https://catalog.example")).toBe(true);
+    expect(seenProviderInputs.length).toBeGreaterThan(0);
+    expect(seenProviderInputs.every((input) => input.baseURL === "https://catalog.example")).toBe(
+      true,
+    );
   });
 
   it("preserves agent baseURL overrides when execution-profile presets are assigned", async () => {
@@ -219,7 +234,102 @@ describe("AgentRuntime baseURL resolution", () => {
 
     await model.doGenerate({} as any);
 
-    expect(seenBaseUrls.length).toBeGreaterThan(0);
-    expect(seenBaseUrls.every((x) => x === "https://override.example/v1")).toBe(true);
+    expect(seenProviderInputs.length).toBeGreaterThan(0);
+    expect(
+      seenProviderInputs.every((input) => input.baseURL === "https://override.example/v1"),
+    ).toBe(true);
+  });
+
+  it("keeps agent model options authoritative over execution-profile preset defaults", async () => {
+    container = createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    tempDir = await (
+      await import("node:fs/promises")
+    ).mkdtemp(join((await import("node:os")).tmpdir(), "tyrum-baseurl-resolution-"));
+    const secretProvider = await createDbSecretProvider({
+      db: container.db,
+      dbPath: ":memory:",
+      tyrumHome: tempDir,
+      tenantId: DEFAULT_TENANT_ID,
+    });
+    await secretProvider.store("openai_api_key", "openai-key");
+    await new AuthProfileDal(container.db).create({
+      tenantId: DEFAULT_TENANT_ID,
+      authProfileKey: "profile-1",
+      providerKey: "openai",
+      type: "api_key",
+      secretKeys: { api_key: "openai_api_key" },
+    });
+
+    const cacheDal = new ModelsDevCacheDal(container.db);
+    const nowIso = new Date().toISOString();
+    await cacheDal.upsert({
+      fetchedAt: nowIso,
+      etag: null,
+      sha256: "sha",
+      json: JSON.stringify({
+        openai: {
+          id: "openai",
+          name: "OpenAI",
+          env: ["OPENAI_API_KEY"],
+          npm: "@ai-sdk/openai",
+          models: { "gpt-4.1": { id: "gpt-4.1", name: "GPT-4.1", reasoning: true } },
+        },
+      }),
+      source: "remote",
+      lastError: null,
+      nowIso,
+    });
+
+    await new ConfiguredModelPresetDal(container.db).create({
+      tenantId: DEFAULT_TENANT_ID,
+      presetKey: "interaction-default",
+      displayName: "Interaction Default",
+      providerKey: "openai",
+      modelId: "gpt-4.1",
+      options: { reasoning_effort: "low" },
+    });
+    await new ExecutionProfileModelAssignmentDal(container.db).upsertMany({
+      tenantId: DEFAULT_TENANT_ID,
+      assignments: [{ executionProfileId: "interaction", presetKey: "interaction-default" }],
+    });
+
+    const fetchImpl: typeof fetch = async () => new Response("not found", { status: 404 });
+
+    const { AgentRuntime } = await import("../../src/modules/agent/runtime.js");
+    const runtime = new AgentRuntime({
+      container,
+      agentId: "agent-1",
+      tenantId: DEFAULT_TENANT_ID,
+      fetchImpl,
+      secretProvider,
+    });
+
+    const model = await (
+      runtime as unknown as {
+        resolveSessionModel: (args: unknown) => Promise<LanguageModelV3>;
+      }
+    ).resolveSessionModel({
+      config: {
+        model: {
+          model: "openai/gpt-4.1",
+          options: { reasoning_effort: "high" },
+        },
+      },
+      tenantId: DEFAULT_TENANT_ID,
+      sessionId: "session-assigned",
+      executionProfileId: "interaction",
+      fetchImpl,
+    });
+
+    await model.doGenerate({} as any);
+
+    expect(seenProviderInputs.length).toBeGreaterThan(0);
+    expect(
+      seenProviderInputs.every((input) => input.options?.["reasoning_effort"] === "high"),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- preserve agent model option precedence over execution-profile preset defaults in session model resolution
- add regression coverage for baseURL preservation and supported preset options (`reasoning_effort`)
- record the provider-config investigation result: the reported `auth_profile_secrets` delete issue is not reproducible because both SQLite and Postgres migrations use `ON DELETE CASCADE`, and SQLite foreign keys are enabled in the gateway DB setup

## Verification
- pnpm vitest run packages/gateway/tests/unit/agent-runtime-baseurl-resolution.test.ts
- pnpm vitest run packages/gateway/tests/unit/agent-runtime-fallback-models.test.ts
- pnpm vitest run packages/gateway/tests/integration/provider-model-config-routes.test.ts
- pnpm typecheck
- pnpm lint
