### PR TITLE
P3: Require tyrum-v1 WS subprotocol (#1011)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -992,7 +992,8 @@ When gateway auth is enabled, the `/ws` upgrade requires a valid token, provided
 - `Authorization: Bearer <token>` header
 - Cookie `tyrum_admin_token=<token>` (same-origin upgrades only)
 - `Sec-WebSocket-Protocol` token transport:
-  - Offer subprotocols including `tyrum-v1` and `tyrum-auth.<base64url(token)>`
+  - Every client MUST offer `tyrum-v1`
+  - Clients using subprotocol token transport additionally offer `tyrum-auth.<base64url(token)>`
 
 ### Handshake (connect.init / connect.proof)
 

--- a/docs/architecture/protocol/handshake.md
+++ b/docs/architecture/protocol/handshake.md
@@ -67,7 +67,8 @@ Tokens MUST NOT be placed in URLs.
 
 ### Subprotocol fallback
 
-When using the fallback, the token is conveyed in the `Sec-WebSocket-Protocol` header. Clients should offer both:
+All WebSocket clients MUST offer `tyrum-v1` in `Sec-WebSocket-Protocol`.
+When using the fallback, the token is conveyed in the same header. Those clients additionally offer:
 
 - `tyrum-v1`
 - `tyrum-auth.<base64url(token)>`

--- a/packages/gateway/src/routes/ws/auth.ts
+++ b/packages/gateway/src/routes/ws/auth.ts
@@ -5,7 +5,7 @@ import { toSingleHeaderValue } from "../../modules/auth/client-ip.js";
 import { AUTH_COOKIE_NAME, extractBearerToken } from "../../modules/auth/http.js";
 import type { NodePairingDal } from "../../modules/node/pairing-dal.js";
 
-const WS_BASE_PROTOCOL = "tyrum-v1";
+export const WS_BASE_PROTOCOL = "tyrum-v1";
 const WS_AUTH_PROTOCOL_PREFIX = "tyrum-auth.";
 
 export type WsTokenTransport = "authorization" | "cookie" | "subprotocol" | "missing";
@@ -172,13 +172,12 @@ export function extractWsTokenWithTransport(req: IncomingMessage): WsTokenInfo {
   return { token: undefined, transport: "missing" };
 }
 
+export function requestOffersWsBaseSubprotocol(req: IncomingMessage): boolean {
+  return parseProtocolHeader(req.headers["sec-websocket-protocol"]).includes(WS_BASE_PROTOCOL);
+}
+
 export function selectWsSubprotocol(protocols: Set<string>): string | false {
   if (protocols.has(WS_BASE_PROTOCOL)) return WS_BASE_PROTOCOL;
-  for (const protocol of protocols) {
-    if (!protocol.startsWith(WS_AUTH_PROTOCOL_PREFIX)) {
-      return protocol;
-    }
-  }
   return false;
 }
 

--- a/packages/gateway/src/routes/ws/upgrade.ts
+++ b/packages/gateway/src/routes/ws/upgrade.ts
@@ -6,6 +6,7 @@ import {
   type TrustedProxyAllowlist,
 } from "../../modules/auth/client-ip.js";
 import type { SlidingWindowRateLimiter } from "../../modules/auth/rate-limiter.js";
+import { requestOffersWsBaseSubprotocol, WS_BASE_PROTOCOL } from "./auth.js";
 
 export interface CreateHandleUpgradeOptions {
   wss: WebSocketServer;
@@ -18,6 +19,9 @@ export function createHandleUpgrade(
 ): (req: IncomingMessage, socket: Duplex, head: Buffer) => void {
   return (req, socket, head) => {
     if (rejectRateLimitedUpgrade(req, socket, opts.upgradeRateLimiter, opts.trustedProxies)) {
+      return;
+    }
+    if (rejectMissingBaseProtocolUpgrade(req, socket)) {
       return;
     }
 
@@ -62,6 +66,33 @@ function rejectRateLimitedUpgrade(
     socket.destroy();
   } catch (err) {
     void err;
+  }
+
+  return true;
+}
+
+function rejectMissingBaseProtocolUpgrade(req: IncomingMessage, socket: Duplex): boolean {
+  if (requestOffersWsBaseSubprotocol(req)) return false;
+
+  const body = `Missing required WebSocket subprotocol: ${WS_BASE_PROTOCOL}\n`;
+  const response = [
+    "HTTP/1.1 400 Bad Request",
+    "Connection: close",
+    "Content-Type: text/plain; charset=utf-8",
+    `Content-Length: ${String(Buffer.byteLength(body))}`,
+    "",
+    body,
+  ].join("\r\n");
+
+  try {
+    socket.end(response);
+  } catch (err) {
+    void err;
+    try {
+      socket.destroy();
+    } catch (destroyErr) {
+      void destroyErr;
+    }
   }
 
   return true;

--- a/packages/gateway/tests/integration/ws-handler.test.ts
+++ b/packages/gateway/tests/integration/ws-handler.test.ts
@@ -58,6 +58,57 @@ function waitForClose(ws: WebSocket, timeoutMs = 5_000): Promise<{ code: number;
   });
 }
 
+function waitForUnexpectedResponse(
+  ws: WebSocket,
+  timeoutMs = 5_000,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("unexpected response timeout"));
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      ws.off("error", onError);
+      ws.off("unexpected-response", onUnexpectedResponse);
+    };
+
+    const onOpen = () => {
+      cleanup();
+      reject(new Error("unexpectedly upgraded connection"));
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const onUnexpectedResponse = (
+      _request: unknown,
+      response: NodeJS.ReadableStream & { statusCode?: number },
+    ) => {
+      let body = "";
+      response.setEncoding?.("utf8");
+      response.on("data", (chunk: string | Buffer) => {
+        body += chunk.toString();
+      });
+      response.on("end", () => {
+        cleanup();
+        resolve({ statusCode: response.statusCode ?? 0, body });
+      });
+      response.on("error", (err) => {
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+      response.resume?.();
+    };
+
+    ws.on("open", onOpen);
+    ws.on("error", onError);
+    ws.on("unexpected-response", onUnexpectedResponse);
+  });
+}
+
 function waitForJsonMessage(ws: WebSocket): Promise<Record<string, unknown>> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error("message timeout")), 5_000);
