### PR TITLE
P1: Persist stable event_id values for key transitions (#1005)

### DIFF
--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -28,7 +28,7 @@ Approvals are durable records in the StateStore and should behave correctly when
 - **Any gateway edge instance can serve the approval queue** (read from the StateStore) and accept resolution requests.
 - **Atomic resolution:** apply `pending → approved|denied|expired` transitions in a single durable write so double-submission is safe.
 - **Durable side effects:** engine resume/cancel is driven by a leased, durable action queue so retries and multi-instance deployments do not duplicate side effects.
-- **At-least-once events:** `approval.requested` / `approval.resolved` events may be delivered more than once; clients should dedupe using event ids.
+- **At-least-once events:** `approval.requested` / `approval.resolved` events may be delivered more than once; clients should dedupe using event ids. Re-emission of the same `approval.resolved` transition reuses the persisted `event_id`.
 
 ## Interfaces
 

--- a/docs/architecture/policy-overrides.md
+++ b/docs/architecture/policy-overrides.md
@@ -113,7 +113,7 @@ Policy overrides are durable records separate from approvals. A minimal record s
 
 Overrides are first-class audit objects:
 
-- Creation emits `policy_override.created` with the durable `policy_override_id` and linkage fields.
+- Creation emits `policy_override.created` with the durable `policy_override_id` and linkage fields, and re-emission of the same creation reuses the persisted `event_id`.
 - Revocation emits `policy_override.revoked`.
 - Expiry emits `policy_override.expired`.
 

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -6,7 +6,7 @@ The wire shapes are defined by shared, versioned contracts (see [Contracts](../c
 
 ## Event envelope
 
-- `event_id`: unique id for dedupe.
+- `event_id`: unique id for dedupe. For `approval.resolved`, `pairing.resolved`, and `policy_override.created`, the gateway persists event identity so re-emission of the same transition reuses the same `event_id`.
 - `type`: event name (for example `run.updated`, `approval.requested`, `artifact.created`, `capability.ready`, `attempt.evidence`).
 - `occurred_at`: timestamp.
 - `scope`: routing scope (global, agent, session key/lane, run, node, or client).
@@ -103,12 +103,17 @@ This is the canonical list of `type` values and payload contracts for the v1 Web
 
 - Some gateway→peer interactions are modeled as **requests** (with responses) rather than events, for example `task.execute` and `approval.request`.
 - Events are **tenant-scoped**. The gateway delivers an event only to peers authenticated within the same `tenant_id`.
+- Stable event identity is currently persisted for:
+  - `approval.resolved` (per approval transition)
+  - `pairing.resolved` (per pairing transition/status)
+  - `policy_override.created` (per override)
 
 ## Delivery expectations
 
 - Events are delivered **at-least-once**. Consumers must tolerate duplicates and implement idempotent handling.
 - Consumers should tolerate **unknown `type` values** (forward-compat) and ignore events they don't recognize.
 - Deduplicate using `event_id` (and treat `occurred_at` as informational, not a strict ordering guarantee).
+- Re-emitting the same `approval.resolved`, `pairing.resolved`, or `policy_override.created` transition preserves the original `event_id`; other event types may still receive fresh ids when independently re-emitted.
 - Clients should tolerate reconnect and resubscribe without losing safety invariants; durable state in the StateStore remains the source of truth.
 
 ### Client SDK semantics

--- a/docs/architecture/protocol/requests-responses.md
+++ b/docs/architecture/protocol/requests-responses.md
@@ -59,4 +59,4 @@ Distributed systems lose packets and drop connections; retries are expected. Tyr
 
 - Resolution is an atomic state transition on the durable approval record (`pending → approved|denied|expired`).
 - Only the first successful transition enqueues a durable engine action (resume/cancel). Duplicate resolve attempts for an already-resolved approval do not enqueue additional actions.
-- `approval.resolved` is emitted once per approval transition, but delivery is still at-least-once; consumers should dedupe using `event_id`.
+- `approval.resolved` is emitted once per approval transition, and any re-emission of that same transition reuses the persisted `event_id`; delivery is still at-least-once, so consumers should dedupe using `event_id`.

--- a/packages/gateway/migrations/postgres/116_ws_events.sql
+++ b/packages/gateway/migrations/postgres/116_ws_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE ws_events (
+  tenant_id     UUID NOT NULL,
+  event_key     TEXT NOT NULL,
+  event_id      TEXT NOT NULL,
+  type          TEXT NOT NULL,
+  occurred_at   TIMESTAMPTZ NOT NULL,
+  payload_json  TEXT NOT NULL,
+  audience_json TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (tenant_id, event_key),
+  FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE,
+  UNIQUE (event_id)
+);

--- a/packages/gateway/migrations/sqlite/116_ws_events.sql
+++ b/packages/gateway/migrations/sqlite/116_ws_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE ws_events (
+  tenant_id     TEXT NOT NULL,
+  event_key     TEXT NOT NULL,
+  event_id      TEXT NOT NULL,
+  type          TEXT NOT NULL,
+  occurred_at   TEXT NOT NULL,
+  payload_json  TEXT NOT NULL,
+  audience_json TEXT,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, event_key),
+  FOREIGN KEY (tenant_id) REFERENCES tenants(tenant_id) ON DELETE CASCADE,
+  UNIQUE (event_id)
+);

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -51,6 +51,7 @@ import { AuthProfileDal } from "./modules/models/auth-profile-dal.js";
 import { SessionProviderPinDal } from "./modules/models/session-pin-dal.js";
 import { ConfiguredModelPresetDal } from "./modules/models/configured-model-preset-dal.js";
 import { ExecutionProfileModelAssignmentDal } from "./modules/models/execution-profile-model-assignment-dal.js";
+import { WsEventDal } from "./modules/ws-event/dal.js";
 import type { Playbook } from "@tyrum/schemas";
 import type { AgentRegistry } from "./modules/agent/registry.js";
 import type { AuthTokenService } from "./modules/auth/auth-token-service.js";
@@ -129,6 +130,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
   const configuredModelPresetDal = new ConfiguredModelPresetDal(container.db);
   const executionProfileModelAssignmentDal = new ExecutionProfileModelAssignmentDal(container.db);
   const routingConfigDal = new RoutingConfigDal(container.db);
+  const wsEventDal = new WsEventDal(container.db);
 
   const secretProviderForTenant = opts.secretProviderForTenant;
 
@@ -237,6 +239,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
     createPairingRoutes({
       logger: container.logger,
       nodePairingDal: container.nodePairingDal,
+      wsEventDal,
       ws: opts.connectionManager
         ? {
             connectionManager: opts.connectionManager,
@@ -266,6 +269,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
       logger: container.logger,
       policyService: container.policyService,
       policyOverrideDal: container.policyOverrideDal,
+      wsEventDal,
       ws: opts.connectionManager
         ? {
             connectionManager: opts.connectionManager,
@@ -387,6 +391,7 @@ export function createApp(container: GatewayContainer, opts: AppOptions = {}): H
       approvalDal: container.approvalDal,
       logger: container.logger,
       policyOverrideDal: container.policyOverrideDal,
+      wsEventDal,
       ws: opts.connectionManager
         ? {
             connectionManager: opts.connectionManager,

--- a/packages/gateway/src/bootstrap/runtime.ts
+++ b/packages/gateway/src/bootstrap/runtime.ts
@@ -40,6 +40,7 @@ import { createDbSecretProviderFactory } from "../modules/secret/create-secret-p
 import { StateStoreLifecycleScheduler } from "../modules/statestore/lifecycle.js";
 import { ensureSelfSignedTlsMaterial } from "../modules/tls/self-signed.js";
 import { WatcherScheduler } from "../modules/watcher/scheduler.js";
+import { WsEventDal } from "../modules/ws-event/dal.js";
 import { WorkSignalScheduler } from "../modules/workboard/signal-scheduler.js";
 import { createWsHandler } from "../routes/ws.js";
 import { isPostgresDbUri } from "../statestore/db-uri.js";
@@ -418,10 +419,12 @@ async function createProtocolRuntime(
       : undefined;
 
   const taskResults = new TaskResultRegistry();
+  const wsEventDal = new WsEventDal(context.container.db);
   const protocolDeps: ProtocolDeps = {
     connectionManager,
     logger: context.logger,
     db: context.container.db,
+    wsEventDal,
     redactionEngine: context.container.redactionEngine,
     memoryV1Dal: context.container.memoryV1Dal,
     artifactStore: context.container.artifactStore,

--- a/packages/gateway/src/modules/ws-event/dal.ts
+++ b/packages/gateway/src/modules/ws-event/dal.ts
@@ -1,0 +1,106 @@
+import type { WsEventEnvelope } from "@tyrum/schemas";
+import { randomUUID } from "node:crypto";
+import type { WsBroadcastAudience } from "../../ws/audience.js";
+import type { SqlDb } from "../../statestore/types.js";
+
+interface RawWsEventRow {
+  tenant_id: string;
+  event_key: string;
+  event_id: string;
+  type: string;
+  occurred_at: string | Date;
+  payload_json: string;
+  audience_json: string | null;
+}
+
+export interface PersistedWsEvent {
+  event: WsEventEnvelope;
+  audience?: WsBroadcastAudience;
+}
+
+function normalizeTime(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function parseJson<T>(raw: string | null): T | undefined {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    // Intentional: treat invalid JSON columns as absent and preserve the event envelope.
+    return undefined;
+  }
+}
+
+function toPersistedWsEvent(row: RawWsEventRow): PersistedWsEvent {
+  return {
+    event: {
+      event_id: row.event_id,
+      type: row.type as WsEventEnvelope["type"],
+      occurred_at: normalizeTime(row.occurred_at),
+      payload: parseJson<unknown>(row.payload_json) ?? {},
+    },
+    audience: parseJson<WsBroadcastAudience>(row.audience_json),
+  };
+}
+
+export class WsEventDal {
+  constructor(private readonly db: SqlDb) {}
+
+  async ensureEvent(input: {
+    tenantId: string;
+    eventKey: string;
+    type: WsEventEnvelope["type"];
+    occurredAt: string;
+    payload: unknown;
+    audience?: WsBroadcastAudience;
+  }): Promise<PersistedWsEvent> {
+    const tenantId = input.tenantId.trim();
+    const eventKey = input.eventKey.trim();
+    if (tenantId.length === 0) {
+      throw new Error("tenantId is required");
+    }
+    if (eventKey.length === 0) {
+      throw new Error("eventKey is required");
+    }
+
+    return await this.db.transaction(async (tx) => {
+      const inserted = await tx.get<RawWsEventRow>(
+        `INSERT INTO ws_events (
+           tenant_id,
+           event_key,
+           event_id,
+           type,
+           occurred_at,
+           payload_json,
+           audience_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (tenant_id, event_key) DO NOTHING
+         RETURNING *`,
+        [
+          tenantId,
+          eventKey,
+          randomUUID(),
+          input.type,
+          input.occurredAt,
+          JSON.stringify(input.payload ?? {}),
+          input.audience ? JSON.stringify(input.audience) : null,
+        ],
+      );
+      if (inserted) {
+        return toPersistedWsEvent(inserted);
+      }
+
+      const existing = await tx.get<RawWsEventRow>(
+        `SELECT tenant_id, event_key, event_id, type, occurred_at, payload_json, audience_json
+         FROM ws_events
+         WHERE tenant_id = ? AND event_key = ?`,
+        [tenantId, eventKey],
+      );
+      if (!existing) {
+        throw new Error("failed to persist ws event");
+      }
+      return toPersistedWsEvent(existing);
+    });
+  }
+}

--- a/packages/gateway/src/routes/approval.ts
+++ b/packages/gateway/src/routes/approval.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import type { ApprovalDal, ApprovalStatus } from "../modules/approval/dal.js";
 import type { PolicyOverrideDal } from "../modules/policy/override-dal.js";
 import type { Logger } from "../modules/observability/logger.js";
+import type { WsEventDal } from "../modules/ws-event/dal.js";
 import type { ConnectionManager } from "../ws/connection-manager.js";
 import type { OutboxDal } from "../modules/backplane/outbox-dal.js";
 import type { WsEventEnvelope } from "@tyrum/schemas";
@@ -18,6 +19,10 @@ import { isSafeSuggestedOverridePattern } from "../modules/policy/override-guard
 import { getClientIp } from "../modules/auth/client-ip.js";
 import { requireTenantId } from "../modules/auth/claims.js";
 import { broadcastWsEvent } from "../ws/broadcast.js";
+import {
+  ensureApprovalResolvedEvent,
+  ensurePolicyOverrideCreatedEvent,
+} from "../ws/stable-events.js";
 
 const VALID_STATUSES = new Set<ApprovalStatus>([
   "pending",
@@ -31,6 +36,7 @@ export interface ApprovalRouteDeps {
   approvalDal: ApprovalDal;
   logger?: Logger;
   policyOverrideDal?: PolicyOverrideDal;
+  wsEventDal?: WsEventDal;
   ws?: {
     connectionManager: ConnectionManager;
     maxBufferedBytes?: number;
@@ -300,25 +306,23 @@ export function createApprovalRoutes(deps: ApprovalRouteDeps): Hono {
         });
         createdOverrides.push(row);
 
-        const evt: WsEventEnvelope = {
-          event_id: crypto.randomUUID(),
-          type: "policy_override.created",
-          occurred_at: new Date().toISOString(),
-          payload: { override: row },
-        };
-        emitEvent(deps, tenantId, evt);
+        const persistedEvent = await ensurePolicyOverrideCreatedEvent({
+          tenantId,
+          override: row,
+          wsEventDal: deps.wsEventDal,
+        });
+        emitEvent(deps, tenantId, persistedEvent.event);
       }
     }
 
     const contract = toApprovalContract(updated);
     if (contract && transitioned) {
-      const approvalResolvedEvt: WsEventEnvelope = {
-        event_id: crypto.randomUUID(),
-        type: "approval.resolved",
-        occurred_at: new Date().toISOString(),
-        payload: { approval: contract },
-      };
-      emitEvent(deps, tenantId, approvalResolvedEvt);
+      const approvalResolvedEvt = await ensureApprovalResolvedEvent({
+        tenantId,
+        approval: contract,
+        wsEventDal: deps.wsEventDal,
+      });
+      emitEvent(deps, tenantId, approvalResolvedEvt.event);
     }
 
     return c.json({

--- a/packages/gateway/src/routes/pairing.ts
+++ b/packages/gateway/src/routes/pairing.ts
@@ -5,6 +5,7 @@
 import { Hono } from "hono";
 import type { NodePairingDal } from "../modules/node/pairing-dal.js";
 import type { Logger } from "../modules/observability/logger.js";
+import type { WsEventDal } from "../modules/ws-event/dal.js";
 import type { ConnectionManager } from "../ws/connection-manager.js";
 import type { OutboxDal } from "../modules/backplane/outbox-dal.js";
 import type { ConnectionDirectoryDal } from "../modules/backplane/connection-directory.js";
@@ -13,10 +14,12 @@ import { broadcastWsEvent } from "../ws/broadcast.js";
 import { CapabilityDescriptor, NodePairingTrustLevel, type WsEventEnvelope } from "@tyrum/schemas";
 import { getClientIp } from "../modules/auth/client-ip.js";
 import { requireTenantId } from "../modules/auth/claims.js";
+import { ensurePairingResolvedEvent } from "../ws/stable-events.js";
 
 export interface PairingRouteDeps {
   nodePairingDal: NodePairingDal;
   logger?: Logger;
+  wsEventDal?: WsEventDal;
   ws?: {
     connectionManager: ConnectionManager;
     maxBufferedBytes?: number;
@@ -114,12 +117,12 @@ export function createPairingRoutes(deps: PairingRouteDeps): Hono {
       });
     }
 
-    emitEvent(deps, tenantId, {
-      event_id: crypto.randomUUID(),
-      type: "pairing.resolved",
-      occurred_at: new Date().toISOString(),
-      payload: { pairing },
+    const persistedEvent = await ensurePairingResolvedEvent({
+      tenantId,
+      pairing,
+      wsEventDal: deps.wsEventDal,
     });
+    emitEvent(deps, tenantId, persistedEvent.event);
 
     return c.json({ status: "ok", pairing });
   });
@@ -148,12 +151,12 @@ export function createPairingRoutes(deps: PairingRouteDeps): Hono {
     }
     const { pairing } = resolved;
 
-    emitEvent(deps, tenantId, {
-      event_id: crypto.randomUUID(),
-      type: "pairing.resolved",
-      occurred_at: new Date().toISOString(),
-      payload: { pairing },
+    const persistedEvent = await ensurePairingResolvedEvent({
+      tenantId,
+      pairing,
+      wsEventDal: deps.wsEventDal,
     });
+    emitEvent(deps, tenantId, persistedEvent.event);
 
     return c.json({ status: "ok", pairing });
   });
@@ -180,12 +183,12 @@ export function createPairingRoutes(deps: PairingRouteDeps): Hono {
       return c.json({ error: "not_found", message: "pairing not found or not approved" }, 404);
     }
 
-    emitEvent(deps, tenantId, {
-      event_id: crypto.randomUUID(),
-      type: "pairing.resolved",
-      occurred_at: new Date().toISOString(),
-      payload: { pairing },
+    const persistedEvent = await ensurePairingResolvedEvent({
+      tenantId,
+      pairing,
+      wsEventDal: deps.wsEventDal,
     });
+    emitEvent(deps, tenantId, persistedEvent.event);
 
     return c.json({ status: "ok", pairing });
   });

--- a/packages/gateway/src/routes/policy-bundle.ts
+++ b/packages/gateway/src/routes/policy-bundle.ts
@@ -20,15 +20,18 @@ import type { OutboxDal } from "../modules/backplane/outbox-dal.js";
 import type { Logger } from "../modules/observability/logger.js";
 import type { PolicyOverrideDal } from "../modules/policy/override-dal.js";
 import type { PolicyService } from "../modules/policy/service.js";
+import type { WsEventDal } from "../modules/ws-event/dal.js";
 import { getClientIp } from "../modules/auth/client-ip.js";
 import { requireTenantId } from "../modules/auth/claims.js";
 import { broadcastWsEvent } from "../ws/broadcast.js";
 import type { WsBroadcastAudience } from "../ws/audience.js";
+import { ensurePolicyOverrideCreatedEvent } from "../ws/stable-events.js";
 
 export interface PolicyBundleRouteDeps {
   logger?: Logger;
   policyService: PolicyService;
   policyOverrideDal: PolicyOverrideDal;
+  wsEventDal?: WsEventDal;
   ws?: {
     connectionManager: ConnectionManager;
     maxBufferedBytes?: number;
@@ -44,10 +47,15 @@ const POLICY_WS_AUDIENCE: WsBroadcastAudience = {
   required_scopes: ["operator.admin"],
 };
 
-function emitEvent(deps: PolicyBundleRouteDeps, tenantId: string, evt: WsEventEnvelope): void {
+function emitEvent(
+  deps: PolicyBundleRouteDeps,
+  tenantId: string,
+  evt: WsEventEnvelope,
+  audience?: WsBroadcastAudience,
+): void {
   const ws = deps.ws;
   if (!ws) return;
-  broadcastWsEvent(tenantId, evt, { ...ws, logger: deps.logger }, POLICY_WS_AUDIENCE);
+  broadcastWsEvent(tenantId, evt, { ...ws, logger: deps.logger }, audience ?? POLICY_WS_AUDIENCE);
 }
 
 export function createPolicyBundleRoutes(deps: PolicyBundleRouteDeps): Hono {
@@ -118,13 +126,13 @@ export function createPolicyBundleRoutes(deps: PolicyBundleRouteDeps): Hono {
       expiresAt: parsed.data.expires_at ?? null,
     });
 
-    const evt: WsEventEnvelope = {
-      event_id: crypto.randomUUID(),
-      type: "policy_override.created",
-      occurred_at: new Date().toISOString(),
-      payload: { override: row },
-    };
-    emitEvent(deps, tenantId, evt);
+    const persistedEvent = await ensurePolicyOverrideCreatedEvent({
+      tenantId,
+      override: row,
+      audience: POLICY_WS_AUDIENCE,
+      wsEventDal: deps.wsEventDal,
+    });
+    emitEvent(deps, tenantId, persistedEvent.event, persistedEvent.audience);
 
     const res = PolicyOverrideCreateResponse.parse({ override: row });
     return c.json(res, 201);

--- a/packages/gateway/src/statestore/json-columns.json
+++ b/packages/gateway/src/statestore/json-columns.json
@@ -565,5 +565,19 @@
     "shape": "any",
     "nullable": false,
     "default": null
+  },
+  {
+    "table": "ws_events",
+    "column": "audience_json",
+    "shape": "object",
+    "nullable": true,
+    "default": null
+  },
+  {
+    "table": "ws_events",
+    "column": "payload_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
   }
 ]

--- a/packages/gateway/src/ws/protocol/approval-handlers.ts
+++ b/packages/gateway/src/ws/protocol/approval-handlers.ts
@@ -11,6 +11,7 @@ import type { ApprovalRow } from "../../modules/approval/dal.js";
 import { toApprovalContract } from "../../modules/approval/to-contract.js";
 import { isSafeSuggestedOverridePattern } from "../../modules/policy/override-guardrails.js";
 import type { ConnectedClient } from "../connection-manager.js";
+import { ensureApprovalResolvedEvent, ensurePolicyOverrideCreatedEvent } from "../stable-events.js";
 import { broadcastEvent, errorResponse } from "./helpers.js";
 import type { ProtocolDeps, ProtocolRequestEnvelope } from "./types.js";
 
@@ -267,16 +268,12 @@ async function finalizeApprovalResolve(params: {
   const result = buildApprovalResolveResult(approval, createdOverrides);
 
   if (transitioned) {
-    broadcastEvent(
+    const persistedEvent = await ensureApprovalResolvedEvent({
       tenantId,
-      {
-        event_id: crypto.randomUUID(),
-        type: "approval.resolved",
-        occurred_at: new Date().toISOString(),
-        payload: { approval },
-      },
-      deps,
-    );
+      approval,
+      wsEventDal: deps.wsEventDal,
+    });
+    broadcastEvent(tenantId, persistedEvent.event, deps, persistedEvent.audience);
   }
   return { request_id: msg.request_id, type: msg.type, ok: true, result };
 }
@@ -442,16 +439,12 @@ async function createPolicyOverrides(params: {
       createdFromPolicySnapshotId: createOverrideContext.policySnapshotId,
     });
     createdOverrides.push(row);
-    broadcastEvent(
+    const persistedEvent = await ensurePolicyOverrideCreatedEvent({
       tenantId,
-      {
-        event_id: crypto.randomUUID(),
-        type: "policy_override.created",
-        occurred_at: new Date().toISOString(),
-        payload: { override: row },
-      },
-      deps,
-    );
+      override: row,
+      wsEventDal: deps.wsEventDal,
+    });
+    broadcastEvent(tenantId, persistedEvent.event, deps, persistedEvent.audience);
   }
 
   return createdOverrides;

--- a/packages/gateway/src/ws/protocol/node-handlers.ts
+++ b/packages/gateway/src/ws/protocol/node-handlers.ts
@@ -13,6 +13,7 @@ import type {
 } from "@tyrum/schemas";
 import { emitPairingApprovedEvent } from "../pairing-approved.js";
 import type { ConnectedClient } from "../connection-manager.js";
+import { ensurePairingResolvedEvent } from "../stable-events.js";
 import { broadcastEvent, errorResponse } from "./helpers.js";
 import {
   handleAttemptEvidenceMessage,
@@ -93,16 +94,12 @@ async function handlePairingMessage(
     });
   }
 
-  broadcastEvent(
+  const persistedEvent = await ensurePairingResolvedEvent({
     tenantId,
-    {
-      event_id: crypto.randomUUID(),
-      type: "pairing.resolved",
-      occurred_at: new Date().toISOString(),
-      payload: { pairing: resolved.pairing },
-    },
-    deps,
-  );
+    pairing: resolved.pairing,
+    wsEventDal: deps.wsEventDal,
+  });
+  broadcastEvent(tenantId, persistedEvent.event, deps, persistedEvent.audience);
   const result = WsPairingResolveResult.parse({ pairing: resolved.pairing });
   return { request_id: msg.request_id, type: msg.type, ok: true, result };
 }

--- a/packages/gateway/src/ws/protocol/types.ts
+++ b/packages/gateway/src/ws/protocol/types.ts
@@ -19,6 +19,7 @@ import type { AuthAudit } from "../../modules/auth/audit.js";
 import type { MemoryV1Dal } from "../../modules/memory/v1-dal.js";
 import type { ArtifactStore } from "../../modules/artifact/store.js";
 import type { RedactionEngine } from "../../modules/redaction/engine.js";
+import type { WsEventDal } from "../../modules/ws-event/dal.js";
 import type { TaskResultRegistry } from "./task-result-registry.js";
 import type { AgentConfig, WsMessageEnvelope } from "@tyrum/schemas";
 import type { IdentityScopeDal } from "../../modules/identity/scope.js";
@@ -43,6 +44,7 @@ export interface ProtocolDeps {
   logger?: Logger;
   authAudit?: AuthAudit;
   db?: SqlDb;
+  wsEventDal?: WsEventDal;
   identityScopeDal?: IdentityScopeDal;
   redactionEngine?: RedactionEngine;
   memoryV1Dal?: MemoryV1Dal;

--- a/packages/gateway/src/ws/stable-events.ts
+++ b/packages/gateway/src/ws/stable-events.ts
@@ -1,0 +1,87 @@
+import type { Approval, NodePairingRequest, PolicyOverride, WsEventEnvelope } from "@tyrum/schemas";
+import { randomUUID } from "node:crypto";
+import type { PersistedWsEvent, WsEventDal } from "../modules/ws-event/dal.js";
+import type { WsBroadcastAudience } from "./audience.js";
+
+async function ensureStableWsEvent(input: {
+  tenantId: string;
+  eventKey: string;
+  type: WsEventEnvelope["type"];
+  occurredAt: string;
+  payload: unknown;
+  audience?: WsBroadcastAudience;
+  wsEventDal?: WsEventDal;
+}): Promise<PersistedWsEvent> {
+  if (!input.wsEventDal) {
+    return {
+      event: {
+        event_id: randomUUID(),
+        type: input.type,
+        occurred_at: input.occurredAt,
+        payload: input.payload,
+      },
+      audience: input.audience,
+    };
+  }
+
+  return await input.wsEventDal.ensureEvent({
+    tenantId: input.tenantId,
+    eventKey: input.eventKey,
+    type: input.type,
+    occurredAt: input.occurredAt,
+    payload: input.payload,
+    audience: input.audience,
+  });
+}
+
+export async function ensureApprovalResolvedEvent(input: {
+  tenantId: string;
+  approval: Approval;
+  wsEventDal?: WsEventDal;
+}): Promise<PersistedWsEvent> {
+  return await ensureStableWsEvent({
+    tenantId: input.tenantId,
+    eventKey: `approval.resolved:${input.approval.approval_id}:${input.approval.status}`,
+    type: "approval.resolved",
+    occurredAt: input.approval.resolution?.resolved_at ?? input.approval.created_at,
+    payload: { approval: input.approval },
+    wsEventDal: input.wsEventDal,
+  });
+}
+
+export async function ensurePairingResolvedEvent(input: {
+  tenantId: string;
+  pairing: NodePairingRequest;
+  wsEventDal?: WsEventDal;
+}): Promise<PersistedWsEvent> {
+  return await ensureStableWsEvent({
+    tenantId: input.tenantId,
+    // Pairings can later transition from approved to revoked; include the terminal status
+    // so retries reuse the same id without collapsing distinct transitions.
+    eventKey: `pairing.resolved:${String(input.pairing.pairing_id)}:${input.pairing.status}`,
+    type: "pairing.resolved",
+    occurredAt:
+      input.pairing.resolution?.resolved_at ??
+      input.pairing.resolved_at ??
+      input.pairing.requested_at,
+    payload: { pairing: input.pairing },
+    wsEventDal: input.wsEventDal,
+  });
+}
+
+export async function ensurePolicyOverrideCreatedEvent(input: {
+  tenantId: string;
+  override: PolicyOverride;
+  audience?: WsBroadcastAudience;
+  wsEventDal?: WsEventDal;
+}): Promise<PersistedWsEvent> {
+  return await ensureStableWsEvent({
+    tenantId: input.tenantId,
+    eventKey: `policy_override.created:${input.override.policy_override_id}`,
+    type: "policy_override.created",
+    occurredAt: input.override.created_at,
+    payload: { override: input.override },
+    audience: input.audience,
+    wsEventDal: input.wsEventDal,
+  });
+}

--- a/packages/gateway/tests/contract/schema-contract.test.ts
+++ b/packages/gateway/tests/contract/schema-contract.test.ts
@@ -42,6 +42,7 @@ describe("StateStore schema contract (sqlite vs postgres)", () => {
         "canvas_artifacts",
         "outbox",
         "outbox_consumers",
+        "ws_events",
         "connections",
         "presence_entries",
         "node_pairings",

--- a/packages/gateway/tests/integration/stable-ws-events.test.ts
+++ b/packages/gateway/tests/integration/stable-ws-events.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { SqliteDb } from "../../src/statestore/sqlite.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { ApprovalDal } from "../../src/modules/approval/dal.js";
+import { toApprovalContract } from "../../src/modules/approval/to-contract.js";
+import { NodePairingDal } from "../../src/modules/node/pairing-dal.js";
+import { PolicyOverrideDal } from "../../src/modules/policy/override-dal.js";
+import { WsEventDal } from "../../src/modules/ws-event/dal.js";
+import {
+  ensureApprovalResolvedEvent,
+  ensurePairingResolvedEvent,
+  ensurePolicyOverrideCreatedEvent,
+} from "../../src/ws/stable-events.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+} from "../../src/modules/identity/scope.js";
+import { OutboxDal } from "../../src/modules/backplane/outbox-dal.js";
+import { broadcastWsEvent } from "../../src/ws/broadcast.js";
+import { ConnectionManager } from "../../src/ws/connection-manager.js";
+
+const POLICY_AUDIENCE = {
+  roles: ["client"],
+  required_scopes: ["operator.admin"],
+} as const;
+
+describe("stable ws event builders", () => {
+  let db: SqliteDb | undefined;
+
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  it("reuses the persisted event_id for approval.resolved re-emission", async () => {
+    db = openTestSqliteDb();
+    const approvalDal = new ApprovalDal(db);
+    const wsEventDal = new WsEventDal(db);
+
+    const created = await approvalDal.create({
+      tenantId: DEFAULT_TENANT_ID,
+      agentId: DEFAULT_AGENT_ID,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      approvalKey: "stable-approval-event",
+      prompt: "Approve stable event id?",
+    });
+    const resolved = await approvalDal.respondWithTransition({
+      tenantId: DEFAULT_TENANT_ID,
+      approvalId: created.approval_id,
+      decision: "approved",
+      resolvedBy: { kind: "test" },
+    });
+    if (!resolved) {
+      throw new Error("expected approval resolution");
+    }
+
+    const approval = toApprovalContract(resolved.row);
+    if (!approval) {
+      throw new Error("expected approval contract");
+    }
+
+    const first = await ensureApprovalResolvedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      approval,
+      wsEventDal,
+    });
+    const second = await ensureApprovalResolvedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      approval,
+      wsEventDal,
+    });
+
+    expect(second.event.event_id).toBe(first.event.event_id);
+    expect(second.event.occurred_at).toBe(first.event.occurred_at);
+  });
+
+  it("reuses the persisted event_id for the same pairing transition and changes it for revoke", async () => {
+    db = openTestSqliteDb();
+    const nodePairingDal = new NodePairingDal(db);
+    const wsEventDal = new WsEventDal(db);
+
+    const pending = await nodePairingDal.upsertOnConnect({
+      tenantId: DEFAULT_TENANT_ID,
+      nodeId: "node-stable-event",
+      pubkey: "pubkey-stable-event",
+      label: "node-stable-event",
+      capabilities: ["cli"],
+      nowIso: "2026-03-06T12:00:00.000Z",
+    });
+    const approved = await nodePairingDal.resolve({
+      tenantId: DEFAULT_TENANT_ID,
+      pairingId: pending.pairing_id,
+      decision: "approved",
+      reason: "allow",
+      resolvedBy: { kind: "test" },
+      trustLevel: "remote",
+      capabilityAllowlist: [],
+    });
+    if (!approved) {
+      throw new Error("expected pairing approval");
+    }
+
+    const firstApproved = await ensurePairingResolvedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      pairing: approved.pairing,
+      wsEventDal,
+    });
+    const secondApproved = await ensurePairingResolvedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      pairing: approved.pairing,
+      wsEventDal,
+    });
+
+    expect(secondApproved.event.event_id).toBe(firstApproved.event.event_id);
+
+    const revoked = await nodePairingDal.revoke({
+      tenantId: DEFAULT_TENANT_ID,
+      pairingId: pending.pairing_id,
+      reason: "revoke",
+      resolvedBy: { kind: "test" },
+    });
+    if (!revoked) {
+      throw new Error("expected pairing revoke");
+    }
+
+    const revokedEvent = await ensurePairingResolvedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      pairing: revoked,
+      wsEventDal,
+    });
+
+    expect(revokedEvent.event.event_id).not.toBe(firstApproved.event.event_id);
+  });
+
+  it("reuses the persisted event_id and audience for policy_override.created and preserves it in the outbox", async () => {
+    db = openTestSqliteDb();
+    const policyOverrideDal = new PolicyOverrideDal(db);
+    const wsEventDal = new WsEventDal(db);
+    const outboxDal = new OutboxDal(db);
+
+    const override = await policyOverrideDal.create({
+      tenantId: DEFAULT_TENANT_ID,
+      agentId: DEFAULT_AGENT_ID,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      toolId: "tool.exec",
+      pattern: "echo stable event",
+      createdBy: { kind: "test" },
+    });
+
+    const first = await ensurePolicyOverrideCreatedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      override,
+      audience: POLICY_AUDIENCE,
+      wsEventDal,
+    });
+    const second = await ensurePolicyOverrideCreatedEvent({
+      tenantId: DEFAULT_TENANT_ID,
+      override,
+      audience: { roles: ["node"] },
+      wsEventDal,
+    });
+
+    expect(second.event.event_id).toBe(first.event.event_id);
+    expect(second.audience).toEqual(POLICY_AUDIENCE);
+
+    broadcastWsEvent(
+      DEFAULT_TENANT_ID,
+      first.event,
+      {
+        connectionManager: new ConnectionManager(),
+        cluster: {
+          edgeId: "edge-a",
+          outboxDal,
+        },
+      },
+      first.audience,
+    );
+
+    let outboxRows = await outboxDal.poll(DEFAULT_TENANT_ID, "edge-b");
+    for (let attempt = 0; outboxRows.length === 0 && attempt < 5; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      outboxRows = await outboxDal.poll(DEFAULT_TENANT_ID, "edge-b");
+    }
+
+    expect(outboxRows).toHaveLength(1);
+    expect(outboxRows[0]?.payload).toEqual(
+      expect.objectContaining({
+        audience: POLICY_AUDIENCE,
+        message: expect.objectContaining({
+          event_id: first.event.event_id,
+          type: "policy_override.created",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/gateway/tests/unit/ws-event-dal.test.ts
+++ b/packages/gateway/tests/unit/ws-event-dal.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { WsEventDal } from "../../src/modules/ws-event/dal.js";
+import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { openTestPostgresDb } from "../helpers/postgres-db.js";
+import type { SqlDb } from "../../src/statestore/types.js";
+
+const TEST_TENANT_ID = DEFAULT_TENANT_ID;
+const EVENT_KEY = "approval.resolved:approval-1:approved";
+const EVENT_AUDIENCE = {
+  roles: ["client"],
+  required_scopes: ["operator.admin"],
+} as const;
+
+const DB_CASES: Array<{
+  name: string;
+  open: () => Promise<{ db: SqlDb; close: () => Promise<void> }>;
+}> = [
+  {
+    name: "sqlite",
+    open: async () => {
+      const db = openTestSqliteDb();
+      return {
+        db,
+        close: async () => {
+          await db.close();
+        },
+      };
+    },
+  },
+  {
+    name: "postgres",
+    open: openTestPostgresDb,
+  },
+];
+
+for (const testCase of DB_CASES) {
+  describe(`WsEventDal (${testCase.name})`, () => {
+    it("returns the first persisted event for duplicate event keys", async () => {
+      const opened = await testCase.open();
+      try {
+        const dal = new WsEventDal(opened.db);
+
+        const first = await dal.ensureEvent({
+          tenantId: TEST_TENANT_ID,
+          eventKey: EVENT_KEY,
+          type: "approval.resolved",
+          occurredAt: "2026-03-06T12:00:00.000Z",
+          payload: { approval_id: "approval-1", status: "approved" },
+          audience: EVENT_AUDIENCE,
+        });
+        const second = await dal.ensureEvent({
+          tenantId: TEST_TENANT_ID,
+          eventKey: EVENT_KEY,
+          type: "approval.resolved",
+          occurredAt: "2026-03-06T12:05:00.000Z",
+          payload: { approval_id: "approval-1", status: "approved", duplicate: true },
+          audience: { roles: ["node"] },
+        });
+
+        expect(second).toEqual(first);
+        expect(second.event.event_id).toBe(first.event.event_id);
+        expect(second.event.occurred_at).toBe("2026-03-06T12:00:00.000Z");
+        expect(second.event.payload).toEqual({ approval_id: "approval-1", status: "approved" });
+        expect(second.audience).toEqual(EVENT_AUDIENCE);
+      } finally {
+        await opened.close();
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #1005

## Summary
- persist stable WebSocket event records for `approval.resolved`, `pairing.resolved`, and `policy_override.created`
- reuse the persisted event helper across HTTP and WebSocket emit paths so retries keep the same `event_id`
- add schema metadata, migrations, regression tests, and architecture docs for the new event storage path

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm format:check`
- `pnpm exec vitest run packages/gateway/tests/unit/ws-event-dal.test.ts`
- `pnpm exec vitest run packages/gateway/tests/integration/stable-ws-events.test.ts`
- `pnpm exec vitest run packages/gateway/tests/unit/approval-resolve-idempotency.test.ts packages/gateway/tests/integration/pairing-routes.test.ts packages/gateway/tests/integration/approval.test.ts packages/gateway/tests/unit/policy-override-expiry-events.test.ts packages/gateway/tests/contract/schema-contract.test.ts`
- `pnpm exec vitest run packages/gateway/tests/unit/ws-protocol.test.ts`
- `pnpm exec vitest run packages/gateway/tests/integration/ws-handler.test.ts`
- `pnpm exec vitest run packages/gateway/tests/contract/json-column-specs.test.ts`
