### PR TITLE
chore: ignore @types/node major Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-minor-patch:
         update-types:
@@ -24,6 +28,10 @@ updates:
     directory: "/web"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary
- add an ignore rule for `@types/node` semver-major updates in both npm Dependabot entries
- keep existing minor/patch and grouped major behavior unchanged for the rest of the dependency set

## Validation
- parsed `.github/dependabot.yml` with Python `yaml.safe_load`
- ran `pnpm typecheck`
- push hook passed `format:check-staged`, `lint`, and the repo pre-push typecheck path

## Risk
- low; this only changes Dependabot configuration and is easy to revert with a one-line rule removal