@@ -351,6 +402,42 @@ describe("WS handler integration", () => {
     const stats = connectionManager.getStats();
     expect(stats.totalClients).toBe(1);
     expect(stats.capabilityCounts["playwright"]).toBe(1);
+
+    stopHeartbeat();
+  });
+
+  it("rejects upgrades that omit the tyrum-v1 base subprotocol", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-ws-"));
+    const { container, authTokens, tenantAdminToken: adminToken } = await createAuthTokens(homeDir);
+    containers.push(container);
+
+    const connectionManager = new ConnectionManager();
+    const { handleUpgrade, stopHeartbeat } = createWsHandler({
+      connectionManager,
+      protocolDeps: { connectionManager },
+      authTokens,
+    });
+
+    server = createServer();
+    server.on("upgrade", (req, socket, head) => {
+      handleUpgrade(req, socket, head);
+    });
+
+    const port = await new Promise<number>((resolve) => {
+      server!.listen(0, "127.0.0.1", () => {
+        const addr = server!.address();
+        resolve(typeof addr === "object" && addr ? addr.port : 0);
+      });
+    });
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, ["custom-protocol"], {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+
+    const response = await waitForUnexpectedResponse(ws, 2_000);
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toContain("tyrum-v1");
+    expect(connectionManager.getStats().totalClients).toBe(0);
 
     stopHeartbeat();
   });

--- a/packages/gateway/tests/unit/ws-route-auth-extraction.test.ts
+++ b/packages/gateway/tests/unit/ws-route-auth-extraction.test.ts
@@ -83,8 +83,6 @@ describe("WS route auth extraction", () => {
       selectWsSubprotocol(new Set(["tyrum-auth.ignored", "custom-protocol", "tyrum-v1"])),
     ).toBe("tyrum-v1");
 
-    expect(selectWsSubprotocol(new Set(["tyrum-auth.ignored", "custom-protocol"]))).toBe(
-      "custom-protocol",
-    );
+    expect(selectWsSubprotocol(new Set(["tyrum-auth.ignored", "custom-protocol"]))).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1011

## Summary
- require `tyrum-v1` on WebSocket upgrades before accepting the connection
- stop negotiating arbitrary fallback subprotocols when the base protocol is missing
- add regression coverage for rejected upgrades without `tyrum-v1` and document the enforced contract

## Verification
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm docs:public-check`
- `pnpm test`
- `pnpm exec vitest run packages/gateway/tests/unit/ws-route-auth-extraction.test.ts packages/gateway/tests/integration/ws-handler.test.ts packages/gateway/tests/integration/ws-upgrade.test.ts packages/gateway/tests/integration/ws-upgrade-unauthorized-close.test.ts packages/gateway/tests/integration/ws-auth-audit.test.ts packages/gateway/tests/integration/ws-upgrade-rate-limit.test.ts packages/client/tests/conformance/ws-conformance.test.ts`