### PR TITLE
docs: link missing architecture pages in sidebar

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -57,6 +57,12 @@ const sidebars: SidebarsConfig = {
           items: [
             "architecture/gateway/index",
             "architecture/gateway/statestore-dialects",
+            "architecture/gateway/postgres-json-fields",
+            "architecture/data-model-map",
+            "architecture/data-model-fk-audit",
+            "architecture/db-naming-conventions",
+            "architecture/db-enum-constraints",
+            "architecture/db-json-hygiene",
             "architecture/client",
             "architecture/node",
           ],
@@ -124,6 +130,7 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "Operations & Observability",
           items: [
+            "architecture/operational-maintenance",
             "architecture/observability",
             "architecture/index-tuning",
             "architecture/presence",


### PR DESCRIPTION
## Summary
- add the missing `docs/architecture` pages to the docs sidebar
- place gateway/data-model references under Runtime Components
- add operational table maintenance under Operations & Observability

## Testing
- pnpm --filter @tyrum/docs build
- repository pre-push checks (lint, dependent package builds, tsc -b)
- direct script check confirming all 53 architecture docs are referenced in `apps/docs/sidebars.ts`