### PR TITLE
Make elevated mode tokenless

### DIFF
--- a/packages/cli/src/cli-command.ts
+++ b/packages/cli/src/cli-command.ts
@@ -20,7 +20,7 @@ export type CliCommand =
   | { kind: "config_show" }
   | { kind: "identity_init" }
   | { kind: "identity_show" }
-  | { kind: "elevated_mode_enter"; elevated_token: string; ttl_seconds?: number }
+  | { kind: "elevated_mode_enter"; ttl_seconds?: number }
   | { kind: "elevated_mode_status" }
   | { kind: "elevated_mode_exit" }
   | { kind: "approvals_list"; limit: number }

--- a/packages/cli/src/cli-help.ts
+++ b/packages/cli/src/cli-help.ts
@@ -10,7 +10,7 @@ export function printCliHelp(): void {
       "  tyrum-cli config set --gateway-url <url> --token <token> [--tls-fingerprint256 <hex>] [--tls-allow-self-signed]",
       "  tyrum-cli identity show",
       "  tyrum-cli identity init",
-      "  tyrum-cli elevated-mode enter --elevated-token <token> [--ttl-seconds <n>]",
+      "  tyrum-cli elevated-mode enter [--ttl-seconds <n>]",
       "  tyrum-cli elevated-mode status",
       "  tyrum-cli elevated-mode exit",
       "  tyrum-cli approvals list [--limit <n>]",

--- a/packages/cli/src/handlers/elevated-mode.ts
+++ b/packages/cli/src/handlers/elevated-mode.ts
@@ -59,7 +59,11 @@ export async function handleElevatedModeEnter(
     const config = await requireOperatorConfig(home);
     const http = createTyrumHttpClient({
       baseUrl: config.gateway_url,
-      auth: { type: "bearer", token: command.elevated_token },
+      auth: { type: "bearer", token: config.auth_token },
+      ...(config.tls_cert_fingerprint256
+        ? { tlsCertFingerprint256: config.tls_cert_fingerprint256 }
+        : {}),
+      ...(config.tls_allow_self_signed ? { tlsAllowSelfSigned: true } : {}),
     });
 
     const issued = await http.deviceTokens.issue({

--- a/packages/cli/src/operator-state.ts
+++ b/packages/cli/src/operator-state.ts
@@ -151,7 +151,7 @@ export async function requireElevatedModeToken(
   if (state) return state.elevatedToken;
 
   throw new Error(
-    "Elevated Mode required: run 'tyrum-cli elevated-mode enter --elevated-token <token>' " +
+    "Elevated Mode required: run 'tyrum-cli elevated-mode enter' " +
       "or pass --elevated-token <token> explicitly for this command.",
   );
 }

--- a/packages/cli/src/parse/elevated-mode.ts
+++ b/packages/cli/src/parse/elevated-mode.ts
@@ -1,6 +1,6 @@
 import type { CliCommand } from "../cli-command.js";
 
-import { parseElevatedToken, parsePositiveInt } from "./common.js";
+import { parsePositiveInt } from "./common.js";
 
 export function parseElevatedModeCommand(argv: readonly string[]): CliCommand {
   const second = argv[1];
@@ -41,18 +41,11 @@ function parseElevatedModeExit(argv: readonly string[]): CliCommand {
 }
 
 function parseElevatedModeEnter(argv: readonly string[]): CliCommand {
-  let elevatedToken: string | undefined;
   let ttlSeconds: number | undefined;
 
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     if (!arg) continue;
-
-    if (arg === "--elevated-token") {
-      elevatedToken = parseElevatedToken(argv[i + 1]);
-      i += 1;
-      continue;
-    }
 
     if (arg === "--ttl-seconds") {
       ttlSeconds = parsePositiveInt(argv[i + 1], "--ttl-seconds");
@@ -68,13 +61,8 @@ function parseElevatedModeEnter(argv: readonly string[]): CliCommand {
     throw new Error(`unexpected elevated-mode.enter argument '${arg}'`);
   }
 
-  if (!elevatedToken) {
-    throw new Error("elevated-mode enter requires --elevated-token <token>");
-  }
-
   return {
     kind: "elevated_mode_enter",
-    elevated_token: elevatedToken,
     ttl_seconds: ttlSeconds,
   };
 }

--- a/packages/cli/tests/unit/admin-mode.test.ts
+++ b/packages/cli/tests/unit/admin-mode.test.ts
@@ -109,19 +109,14 @@ describe("@tyrum/cli elevated-mode", () => {
       vi.resetModules();
       const { runCli } = await import("../../src/index.js");
 
-      const code = await runCli([
-        "elevated-mode",
-        "enter",
-        "--elevated-token",
-        "elevated-access-token",
-      ]);
+      const code = await runCli(["elevated-mode", "enter", "--ttl-seconds", "42"]);
 
       expect(code).toBe(0);
       expect(errSpy).not.toHaveBeenCalled();
       expect(httpCtorSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           baseUrl: "http://127.0.0.1:8788",
-          auth: { type: "bearer", token: "elevated-access-token" },
+          auth: { type: "bearer", token: "base" },
         }),
       );
       expect(httpDeviceTokensIssueSpy).toHaveBeenCalledWith(
@@ -129,6 +124,7 @@ describe("@tyrum/cli elevated-mode", () => {
           device_id: "operator-cli",
           role: "client",
           scopes: ["operator.admin"],
+          ttl_seconds: 42,
         }),
       );
 

--- a/packages/operator-ui/src/components/elevated-mode/elevated-mode-enter-dialog.tsx
+++ b/packages/operator-ui/src/components/elevated-mode/elevated-mode-enter-dialog.tsx
@@ -1,9 +1,6 @@
-import { createTyrumHttpClient } from "@tyrum/client";
 import { useEffect, useRef, useState } from "react";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
-import { Input } from "../ui/input.js";
-import { Label } from "../ui/label.js";
 import {
   Dialog,
   DialogContent,
@@ -14,24 +11,17 @@ import {
 } from "../ui/dialog.js";
 import { useElevatedModeUiContext } from "./elevated-mode-provider.js";
 import { formatErrorMessage } from "../../utils/format-error-message.js";
-import { resolveTyrumHttpFetch } from "../../utils/tyrum-http-fetch.js";
 
 export function ElevatedModeEnterDialog() {
-  const { core, mode, isEnterOpen, requestEnter, closeEnter } = useElevatedModeUiContext();
+  const { core, isEnterOpen, requestEnter, closeEnter } = useElevatedModeUiContext();
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(busy);
   busyRef.current = busy;
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [revealToken, setRevealToken] = useState(false);
   const confirmRef = useRef<HTMLInputElement | null>(null);
-  const tokenRef = useRef<HTMLInputElement | null>(null);
 
   const resetForm = (): void => {
     setErrorMessage(null);
-    setRevealToken(false);
-    if (tokenRef.current) {
-      tokenRef.current.value = "";
-    }
     if (confirmRef.current) {
       confirmRef.current.checked = false;
     }
@@ -42,14 +32,8 @@ export function ElevatedModeEnterDialog() {
     resetForm();
   }, [isEnterOpen]);
 
-  const issueDeviceToken = async (accessToken: string): Promise<void> => {
-    const http = createTyrumHttpClient({
-      baseUrl: core.httpBaseUrl,
-      auth: { type: "bearer", token: accessToken },
-      fetch: resolveTyrumHttpFetch(mode),
-    });
-
-    const issued = await http.deviceTokens.issue({
+  const issueDeviceToken = async (): Promise<void> => {
+    const issued = await core.http.deviceTokens.issue({
       device_id: "operator-ui",
       role: "client",
       scopes: [
@@ -77,16 +61,10 @@ export function ElevatedModeEnterDialog() {
       return;
     }
 
-    const accessToken = tokenRef.current?.value.trim() ?? "";
-    if (!accessToken) {
-      setErrorMessage("Elevated access token is required");
-      return;
-    }
-
     setBusy(true);
     setErrorMessage(null);
     try {
-      await issueDeviceToken(accessToken);
+      await issueDeviceToken();
       resetForm();
       closeEnter();
     } catch (error) {
@@ -128,14 +106,14 @@ export function ElevatedModeEnterDialog() {
         }}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
-          tokenRef.current?.focus();
+          confirmRef.current?.focus();
         }}
       >
         <DialogHeader>
           <DialogTitle>Enter Elevated Mode</DialogTitle>
           <DialogDescription>
             Elevated Mode enables dangerous operator actions. It is time-limited and can be exited
-            at any time.
+            at any time. Entering it uses your current authenticated session.
           </DialogDescription>
         </DialogHeader>
 
@@ -144,37 +122,6 @@ export function ElevatedModeEnterDialog() {
             <input type="checkbox" data-testid="elevated-mode-confirm" ref={confirmRef} />
             <span>I understand and want to proceed.</span>
           </label>
-
-          <div className="grid gap-2">
-            <Label htmlFor="elevated-mode-token">Elevated access token</Label>
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <Input
-                  id="elevated-mode-token"
-                  data-testid="elevated-mode-token"
-                  ref={tokenRef}
-                  type={revealToken ? "text" : "password"}
-                  spellCheck={false}
-                  autoCapitalize="none"
-                  autoCorrect="off"
-                  autoComplete="off"
-                />
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                data-testid="elevated-mode-token-toggle"
-                disabled={busy}
-                aria-pressed={revealToken}
-                onClick={() => {
-                  setRevealToken((prev) => !prev);
-                }}
-              >
-                {revealToken ? "Hide" : "Show"}
-              </Button>
-            </div>
-          </div>
 
           {errorMessage ? (
             <Alert variant="error" title="Elevated Mode error" description={errorMessage} />

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -70,6 +70,12 @@ function setControlledInputValue(input: HTMLInputElement, value: string): void {
   input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+function requestInfoToUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
 function stubUrlObjectUrls(): { restore: () => void } {
   const originalCreateObjectURL = (URL as unknown as { createObjectURL?: unknown }).createObjectURL;
   const originalRevokeObjectURL = (URL as unknown as { revokeObjectURL?: unknown }).revokeObjectURL;
@@ -395,6 +401,7 @@ function sampleExecutionAttempt({
 
 function createFakeHttpClient(): {
   http: OperatorHttpClient;
+  deviceTokensIssue: ReturnType<typeof vi.fn>;
   statusGet: ReturnType<typeof vi.fn>;
   usageGet: ReturnType<typeof vi.fn>;
   presenceList: ReturnType<typeof vi.fn>;
@@ -406,6 +413,22 @@ function createFakeHttpClient(): {
   agentStatusGet: ReturnType<typeof vi.fn>;
   modelAssignmentsUpdate: ReturnType<typeof vi.fn>;
 } {
+  const deviceTokensIssue = vi.fn(async () => ({
+    token_kind: "device" as const,
+    token: "elevated-device-token",
+    token_id: "token-1",
+    device_id: "operator-ui",
+    role: "client" as const,
+    scopes: [
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+      "operator.admin",
+    ],
+    issued_at: "2026-02-27T00:00:00.000Z",
+    expires_at: "2099-01-01T00:00:00.000Z",
+  }));
   const statusGet = vi.fn(async () => sampleStatusResponse());
   const usageGet = vi.fn(async () => sampleUsageResponse());
   const presenceList = vi.fn(async () => samplePresenceResponse());
@@ -435,6 +458,10 @@ function createFakeHttpClient(): {
   }));
 
   const http: OperatorHttpClient = {
+    deviceTokens: {
+      issue: deviceTokensIssue,
+      revoke: vi.fn(async () => ({ revoked: true })),
+    },
     status: { get: statusGet },
     usage: { get: usageGet },
     presence: { list: presenceList },
@@ -554,6 +581,7 @@ function createFakeHttpClient(): {
 
   return {
     http,
+    deviceTokensIssue,
     statusGet,
     usageGet,
     presenceList,
@@ -3731,11 +3759,6 @@ describe("operator-ui", () => {
   });
 
   it("gates an admin-only Settings action behind Elevated Mode", async () => {
-    const issuedAt = "2026-02-27T00:00:00.000Z";
-    const expiresAt = "2026-02-27T00:10:00.000Z";
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(issuedAt));
-
     const expectedScopes = [
       "operator.read",
       "operator.write",
@@ -3744,29 +3767,8 @@ describe("operator-ui", () => {
       "operator.admin",
     ];
 
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      expect(init?.method).toBe("POST");
-      expect(headers.get("authorization")).toBe("Bearer admin-token");
-
-      return new Response(
-        JSON.stringify({
-          token_kind: "device",
-          token: "elevated-device-token",
-          token_id: "token-1",
-          device_id: "operator-ui",
-          role: "client",
-          scopes: expectedScopes,
-          issued_at: issuedAt,
-          expires_at: expiresAt,
-        }),
-        { status: 201, headers: { "content-type": "application/json" } },
-      );
-    });
-    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-
     const ws = new FakeWsClient();
-    const { http } = createFakeHttpClient();
+    const { http, deviceTokensIssue } = createFakeHttpClient();
     const core = createOperatorCore({
       wsUrl: "ws://example.test/ws",
       httpBaseUrl: "http://example.test",
@@ -3797,14 +3799,6 @@ describe("operator-ui", () => {
       enterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    const tokenField = document.querySelector<HTMLInputElement>(
-      '[data-testid="elevated-mode-token"]',
-    );
-    expect(tokenField).not.toBeNull();
-    act(() => {
-      tokenField!.value = "admin-token";
-    });
-
     const confirmCheckbox = document.querySelector<HTMLInputElement>(
       '[data-testid="elevated-mode-confirm"]',
     );
@@ -3824,19 +3818,17 @@ describe("operator-ui", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, callInit] = fetchMock.mock.calls[0] ?? [];
-    const bodyText = typeof callInit?.body === "string" ? callInit.body : "";
-    const body = JSON.parse(bodyText) as { scopes?: unknown; ttl_seconds?: unknown };
-    expect(body).toMatchObject({
+    expect(deviceTokensIssue).toHaveBeenCalledTimes(1);
+    expect(deviceTokensIssue).toHaveBeenCalledWith({
+      device_id: "operator-ui",
+      role: "client",
+      scopes: expectedScopes,
       ttl_seconds: 60 * 10,
     });
-    expect(body.scopes).toEqual(expect.arrayContaining(expectedScopes));
-    expect(body.scopes).toHaveLength(expectedScopes.length);
     expect(core.elevatedModeStore.getSnapshot()).toMatchObject({
       status: "active",
       elevatedToken: "elevated-device-token",
-      expiresAt,
+      expiresAt: "2099-01-01T00:00:00.000Z",
     });
     expect(container.querySelector('[data-testid="elevated-mode-banner"]')).not.toBeNull();
     expect(
@@ -3870,17 +3862,13 @@ describe("operator-ui", () => {
     container.remove();
   });
 
-  it("gates admin-only actions behind a shared Elevated Mode flow", async () => {
+  it("uses baseline bearer auth to enter Elevated Mode", async () => {
     const issuedAt = "2026-02-27T00:00:00.000Z";
     const expiresAt = "2026-02-27T00:10:00.000Z";
     vi.useFakeTimers();
     vi.setSystemTime(new Date(issuedAt));
 
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const headers = new Headers(init?.headers);
-      expect(init?.method).toBe("POST");
-      expect(headers.get("authorization")).toBe("Bearer admin-token");
-
+    const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           token_kind: "device",
@@ -3898,12 +3886,11 @@ describe("operator-ui", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const ws = new FakeWsClient();
-    const { http } = createFakeHttpClient();
     const core = createOperatorCore({
       wsUrl: "ws://example.test/ws",
       httpBaseUrl: "http://example.test",
       auth: createBearerTokenAuth("baseline"),
-      deps: { ws, http },
+      deps: { ws },
     });
 
     const container = document.createElement("div");
@@ -3944,28 +3931,106 @@ describe("operator-ui", () => {
     const dialog = document.querySelector('[data-testid="elevated-mode-dialog"]');
     expect(dialog).not.toBeNull();
 
-    const tokenField = document.querySelector<HTMLInputElement>(
-      '[data-testid="elevated-mode-token"]',
+    const confirmCheckbox = document.querySelector<HTMLInputElement>(
+      '[data-testid="elevated-mode-confirm"]',
     );
-    expect(tokenField).not.toBeNull();
-    expect(tokenField!.type).toBe("password");
-    expect(tokenField!.getAttribute("autocomplete")).toBe("off");
+    expect(confirmCheckbox).not.toBeNull();
+    act(() => {
+      confirmCheckbox!.checked = true;
+      confirmCheckbox!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
 
-    const toggleTokenButton = document.querySelector<HTMLButtonElement>(
-      '[data-testid="elevated-mode-token-toggle"]',
+    const submitButton = document.querySelector<HTMLButtonElement>(
+      '[data-testid="elevated-mode-submit"]',
     );
-    expect(toggleTokenButton).not.toBeNull();
-    act(() => {
-      toggleTokenButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(submitButton).not.toBeNull();
+
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
     });
-    expect(tokenField!.type).toBe("text");
-    act(() => {
-      toggleTokenButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    const issueCalls = fetchMock.mock.calls.filter(([input]) =>
+      requestInfoToUrl(input).endsWith("/auth/device-tokens/issue"),
+    );
+    expect(issueCalls).toHaveLength(1);
+    const [, callInit] = issueCalls[0] ?? [];
+    const headers = new Headers(callInit?.headers);
+    expect(callInit?.method).toBe("POST");
+    expect(headers.get("authorization")).toBe("Bearer baseline");
+    expect(core.elevatedModeStore.getSnapshot()).toMatchObject({
+      status: "active",
+      elevatedToken: "elevated-device-token",
+      expiresAt,
     });
-    expect(tokenField!.type).toBe("password");
+
+    expect(container.querySelector('[data-testid="elevated-mode-banner"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="danger-action"]')).not.toBeNull();
 
     act(() => {
-      tokenField!.value = "  admin-token  ";
+      root?.unmount();
+    });
+    container.remove();
+  });
+
+  it("uses baseline cookie auth to enter Elevated Mode in web mode", async () => {
+    const issuedAt = "2026-02-27T00:00:00.000Z";
+    const expiresAt = "2026-02-27T00:10:00.000Z";
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          token_kind: "device",
+          token: "elevated-device-token",
+          token_id: "token-1",
+          device_id: "operator-ui",
+          role: "client",
+          scopes: ["operator.admin"],
+          issued_at: issuedAt,
+          expires_at: expiresAt,
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const ws = new FakeWsClient();
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBrowserCookieAuth(),
+      deps: { ws },
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(ElevatedModeProvider, {
+          core,
+          mode: "web",
+          children: React.createElement(
+            ElevatedModeGate,
+            null,
+            React.createElement(
+              "button",
+              { type: "button", "data-testid": "danger-action" },
+              "Danger action",
+            ),
+          ),
+        }),
+      );
+    });
+
+    const enterButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="elevated-mode-enter"]',
+    );
+    expect(enterButton).not.toBeNull();
+
+    act(() => {
+      enterButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     const confirmCheckbox = document.querySelector<HTMLInputElement>(
@@ -3987,15 +4052,14 @@ describe("operator-ui", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(core.elevatedModeStore.getSnapshot()).toMatchObject({
-      status: "active",
-      elevatedToken: "elevated-device-token",
-      expiresAt,
-    });
-
-    expect(container.querySelector('[data-testid="elevated-mode-banner"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="danger-action"]')).not.toBeNull();
+    const issueCalls = fetchMock.mock.calls.filter(([input]) =>
+      requestInfoToUrl(input).endsWith("/auth/device-tokens/issue"),
+    );
+    expect(issueCalls).toHaveLength(1);
+    const [, callInit] = issueCalls[0] ?? [];
+    const headers = new Headers(callInit?.headers);
+    expect(headers.has("authorization")).toBe(false);
+    expect(callInit?.credentials).toBe("include");
 
     act(() => {
       root?.unmount();
@@ -4052,14 +4116,8 @@ describe("operator-ui", () => {
     expect(dialog?.getAttribute("aria-modal")).toBe("true");
     expect(dialog?.getAttribute("aria-labelledby")).toBeTruthy();
 
-    const tokenField = document.querySelector<HTMLInputElement>(
-      '[data-testid="elevated-mode-token"]',
-    );
-    expect(tokenField).not.toBeNull();
-    expect(tokenField!.type).toBe("password");
-
     act(() => {
-      tokenField?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      dialog?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
 
     expect(document.querySelector('[data-testid="elevated-mode-dialog"]')).toBeNull();


### PR DESCRIPTION
## Summary
- remove the separate token field from the operator UI Elevated Mode dialog and mint the short-lived elevated token through the existing authenticated session
- make `tyrum-cli elevated-mode enter` mint Elevated Mode from the configured operator token instead of requiring `--elevated-token`
- keep explicit per-command `--elevated-token` overrides for admin-only CLI commands unchanged

## Why
Elevated Mode is intended to be a temporary guard against accidental admin/config changes, not a second manual token-entry workflow.

## How to test
- `pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts packages/cli/tests/unit/admin-mode.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Risk
Low. This keeps the existing short-lived elevated device token model and only changes how clients enter that mode.

## Rollback
Revert commit `863fc4f7`.
