### PR TITLE
Fix models tab load states

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-models.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-models.tsx
@@ -361,37 +361,68 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
   const [loading, setLoading] = React.useState(true);
   const [refreshing, setRefreshing] = React.useState(false);
   const [savingAssignments, setSavingAssignments] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+  const [executionProfilesErrorMessage, setExecutionProfilesErrorMessage] = React.useState<
+    string | null
+  >(null);
+  const [availableModelsErrorMessage, setAvailableModelsErrorMessage] = React.useState<
+    string | null
+  >(null);
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editingPreset, setEditingPreset] = React.useState<ModelPreset | null>(null);
   const [deletingPreset, setDeletingPreset] = React.useState<DeletePresetDialogState>(null);
 
   const refresh = React.useCallback(async (): Promise<void> => {
     setRefreshing(true);
-    setErrorMessage(null);
-    try {
-      const [presetResult, availableResult, assignmentResult] = await Promise.all([
-        readHttp.modelConfig.listPresets(),
-        readHttp.modelConfig.listAvailable(),
-        readHttp.modelConfig.listAssignments(),
-      ]);
-      setPresets(presetResult.presets);
-      setAvailableModels(availableResult.models);
-      setAssignments(assignmentResult.assignments);
+    setExecutionProfilesErrorMessage(null);
+    setAvailableModelsErrorMessage(null);
+
+    const [presetResult, availableResult, assignmentResult] = await Promise.allSettled([
+      readHttp.modelConfig.listPresets(),
+      readHttp.modelConfig.listAvailable(),
+      readHttp.modelConfig.listAssignments(),
+    ]);
+
+    let nextExecutionProfilesErrorMessage: string | null = null;
+    let nextAvailableModelsErrorMessage: string | null = null;
+    let nextPresetCount = 0;
+
+    if (presetResult.status === "fulfilled") {
+      setPresets(presetResult.value.presets);
+      nextPresetCount = presetResult.value.presets.length;
+    } else {
+      nextExecutionProfilesErrorMessage = formatErrorMessage(presetResult.reason);
+      setPresets([]);
+    }
+
+    if (availableResult.status === "fulfilled") {
+      setAvailableModels(availableResult.value.models);
+    } else {
+      nextAvailableModelsErrorMessage = formatErrorMessage(availableResult.reason);
+      setAvailableModels([]);
+    }
+
+    if (assignmentResult.status === "fulfilled") {
+      setAssignments(assignmentResult.value.assignments);
       setAssignmentDraft(
         Object.fromEntries(
-          assignmentResult.assignments.map((assignment) => [
+          assignmentResult.value.assignments.map((assignment) => [
             assignment.execution_profile_id,
             assignment.preset_key,
           ]),
         ),
       );
-    } catch (error) {
-      setErrorMessage(formatErrorMessage(error));
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
+    } else {
+      setAssignments([]);
+      setAssignmentDraft({});
+      if (!nextExecutionProfilesErrorMessage && nextPresetCount > 0) {
+        nextExecutionProfilesErrorMessage = formatErrorMessage(assignmentResult.reason);
+      }
     }
+
+    setExecutionProfilesErrorMessage(nextExecutionProfilesErrorMessage);
+    setAvailableModelsErrorMessage(nextAvailableModelsErrorMessage);
+    setLoading(false);
+    setRefreshing(false);
   }, [readHttp.modelConfig]);
 
   React.useEffect(() => {
@@ -412,12 +443,12 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
       return;
     }
     setSavingAssignments(true);
-    setErrorMessage(null);
+    setExecutionProfilesErrorMessage(null);
     try {
       await mutationHttp.modelConfig.updateAssignments({ assignments: assignmentDraft });
       await refresh();
     } catch (error) {
-      setErrorMessage(formatErrorMessage(error));
+      setExecutionProfilesErrorMessage(formatErrorMessage(error));
     } finally {
       setSavingAssignments(false);
     }
@@ -497,12 +528,14 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
           </div>
         </CardHeader>
         <CardContent className="grid gap-4">
-          {errorMessage ? (
-            <Alert variant="error" title="Model config failed" description={errorMessage} />
-          ) : null}
-
           {loading ? (
             <div className="text-sm text-fg-muted">Loading model config…</div>
+          ) : executionProfilesErrorMessage ? (
+            <Alert
+              variant="error"
+              title="Model config failed"
+              description={executionProfilesErrorMessage}
+            />
           ) : presets.length === 0 ? (
             <Alert
               variant="info"
@@ -577,7 +610,15 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
           </div>
         </CardHeader>
         <CardContent className="grid gap-4">
-          {availableModels.length === 0 ? (
+          {availableModelsErrorMessage ? (
+            <Alert
+              variant="error"
+              title="Available model discovery failed"
+              description={availableModelsErrorMessage}
+            />
+          ) : null}
+
+          {!availableModelsErrorMessage && availableModels.length === 0 ? (
             <Alert
               variant="warning"
               title="No configured provider models available"

--- a/packages/operator-ui/tests/pages/admin-page.http.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.test.ts
@@ -538,6 +538,42 @@ describe("ConfigurePage (HTTP) policy + config", () => {
     cleanupTestRoot({ container, root });
   });
 
+  it("keeps execution profiles in the empty state when provider models fail to load before any preset exists", async () => {
+    const { core } = createTestCore();
+    const modelConfig = core.http.modelConfig as {
+      listPresets: ReturnType<typeof vi.fn>;
+      listAvailable: ReturnType<typeof vi.fn>;
+      listAssignments: ReturnType<typeof vi.fn>;
+    };
+    modelConfig.listPresets = vi.fn(async () => ({
+      status: "ok",
+      presets: [],
+    }));
+    modelConfig.listAvailable = vi.fn(async () => {
+      throw new Error("Catalog unavailable");
+    });
+    modelConfig.listAssignments = vi.fn(async () => {
+      throw new Error("Assignments unavailable");
+    });
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(ElevatedModeProvider, { core, mode: "web" }, [
+        React.createElement(ConfigurePage, { key: "page", core }),
+      ]),
+    );
+
+    await switchHttpTab(container, "admin-http-tab-models");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("No models configured");
+    expect(container.textContent).toContain("Available model discovery failed");
+    expect(container.textContent).not.toContain("Model config failed");
+
+    cleanupTestRoot({ container, root });
+  });
+
   it("saves execution-profile assignments from the models tab", async () => {
     const { core } = createTestCore();
     const modelConfig = core.http.modelConfig as {


### PR DESCRIPTION
## Summary
- decouple the Models tab data loads so preset/assignment failures do not blank provider model availability
- keep the execution-profiles card in its empty state until presets exist instead of surfacing a premature config error
- add a regression test for the no-provider/no-preset state handling

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm test

Closes #1116