### PR TITLE
P3: Align ping/heartbeat semantics (WS ping vs protocol ping) (#1013)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1038,10 +1038,11 @@ Client-sent events are rejected.
 
 - Direction:
   - client → gateway (request)
-  - gateway → client (request) and client → gateway (response) (heartbeat)
+  - gateway → client (response)
 - Scope (device tokens): allowed (no scopes required)
 - Schema: `WsPingRequest`
 - Result: none (`ok: true`)
+- Notes: This is a protocol-level health-check request initiated by clients. Gateway connection liveness and eviction use WebSocket ping/pong control frames, not protocol `ping`, and the gateway does not send protocol `ping` heartbeats.
 
 #### `approval.list`
 

--- a/docs/architecture/protocol/requests-responses.md
+++ b/docs/architecture/protocol/requests-responses.md
@@ -16,7 +16,7 @@ The wire shapes are defined by shared, versioned contracts (see [Contracts](../c
 The gateway, clients, and nodes support these request types:
 
 - `connect.init` / `connect.proof` — handshake and device proof (see [Handshake](./handshake.md)).
-- `ping` — gateway heartbeat request (peer replies with `ok: true`).
+- `ping` — client-initiated protocol health-check request (gateway replies with `ok: true`); connection heartbeat and eviction use WebSocket ping/pong control frames.
 - `session.send` — send a message into a session (chat input).
 - `workflow.run` — start a deterministic workflow run (playbook file or inline pipeline).
 - `workflow.resume` — resume a paused workflow run using a resume token (after an approval decision).

--- a/packages/client/src/ws-client.ts
+++ b/packages/client/src/ws-client.ts
@@ -552,7 +552,7 @@ export class TyrumClient {
     return this.request("command.execute", payload, WsCommandExecuteResult);
   }
 
-  /** Send a heartbeat ping request to the gateway. */
+  /** Send a protocol-level health-check ping request to the gateway. */
   ping(): Promise<void> {
     return this.requestVoid("ping", {});
   }
@@ -1310,7 +1310,7 @@ export class TyrumClient {
     // Requests (gateway -> client)
     switch (msg.type) {
       case "ping":
-        // heartbeat: reply with an ok response
+        // Protocol-level health check: acknowledge without affecting WS heartbeat state.
         this.send({
           request_id: msg.request_id,
           type: "ping",

--- a/packages/client/tests/conformance/ws-conformance.test.ts
+++ b/packages/client/tests/conformance/ws-conformance.test.ts
@@ -120,7 +120,7 @@ describe("WS SDK conformance (client <-> gateway)", () => {
 
     await withTimeout(result.connectedP, TIMEOUT, "connected");
 
-    // ping() sends a ping request and awaits the pong — resolves without error
+    // ping() sends a protocol health-check request and awaits the ack.
     await withTimeout(client.ping(), TIMEOUT, "ping");
   });
 

--- a/packages/gateway/src/ws/connection-manager.ts
+++ b/packages/gateway/src/ws/connection-manager.ts
@@ -23,7 +23,7 @@ export interface ConnectedClient {
   readonly protocol_rev: number;
   readonly capabilities: readonly ClientCapability[];
   readyCapabilities: Set<ClientCapability>;
-  lastPong: number;
+  lastWsPongAt: number;
 }
 
 export interface ConnectionStats {
@@ -80,10 +80,10 @@ export class ConnectionManager {
       protocol_rev: opts?.protocolRev ?? 1,
       capabilities,
       readyCapabilities,
-      lastPong: Date.now(),
+      lastWsPongAt: Date.now(),
     };
     ws.on("pong", () => {
-      client.lastPong = Date.now();
+      client.lastWsPongAt = Date.now();
     });
     this.clients.set(id, client);
     this.updateWsConnectionsActive();
@@ -170,7 +170,7 @@ export class ConnectionManager {
         changed = true;
         continue;
       }
-      if (now - client.lastPong > HEARTBEAT_TIMEOUT_MS) {
+      if (now - client.lastWsPongAt > HEARTBEAT_TIMEOUT_MS) {
         try {
           client.ws.terminate();
         } catch (_err) {

--- a/packages/gateway/src/ws/protocol/control-plane-handlers.ts
+++ b/packages/gateway/src/ws/protocol/control-plane-handlers.ts
@@ -22,7 +22,7 @@ export async function handleControlPlaneMessage(
   deps: ProtocolDeps,
 ): Promise<WsResponseEnvelope | undefined> {
   if (msg.type === "ping") {
-    return handlePingMessage(client, msg);
+    return handlePingMessage(msg);
   }
 
   if (msg.type === "command.execute") {
@@ -44,17 +44,13 @@ export async function handleControlPlaneMessage(
   return handleWorkflowCancelMessage(client, msg, deps);
 }
 
-function handlePingMessage(
-  client: ConnectedClient,
-  msg: ProtocolRequestEnvelope,
-): WsResponseEnvelope {
+function handlePingMessage(msg: ProtocolRequestEnvelope): WsResponseEnvelope {
   const parsedReq = WsPingRequest.safeParse(msg);
   if (!parsedReq.success) {
     return errorResponse(msg.request_id, msg.type, "invalid_request", parsedReq.error.message, {
       issues: parsedReq.error.issues,
     });
   }
-  client.lastPong = Date.now();
   return {
     request_id: msg.request_id,
     type: msg.type,

--- a/packages/gateway/src/ws/protocol/response-handlers.ts
+++ b/packages/gateway/src/ws/protocol/response-handlers.ts
@@ -10,11 +10,6 @@ export async function handleResponseMessage(
   msg: ProtocolResponseEnvelope,
   deps: ProtocolDeps,
 ): Promise<WsResponseEnvelope | WsEventEnvelope | undefined> {
-  if (msg.type === "ping" && msg.ok === true) {
-    client.lastPong = Date.now();
-    return undefined;
-  }
-
   if (msg.type === "task.execute") {
     return handleTaskExecuteResponse(client, msg, deps);
   }

--- a/packages/gateway/tests/helpers/ws-protocol-test-helpers.ts
+++ b/packages/gateway/tests/helpers/ws-protocol-test-helpers.ts
@@ -19,7 +19,7 @@ export function createAdminWsClient(
     protocol_rev: 1,
     capabilities: [],
     readyCapabilities: overrides?.readyCapabilities ?? new Set(),
-    lastPong: Date.now(),
+    lastWsPongAt: Date.now(),
     ...overrides,
   };
 }

--- a/packages/gateway/tests/unit/authz-scope-normalization.test.ts
+++ b/packages/gateway/tests/unit/authz-scope-normalization.test.ts
@@ -53,7 +53,7 @@ describe("scope normalization", () => {
       protocol_rev: 1,
       capabilities: [],
       readyCapabilities: new Set(),
-      lastPong: 0,
+      lastWsPongAt: 0,
     } satisfies ConnectedClient;
 
     const approvalId = randomUUID();

--- a/packages/gateway/tests/unit/connection-manager.test.ts
+++ b/packages/gateway/tests/unit/connection-manager.test.ts
@@ -166,10 +166,10 @@ describe("ConnectionManager", () => {
       const ws = createMockWs();
       const id = cm.addClient(ws as never, ["playwright"]);
 
-      // Simulate a stale client by setting lastPong to the past.
+      // Simulate a stale client by setting the WS pong timestamp to the past.
       const client = cm.getClient(id);
       expect(client).toBeDefined();
-      client!.lastPong = Date.now() - 20_000; // 20 seconds ago
+      client!.lastWsPongAt = Date.now() - 20_000; // 20 seconds ago
 
       cm.heartbeat();
 
@@ -186,7 +186,7 @@ describe("ConnectionManager", () => {
       // Client just ponged.
       const client = cm.getClient(id);
       expect(client).toBeDefined();
-      client!.lastPong = Date.now();
+      client!.lastWsPongAt = Date.now();
 
       cm.heartbeat();
 
@@ -195,20 +195,20 @@ describe("ConnectionManager", () => {
       expect(cm.getClient(id)).toBeDefined();
     });
 
-    it("updates lastPong on websocket pong frames", () => {
+    it("updates lastWsPongAt on websocket pong frames", () => {
       const cm = new ConnectionManager();
       const ws = createMockWs();
       const id = cm.addClient(ws as never, ["playwright"]);
       const client = cm.getClient(id);
       expect(client).toBeDefined();
 
-      client!.lastPong = 1000;
+      client!.lastWsPongAt = 1000;
       const before = Date.now();
       ws.emitPong();
       const after = Date.now();
 
-      expect(client!.lastPong).toBeGreaterThanOrEqual(before);
-      expect(client!.lastPong).toBeLessThanOrEqual(after);
+      expect(client!.lastWsPongAt).toBeGreaterThanOrEqual(before);
+      expect(client!.lastWsPongAt).toBeLessThanOrEqual(after);
     });
   });
 

--- a/packages/gateway/tests/unit/ws-protocol.test.ts
+++ b/packages/gateway/tests/unit/ws-protocol.test.ts
@@ -1104,49 +1104,43 @@ describe("handleClientMessage", () => {
     expect(payload.code).toBe("invalid_approval_decision");
   });
 
-  it("updates lastPong on ping response", async () => {
+  it("does not update lastWsPongAt on ping response", async () => {
     const cm = new ConnectionManager();
     const { id } = makeClient(cm, ["playwright"]);
     const client = cm.getClient(id)!;
     const deps = makeDeps(cm);
 
-    // Set lastPong to something old.
-    client.lastPong = 1000;
+    client.lastWsPongAt = 1000;
 
-    const before = Date.now();
     const result = await handleClientMessage(
       client,
       JSON.stringify({ request_id: "ping-1", type: "ping", ok: true }),
       deps,
     );
-    const after = Date.now();
 
     expect(result).toBeUndefined();
-    expect(client.lastPong).toBeGreaterThanOrEqual(before);
-    expect(client.lastPong).toBeLessThanOrEqual(after);
+    expect(client.lastWsPongAt).toBe(1000);
   });
 
-  it("responds to ping requests with pong", async () => {
+  it("responds to ping requests without updating lastWsPongAt", async () => {
     const cm = new ConnectionManager();
     const { id } = makeClient(cm, ["playwright"]);
     const client = cm.getClient(id)!;
     const deps = makeDeps(cm);
 
-    const before = Date.now();
+    client.lastWsPongAt = 1000;
     const result = await handleClientMessage(
       client,
       JSON.stringify({ request_id: "ping-req-1", type: "ping", payload: {} }),
       deps,
     );
-    const after = Date.now();
 
     expect(result).toEqual({
       request_id: "ping-req-1",
       type: "ping",
       ok: true,
     });
-    expect(client.lastPong).toBeGreaterThanOrEqual(before);
-    expect(client.lastPong).toBeLessThanOrEqual(after);
+    expect(client.lastWsPongAt).toBe(1000);
   });
 
   it("handles approval.list requests when approvalDal is configured", async () => {


### PR DESCRIPTION
Closes #1013

## Summary
- make WebSocket ping/pong control frames the authoritative connection heartbeat in code and docs
- rename the eviction timestamp to `lastWsPongAt` and stop protocol `ping` from mutating it
- keep protocol `ping` as a client-initiated health-check request and update tests/docs accordingly

## Verification
- pnpm exec vitest run packages/gateway/tests/unit/connection-manager.test.ts packages/gateway/tests/unit/ws-protocol.test.ts packages/gateway/tests/unit/authz-scope-normalization.test.ts packages/client/tests/conformance/ws-conformance.test.ts
- pnpm format:check
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm docs:public-check

## Playwright
- Not used; this change is limited to gateway/client heartbeat semantics and docs.