### PR TITLE
Fix model preset refresh and OpenRouter model IDs

### DIFF
--- a/packages/gateway/src/modules/models/configured-model-preset-dal.ts
+++ b/packages/gateway/src/modules/models/configured-model-preset-dal.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { stableJsonStringify } from "../policy/canonical-json.js";
 import type { SqlDb } from "../../statestore/types.js";
+import { normalizeDbDateTime } from "../../utils/db-time.js";
 import { buildUpdatedAtMutation } from "../../statestore/updated-at.js";
 import { safeJsonParse } from "../../utils/json.js";
+import { normalizeProviderScopedModelId } from "./provider-model-id.js";
 
 export interface ConfiguredModelPresetRow {
   tenant_id: string;
@@ -29,7 +31,7 @@ interface RawConfiguredModelPresetRow {
 }
 
 function normalizeTime(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : value;
+  return normalizeDbDateTime(value) ?? new Date().toISOString();
 }
 
 function parseOptions(value: string): Record<string, unknown> {
@@ -50,7 +52,7 @@ function toRow(raw: RawConfiguredModelPresetRow): ConfiguredModelPresetRow {
     preset_key: raw.preset_key,
     display_name: raw.display_name,
     provider_key: raw.provider_key,
-    model_id: raw.model_id,
+    model_id: normalizeProviderScopedModelId(raw.provider_key, raw.model_id),
     options: parseOptions(raw.options_json),
     created_at: normalizeTime(raw.created_at),
     updated_at: normalizeTime(raw.updated_at),
@@ -107,6 +109,7 @@ export class ConfiguredModelPresetDal {
   }): Promise<ConfiguredModelPresetRow> {
     const presetId = randomUUID();
     const nowIso = new Date().toISOString();
+    const normalizedModelId = normalizeProviderScopedModelId(input.providerKey, input.modelId);
     await this.db.run(
       `INSERT INTO configured_model_presets (
          tenant_id,
@@ -125,7 +128,7 @@ export class ConfiguredModelPresetDal {
         input.presetKey,
         input.displayName,
         input.providerKey,
-        input.modelId,
+        normalizedModelId,
         JSON.stringify(input.options),
         nowIso,
         nowIso,

--- a/packages/gateway/src/modules/models/model-catalog-service.ts
+++ b/packages/gateway/src/modules/models/model-catalog-service.ts
@@ -8,6 +8,7 @@ import {
   type CatalogProviderOverrideRow,
 } from "./catalog-override-dal.js";
 import type { ModelsDevLoadResult, ModelsDevService } from "./models-dev-service.js";
+import { normalizeProviderScopedModelId } from "./provider-model-id.js";
 
 function normalizeOptionalString(raw: string | null | undefined): string | undefined {
   const trimmed = raw?.trim();
@@ -80,10 +81,39 @@ function groupModelOverrides(
   const byProvider = new Map<string, Map<string, CatalogModelOverrideRow>>();
   for (const row of rows) {
     const inner = byProvider.get(row.provider_id) ?? new Map<string, CatalogModelOverrideRow>();
-    inner.set(row.model_id, row);
+    const normalizedModelId = normalizeProviderScopedModelId(row.provider_id, row.model_id);
+    const existing = inner.get(normalizedModelId);
+    if (!existing || row.model_id === normalizedModelId) {
+      inner.set(normalizedModelId, row);
+    }
     byProvider.set(row.provider_id, inner);
   }
   return byProvider;
+}
+
+function normalizeBaseModels(
+  providerId: string,
+  models: Record<string, unknown>,
+): Map<string, Record<string, unknown>> {
+  const normalized = new Map<string, Record<string, unknown>>();
+
+  for (const [rawModelId, rawModel] of Object.entries(models)) {
+    const normalizedModelId = normalizeProviderScopedModelId(providerId, rawModelId);
+    const modelRecord =
+      rawModel && typeof rawModel === "object" && !Array.isArray(rawModel)
+        ? { ...(rawModel as Record<string, unknown>) }
+        : {};
+    const embeddedModelId =
+      typeof modelRecord["id"] === "string" ? modelRecord["id"] : normalizedModelId;
+    modelRecord["id"] = normalizeProviderScopedModelId(providerId, embeddedModelId);
+
+    const existing = normalized.get(normalizedModelId);
+    if (!existing || rawModelId === normalizedModelId) {
+      normalized.set(normalizedModelId, modelRecord);
+    }
+  }
+
+  return normalized;
 }
 
 export class ModelCatalogService {
@@ -190,16 +220,18 @@ export class ModelCatalogService {
         delete provider["headers"];
       }
 
-      const baseModels =
-        (baseProvider as { models?: Record<string, unknown> } | undefined)?.models ?? {};
+      const baseModels = normalizeBaseModels(
+        providerId,
+        (baseProvider as { models?: Record<string, unknown> } | undefined)?.models ?? {},
+      );
       const overrideModels =
         modelOverridesByProvider.get(providerId) ?? new Map<string, CatalogModelOverrideRow>();
-      const modelIds = new Set<string>([...Object.keys(baseModels), ...overrideModels.keys()]);
+      const modelIds = new Set<string>([...baseModels.keys(), ...overrideModels.keys()]);
 
       const models: Record<string, unknown> = {};
       const sortedModelIds = Array.from(modelIds).toSorted((a, b) => a.localeCompare(b));
       for (const modelId of sortedModelIds) {
-        const baseModel = baseModels[modelId] as Record<string, unknown> | undefined;
+        const baseModel = baseModels.get(modelId);
         const modelOverride = overrideModels.get(modelId);
         const modelEnabled = modelOverride ? modelOverride.enabled : true;
 

--- a/packages/gateway/src/modules/models/provider-model-id.ts
+++ b/packages/gateway/src/modules/models/provider-model-id.ts
@@ -1,0 +1,10 @@
+export function normalizeProviderScopedModelId(providerId: string, modelId: string): string {
+  const normalizedProviderId = providerId.trim();
+  const normalizedModelId = modelId.trim();
+  if (!normalizedProviderId || !normalizedModelId) return normalizedModelId;
+
+  const redundantPrefix = `${normalizedProviderId}/`;
+  return normalizedModelId.startsWith(redundantPrefix)
+    ? normalizedModelId.slice(redundantPrefix.length)
+    : normalizedModelId;
+}

--- a/packages/gateway/src/routes/model-config.ts
+++ b/packages/gateway/src/routes/model-config.ts
@@ -26,6 +26,7 @@ import {
   ExecutionProfileModelAssignmentDal,
   type ExecutionProfileModelAssignmentRow,
 } from "../modules/models/execution-profile-model-assignment-dal.js";
+import { normalizeProviderScopedModelId } from "../modules/models/provider-model-id.js";
 import { coerceRecord, coerceString } from "../modules/util/coerce.js";
 import { createUniqueKey, slugifyKey } from "./config-key-utils.js";
 
@@ -199,7 +200,7 @@ export function createModelConfigRoutes(deps: ModelConfigRouteDeps): Hono {
           .map((model) => ({
             provider_key: provider.id,
             provider_name: provider.name,
-            model_id: model.id,
+            model_id: normalizeProviderScopedModelId(provider.id, model.id),
             model_name: model.name,
             family: model.family ?? null,
             reasoning: typeof model.reasoning === "boolean" ? model.reasoning : null,
@@ -239,8 +240,12 @@ export function createModelConfigRoutes(deps: ModelConfigRouteDeps): Hono {
       return c.json({ error: "invalid_request", message: "provider is not configured" }, 400);
     }
 
+    const normalizedModelId = normalizeProviderScopedModelId(
+      parsed.data.provider_key,
+      parsed.data.model_id,
+    );
     const provider = loaded.catalog[parsed.data.provider_key];
-    const model = provider?.models?.[parsed.data.model_id];
+    const model = provider?.models?.[normalizedModelId] ?? provider?.models?.[parsed.data.model_id];
     if (!provider || !model || !isLanguageModel(model as Record<string, unknown>)) {
       return c.json({ error: "invalid_request", message: "model is not available" }, 400);
     }
@@ -254,7 +259,7 @@ export function createModelConfigRoutes(deps: ModelConfigRouteDeps): Hono {
       presetKey,
       displayName: parsed.data.display_name,
       providerKey: parsed.data.provider_key,
-      modelId: parsed.data.model_id,
+      modelId: normalizedModelId,
       options: parsed.data.options,
     });
 

--- a/packages/gateway/tests/integration/provider-model-config-routes.test.ts
+++ b/packages/gateway/tests/integration/provider-model-config-routes.test.ts
@@ -325,6 +325,116 @@ describe("provider + model config routes", () => {
     ).toBe(true);
   });
 
+  it("normalizes legacy self-prefixed OpenRouter model ids in available and preset routes", async () => {
+    const { app, container } = await createTestApp();
+    await seedCatalog(new ModelsDevCacheDal(container.db), {
+      openrouter: {
+        id: "openrouter",
+        name: "OpenRouter",
+        env: ["OPENROUTER_API_KEY"],
+        npm: "@openrouter/ai-sdk-provider",
+        api: "https://openrouter.ai/api/v1",
+        doc: "https://openrouter.ai/docs/api-reference/overview",
+        models: {
+          "openrouter/openai/gpt-5.4": {
+            id: "openrouter/openai/gpt-5.4",
+            name: "GPT-5.4",
+            modalities: { output: ["text"] },
+            reasoning: true,
+            tool_call: true,
+          },
+        },
+      },
+    });
+
+    await container.db.run(
+      `INSERT INTO auth_profiles (
+         tenant_id,
+         auth_profile_id,
+         auth_profile_key,
+         provider_key,
+         type,
+         status
+       ) VALUES (?, ?, ?, ?, 'api_key', 'active')`,
+      [DEFAULT_TENANT_ID, randomUUID(), "openrouter-primary", "openrouter"],
+    );
+
+    const nowIso = "2026-03-01T00:00:00.000Z";
+    await container.db.run(
+      `INSERT INTO configured_model_presets (
+         tenant_id,
+         preset_id,
+         preset_key,
+         display_name,
+         provider_key,
+         model_id,
+         options_json,
+         created_at,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        DEFAULT_TENANT_ID,
+        randomUUID(),
+        "legacy-openrouter",
+        "Legacy OpenRouter",
+        "openrouter",
+        "openrouter/openai/gpt-5.4",
+        "{}",
+        nowIso,
+        nowIso,
+      ],
+    );
+
+    const availableRes = await app.request("/config/models/presets/available");
+    expect(availableRes.status).toBe(200);
+    const available = (await availableRes.json()) as {
+      models: Array<{ provider_key: string; model_id: string }>;
+    };
+    expect(available.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider_key: "openrouter",
+          model_id: "openai/gpt-5.4",
+        }),
+      ]),
+    );
+
+    const presetListRes = await app.request("/config/models/presets");
+    expect(presetListRes.status).toBe(200);
+    const presetList = (await presetListRes.json()) as {
+      presets: Array<{ preset_key: string; model_id: string }>;
+    };
+    expect(presetList.presets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          preset_key: "legacy-openrouter",
+          model_id: "openai/gpt-5.4",
+        }),
+      ]),
+    );
+
+    const createRes = await app.request("/config/models/presets", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        display_name: "GPT-5.4",
+        provider_key: "openrouter",
+        model_id: "openai/gpt-5.4",
+        options: {},
+      }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as {
+      preset: { provider_key: string; model_id: string };
+    };
+    expect(created.preset).toEqual(
+      expect.objectContaining({
+        provider_key: "openrouter",
+        model_id: "openai/gpt-5.4",
+      }),
+    );
+  });
+
   it("returns 400 when assignments reference a missing preset", async () => {
     const { app } = await createTestApp();
 

--- a/packages/operator-ui/src/components/pages/admin-http-models.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-models.tsx
@@ -58,6 +58,7 @@ type AvailableModel = Awaited<
 type Assignment = Awaited<
   ReturnType<AdminHttpClient["modelConfig"]["listAssignments"]>
 >["assignments"][number];
+type ModelConfigHttpClient = Pick<AdminHttpClient, "modelConfig">;
 
 type ModelDialogState = {
   displayName: string;
@@ -371,63 +372,66 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
   const [editingPreset, setEditingPreset] = React.useState<ModelPreset | null>(null);
   const [deletingPreset, setDeletingPreset] = React.useState<DeletePresetDialogState>(null);
 
-  const refresh = React.useCallback(async (): Promise<void> => {
-    setRefreshing(true);
-    setExecutionProfilesErrorMessage(null);
-    setAvailableModelsErrorMessage(null);
+  const refresh = React.useCallback(
+    async (httpClient: ModelConfigHttpClient = readHttp): Promise<void> => {
+      setRefreshing(true);
+      setExecutionProfilesErrorMessage(null);
+      setAvailableModelsErrorMessage(null);
 
-    const [presetResult, availableResult, assignmentResult] = await Promise.allSettled([
-      readHttp.modelConfig.listPresets(),
-      readHttp.modelConfig.listAvailable(),
-      readHttp.modelConfig.listAssignments(),
-    ]);
+      const [presetResult, availableResult, assignmentResult] = await Promise.allSettled([
+        httpClient.modelConfig.listPresets(),
+        httpClient.modelConfig.listAvailable(),
+        httpClient.modelConfig.listAssignments(),
+      ]);
 
-    let nextExecutionProfilesErrorMessage: string | null = null;
-    let nextAvailableModelsErrorMessage: string | null = null;
-    let nextPresetCount = 0;
+      let nextExecutionProfilesErrorMessage: string | null = null;
+      let nextAvailableModelsErrorMessage: string | null = null;
+      let nextPresetCount = 0;
 
-    if (presetResult.status === "fulfilled") {
-      setPresets(presetResult.value.presets);
-      nextPresetCount = presetResult.value.presets.length;
-    } else {
-      nextExecutionProfilesErrorMessage = formatErrorMessage(presetResult.reason);
-      setPresets([]);
-    }
-
-    if (availableResult.status === "fulfilled") {
-      setAvailableModels(availableResult.value.models);
-    } else {
-      nextAvailableModelsErrorMessage = formatErrorMessage(availableResult.reason);
-      setAvailableModels([]);
-    }
-
-    if (assignmentResult.status === "fulfilled") {
-      setAssignments(assignmentResult.value.assignments);
-      setAssignmentDraft(
-        Object.fromEntries(
-          assignmentResult.value.assignments.map((assignment) => [
-            assignment.execution_profile_id,
-            assignment.preset_key,
-          ]),
-        ),
-      );
-    } else {
-      setAssignments([]);
-      setAssignmentDraft({});
-      if (!nextExecutionProfilesErrorMessage && nextPresetCount > 0) {
-        nextExecutionProfilesErrorMessage = formatErrorMessage(assignmentResult.reason);
+      if (presetResult.status === "fulfilled") {
+        setPresets(presetResult.value.presets);
+        nextPresetCount = presetResult.value.presets.length;
+      } else {
+        nextExecutionProfilesErrorMessage = formatErrorMessage(presetResult.reason);
+        setPresets([]);
       }
-    }
 
-    setExecutionProfilesErrorMessage(nextExecutionProfilesErrorMessage);
-    setAvailableModelsErrorMessage(nextAvailableModelsErrorMessage);
-    setLoading(false);
-    setRefreshing(false);
-  }, [readHttp.modelConfig]);
+      if (availableResult.status === "fulfilled") {
+        setAvailableModels(availableResult.value.models);
+      } else {
+        nextAvailableModelsErrorMessage = formatErrorMessage(availableResult.reason);
+        setAvailableModels([]);
+      }
+
+      if (assignmentResult.status === "fulfilled") {
+        setAssignments(assignmentResult.value.assignments);
+        setAssignmentDraft(
+          Object.fromEntries(
+            assignmentResult.value.assignments.map((assignment) => [
+              assignment.execution_profile_id,
+              assignment.preset_key,
+            ]),
+          ),
+        );
+      } else {
+        setAssignments([]);
+        setAssignmentDraft({});
+        if (!nextExecutionProfilesErrorMessage && nextPresetCount > 0) {
+          nextExecutionProfilesErrorMessage = formatErrorMessage(assignmentResult.reason);
+        }
+      }
+
+      setExecutionProfilesErrorMessage(nextExecutionProfilesErrorMessage);
+      setAvailableModelsErrorMessage(nextAvailableModelsErrorMessage);
+      setLoading(false);
+      setRefreshing(false);
+    },
+    [readHttp],
+  );
 
   React.useEffect(() => {
-    void refresh();
-  }, [refresh]);
+    void refresh(readHttp);
+  }, [readHttp, refresh]);
 
   const assignmentPresetKeys = new Map(
     assignments.map((assignment) => [assignment.execution_profile_id, assignment.preset_key]),
@@ -446,7 +450,7 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
     setExecutionProfilesErrorMessage(null);
     try {
       await mutationHttp.modelConfig.updateAssignments({ assignments: assignmentDraft });
-      await refresh();
+      await refresh(mutationHttp);
     } catch (error) {
       setExecutionProfilesErrorMessage(formatErrorMessage(error));
     } finally {
@@ -484,7 +488,7 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
     }
 
     setDeletingPreset(null);
-    await refresh();
+    await refresh(mutationHttp);
   };
 
   const candidatePresets = deletingPreset
@@ -508,7 +512,7 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
                 variant="secondary"
                 isLoading={refreshing}
                 onClick={() => {
-                  void refresh();
+                  void refresh(readHttp);
                 }}
               >
                 Refresh
@@ -708,7 +712,9 @@ export function AdminHttpModelsPanel({ core }: { core: OperatorCore }): React.Re
         }}
         preset={editingPreset}
         availableModels={availableModels}
