### PR TITLE
P4: Terminology cleanup: ClientCapability vs node capabilities (#1014)

### DIFF
--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -55,6 +55,7 @@ Clients may also present a unified "Session" timeline view that merges chat, run
 
 ## What a client is not
 
-- A client is not a capability provider. Capabilities live on nodes.
-- A client never executes `task.execute` capability calls, even if it advertises a capability.
+- A client is not a capability provider. Nodes advertise and execute capability kinds.
+- The shared `ClientCapability` enum name is legacy handshake/routing terminology; those values still refer to node-side executor capabilities.
+- A client never executes `task.execute` capability calls, even if it reports legacy capability kinds for compatibility.
 - A client is not required for automation to run, but it is the primary interface for oversight.

--- a/packages/gateway/src/ws/protocol/dispatch.ts
+++ b/packages/gateway/src/ws/protocol/dispatch.ts
@@ -3,7 +3,7 @@ import {
   descriptorIdForClientCapability,
   requiredCapability,
 } from "@tyrum/schemas";
-import type { ActionPrimitive, ClientCapability, WsRequestEnvelope } from "@tyrum/schemas";
+import type { ActionPrimitive, CapabilityKind, WsRequestEnvelope } from "@tyrum/schemas";
 import { canonicalizeNodeDispatchMatchTarget } from "../../modules/policy/match-target.js";
 import type { ConnectedClient } from "../connection-manager.js";
 import {
@@ -33,7 +33,7 @@ export function dispatchTask(
 ): Promise<string> {
   const capability = requiredCapability(action.type);
   if (capability === undefined) {
-    throw new NoCapableClientError(action.type as ClientCapability);
+    throw new NoCapableClientError(action.type as CapabilityKind);
   }
 
   const descriptorId = descriptorIdForClientCapability(capability);

--- a/packages/gateway/src/ws/protocol/errors.ts
+++ b/packages/gateway/src/ws/protocol/errors.ts
@@ -1,25 +1,25 @@
-import type { ClientCapability } from "@tyrum/schemas";
+import type { CapabilityKind } from "@tyrum/schemas";
 
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
 
 export class NoCapableClientError extends Error {
-  constructor(public readonly capability: ClientCapability) {
+  constructor(public readonly capability: CapabilityKind) {
     super(`no connected client with capability: ${capability}`);
     this.name = "NoCapableClientError";
   }
 }
 
 export class NoCapableNodeError extends Error {
-  constructor(public readonly capability: ClientCapability) {
+  constructor(public readonly capability: CapabilityKind) {
     super(`no connected node with capability: ${capability}`);
     this.name = "NoCapableNodeError";
   }
 }
 
 export class NodeNotPairedError extends Error {
-  constructor(public readonly capability: ClientCapability) {
+  constructor(public readonly capability: CapabilityKind) {
     super(`no paired node with capability: ${capability}`);
     this.name = "NodeNotPairedError";
   }
@@ -27,7 +27,7 @@ export class NodeNotPairedError extends Error {
 
 export class NodeDispatchDeniedError extends Error {
   constructor(
-    public readonly capability: ClientCapability,
+    public readonly capability: CapabilityKind,
     public readonly policySnapshotId?: string,
   ) {
     const suffix = policySnapshotId ? ` (policy snapshot: ${policySnapshotId})` : "";

--- a/packages/schemas/src/capability.ts
+++ b/packages/schemas/src/capability.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-/** Client capability kinds. */
+/**
+ * Legacy capability kind enum kept for routing and handshake compatibility.
+ *
+ * Nodes advertise and execute these capabilities; clients do not execute
+ * capability calls.
+ */
 export const ClientCapability = z.enum([
   "playwright",
   "android",
@@ -10,6 +15,10 @@ export const ClientCapability = z.enum([
   "browser",
 ]);
 export type ClientCapability = z.infer<typeof ClientCapability>;
+
+/** Preferred alias for the legacy `ClientCapability` enum. */
+export const CapabilityKind = ClientCapability;
+export type CapabilityKind = ClientCapability;
 
 const CAPABILITY_ID_SEGMENT = "[a-z][a-z0-9-]*";
 const CAPABILITY_ID_PATTERN = new RegExp(
@@ -43,21 +52,19 @@ const LEGACY_TO_DESCRIPTOR_ID = {
   browser: "tyrum.browser",
 } as const;
 
-type LegacyCapabilityDescriptorId = (typeof LEGACY_TO_DESCRIPTOR_ID)[ClientCapability];
+type LegacyCapabilityDescriptorId = (typeof LEGACY_TO_DESCRIPTOR_ID)[CapabilityKind];
 
 const DESCRIPTOR_TO_LEGACY = Object.fromEntries(
   (
-    Object.entries(LEGACY_TO_DESCRIPTOR_ID) as Array<
-      [ClientCapability, LegacyCapabilityDescriptorId]
-    >
+    Object.entries(LEGACY_TO_DESCRIPTOR_ID) as Array<[CapabilityKind, LegacyCapabilityDescriptorId]>
   ).map(([capability, id]) => [id, capability]),
-) as Record<LegacyCapabilityDescriptorId, ClientCapability>;
+) as Record<LegacyCapabilityDescriptorId, CapabilityKind>;
 
 /**
  * Capability descriptor used in the vNext handshake.
  *
  * Descriptors are namespaced and explicitly versioned so nodes can advertise
- * stable contracts independently from legacy enum routing keys.
+ * stable contracts independently from legacy capability-kind routing keys.
  */
 export const CapabilityDescriptor = z
   .object({
@@ -68,11 +75,11 @@ export const CapabilityDescriptor = z
 export type CapabilityDescriptor = z.infer<typeof CapabilityDescriptor>;
 
 export function descriptorIdForClientCapability(
-  capability: ClientCapability,
+  capability: CapabilityKind,
 ): LegacyCapabilityDescriptorId {
   return LEGACY_TO_DESCRIPTOR_ID[capability];
 }
 
-export function clientCapabilityFromDescriptorId(id: string): ClientCapability | undefined {
+export function clientCapabilityFromDescriptorId(id: string): CapabilityKind | undefined {
   return DESCRIPTOR_TO_LEGACY[id as LegacyCapabilityDescriptorId];
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -254,6 +254,7 @@ export type {
 export {
   CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
   CapabilityDescriptor,
+  CapabilityKind,
   ClientCapability,
   clientCapabilityFromDescriptorId,
   descriptorIdForClientCapability,

--- a/packages/schemas/src/node.ts
+++ b/packages/schemas/src/node.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { DateTimeSchema } from "./common.js";
 import { NodeId } from "./keys.js";
-import { CapabilityDescriptor, ClientCapability } from "./capability.js";
+import { CapabilityDescriptor, CapabilityKind } from "./capability.js";
 
 export const NodeIdentity = z
   .object({
     node_id: NodeId,
     label: z.string().trim().min(1).optional(),
-    capabilities: z.array(ClientCapability).default([]),
+    capabilities: z.array(CapabilityKind).default([]),
     last_seen_at: DateTimeSchema,
     metadata: z.unknown().optional(),
   })

--- a/packages/schemas/src/protocol.ts
+++ b/packages/schemas/src/protocol.ts
@@ -1,6 +1,7 @@
 export {
   CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
   CapabilityDescriptor,
+  CapabilityKind,
   ClientCapability,
   clientCapabilityFromDescriptorId,
   descriptorIdForClientCapability,

--- a/packages/schemas/src/protocol/capability-ready.ts
+++ b/packages/schemas/src/protocol/capability-ready.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CapabilityDescriptor, ClientCapability } from "../capability.js";
+import { CapabilityDescriptor, CapabilityKind } from "../capability.js";
 import { NodeId } from "../keys.js";
 import { ActionPrimitiveKind } from "../planner.js";
 import {
@@ -68,8 +68,8 @@ export const WsCapabilityReadyEvent = WsEventEnvelope.extend({
 });
 export type WsCapabilityReadyEvent = z.infer<typeof WsCapabilityReadyEvent>;
 
-/** Maps ActionPrimitiveKind to the required client capability. */
-const CAPABILITY_MAP: Partial<Record<ActionPrimitiveKind, ClientCapability>> = {
+/** Maps ActionPrimitiveKind to the legacy capability kind used for node routing. */
+const CAPABILITY_MAP: Partial<Record<ActionPrimitiveKind, CapabilityKind>> = {
   Web: "playwright",
   Browser: "browser",
   Android: "android",
@@ -78,6 +78,6 @@ const CAPABILITY_MAP: Partial<Record<ActionPrimitiveKind, ClientCapability>> = {
   Http: "http",
 };
 
-export function requiredCapability(kind: ActionPrimitiveKind): ClientCapability | undefined {
+export function requiredCapability(kind: ActionPrimitiveKind): CapabilityKind | undefined {
   return CAPABILITY_MAP[kind];
 }

--- a/packages/schemas/src/protocol/connect.ts
+++ b/packages/schemas/src/protocol/connect.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CapabilityDescriptor, ClientCapability } from "../capability.js";
+import { CapabilityDescriptor, CapabilityKind } from "../capability.js";
 import { WsRequestEnvelope, WsResponseErrEnvelope, WsResponseOkEnvelope } from "./envelopes.js";
 
 // ---------------------------------------------------------------------------
@@ -73,7 +73,7 @@ export type WsConnectProofResult = z.infer<typeof WsConnectProofResult>;
  */
 export const WsConnectPayload = z
   .object({
-    capabilities: z.array(ClientCapability).default([]),
+    capabilities: z.array(CapabilityKind).default([]),
     client_id: z.string().min(1).optional(),
   })
   .strict();

--- a/packages/schemas/tests/capability.test.ts
+++ b/packages/schemas/tests/capability.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { CapabilityKind } from "../src/index.js";
 import {
   CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
   CapabilityDescriptor,
+  ClientCapability,
   clientCapabilityFromDescriptorId,
   descriptorIdForClientCapability,
 } from "../src/capability.js";
@@ -44,6 +46,11 @@ describe("CapabilityDescriptor", () => {
 });
 
 describe("descriptor legacy mappings", () => {
+  it("exports CapabilityKind as the legacy compatibility alias", () => {
+    expect(CapabilityKind).toBe(ClientCapability);
+    expect(CapabilityKind.parse("http")).toBe("http");
+  });
+
   it("maps core client capability to namespaced ID", () => {
     expect(descriptorIdForClientCapability("cli")).toBe("tyrum.cli");
   });


### PR DESCRIPTION
Closes #1014

## Summary
- add `CapabilityKind` as the preferred alias for the legacy `ClientCapability` schema export
- switch the touched schema and gateway protocol paths to prefer `CapabilityKind` while preserving compatibility
- clarify the architecture docs that capability execution belongs to nodes, not clients

## Testing
- `pnpm exec vitest run packages/schemas/tests/capability.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
