### PR TITLE
P3: Avoid tyrum-auth.* WS subprotocol when token is empty (cookie auth) (#1012)

### DIFF
--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -802,8 +802,11 @@ export class TyrumClient {
   }
 
   private buildProtocols(): string[] {
-    const token = toBase64UrlUtf8(this.opts.token);
-    return [WS_BASE_PROTOCOL, `${WS_AUTH_PROTOCOL_PREFIX}${token}`];
+    const token = this.opts.token;
+    if (token.trim().length === 0) {
+      return [WS_BASE_PROTOCOL];
+    }
+    return [WS_BASE_PROTOCOL, `${WS_AUTH_PROTOCOL_PREFIX}${toBase64UrlUtf8(token)}`];
   }
 
   private destroyPinnedDispatcher(ws: WebSocket): void {

--- a/packages/client/tests/ws-client.test.ts
+++ b/packages/client/tests/ws-client.test.ts
@@ -2793,6 +2793,32 @@ describe("TyrumClient", () => {
     expect(client.connected).toBe(true);
   });
 
+  it("builds websocket protocols without auth metadata when token is empty", () => {
+    client = new TyrumClient({
+      url: "ws://127.0.0.1:65535",
+      token: "   ",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const protocols = (client as unknown as { buildProtocols(): string[] }).buildProtocols();
+
+    expect(protocols).toEqual(["tyrum-v1"]);
+  });
+
+  it("builds websocket protocols with auth metadata when token is present", () => {
+    client = new TyrumClient({
+      url: "ws://127.0.0.1:65535",
+      token: "my-token",
+      capabilities: [],
+      reconnect: false,
+    });
+
+    const protocols = (client as unknown as { buildProtocols(): string[] }).buildProtocols();
+
+    expect(protocols).toEqual(["tyrum-v1", "tyrum-auth.bXktdG9rZW4"]);
+  });
+
   it("does not reconnect after intentional disconnect", async () => {
     server = createTestServer();
     client = new TyrumClient({


### PR DESCRIPTION
Closes #1012

## Summary
- omit the `tyrum-auth.*` WebSocket subprotocol entry when the configured token is empty or whitespace-only
- preserve existing subprotocol auth behavior for non-empty tokens
- add focused regression coverage for `buildProtocols()` in both modes

## Test evidence
- `pnpm exec vitest run packages/client/tests/ws-client.test.ts -t "builds websocket protocols"`
- `pnpm exec vitest run packages/client/tests/ws-client.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
