### PR TITLE
Remove dashboard instance and usage stats

### DIFF
--- a/packages/operator-ui/src/components/pages/dashboard-page.tsx
+++ b/packages/operator-ui/src/components/pages/dashboard-page.tsx
@@ -1,7 +1,7 @@
 import type { OperatorCore } from "@tyrum/operator-core";
 import { useEffect, useState } from "react";
 import type * as React from "react";
-import { Activity, Bot, Hash, Link2, Play, ShieldCheck, Tag, Wallet } from "lucide-react";
+import { Activity, Bot, Link2, ShieldCheck, Tag } from "lucide-react";
 import { PageHeader } from "../layout/page-header.js";
 import { Badge } from "../ui/badge.js";
 import { Card, CardContent, CardHeader } from "../ui/card.js";
@@ -12,7 +12,6 @@ import { cn } from "../../lib/cn.js";
 import { getConnectionDisplay } from "../../lib/connection-display.js";
 import {
   getActiveAgentIdsFromSessionLanes,
-  getActiveExecutionRunsCountFromQueueDepth,
   parseAgentIdFromKey,
 } from "../../lib/status-session-lanes.js";
 import { useHostApiOptional } from "../../host/host-api.js";
@@ -143,15 +142,6 @@ export function DashboardPage({ core, onNavigate, hideHeader }: DashboardPagePro
     };
   }, [desktopApi]);
 
-  const activeRunsLiveCount = Object.values(runs.runsById).filter(
-    (run) => run.status === "queued" || run.status === "running" || run.status === "paused",
-  ).length;
-  const activeRunsSeedCount = getActiveExecutionRunsCountFromQueueDepth(status.status?.queue_depth);
-  const activeRunsCount =
-    activeRunsSeedCount === null
-      ? activeRunsLiveCount
-      : Math.max(activeRunsLiveCount, activeRunsSeedCount);
-
   const agentIds = new Set<string>();
   const activeAgentIds = new Set<string>();
   for (const run of Object.values(runs.runsById)) {
@@ -173,10 +163,6 @@ export function DashboardPage({ core, onNavigate, hideHeader }: DashboardPagePro
   const totalAgentsCount = totalAgentIds.size;
   const activeAgentsText =
     totalAgentsCount > 0 ? `${activeAgentsCount}/${totalAgentsCount}` : `${activeAgentsCount}/-`;
-
-  const tokensUsed = status.usage?.local.totals.total_tokens;
-  const tokensUsedText =
-    typeof tokensUsed === "number" ? new Intl.NumberFormat().format(tokensUsed) : "-";
 
   const connectionDisplay = getConnectionDisplay(connection.status);
   const connectionVariant = connectionDisplay.variant;
@@ -229,22 +215,6 @@ export function DashboardPage({ core, onNavigate, hideHeader }: DashboardPagePro
           }}
           testId="dashboard-card-version"
         />
-
-        <StatCard
-          label="Instance ID"
-          icon={Hash}
-          loading={status.loading.status && status.status === null}
-          value={status.status?.instance_id ?? "-"}
-        />
-
-        <StatCard
-          label="Tokens Used"
-          icon={Wallet}
-          loading={status.loading.usage && status.usage === null}
-          value={tokensUsedText}
-        />
-
-        <StatCard label="Active Runs" icon={Play} value={String(activeRunsCount)} />
 
         <StatCard
           label="Active Agents"

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -2578,9 +2578,10 @@ describe("operator-ui", () => {
     expect(presenceList.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(pairingsList.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(ws.approvalList.mock.calls.length).toBeGreaterThanOrEqual(1);
-    expect(container.textContent).toContain("gateway-1");
-    expect(container.textContent).toContain("Tokens Used");
     expect(container.textContent).toContain("Pending Approvals");
+    expect(container.textContent).not.toContain("Instance ID");
+    expect(container.textContent).not.toContain("Tokens Used");
+    expect(container.textContent).not.toContain("Active Runs");
 
     const approvalsBadge = container.querySelector<HTMLSpanElement>(
       '[data-testid="dashboard-approvals-badge"]',


### PR DESCRIPTION
## Summary
- remove the `Instance ID`, `Tokens Used`, and `Active Runs` stat cards from the dashboard UI
- clean up the now-unused dashboard imports and computations
- update the dashboard regression test to assert those fields are no longer rendered

## Testing
- `pnpm --filter @tyrum/operator-ui build`
- `pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts`
- `git push -u origin 0-remove-dashboard-metrics`
