### PR TITLE
Fix add-provider display name sync

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-providers.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-providers.tsx
@@ -373,21 +373,26 @@ function ProviderAccountDialog({
               const nextProvider = supportedProviders.find(
                 (provider) => provider.provider_key === event.currentTarget.value,
               );
-              setState((current) => ({
-                providerKey: nextProvider?.provider_key ?? "",
-                methodKey: nextProvider?.methods[0]?.method_key ?? "",
-                displayName: syncDisplayNameOnProviderChange({
-                  currentDisplayName: current.displayName,
-                  currentProviderName: selectedProvider?.name,
-                  nextProviderName: nextProvider?.name,
-                }),
-                configValues: Object.fromEntries(
-                  (nextProvider?.methods[0]?.fields ?? [])
-                    .filter((field) => field.kind === "config" && field.input === "boolean")
-                    .map((field) => [field.key, false]),
-                ),
-                secretValues: {},
-              }));
+              setState((current) => {
+                const currentProviderName = supportedProviders.find(
+                  (provider) => provider.provider_key === current.providerKey,
+                )?.name;
+                return {
+                  providerKey: nextProvider?.provider_key ?? "",
+                  methodKey: nextProvider?.methods[0]?.method_key ?? "",
+                  displayName: syncDisplayNameOnProviderChange({
+                    currentDisplayName: current.displayName,
+                    currentProviderName,
+                    nextProviderName: nextProvider?.name,
+                  }),
+                  configValues: Object.fromEntries(
+                    (nextProvider?.methods[0]?.fields ?? [])
+                      .filter((field) => field.kind === "config" && field.input === "boolean")
+                      .map((field) => [field.key, false]),
+                  ),
+                  secretValues: {},
+                };
+              });
             }}
             helperText={
               state.providerKey && configuredCounts.get(state.providerKey)

--- a/packages/operator-ui/tests/pages/admin-http-providers.test.ts
+++ b/packages/operator-ui/tests/pages/admin-http-providers.test.ts
@@ -22,6 +22,14 @@ function setSelectValue(select: HTMLSelectElement, value: string): void {
   });
 }
 
+function setSelectValueWithoutAct(select: HTMLSelectElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set as
+    | ((this: HTMLSelectElement, value: string) => void)
+    | undefined;
+  setter?.call(select, value);
+  select.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 function findLabeledInput(root: ParentNode, labelPrefix: string): HTMLInputElement | null {
   const label = Array.from(root.querySelectorAll<HTMLLabelElement>("label")).find((candidate) =>
     candidate.textContent?.trim().startsWith(labelPrefix),
@@ -247,6 +255,49 @@ describe("AdminHttpProvidersPanel", () => {
     setSelectValue(providerSelect!, "anthropic");
 
     expect(displayNameInput?.value).toBe("Team account");
+
+    cleanupTestRoot({ container, root });
+  });
+
+  it("keeps the auto-filled display name aligned during rapid provider changes", async () => {
+    const { core } = createTestCore();
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(
+        ElevatedModeProvider,
+        { core, mode: "web" },
+        React.createElement(AdminHttpProvidersPanel, { core }),
+      ),
+    );
+
+    await flush();
+
+    const addButton = container.querySelector<HTMLButtonElement>(
+      "[data-testid='providers-add-open']",
+    );
+    expect(addButton).not.toBeNull();
+    act(() => {
+      addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const dialog = document.body.querySelector<HTMLElement>(
+      "[data-testid='providers-account-dialog']",
+    );
+    expect(dialog).not.toBeNull();
+
+    const providerSelect = findLabeledSelect(dialog!, "Provider");
+    const displayNameInput = findLabeledInput(dialog!, "Display name");
+    expect(providerSelect).not.toBeNull();
+    expect(displayNameInput).not.toBeNull();
+    expect(displayNameInput?.value).toBe("OpenAI");
+
+    act(() => {
+      setSelectValueWithoutAct(providerSelect!, "anthropic");
+      setSelectValueWithoutAct(providerSelect!, "openai");
+    });
+
+    expect(providerSelect?.value).toBe("openai");
+    expect(displayNameInput?.value).toBe("OpenAI");
 
     cleanupTestRoot({ container, root });
   });


### PR DESCRIPTION
Closes #1106\n\n## What\n- sync the add-provider dialog display name when the selected provider changes\n- preserve manually entered display names instead of overwriting user edits\n- add regression coverage for both the default-sync and custom-name cases\n\n## How to test\n- pnpm test packages/operator-ui/tests/pages/admin-http-providers.test.ts\n- pnpm typecheck\n- pnpm lint\n- git push -u origin 1106-fix-provider-display-name-sync (pre-push hook passed)\n\n## Risk\nLow. This is a local operator UI form-state change in the add-provider dialog only.\n\n## Rollback\nRevert commit 087f96f5.