-        onSaved={refresh}
+        onSaved={async () => {
+          await refresh(mutationHttp);
+        }}
         canMutate={canMutate}
         core={core}
       />

--- a/packages/operator-ui/tests/pages/admin-page.http.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.test.ts
@@ -711,7 +711,7 @@ describe("ConfigurePage (HTTP) policy + config", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(saveButton?.disabled).toBe(true);
 
     cleanupTestRoot({ container, root });
@@ -761,8 +761,7 @@ describe("ConfigurePage (HTTP) policy + config", () => {
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
-      expect(url).toBe("http://example.test/config/models/presets");
-      expect(init?.method).toBe("POST");
+      const method = init?.method ?? "GET";
 
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer test-elevated-token");
@@ -777,18 +776,61 @@ describe("ConfigurePage (HTTP) policy + config", () => {
         created_at: "2026-03-01T00:00:00.000Z",
         updated_at: "2026-03-01T00:00:00.000Z",
       };
-      const bodyRaw = String(init?.body ?? "");
-      expect(JSON.parse(bodyRaw)).toEqual({
-        display_name: "GPT-4.1 Mini",
-        provider_key: "openai",
-        model_id: "gpt-4.1-mini",
-        options: { reasoning_effort: "high" },
-      });
-      presets = [createdPreset];
 
-      return new Response(JSON.stringify({ status: "ok", preset: createdPreset }), {
-        status: 201,
-      });
+      if (method === "POST" && url === "http://example.test/config/models/presets") {
+        const bodyRaw = String(init?.body ?? "");
+        expect(JSON.parse(bodyRaw)).toEqual({
+          display_name: "GPT-4.1 Mini",
+          provider_key: "openai",
+          model_id: "gpt-4.1-mini",
+          options: { reasoning_effort: "high" },
+        });
+        presets = [createdPreset];
+        return new Response(JSON.stringify({ status: "ok", preset: createdPreset }), {
+          status: 201,
+        });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets") {
+        return new Response(JSON.stringify({ status: "ok", presets }), { status: 200 });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets/available") {
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            models: [
+              {
+                provider_key: "openai",
+                provider_name: "OpenAI",
+                model_id: "gpt-4.1",
+                model_name: "GPT-4.1",
+                family: null,
+                reasoning: true,
+                tool_call: true,
+                modalities: { output: ["text"] },
+              },
+              {
+                provider_key: "openai",
+                provider_name: "OpenAI",
+                model_id: "gpt-4.1-mini",
+                model_name: "GPT-4.1 Mini",
+                family: null,
+                reasoning: true,
+                tool_call: true,
+                modalities: { output: ["text"] },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/assignments") {
+        return new Response(JSON.stringify({ status: "ok", assignments: [] }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -837,7 +879,132 @@ describe("ConfigurePage (HTTP) policy + config", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(container.textContent).toContain("GPT-4.1 Mini");
+
+    cleanupTestRoot({ container, root });
+  });
+
+  it("refreshes configured models with the elevated client after creating a preset", async () => {
+    const { core } = createTestCore();
+    const modelConfig = core.http.modelConfig as {
+      listPresets: ReturnType<typeof vi.fn>;
+      listAvailable: ReturnType<typeof vi.fn>;
+      listAssignments: ReturnType<typeof vi.fn>;
+    };
+    const availableModels = [
+      {
+        provider_key: "openai",
+        provider_name: "OpenAI",
+        model_id: "gpt-4.1-mini",
+        model_name: "GPT-4.1 Mini",
+        family: null,
+        reasoning: true,
+        tool_call: true,
+        modalities: { output: ["text"] },
+      },
+    ];
+    const createdPreset = {
+      preset_id: "00000000-0000-4000-8000-000000000022",
+      preset_key: "preset-gpt-4-1-mini",
+      display_name: "GPT-4.1 Mini",
+      provider_key: "openai",
+      model_id: "gpt-4.1-mini",
+      options: {},
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
+    };
+    modelConfig.listPresets = vi.fn(async () => ({
+      status: "ok",
+      presets: [],
+    }));
+    modelConfig.listAvailable = vi.fn(async () => ({
+      status: "ok",
+      models: availableModels,
+    }));
+    modelConfig.listAssignments = vi.fn(async () => ({
+      status: "ok",
+      assignments: [],
+    }));
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
+      const method = init?.method ?? "GET";
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer test-elevated-token");
+
+      if (method === "POST" && url === "http://example.test/config/models/presets") {
+        expect(JSON.parse(String(init?.body ?? ""))).toEqual({
+          display_name: "GPT-4.1 Mini",
+          provider_key: "openai",
+          model_id: "gpt-4.1-mini",
+          options: {},
+        });
+        return new Response(JSON.stringify({ status: "ok", preset: createdPreset }), {
+          status: 201,
+        });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets") {
+        return new Response(JSON.stringify({ status: "ok", presets: [createdPreset] }), {
+          status: 200,
+        });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets/available") {
+        return new Response(JSON.stringify({ status: "ok", models: availableModels }), {
+          status: 200,
+        });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/assignments") {
+        return new Response(JSON.stringify({ status: "ok", assignments: [] }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(ElevatedModeProvider, { core, mode: "web" }, [
+        React.createElement(ConfigurePage, { key: "page", core }),
+      ]),
+    );
+
+    await switchHttpTab(container, "admin-http-tab-models");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const addButton = container.querySelector<HTMLButtonElement>("[data-testid='models-add-open']");
+    expect(addButton).not.toBeNull();
+
+    act(() => {
+      addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const dialog = document.body.querySelector<HTMLElement>("[data-testid='models-preset-dialog']");
+    expect(dialog).not.toBeNull();
+
+    const dialogSelects = Array.from(dialog?.querySelectorAll<HTMLSelectElement>("select") ?? []);
+    expect(dialogSelects.length).toBe(2);
+    setSelectValue(dialogSelects[0]!, "openai/gpt-4.1-mini");
+
+    const saveButton = document.body.querySelector<HTMLButtonElement>(
+      "[data-testid='models-save']",
+    );
+    expect(saveButton).not.toBeNull();
+
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(modelConfig.listPresets).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(container.textContent).toContain("GPT-4.1 Mini");
 
     cleanupTestRoot({ container, root });
@@ -888,27 +1055,59 @@ describe("ConfigurePage (HTTP) policy + config", () => {
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
-      expect(url).toBe("http://example.test/config/models/presets/legacy-openai");
-      expect(init?.method).toBe("PATCH");
+      const method = init?.method ?? "GET";
 
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer test-elevated-token");
 
-      const bodyRaw = String(init?.body ?? "");
-      expect(JSON.parse(bodyRaw)).toEqual({
-        display_name: "Renamed preset",
-        options: { reasoning_effort: "medium" },
-      });
-
-      presets = [
-        {
-          ...presets[0],
+      if (method === "PATCH" && url === "http://example.test/config/models/presets/legacy-openai") {
+        const bodyRaw = String(init?.body ?? "");
+        expect(JSON.parse(bodyRaw)).toEqual({
           display_name: "Renamed preset",
           options: { reasoning_effort: "medium" },
-        },
-      ];
+        });
 
-      return new Response(JSON.stringify({ status: "ok", preset: presets[0] }), { status: 200 });
+        presets = [
+          {
+            ...presets[0],
+            display_name: "Renamed preset",
+            options: { reasoning_effort: "medium" },
+          },
+        ];
+
+        return new Response(JSON.stringify({ status: "ok", preset: presets[0] }), { status: 200 });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets") {
+        return new Response(JSON.stringify({ status: "ok", presets }), { status: 200 });
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/presets/available") {
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            models: [
+              {
+                provider_key: "anthropic",
+                provider_name: "Anthropic",
+                model_id: "claude-3.7-sonnet",
+                model_name: "Claude 3.7 Sonnet",
+                family: null,
+                reasoning: true,
+                tool_call: true,
+                modalities: { output: ["text"] },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (method === "GET" && url === "http://example.test/config/models/assignments") {
+        return new Response(JSON.stringify({ status: "ok", assignments: [] }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -966,7 +1165,7 @@ describe("ConfigurePage (HTTP) policy + config", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(container.textContent).toContain("Renamed preset");
 
     cleanupTestRoot({ container, root });
@@ -1172,7 +1371,7 @@ describe("ConfigurePage (HTTP) policy + config", () => {
       await Promise.resolve();
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(container.textContent).not.toContain("Default (openai/gpt-4.1)");
 
     cleanupTestRoot({ container, root });


### PR DESCRIPTION
Closes #1122

## Summary
- refresh Configure > Models with the elevated client after model mutations so newly created presets appear immediately
- normalize configured model preset timestamps from SQLite so `/config/models/presets` always returns contract-valid ISO datetimes
- canonicalize self-prefixed provider model IDs so OpenRouter models are stored and surfaced as upstream IDs like `openai/gpt-5.4`
- add regression coverage for the UI refresh path and OpenRouter normalization compatibility

## Testing
- `pnpm exec vitest run packages/operator-ui/tests/pages/admin-page.http.test.ts packages/gateway/tests/integration/provider-model-config-routes.test.ts`
- `pnpm exec tsc -b packages/gateway/tsconfig.json packages/operator-ui/tsconfig.json --pretty false`
- pre-push hook passed: `pnpm lint`, `pnpm typecheck`, and `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`

## Risk
- scoped to model config read/write flows and provider/model ID canonicalization
- legacy self-prefixed catalog rows and preset rows are normalized for compatibility

## Rollback
- revert commit `76c7913e`
