### PR TITLE
fix(gateway): harden provider runtime resolution

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/embedding-pipeline-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/embedding-pipeline-resolution.ts
@@ -9,6 +9,7 @@ import {
   listOrderedEligibleProfilesForProvider,
   OAUTH_REFRESH_LEASE_UNAVAILABLE,
   parseProviderModelId,
+  providerRequiresConfiguredAccount,
   resolveProfileSecrets,
   resolveProviderBaseURL,
 } from "./provider-resolution.js";
@@ -168,16 +169,6 @@ async function resolveProviderAccount(input: {
   return undefined;
 }
 
-function providerRequiresConfiguredAccount(candidate: ResolvedEmbeddingCandidate): boolean {
-  if (/\$\{[A-Z0-9_]+\}/.test(candidate.api ?? "")) {
-    return true;
-  }
-  const providerEnv = (candidate.provider as { env?: unknown }).env;
-  return Array.isArray(providerEnv)
-    ? providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
-    : true;
-}
-
 function buildEmbeddingPipeline(input: {
   db: GatewayContainer["db"];
   fetchImpl: typeof fetch;
@@ -252,7 +243,15 @@ export async function resolveEmbeddingPipeline(input: {
         sessionId: input.sessionId,
         providerId: candidate.providerId,
       });
-      if (!providerAccount && providerRequiresConfiguredAccount(candidate)) continue;
+      if (
+        !providerAccount &&
+        providerRequiresConfiguredAccount({
+          providerApi: candidate.api,
+          providerEnv: (candidate.provider as { env?: unknown }).env,
+        })
+      ) {
+        continue;
+      }
 
       const pipeline = buildEmbeddingPipeline({
         db: input.container.db,

--- a/packages/gateway/src/modules/agent/runtime/provider-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/provider-resolution.ts
@@ -114,6 +114,19 @@ export function resolveProviderBaseURL(input: {
   return undefined;
 }
 
+export function providerRequiresConfiguredAccount(input: {
+  providerApi: string | undefined;
+  providerEnv: unknown;
+}): boolean {
+  if (/\$\{[A-Z0-9_]+\}/.test(input.providerApi ?? "")) {
+    return true;
+  }
+
+  return Array.isArray(input.providerEnv)
+    ? input.providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
+    : true;
+}
+
 export async function listOrderedEligibleProfilesForProvider(input: {
   tenantId: string;
   sessionId: string;
@@ -230,7 +243,10 @@ export async function resolveProfileSecrets(
   const selection = pickSecretSlots(profile);
   let refreshLeaseUnavailable = false;
 
-  const maybeRefresh = async (): Promise<string | null> => {
+  const maybeRefresh = async (): Promise<{
+    accessToken: string;
+    refreshToken: string;
+  } | null> => {
     if (profile.type !== "oauth") return null;
     if (!selection.authSecretKey || !selection.refreshTokenKey) return null;
 
@@ -288,13 +304,17 @@ export async function resolveProfileSecrets(
 
       const accessToken = token.access_token?.trim();
       if (!accessToken) return null;
+      const nextRefreshToken = token.refresh_token?.trim() || refreshToken;
 
       await deps.secretProvider!.store(selection.authSecretKey, accessToken);
       if (token.refresh_token?.trim()) {
-        await deps.secretProvider!.store(selection.refreshTokenKey, token.refresh_token.trim());
+        await deps.secretProvider!.store(selection.refreshTokenKey, nextRefreshToken);
       }
 
-      return accessToken;
+      return {
+        accessToken,
+        refreshToken: nextRefreshToken,
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       deps.logger.warn("oauth.refresh_failed", {
@@ -314,15 +334,30 @@ export async function resolveProfileSecrets(
     }
   };
 
+  let forcedRefreshResult:
+    | {
+        accessToken: string;
+        refreshToken: string;
+      }
+    | undefined;
   if (opts?.forceOAuthRefresh && profile.type === "oauth") {
     const refreshed = await maybeRefresh();
     if (!refreshed) {
       return refreshLeaseUnavailable ? OAUTH_REFRESH_LEASE_UNAVAILABLE : null;
     }
+    forcedRefreshResult = refreshed;
   }
 
   const resolvedSecrets: Record<string, string> = {};
   for (const [slot, secretKey] of slotEntries) {
+    if (forcedRefreshResult && slot === "access_token") {
+      resolvedSecrets[slot] = forcedRefreshResult.accessToken;
+      continue;
+    }
+    if (forcedRefreshResult && slot === "refresh_token") {
+      resolvedSecrets[slot] = forcedRefreshResult.refreshToken;
+      continue;
+    }
     const value = await deps.secretProvider.resolve(buildDbHandle(secretKey));
     if (!value) continue;
     resolvedSecrets[slot] = value;
@@ -336,15 +371,8 @@ export async function resolveProfileSecrets(
   ) {
     const refreshed = await maybeRefresh();
     if (refreshed) {
-      resolvedSecrets["access_token"] = refreshed;
-      if (selection.refreshTokenKey) {
-        const refreshTokenValue = await deps.secretProvider.resolve(
-          buildDbHandle(selection.refreshTokenKey),
-        );
-        if (refreshTokenValue) {
-          resolvedSecrets["refresh_token"] = refreshTokenValue;
-        }
-      }
+      resolvedSecrets["access_token"] = refreshed.accessToken;
+      resolvedSecrets["refresh_token"] = refreshed.refreshToken;
     }
   }
 

--- a/packages/gateway/src/modules/agent/runtime/session-model-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/session-model-resolution.ts
@@ -26,6 +26,7 @@ import {
   listOrderedEligibleProfilesForProvider,
   OAUTH_REFRESH_LEASE_UNAVAILABLE,
   parseProviderModelId,
+  providerRequiresConfiguredAccount,
   resolveProfileSecrets,
   resolveProviderBaseURL,
 } from "./provider-resolution.js";
@@ -225,6 +226,20 @@ export async function resolveSessionModel(
     throw new Error(`model not found in models.dev catalog: ${attemptedLabel}`);
   }
 
+  const specsByCandidate = resolvedCandidates.map((candidate) => ({
+    candidateId: `${candidate.providerId}/${candidate.modelId}`,
+    specificationVersion: expectedSpecificationVersionForNpm(candidate.npm),
+  }));
+  const distinctSpecs = Array.from(
+    new Set(specsByCandidate.map((entry) => entry.specificationVersion)),
+  );
+  if (distinctSpecs.length > 1) {
+    const details = specsByCandidate
+      .map((entry) => `${entry.candidateId} (${entry.specificationVersion})`)
+      .join(", ");
+    throw new Error(`configured model candidates must share one specification version: ${details}`);
+  }
+
   const fetchImpl = input.fetchImpl ?? deps.fetchImpl;
   const {
     secretProvider,
@@ -280,12 +295,10 @@ export async function resolveSessionModel(
     const expectedSpec = expectedSpecificationVersionForNpm(chosen.npm);
     const providerLabel = `${chosen.providerId}/${chosen.modelId}`;
     const supportedUrls: PromiseLike<Record<string, RegExp[]>> = Promise.resolve({});
-    const providerEnv = (chosen.provider as { env?: unknown }).env;
-    const providerRequiresConfiguredAccount =
-      /\$\{[A-Z0-9_]+\}/.test(chosen.api ?? "") ||
-      (Array.isArray(providerEnv)
-        ? providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
-        : true);
+    const requiresConfiguredAccount = providerRequiresConfiguredAccount({
+      providerApi: chosen.api,
+      providerEnv: (chosen.provider as { env?: unknown }).env,
+    });
 
     async function buildModelFromProfile(
       profile?: AuthProfileRow,
@@ -369,7 +382,7 @@ export async function resolveSessionModel(
       });
 
       if (orderedProfiles.length === 0) {
-        if (providerRequiresConfiguredAccount) {
+        if (requiresConfiguredAccount) {
           throw new Error(
             `no active auth profiles with credentials configured for provider '${chosen.providerId}'`,
           );

--- a/packages/gateway/src/modules/execution/gateway-step-executor.ts
+++ b/packages/gateway/src/modules/execution/gateway-step-executor.ts
@@ -11,6 +11,7 @@ import { AuthProfileDal } from "../models/auth-profile-dal.js";
 import { createProviderFromNpm } from "../models/provider-factory.js";
 import {
   OAUTH_REFRESH_LEASE_UNAVAILABLE,
+  providerRequiresConfiguredAccount,
   resolveProfileSecrets,
   resolveProviderBaseURL,
 } from "../agent/runtime/provider-resolution.js";
@@ -293,13 +294,11 @@ async function resolveLanguageModel(input: {
     break;
   }
 
-  const providerEnv = (provider as { env?: unknown }).env;
-  const providerRequiresConfiguredAccount =
-    /\$\{[A-Z0-9_]+\}/.test(api ?? "") ||
-    (Array.isArray(providerEnv)
-      ? providerEnv.some((entry) => typeof entry === "string" && entry.trim().length > 0)
-      : true);
-  if (!selectedProfile && providerRequiresConfiguredAccount) {
+  const requiresConfiguredAccount = providerRequiresConfiguredAccount({
+    providerApi: api,
+    providerEnv: (provider as { env?: unknown }).env,
+  });
+  if (!selectedProfile && requiresConfiguredAccount) {
     throw new Error(
       `no active auth profiles with credentials configured for provider '${parsed.providerId}'`,
     );

--- a/packages/gateway/tests/unit/agent-runtime-fallback-models.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-fallback-models.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { createContainer, type GatewayContainer } from "../../src/container.js";
 import { ModelsDevCacheDal } from "../../src/modules/models/models-dev-cache-dal.js";
 import { APICallError } from "@ai-sdk/provider";
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV2, LanguageModelV3 } from "@ai-sdk/provider";
 import { ConfiguredModelPresetDal } from "../../src/modules/models/configured-model-preset-dal.js";
 import { ExecutionProfileModelAssignmentDal } from "../../src/modules/models/execution-profile-model-assignment-dal.js";
 import { SessionModelOverrideDal } from "../../src/modules/models/session-model-override-dal.js";
@@ -22,6 +22,28 @@ vi.mock("../../src/modules/models/provider-factory.js", () => {
   return {
     createProviderFromNpm: (input: { providerId: string }) => {
       const providerId = input.providerId;
+      if (providerId === "gitlab") {
+        const model: LanguageModelV2 = {
+          specificationVersion: "v2",
+          provider: providerId,
+          modelId: `${providerId}/mock`,
+          supportedUrls: {},
+          async doGenerate() {
+            seenProviders.push(providerId);
+            return {} as Awaited<ReturnType<LanguageModelV2["doGenerate"]>>;
+          },
+          async doStream() {
+            throw new Error("not implemented");
+          },
+        };
+
+        return {
+          languageModel() {
+            return model;
+          },
+        };
+      }
+
       const model: LanguageModelV3 = {
         specificationVersion: "v3",
         provider: providerId,
@@ -167,6 +189,65 @@ describe("AgentRuntime model fallbacks", () => {
     const res = await model.doGenerate({} as any);
     expect((res as any).text).toBe("ok");
     expect(seenProviders).toEqual(["openai", "anthropic"]);
+  });
+
+  it("rejects fallback chains that mix model specification versions", async () => {
+    container = createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    const cacheDal = new ModelsDevCacheDal(container.db);
+    const nowIso = new Date().toISOString();
+    await cacheDal.upsert({
+      fetchedAt: nowIso,
+      etag: null,
+      sha256: "sha",
+      json: JSON.stringify({
+        openai: {
+          id: "openai",
+          name: "OpenAI",
+          env: ["OPENAI_API_KEY"],
+          npm: "@ai-sdk/openai",
+          models: { "gpt-4.1": { id: "gpt-4.1", name: "GPT-4.1" } },
+        },
+        gitlab: {
+          id: "gitlab",
+          name: "GitLab",
+          env: ["GITLAB_TOKEN"],
+          npm: "@gitlab/gitlab-ai-provider",
+          models: { "duo-chat": { id: "duo-chat", name: "Duo Chat" } },
+        },
+      }),
+      source: "remote",
+      lastError: null,
+      nowIso,
+    });
+
+    const fetchImpl: typeof fetch = async () => new Response("not found", { status: 404 });
+
+    const { AgentRuntime } = await import("../../src/modules/agent/runtime.js");
+    const runtime = new AgentRuntime({
+      container,
+      agentId: "agent-1",
+      fetchImpl,
+    });
+
+    await expect(
+      (runtime as any).resolveSessionModel({
+        config: {
+          model: {
+            model: "openai/gpt-4.1",
+            fallback: ["gitlab/duo-chat"],
+            options: {},
+          },
+        },
+        tenantId: DEFAULT_TENANT_ID,
+        sessionId: "session-mixed-specs",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("configured model candidates must share one specification version");
+    expect(seenProviders).toEqual([]);
   });
 
   it("rejects legacy short fallback model ids", async () => {

--- a/packages/gateway/tests/unit/agent-runtime-oauth-refresh.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-oauth-refresh.test.ts
@@ -4,10 +4,11 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { APICallError, type LanguageModelV3 } from "@ai-sdk/provider";
 import { createContainer, type GatewayContainer } from "../../src/container.js";
-import { AuthProfileDal } from "../../src/modules/models/auth-profile-dal.js";
+import { AuthProfileDal, type AuthProfileRow } from "../../src/modules/models/auth-profile-dal.js";
 import { ModelsDevCacheDal } from "../../src/modules/models/models-dev-cache-dal.js";
 import { DbSecretProvider } from "../../src/modules/secret/provider.js";
 import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
+import { resolveProfileSecrets } from "../../src/modules/agent/runtime/provider-resolution.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
@@ -89,6 +90,107 @@ describe("AgentRuntime OAuth refresh", () => {
       nowIso,
     });
   }
+
+  it("returns freshly refreshed OAuth secrets without rereading stale auth slots", async () => {
+    const nowIso = new Date().toISOString();
+    const profile: AuthProfileRow = {
+      tenant_id: DEFAULT_TENANT_ID,
+      auth_profile_id: "profile-1",
+      auth_profile_key: "profile-1",
+      provider_key: "openai",
+      display_name: "profile-1",
+      method_key: "oauth",
+      type: "oauth",
+      status: "active",
+      config: {},
+      secret_keys: {
+        access_token: "oauth:access",
+        refresh_token: "oauth:refresh",
+        workspace_id: "oauth:workspace",
+      },
+      labels: {},
+      created_at: nowIso,
+      updated_at: nowIso,
+    };
+
+    const resolvedValues = new Map<string, string>([
+      ["oauth:access", "OLD_ACCESS"],
+      ["oauth:refresh", "OLD_REFRESH"],
+      ["oauth:workspace", "workspace-1"],
+      ["oauth:client_secret", "client-secret"],
+    ]);
+    const storedValues = new Map<string, string>();
+    const secretProvider = {
+      async resolve(handle: { handle_id: string }) {
+        return resolvedValues.get(handle.handle_id) ?? null;
+      },
+      async store(secretKey: string, value: string) {
+        storedValues.set(secretKey, value);
+        return {
+          handle_id: secretKey,
+          provider: "db" as const,
+          scope: secretKey,
+          created_at: nowIso,
+        };
+      },
+      async revoke() {
+        return false;
+      },
+      async list() {
+        return [];
+      },
+    };
+
+    const resolved = await resolveProfileSecrets(
+      profile,
+      {
+        tenantId: DEFAULT_TENANT_ID,
+        secretProvider,
+        oauthProviderRegistry: {
+          async get() {
+            return {
+              tenant_id: DEFAULT_TENANT_ID,
+              provider_id: "openai",
+              scopes: [],
+              client_id: "client-id",
+              client_secret_key: "oauth:client_secret",
+              token_endpoint: "https://oauth.example/token",
+              token_endpoint_basic_auth: true,
+            };
+          },
+        } as any,
+        oauthRefreshLeaseDal: {
+          async tryAcquire() {
+            return true;
+          },
+          async release() {},
+        } as any,
+        oauthLeaseOwner: "test-owner",
+        logger: { warn: vi.fn() } as any,
+        fetchImpl: async (input, init) => {
+          expect(String(input)).toBe("https://oauth.example/token");
+          expect(init?.method).toBe("POST");
+          return new Response(
+            JSON.stringify({
+              access_token: "NEW_ACCESS",
+              refresh_token: "NEW_REFRESH",
+              token_type: "Bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        },
+      },
+      { forceOAuthRefresh: true },
+    );
+
+    expect(resolved).toEqual({
+      access_token: "NEW_ACCESS",
+      refresh_token: "NEW_REFRESH",
+      workspace_id: "workspace-1",
+    });
+    expect(storedValues.get("oauth:access")).toBe("NEW_ACCESS");
+    expect(storedValues.get("oauth:refresh")).toBe("NEW_REFRESH");
+  });
 
   it("refreshes an OAuth profile on 401 and reuses the refreshed access token", async () => {
     container = createContainer({

--- a/packages/gateway/tests/unit/gateway-step-executor.test.ts
+++ b/packages/gateway/tests/unit/gateway-step-executor.test.ts
@@ -8,6 +8,10 @@ import { createGatewayStepExecutor } from "../../src/modules/execution/gateway-s
 import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
 import { ModelsDevCacheDal } from "../../src/modules/models/models-dev-cache-dal.js";
 
+vi.mock("../../src/modules/models/provider-factory.js", () => ({
+  createProviderFromNpm: vi.fn(),
+}));
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
 


### PR DESCRIPTION
## Summary
- keep forced OAuth refresh on the freshly returned auth secrets instead of rereading potentially stale secret-provider slots
- reject configured fallback chains that mix AI SDK specification versions so incompatible fallbacks are surfaced instead of silently ignored
- share the configured-account detection helper across session model resolution, embedding resolution, and gateway step execution
- isolate `gateway-step-executor` unit coverage from optional provider package installation state

## Investigation
- `resolveProfileSecrets(..., { forceOAuthRefresh: true })` refreshed and stored new OAuth credentials, but then fell through to a generic reread path. That made the refreshed result depend on secret-provider read-after-write consistency and could reuse stale auth slots.
- `resolveSessionModel` filtered fallback models down to the primary candidate's specification version with no warning or error. Mixed `v2`/`v3` fallback chains therefore lost candidates silently.
- The provider-account requirement check was duplicated in three runtime paths with identical logic, which created drift risk.

## Validation
- `pnpm exec vitest run packages/gateway/tests/unit/agent-runtime-oauth-refresh.test.ts packages/gateway/tests/unit/agent-runtime-fallback-models.test.ts packages/gateway/tests/unit/agent-runtime-embedding.test.ts packages/gateway/tests/unit/gateway-step-executor.test.ts`
- `pnpm lint`
- pre-push checks passed, including workspace typecheck, after restoring the declared workspace dependencies with `pnpm install --frozen-lockfile`
