### PR TITLE
[Data model] Make persisted JSON corruption detectable (and prevent it where feasible) (#977)

### DIFF
--- a/packages/gateway/src/modules/agent/session-dal.ts
+++ b/packages/gateway/src/modules/agent/session-dal.ts
@@ -14,9 +14,15 @@ import {
 } from "../channels/interface.js";
 import { renderNormalizedThreadMessageText } from "./session-message-text.js";
 import { Logger } from "../observability/logger.js";
+import { gatewayMetrics } from "../observability/metrics.js";
+import {
+  parsePersistedJson,
+  reportPersistedJsonReadFailure,
+  stringifyPersistedJson,
+  type PersistedJsonObserver,
+} from "../observability/persisted-json.js";
 
 const logger = new Logger({ base: { module: "agent.session_dal" } });
-let warnedTurnsJsonParse = false;
 
 export interface SessionMessage {
   role: "user" | "assistant";
@@ -79,9 +85,7 @@ interface RawSessionListRow {
   connector_key: string;
   provider_thread_id: string;
   summary: string;
-  turns_count: number | string;
-  last_turn_role: string | null;
-  last_turn_content: string | null;
+  turns_json: string;
   created_at: string | Date;
   updated_at: string | Date;
 }
@@ -102,6 +106,8 @@ interface RawChannelTranscriptRow {
   processed_at: string | Date | null;
 }
 
+export interface SessionDalOptions extends PersistedJsonObserver {}
+
 export interface SessionRepairResult {
   source_rows: number;
   rebuilt_messages: number;
@@ -120,41 +126,53 @@ function normalizeTime(value: string | Date): string {
   return value;
 }
 
-function parseTurns(raw: string): SessionMessage[] {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    const safe: SessionMessage[] = [];
-    for (const entry of parsed) {
-      if (
-        entry &&
-        typeof entry === "object" &&
-        ((entry as Record<string, unknown>)["role"] === "user" ||
-          (entry as Record<string, unknown>)["role"] === "assistant") &&
-        typeof (entry as Record<string, unknown>)["content"] === "string" &&
-        typeof (entry as Record<string, unknown>)["timestamp"] === "string"
-      ) {
-        safe.push({
-          role: (entry as Record<string, unknown>)["role"] as "user" | "assistant",
-          content: (entry as Record<string, unknown>)["content"] as string,
-          timestamp: (entry as Record<string, unknown>)["timestamp"] as string,
-        });
-      }
-    }
-    return safe;
-  } catch (err) {
-    if (!warnedTurnsJsonParse) {
-      warnedTurnsJsonParse = true;
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn("sessions.turns_json_parse_failed", { error: message });
-    }
-    return [];
-  }
+function isSessionMessage(value: unknown): value is SessionMessage {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    ((value as Record<string, unknown>)["role"] === "user" ||
+      (value as Record<string, unknown>)["role"] === "assistant") &&
+    typeof (value as Record<string, unknown>)["content"] === "string" &&
+    typeof (value as Record<string, unknown>)["timestamp"] === "string"
+  );
 }
 
-function toSessionRow(raw: RawSessionRow): SessionRow {
+function isSessionMessageArray(value: unknown): value is SessionMessage[] {
+  return Array.isArray(value) && value.every(isSessionMessage);
+}
+
+function parseTurns(raw: string, observer: PersistedJsonObserver): SessionMessage[] {
+  const parsed = parsePersistedJson<unknown[]>({
+    raw,
+    fallback: [],
+    table: "sessions",
+    column: "turns_json",
+    shape: "array",
+    observer,
+  });
+
+  const safe: SessionMessage[] = [];
+  let invalidItems = 0;
+  for (const entry of parsed) {
+    if (!isSessionMessage(entry)) {
+      invalidItems += 1;
+      continue;
+    }
+    safe.push(entry);
+  }
+  if (invalidItems > 0) {
+    reportPersistedJsonReadFailure({
+      observer,
+      table: "sessions",
+      column: "turns_json",
+      reason: "invalid_value",
+      extra: { invalid_items: invalidItems },
+    });
+  }
+  return safe;
+}
+
+function toSessionRow(raw: RawSessionRow, observer: PersistedJsonObserver): SessionRow {
   return {
     tenant_id: raw.tenant_id,
     session_id: raw.session_id,
@@ -163,7 +181,7 @@ function toSessionRow(raw: RawSessionRow): SessionRow {
     workspace_id: raw.workspace_id,
     channel_thread_id: raw.channel_thread_id,
     summary: raw.summary,
-    turns: parseTurns(raw.turns_json),
+    turns: parseTurns(raw.turns_json, observer),
     created_at: normalizeTime(raw.created_at),
     updated_at: normalizeTime(raw.updated_at),
   };
@@ -174,22 +192,15 @@ function normalizeContainerKind(value: string): NormalizedContainerKind {
   return "channel";
 }
 
-function asNumber(value: number | string): number {
-  if (typeof value === "number") return value;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function toSessionListRow(raw: RawSessionListRow): SessionListRow {
+function toSessionListRow(raw: RawSessionListRow, observer: PersistedJsonObserver): SessionListRow {
   const createdAt = normalizeTime(raw.created_at);
   const updatedAt = normalizeTime(raw.updated_at);
-  const turnsCount = asNumber(raw.turns_count);
-
-  const role = raw.last_turn_role;
-  const content = raw.last_turn_content;
+  const turns = parseTurns(raw.turns_json, observer);
+  const turnsCount = turns.length;
+  const lastMessage = turns.at(-1);
   let lastTurn: { role: "user" | "assistant"; content: string } | null = null;
-  if ((role === "user" || role === "assistant") && typeof content === "string") {
-    lastTurn = { role, content };
+  if (lastMessage) {
+    lastTurn = { role: lastMessage.role, content: lastMessage.content };
   }
 
   return {
@@ -268,11 +279,19 @@ function normalizeRepairTimestamp(
 }
 
 export class SessionDal {
+  private readonly jsonObserver: PersistedJsonObserver;
+
   constructor(
     private readonly db: SqlDb,
     private readonly identityScopeDal: IdentityScopeDal,
     private readonly channelThreadDal: ChannelThreadDal,
-  ) {}
+    opts?: SessionDalOptions,
+  ) {
+    this.jsonObserver = {
+      logger: opts?.logger ?? logger,
+      metrics: opts?.metrics ?? gatewayMetrics,
+    };
+  }
 
   private static encodeCursor(input: { updated_at: string; session_id: string }): string {
     const payload = { updated_at: input.updated_at, session_id: input.session_id };
@@ -304,10 +323,10 @@ export class SessionDal {
        FROM sessions
        WHERE tenant_id = ?
          AND session_id = ?
-       LIMIT 1`,
+      LIMIT 1`,
       [input.tenantId, input.sessionId],
     );
-    return row ? toSessionRow(row) : undefined;
+    return row ? toSessionRow(row, this.jsonObserver) : undefined;
   }
 
   async getByKey(input: { tenantId: string; sessionKey: string }): Promise<SessionRow | undefined> {
@@ -316,10 +335,10 @@ export class SessionDal {
        FROM sessions
        WHERE tenant_id = ?
          AND session_key = ?
-       LIMIT 1`,
+      LIMIT 1`,
       [input.tenantId, input.sessionKey],
     );
-    return row ? toSessionRow(row) : undefined;
+    return row ? toSessionRow(row, this.jsonObserver) : undefined;
   }
 
   async getWithDeliveryByKey(input: {
@@ -357,7 +376,7 @@ export class SessionDal {
     );
     if (!row) return undefined;
     return {
-      session: toSessionRow(row),
+      session: toSessionRow(row, this.jsonObserver),
       agent_key: row.agent_key,
       workspace_key: row.workspace_key,
       connector_key: row.connector_key,
@@ -424,13 +443,13 @@ export class SessionDal {
          turns_json,
          created_at,
          updated_at
-       )
-       VALUES (?, ?, ?, ?, ?, ?, '', '[]', ?, ?)
+      )
+      VALUES (?, ?, ?, ?, ?, ?, '', '[]', ?, ?)
        ON CONFLICT (tenant_id, session_key) DO NOTHING
       RETURNING *`,
       [tenantId, randomUUID(), sessionKey, agentId, workspaceId, channelThreadId, nowIso, nowIso],
     );
-    if (inserted) return toSessionRow(inserted);
+    if (inserted) return toSessionRow(inserted, this.jsonObserver);
 
     const created = await this.getByKey({ tenantId, sessionKey });
     if (!created) {
@@ -470,32 +489,16 @@ export class SessionDal {
       params.push(cursor.updated_at, cursor.updated_at, cursor.session_id);
     }
 
-    const listSql =
-      this.db.kind === "sqlite"
-        ? `SELECT
+    const listSql = `SELECT
              s.session_id,
              s.session_key,
              ag.agent_key,
              ca.connector_key,
              ct.provider_thread_id,
              s.summary,
+             s.turns_json,
              s.created_at,
-             s.updated_at,
-             CASE
-               WHEN json_valid(s.turns_json)
-                 THEN json_array_length(s.turns_json)
-               ELSE 0
-             END AS turns_count,
-             CASE
-               WHEN json_valid(s.turns_json)
-                 THEN json_extract(s.turns_json, '$[#-1].role')
-               ELSE NULL
-             END AS last_turn_role,
-             CASE
-               WHEN json_valid(s.turns_json)
-                 THEN json_extract(s.turns_json, '$[#-1].content')
-               ELSE NULL
-             END AS last_turn_content
+             s.updated_at
            FROM sessions s
            JOIN agents ag
              ON ag.tenant_id = s.tenant_id
@@ -510,56 +513,11 @@ export class SessionDal {
             AND ca.channel_account_id = ct.channel_account_id
            WHERE ${where.join(" AND ")}
            ORDER BY s.updated_at DESC, s.session_id DESC
-           LIMIT ?`
-        : `SELECT
-             session_id,
-             session_key,
-             agent_key,
-             connector_key,
-             provider_thread_id,
-             summary,
-             created_at,
-             updated_at,
-             CASE
-               WHEN jsonb_typeof(turns) = 'array' THEN jsonb_array_length(turns)
-               ELSE 0
-             END AS turns_count,
-             (turns -> -1 ->> 'role') AS last_turn_role,
-             (turns -> -1 ->> 'content') AS last_turn_content
-           FROM (
-             SELECT
-               s.session_id,
-               s.session_key,
-               ag.agent_key,
-               ca.connector_key,
-               ct.provider_thread_id,
-               s.summary,
-               s.created_at,
-               s.updated_at,
-               CASE
-                 WHEN pg_input_is_valid(s.turns_json, 'jsonb') THEN s.turns_json::jsonb
-                 ELSE '[]'::jsonb
-               END AS turns
-             FROM sessions s
-             JOIN agents ag
-               ON ag.tenant_id = s.tenant_id
-              AND ag.agent_id = s.agent_id
-             JOIN channel_threads ct
-               ON ct.tenant_id = s.tenant_id
-              AND ct.workspace_id = s.workspace_id
-              AND ct.channel_thread_id = s.channel_thread_id
-             JOIN channel_accounts ca
-               ON ca.tenant_id = ct.tenant_id
-              AND ca.workspace_id = ct.workspace_id
-              AND ca.channel_account_id = ct.channel_account_id
-             WHERE ${where.join(" AND ")}
-           ) sessions_with_turns
-           ORDER BY updated_at DESC, session_id DESC
            LIMIT ?`;
 
     const rows = await this.db.all<RawSessionListRow>(listSql, [...params, limit + 1]);
     const selectedRows = rows.slice(0, limit);
-    const sessions = selectedRows.map(toSessionListRow);
+    const sessions = selectedRows.map((row) => toSessionListRow(row, this.jsonObserver));
 
     const hasMore = rows.length > limit;
     const last = selectedRows.at(-1);
@@ -623,7 +581,19 @@ export class SessionDal {
       `UPDATE sessions
        SET turns_json = ?, summary = ?, updated_at = ?
        WHERE tenant_id = ? AND session_id = ?`,
-      [JSON.stringify(stored.turns), stored.summary, nowIso, input.tenantId, input.sessionId],
+      [
+        stringifyPersistedJson({
+          value: stored.turns,
+          table: "sessions",
+          column: "turns_json",
+          shape: "array",
+          validate: isSessionMessageArray,
+        }),
+        stored.summary,
+        nowIso,
+        input.tenantId,
+        input.sessionId,
+      ],
     );
 
     const updated = await this.getById({ tenantId: input.tenantId, sessionId: input.sessionId });
@@ -655,7 +625,19 @@ export class SessionDal {
       `UPDATE sessions
        SET turns_json = ?, summary = ?, updated_at = ?
        WHERE tenant_id = ? AND session_id = ?`,
-      [JSON.stringify(stored.turns), stored.summary, nowIso, input.tenantId, input.sessionId],
+      [
+        stringifyPersistedJson({
+          value: stored.turns,
+          table: "sessions",
+          column: "turns_json",
+          shape: "array",
+          validate: isSessionMessageArray,
+        }),
+        stored.summary,
+        nowIso,
+        input.tenantId,
+        input.sessionId,
+      ],
     );
 
     return { droppedMessages: stored.droppedMessages, keptMessages: stored.turns.length };
@@ -724,7 +706,19 @@ export class SessionDal {
       `UPDATE sessions
        SET turns_json = ?, summary = ?, updated_at = ?
        WHERE tenant_id = ? AND session_id = ?`,
-      [JSON.stringify(stored.turns), stored.summary, updatedAt, input.tenantId, input.sessionId],
+      [
+        stringifyPersistedJson({
+          value: stored.turns,
+          table: "sessions",
+          column: "turns_json",
+          shape: "array",
+          validate: isSessionMessageArray,
+        }),
+        stored.summary,
+        updatedAt,
+        input.tenantId,
+        input.sessionId,
+      ],
     );
 
     return {

--- a/packages/gateway/src/modules/memory/vector-dal.ts
+++ b/packages/gateway/src/modules/memory/vector-dal.ts
@@ -7,6 +7,13 @@
 
 import { randomUUID } from "node:crypto";
 import type { SqlDb } from "../../statestore/types.js";
+import { Logger } from "../observability/logger.js";
+import { gatewayMetrics } from "../observability/metrics.js";
+import {
+  parsePersistedJson,
+  stringifyPersistedJson,
+  type PersistedJsonObserver,
+} from "../observability/persisted-json.js";
 
 export interface VectorRow {
   id: number;
@@ -29,25 +36,39 @@ interface RawVectorRow {
   vector_data: string | null;
   created_at: string | Date;
 }
+const logger = new Logger({ base: { module: "memory.vector_dal" } });
+
+export interface VectorDalOptions extends PersistedJsonObserver {}
 
 function normalizeTime(value: string | Date): string {
   return value instanceof Date ? value.toISOString() : value;
 }
 
-function toVectorRow(raw: RawVectorRow): VectorRow {
-  let metadata: unknown = {};
-  try {
-    if (raw.metadata_json) metadata = JSON.parse(raw.metadata_json) as unknown;
-  } catch {
-    // Intentional: treat invalid JSON metadata as an empty object.
-  }
+function isFiniteNumberArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.every((entry) => typeof entry === "number" && Number.isFinite(entry))
+  );
+}
 
-  let vector: number[] = [];
-  try {
-    if (raw.vector_data) vector = JSON.parse(raw.vector_data) as number[];
-  } catch {
-    // Intentional: treat invalid JSON vectors as an empty array.
-  }
+function toVectorRow(raw: RawVectorRow, observer: PersistedJsonObserver): VectorRow {
+  const metadata = parsePersistedJson<Record<string, unknown>>({
+    raw: raw.metadata_json,
+    fallback: {},
+    table: "vector_metadata",
+    column: "metadata_json",
+    shape: "object",
+    observer,
+  });
+  const vector = parsePersistedJson<number[]>({
+    raw: raw.vector_data,
+    fallback: [],
+    table: "vector_metadata",
+    column: "vector_data",
+    shape: "array",
+    observer,
+    validate: isFiniteNumberArray,
+  });
 
   return {
     id: raw.vector_metadata_id,
@@ -100,7 +121,17 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 }
 
 export class VectorDal {
-  constructor(private readonly db: SqlDb) {}
+  private readonly jsonObserver: PersistedJsonObserver;
+
+  constructor(
+    private readonly db: SqlDb,
+    opts?: VectorDalOptions,
+  ) {
+    this.jsonObserver = {
+      logger: opts?.logger ?? logger,
+      metrics: opts?.metrics ?? gatewayMetrics,
+    };
+  }
 
   /** Insert a vector embedding. Returns the embedding_id. */
   async insertEmbedding(
@@ -145,8 +176,21 @@ export class VectorDal {
         embeddingId,
         model,
         label,
-        metadata !== undefined ? JSON.stringify(metadata) : null,
-        JSON.stringify(vector),
+        metadata !== undefined
+          ? stringifyPersistedJson({
+              value: metadata,
+              table: "vector_metadata",
+              column: "metadata_json",
+              shape: "object",
+            })
+          : null,
+        stringifyPersistedJson({
+          value: vector,
+          table: "vector_metadata",
+          column: "vector_data",
+          shape: "array",
+          validate: isFiniteNumberArray,
+        }),
       ],
     );
 
@@ -171,7 +215,7 @@ export class VectorDal {
     const scored: VectorSearchResult[] = [];
 
     for (const raw of rows) {
-      const row = toVectorRow(raw);
+      const row = toVectorRow(raw, this.jsonObserver);
       if (row.vector.length === 0) continue;
       const similarity = cosineSimilarity(queryVector, row.vector);
       scored.push({ row, similarity });
@@ -200,7 +244,7 @@ export class VectorDal {
       [resolved.tenantId, resolved.agentId, embeddingId],
     );
 
-    return raw ? toVectorRow(raw) : undefined;
+    return raw ? toVectorRow(raw, this.jsonObserver) : undefined;
   }
 
   /** List all embeddings, ordered by creation time descending. */
@@ -210,6 +254,6 @@ export class VectorDal {
       "SELECT * FROM vector_metadata WHERE tenant_id = ? AND agent_id = ? ORDER BY created_at DESC, vector_metadata_id DESC",
       [resolved.tenantId, resolved.agentId],
     );
-    return rows.map(toVectorRow);
+    return rows.map((row) => toVectorRow(row, this.jsonObserver));
   }
 }

--- a/packages/gateway/src/modules/observability/metrics.ts
+++ b/packages/gateway/src/modules/observability/metrics.ts
@@ -6,6 +6,7 @@ type HttpRequestTotalLabels = "method" | "path" | "status";
 type HttpRequestDurationLabels = "method" | "path";
 type LifecyclePruneRowsLabels = "scheduler" | "table";
 type LifecycleTickErrorsLabels = "scheduler";
+type PersistedJsonReadFailuresLabels = "table" | "column" | "reason";
 
 export type LifecycleSchedulerName = "outbox" | "statestore";
 
@@ -15,6 +16,7 @@ export class MetricsRegistry {
   readonly httpRequestDurationSeconds: Histogram<HttpRequestDurationLabels>;
   readonly lifecyclePruneRowsTotal: Counter<LifecyclePruneRowsLabels>;
   readonly lifecycleTickErrorsTotal: Counter<LifecycleTickErrorsLabels>;
+  readonly persistedJsonReadFailuresTotal: Counter<PersistedJsonReadFailuresLabels>;
   readonly wsConnectionsActive: Gauge<never>;
 
   constructor() {
@@ -48,6 +50,13 @@ export class MetricsRegistry {
       registers: [this.registry],
     });
 
+    this.persistedJsonReadFailuresTotal = new Counter<PersistedJsonReadFailuresLabels>({
+      name: "persisted_json_read_failures_total",
+      help: "Persisted JSON read failures by table, column, and reason.",
+      labelNames: ["table", "column", "reason"] as const,
+      registers: [this.registry],
+    });
+
     this.wsConnectionsActive = new Gauge<never>({
       name: "ws_connections_active",
       help: "Number of active WebSocket connections.",
@@ -73,6 +82,14 @@ export class MetricsRegistry {
       this.lifecycleTickErrorsTotal.inc({ scheduler });
     } catch {
       // Intentional: error accounting must not make a failed lifecycle tick worse.
+    }
+  }
+
+  recordPersistedJsonReadFailure(table: string, column: string, reason: string): void {
+    try {
+      this.persistedJsonReadFailuresTotal.inc({ table, column, reason });
+    } catch {
+      // Intentional: read-path observability must not break normal request handling.
     }
   }
 }

--- a/packages/gateway/src/modules/observability/persisted-json.ts
+++ b/packages/gateway/src/modules/observability/persisted-json.ts
@@ -1,0 +1,121 @@
+import type { Logger } from "./logger.js";
+import type { MetricsRegistry } from "./metrics.js";
+
+export type PersistedJsonReason = "invalid_json" | "unexpected_shape" | "invalid_value";
+export type PersistedJsonShape = "any" | "array" | "object";
+
+export interface PersistedJsonObserver {
+  logger?: Pick<Logger, "warn">;
+  metrics?: Pick<MetricsRegistry, "recordPersistedJsonReadFailure">;
+}
+
+function matchesShape(value: unknown, shape: PersistedJsonShape): boolean {
+  if (shape === "any") return true;
+  if (shape === "array") return Array.isArray(value);
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function describeShape(shape: PersistedJsonShape): string {
+  if (shape === "any") return "value";
+  return shape;
+}
+
+export function reportPersistedJsonReadFailure(input: {
+  observer?: PersistedJsonObserver;
+  table: string;
+  column: string;
+  reason: PersistedJsonReason;
+  error?: string;
+  extra?: Record<string, unknown>;
+}): void {
+  input.observer?.metrics?.recordPersistedJsonReadFailure(input.table, input.column, input.reason);
+  input.observer?.logger?.warn("persisted_json.read_failed", {
+    table: input.table,
+    column: input.column,
+    reason: input.reason,
+    ...(input.error ? { error: input.error } : {}),
+    ...input.extra,
+  });
+}
+
+export function parsePersistedJson<T>(input: {
+  raw: string | null | undefined;
+  fallback: T;
+  table: string;
+  column: string;
+  shape: PersistedJsonShape;
+  observer?: PersistedJsonObserver;
+  validate?: (value: unknown) => value is T;
+}): T {
+  if (input.raw == null) return input.fallback;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input.raw) as unknown;
+  } catch (error) {
+    reportPersistedJsonReadFailure({
+      observer: input.observer,
+      table: input.table,
+      column: input.column,
+      reason: "invalid_json",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return input.fallback;
+  }
+
+  if (!matchesShape(parsed, input.shape)) {
+    reportPersistedJsonReadFailure({
+      observer: input.observer,
+      table: input.table,
+      column: input.column,
+      reason: "unexpected_shape",
+      extra: { expected_shape: input.shape },
+    });
+    return input.fallback;
+  }
+
+  if (input.validate && !input.validate(parsed)) {
+    reportPersistedJsonReadFailure({
+      observer: input.observer,
+      table: input.table,
+      column: input.column,
+      reason: "invalid_value",
+    });
+    return input.fallback;
+  }
+
+  return parsed as T;
+}
+
+export function stringifyPersistedJson<T>(input: {
+  value: T;
+  table: string;
+  column: string;
+  shape: PersistedJsonShape;
+  validate?: (value: unknown) => value is T;
+}): string {
+  if (!matchesShape(input.value, input.shape)) {
+    throw new Error(`${input.table}.${input.column} must be a JSON ${describeShape(input.shape)}`);
+  }
+
+  if (input.validate && !input.validate(input.value)) {
+    throw new Error(`${input.table}.${input.column} contains an invalid JSON value`);
+  }
+
+  const serialized = JSON.stringify(input.value);
+  if (typeof serialized !== "string") {
+    throw new Error(`${input.table}.${input.column} could not be serialized as JSON`);
+  }
+
+  const reparsed = JSON.parse(serialized) as unknown;
+  if (!matchesShape(reparsed, input.shape)) {
+    throw new Error(
+      `${input.table}.${input.column} must serialize to a JSON ${describeShape(input.shape)}`,
+    );
+  }
+
+  if (input.validate && !input.validate(reparsed)) {
+    throw new Error(`${input.table}.${input.column} contains an invalid JSON value`);
+  }
+  return serialized;
+}

--- a/packages/gateway/src/modules/presence/dal.ts
+++ b/packages/gateway/src/modules/presence/dal.ts
@@ -1,6 +1,14 @@
 import type { SqlDb } from "../../statestore/types.js";
+import { Logger } from "../observability/logger.js";
+import { gatewayMetrics } from "../observability/metrics.js";
+import {
+  parsePersistedJson,
+  stringifyPersistedJson,
+  type PersistedJsonObserver,
+} from "../observability/persisted-json.js";
 
 export type PresenceRole = "gateway" | "client" | "node";
+const logger = new Logger({ base: { module: "presence.dal" } });
 
 export interface PresenceRow {
   instance_id: string;
@@ -32,16 +40,20 @@ interface RawPresenceRow {
   expires_at_ms: number;
 }
 
-function parseMetadata(raw: string): unknown {
-  try {
-    return JSON.parse(raw) as unknown;
-  } catch {
-    // Intentional: treat invalid JSON metadata as an empty object.
-    return {};
-  }
+export interface PresenceDalOptions extends PersistedJsonObserver {}
+
+function parseMetadata(raw: string, observer: PersistedJsonObserver): unknown {
+  return parsePersistedJson<Record<string, unknown>>({
+    raw,
+    fallback: {},
+    table: "presence_entries",
+    column: "metadata_json",
+    shape: "object",
+    observer,
+  });
 }
 
-function toPresenceRow(raw: RawPresenceRow): PresenceRow {
+function toPresenceRow(raw: RawPresenceRow, observer: PersistedJsonObserver): PresenceRow {
   const role = raw.role === "gateway" || raw.role === "node" ? raw.role : "client";
   return {
     instance_id: raw.instance_id,
@@ -52,7 +64,7 @@ function toPresenceRow(raw: RawPresenceRow): PresenceRow {
     version: raw.version,
     mode: raw.mode,
     last_input_seconds: raw.last_input_seconds,
-    metadata: parseMetadata(raw.metadata_json),
+    metadata: parseMetadata(raw.metadata_json, observer),
     connected_at_ms: raw.connected_at_ms,
     last_seen_at_ms: raw.last_seen_at_ms,
     expires_at_ms: raw.expires_at_ms,
@@ -60,7 +72,17 @@ function toPresenceRow(raw: RawPresenceRow): PresenceRow {
 }
 
 export class PresenceDal {
-  constructor(private readonly db: SqlDb) {}
+  private readonly jsonObserver: PersistedJsonObserver;
+
+  constructor(
+    private readonly db: SqlDb,
+    opts?: PresenceDalOptions,
+  ) {
+    this.jsonObserver = {
+      logger: opts?.logger ?? logger,
+      metrics: opts?.metrics ?? gatewayMetrics,
+    };
+  }
 
   async upsert(params: {
     instanceId: string;
@@ -76,7 +98,12 @@ export class PresenceDal {
     ttlMs: number;
   }): Promise<PresenceRow> {
     const expiresAtMs = params.nowMs + Math.max(1, params.ttlMs);
-    const metadataJson = JSON.stringify(params.metadata ?? {});
+    const metadataJson = stringifyPersistedJson({
+      value: params.metadata ?? {},
+      table: "presence_entries",
+      column: "metadata_json",
+      shape: "object",
+    });
     const nowIso = new Date().toISOString();
 
     await this.db.run(
@@ -165,7 +192,7 @@ export class PresenceDal {
        WHERE instance_id = ?`,
       [instanceId],
     );
-    return row ? toPresenceRow(row) : undefined;
+    return row ? toPresenceRow(row, this.jsonObserver) : undefined;
   }
 
   async listNonExpired(nowMs: number, limit = 200): Promise<PresenceRow[]> {
@@ -177,7 +204,7 @@ export class PresenceDal {
        LIMIT ?`,
       [nowMs, Math.max(1, Math.min(1000, limit))],
     );
-    return rows.map(toPresenceRow);
+    return rows.map((row) => toPresenceRow(row, this.jsonObserver));
   }
 
   async pruneExpired(nowMs: number): Promise<string[]> {

--- a/packages/gateway/tests/unit/presence-dal.test.ts
+++ b/packages/gateway/tests/unit/presence-dal.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PresenceDal } from "../../src/modules/presence/dal.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import type { SqliteDb } from "../../src/statestore/sqlite.js";
+import { MetricsRegistry } from "../../src/modules/observability/metrics.js";
+
+describe("PresenceDal", () => {
+  let db: SqliteDb | undefined;
+
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  it("flags malformed metadata_json and falls back to an empty object", async () => {
+    db = openTestSqliteDb();
+    const logger = { warn: vi.fn() };
+    const metrics = new MetricsRegistry();
+    const dal = new PresenceDal(db, { logger, metrics });
+
+    await dal.upsert({
+      instanceId: "presence-1",
+      role: "gateway",
+      metadata: { ok: true },
+      nowMs: 1_700_000_000_000,
+      ttlMs: 10_000,
+    });
+
+    await db.run("UPDATE presence_entries SET metadata_json = ? WHERE instance_id = ?", [
+      "{ not: json",
+      "presence-1",
+    ]);
+
+    const row = await dal.getByInstanceId("presence-1");
+    expect(row?.metadata).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      "persisted_json.read_failed",
+      expect.objectContaining({
+        table: "presence_entries",
+        column: "metadata_json",
+        reason: "invalid_json",
+      }),
+    );
+
+    const metricsText = await metrics.registry.getSingleMetricAsString(
+      "persisted_json_read_failures_total",
+    );
+    expect(metricsText).toContain(
+      'table="presence_entries",column="metadata_json",reason="invalid_json"',
+    );
+  });
+
+  it("rejects non-object metadata on write", async () => {
+    db = openTestSqliteDb();
+    const dal = new PresenceDal(db);
+
+    await expect(
+      dal.upsert({
+        instanceId: "presence-invalid",
+        role: "gateway",
+        metadata: "not-an-object",
+        nowMs: 1_700_000_000_000,
+        ttlMs: 10_000,
+      }),
+    ).rejects.toThrow("presence_entries.metadata_json must be a JSON object");
+  });
+
+  it("rejects values that serialize to the wrong JSON shape", async () => {
+    db = openTestSqliteDb();
+    const dal = new PresenceDal(db);
+
+    await expect(
+      dal.upsert({
+        instanceId: "presence-date",
+        role: "gateway",
+        metadata: new Date("2026-01-02T03:04:05.000Z"),
+        nowMs: 1_700_000_000_000,
+        ttlMs: 10_000,
+      }),
+    ).rejects.toThrow("presence_entries.metadata_json must serialize to a JSON object");
+  });
+});

--- a/packages/gateway/tests/unit/session-dal.postgres-list.test.ts
+++ b/packages/gateway/tests/unit/session-dal.postgres-list.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SessionDal } from "../../src/modules/agent/session-dal.js";
 import { ChannelThreadDal } from "../../src/modules/channels/thread-dal.js";
 import { IdentityScopeDal } from "../../src/modules/identity/scope.js";
 import { openTestPostgresDb } from "../helpers/postgres-db.js";
+import { MetricsRegistry } from "../../src/modules/observability/metrics.js";
 
 describe("SessionDal.list (postgres)", () => {
   it("treats malformed turns_json as empty instead of failing the whole query", async () => {
@@ -10,7 +11,9 @@ describe("SessionDal.list (postgres)", () => {
     try {
       const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
       const channelThreadDal = new ChannelThreadDal(db);
-      const dal = new SessionDal(db, identityScopeDal, channelThreadDal);
+      const logger = { warn: vi.fn() };
+      const metrics = new MetricsRegistry();
+      const dal = new SessionDal(db, identityScopeDal, channelThreadDal, { logger, metrics });
       const s1 = await dal.getOrCreate({
         connectorKey: "ui",
         providerThreadId: "thread-1",
@@ -36,6 +39,19 @@ describe("SessionDal.list (postgres)", () => {
       const corrupted = page.sessions.find((s) => s.session_id === s1.session_key);
       expect(corrupted?.turns_count).toBe(0);
       expect(corrupted?.last_turn).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "persisted_json.read_failed",
+        expect.objectContaining({
+          table: "sessions",
+          column: "turns_json",
+          reason: "invalid_json",
+        }),
+      );
+
+      const metricsText = await metrics.registry.getSingleMetricAsString(
+        "persisted_json_read_failures_total",
+      );
+      expect(metricsText).toContain('table="sessions",column="turns_json",reason="invalid_json"');
     } finally {
       await close();
     }
@@ -46,7 +62,9 @@ describe("SessionDal.list (postgres)", () => {
     try {
       const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
       const channelThreadDal = new ChannelThreadDal(db);
-      const dal = new SessionDal(db, identityScopeDal, channelThreadDal);
+      const logger = { warn: vi.fn() };
+      const metrics = new MetricsRegistry();
+      const dal = new SessionDal(db, identityScopeDal, channelThreadDal, { logger, metrics });
       const s1 = await dal.getOrCreate({
         connectorKey: "ui",
         providerThreadId: "thread-1",
@@ -72,6 +90,63 @@ describe("SessionDal.list (postgres)", () => {
       const corrupted = page.sessions.find((s) => s.session_id === s1.session_key);
       expect(corrupted?.turns_count).toBe(0);
       expect(corrupted?.last_turn).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "persisted_json.read_failed",
+        expect.objectContaining({
+          table: "sessions",
+          column: "turns_json",
+          reason: "unexpected_shape",
+        }),
+      );
+
+      const metricsText = await metrics.registry.getSingleMetricAsString(
+        "persisted_json_read_failures_total",
+      );
+      expect(metricsText).toContain(
+        'table="sessions",column="turns_json",reason="unexpected_shape"',
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it("treats arrays with malformed turn items as empty and reports invalid_value", async () => {
+    const { db, close } = await openTestPostgresDb();
+    try {
+      const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
+      const channelThreadDal = new ChannelThreadDal(db);
+      const logger = { warn: vi.fn() };
+      const metrics = new MetricsRegistry();
+      const dal = new SessionDal(db, identityScopeDal, channelThreadDal, { logger, metrics });
+      const session = await dal.getOrCreate({
+        connectorKey: "ui",
+        providerThreadId: "thread-invalid-items",
+        containerKind: "group",
+      });
+
+      await db.run("UPDATE sessions SET turns_json = ? WHERE tenant_id = ? AND session_id = ?", [
+        '[{"role":"user"}]',
+        session.tenant_id,
+        session.session_id,
+      ]);
+
+      const page = await dal.list({ connectorKey: "ui", limit: 10 });
+      const corrupted = page.sessions.find((s) => s.session_id === session.session_key);
+      expect(corrupted?.turns_count).toBe(0);
+      expect(corrupted?.last_turn).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "persisted_json.read_failed",
+        expect.objectContaining({
+          table: "sessions",
+          column: "turns_json",
+          reason: "invalid_value",
+        }),
+      );
+
+      const metricsText = await metrics.registry.getSingleMetricAsString(
+        "persisted_json_read_failures_total",
+      );
+      expect(metricsText).toContain('table="sessions",column="turns_json",reason="invalid_value"');
     } finally {
       await close();
     }

--- a/packages/gateway/tests/unit/session-dal.test.ts
+++ b/packages/gateway/tests/unit/session-dal.test.ts
@@ -7,6 +7,7 @@ import { IdentityScopeDal } from "../../src/modules/identity/scope.js";
 import { ChannelInboxDal } from "../../src/modules/channels/inbox-dal.js";
 import { ChannelOutboxDal } from "../../src/modules/channels/outbox-dal.js";
 import { seedCompletedTelegramTurn } from "../helpers/channel-session-repair.js";
+import { MetricsRegistry } from "../../src/modules/observability/metrics.js";
 
 describe("SessionDal", () => {
   let db: SqliteDb | undefined;
@@ -159,6 +160,43 @@ describe("SessionDal", () => {
     expect(third.summary).toContain("u1");
     expect(third.summary).toContain("u2");
     expect(third.summary).not.toContain("u3");
+  });
+
+  it("flags malformed turns_json on direct reads while keeping the session usable", async () => {
+    db = openTestSqliteDb();
+    const logger = { warn: vi.fn() };
+    const metrics = new MetricsRegistry();
+    const identityScopeDal = new IdentityScopeDal(db, { cacheTtlMs: 60_000 });
+    const channelThreadDal = new ChannelThreadDal(db);
+    const dal = new SessionDal(db, identityScopeDal, channelThreadDal, { logger, metrics });
+
+    const session = await dal.getOrCreate({
+      connectorKey: "telegram",
+      providerThreadId: "thread-corrupt",
+      containerKind: "group",
+    });
+
+    await db.run("UPDATE sessions SET turns_json = ? WHERE tenant_id = ? AND session_id = ?", [
+      "{ not: json",
+      session.tenant_id,
+      session.session_id,
+    ]);
+
+    const row = await dal.getById({ tenantId: session.tenant_id, sessionId: session.session_id });
+    expect(row?.turns).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "persisted_json.read_failed",
+      expect.objectContaining({
+        table: "sessions",
+        column: "turns_json",
+        reason: "invalid_json",
+      }),
+    );
+
+    const metricsText = await metrics.registry.getSingleMetricAsString(
+      "persisted_json_read_failures_total",
+    );
+    expect(metricsText).toContain('table="sessions",column="turns_json",reason="invalid_json"');
   });
 
   it("repairs bounded session turns and summary from retained channel logs", async () => {

--- a/packages/gateway/tests/unit/vector-dal.test.ts
+++ b/packages/gateway/tests/unit/vector-dal.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VectorDal, type VectorScope } from "../../src/modules/memory/vector-dal.js";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
 import type { SqliteDb } from "../../src/statestore/sqlite.js";
@@ -7,6 +7,7 @@ import {
   DEFAULT_TENANT_ID,
   IdentityScopeDal,
 } from "../../src/modules/identity/scope.js";
+import { MetricsRegistry } from "../../src/modules/observability/metrics.js";
 
 describe("VectorDal", () => {
   let db: SqliteDb;
@@ -98,6 +99,30 @@ describe("VectorDal", () => {
 
       const defaultResults = await dal.searchByCosineSimilarity([0, 1], 10, defaultScope);
       expect(defaultResults.map((r) => r.row.label)).toEqual(["default-tenant"]);
+    });
+
+    it("rejects non-object metadata on write", async () => {
+      await expect(
+        dal.insertEmbedding("bad-meta", [1, 0], "model", "not-an-object" as unknown, defaultScope),
+      ).rejects.toThrow("vector_metadata.metadata_json must be a JSON object");
+    });
+
+    it("rejects invalid numeric vectors on write", async () => {
+      await expect(
+        dal.insertEmbedding("bad-vector", [1, Number.NaN], "model", undefined, defaultScope),
+      ).rejects.toThrow("vector_metadata.vector_data contains an invalid JSON value");
+    });
+
+    it("rejects metadata that serializes to the wrong JSON shape", async () => {
+      await expect(
+        dal.insertEmbedding(
+          "date-meta",
+          [1, 0],
+          "model",
+          new Date("2026-01-02T03:04:05.000Z"),
+          defaultScope,
+        ),
+      ).rejects.toThrow("vector_metadata.metadata_json must serialize to a JSON object");
     });
   });
 
@@ -195,6 +220,54 @@ describe("VectorDal", () => {
     it("returns empty when no embeddings exist", async () => {
       const items = await dal.list(defaultScope);
       expect(items).toHaveLength(0);
+    });
+
+    it("flags malformed persisted metadata and vector payloads while returning safe defaults", async () => {
+      const logger = { warn: vi.fn() };
+      const metrics = new MetricsRegistry();
+      const observedDal = new VectorDal(db, { logger, metrics });
+      const id = await observedDal.insertEmbedding(
+        "broken",
+        [1, 2],
+        "model",
+        undefined,
+        defaultScope,
+      );
+
+      await db.run(
+        "UPDATE vector_metadata SET metadata_json = ?, vector_data = ? WHERE tenant_id = ? AND embedding_id = ?",
+        ["{ not: json", '{"not":"an-array"}', defaultScope.tenantId, id],
+      );
+
+      const row = await observedDal.getById(id, defaultScope);
+      expect(row?.metadata).toEqual({});
+      expect(row?.vector).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "persisted_json.read_failed",
+        expect.objectContaining({
+          table: "vector_metadata",
+          column: "metadata_json",
+          reason: "invalid_json",
+        }),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        "persisted_json.read_failed",
+        expect.objectContaining({
+          table: "vector_metadata",
+          column: "vector_data",
+          reason: "unexpected_shape",
+        }),
+      );
+
+      const metricsText = await metrics.registry.getSingleMetricAsString(
+        "persisted_json_read_failures_total",
+      );
+      expect(metricsText).toContain(
+        'table="vector_metadata",column="metadata_json",reason="invalid_json"',
+      );
+      expect(metricsText).toContain(
+        'table="vector_metadata",column="vector_data",reason="unexpected_shape"',
+      );
     });
   });
 


### PR DESCRIPTION
Closes #977

## Summary
- add a shared persisted-JSON helper that records structured warnings and a Prometheus counter when persisted JSON is invalid, the wrong root shape, or contains invalid values
- route session list/direct reads, presence metadata reads, and vector metadata/vector payload reads through the shared parser so corruption stays visible instead of being silently healed
- harden the write paths we control so presence/vector JSON only persist expected shapes, with regression coverage for both read detection and write prevention

## Verification
- `pnpm exec vitest run packages/gateway/tests/unit/session-dal.test.ts packages/gateway/tests/unit/session-dal.postgres-list.test.ts packages/gateway/tests/unit/presence-dal.test.ts packages/gateway/tests/unit/vector-dal.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`