### PR TITLE
Fix chat panel scrolling and remove compact action

### DIFF
--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -276,6 +276,7 @@ function OperatorUiAppRoot({
   const shell = (
     <AppShell
       mode={mode}
+      viewportLocked={route === "chat"}
       sidebar={
         showShell ? (
           <Sidebar

--- a/packages/operator-ui/src/components/layout/app-shell.tsx
+++ b/packages/operator-ui/src/components/layout/app-shell.tsx
@@ -9,6 +9,7 @@ export interface AppShellProps extends React.HTMLAttributes<HTMLDivElement> {
   sidebar: React.ReactNode;
   mobileNav: React.ReactNode;
   fullBleed?: boolean;
+  viewportLocked?: boolean;
 }
 
 export function AppShell({
@@ -16,6 +17,7 @@ export function AppShell({
   sidebar,
   mobileNav,
   fullBleed = false,
+  viewportLocked = false,
   children,
   className,
   ...props
@@ -23,31 +25,38 @@ export function AppShell({
   const mdUp = useMediaQuery("(min-width: 768px)");
   const showSidebar = mode === "desktop" || mdUp;
   const showMobileNav = mode === "web" && !mdUp;
+  const lockViewport = mode === "desktop" || viewportLocked;
 
   return (
     <div
       className={cn(
         "bg-bg text-fg font-sans antialiased overflow-hidden",
-        mode === "desktop" ? "h-screen" : "min-h-screen",
+        mode === "desktop" ? "h-screen" : lockViewport ? "h-dvh" : "min-h-screen",
         className,
       )}
       style={{ backgroundImage: "var(--tyrum-app-bg-image)" }}
       {...props}
     >
-      <div className={cn("flex", mode === "desktop" ? "h-full" : "min-h-screen")}>
+      <div className={cn("flex", lockViewport ? "h-full min-h-0" : "min-h-screen")}>
         {showSidebar ? sidebar : null}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <main
             className={cn(
-              "flex-1 overflow-x-hidden",
-              fullBleed ? "overflow-y-hidden" : "overflow-y-auto",
+              "flex-1 min-h-0 overflow-x-hidden",
+              fullBleed || viewportLocked ? "overflow-y-hidden" : "overflow-y-auto",
               showMobileNav ? "pb-[calc(4rem+env(safe-area-inset-bottom))]" : null,
             )}
           >
             {fullBleed ? (
               children
             ) : (
-              <div className={cn("min-w-0 px-4 py-6", mode === "web" ? "mx-auto max-w-6xl" : null)}>
+              <div
+                className={cn(
+                  "min-w-0 px-4 py-6",
+                  mode === "web" ? "mx-auto max-w-6xl" : null,
+                  viewportLocked ? "flex h-full min-h-0 flex-col overflow-hidden" : null,
+                )}
+              >
                 {children}
               </div>
             )}

--- a/packages/operator-ui/src/components/pages/chat-page.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page.tsx
@@ -79,7 +79,7 @@ export function ChatPage({ core }: { core: OperatorCore }) {
   const activeTurns = active?.turns ?? [];
 
   return (
-    <div className="grid gap-6" data-testid="chat-page">
+    <div className="flex h-full min-h-0 flex-col gap-6" data-testid="chat-page">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold tracking-tight text-fg">Chat</h1>
         <div className="flex flex-wrap items-center gap-2">
@@ -124,8 +124,11 @@ export function ChatPage({ core }: { core: OperatorCore }) {
         />
       ) : null}
 
-      <div className="grid gap-6 md:grid-cols-[320px_1fr]">
-        <Card className="flex min-h-[32rem] flex-col">
+      <div
+        className="grid min-h-0 flex-1 gap-6 grid-rows-[minmax(0,2fr)_minmax(0,3fr)] md:grid-cols-[320px_minmax(0,1fr)] md:grid-rows-1"
+        data-testid="chat-panels"
+      >
+        <Card className="flex h-full min-h-0 flex-col" data-testid="chat-threads-panel">
           <CardHeader className="pb-4">
             <div className="flex items-center justify-between gap-3">
               <div className="text-sm font-medium text-fg-muted">Threads</div>
@@ -143,7 +146,7 @@ export function ChatPage({ core }: { core: OperatorCore }) {
             </div>
           </CardHeader>
           <Separator />
-          <CardContent className="flex-1 overflow-hidden">
+          <CardContent className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
             {chat.sessions.error ? (
               <Alert
                 variant="error"
@@ -151,51 +154,53 @@ export function ChatPage({ core }: { core: OperatorCore }) {
                 description={chat.sessions.error.message}
               />
             ) : null}
-            {chat.sessions.loading && threads.length === 0 ? (
-              <div className="text-sm text-fg-muted">Loading…</div>
-            ) : threads.length === 0 ? (
-              <div className="text-sm text-fg-muted">No chats yet.</div>
-            ) : (
-              <ScrollArea className="h-full">
-                <div className="grid gap-2 pr-3">
-                  {threads.map((session) => {
-                    const isActive = chat.active.sessionId === session.session_id;
-                    return (
-                      <button
-                        key={session.session_id}
-                        type="button"
-                        data-testid={`chat-thread-${session.session_id}`}
-                        data-active={isActive ? "true" : undefined}
-                        className={cn(
-                          "w-full rounded-xl border px-3 py-2 text-left transition-colors",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
-                          isActive
-                            ? "border-border bg-bg-subtle/80"
-                            : "border-border/50 bg-bg-card/40 hover:bg-bg-card/60",
-                        )}
-                        onClick={() => {
-                          void core.chatStore.openSession(session.session_id);
-                        }}
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium text-fg">
-                              {session.title}
+            <div className="min-h-0 flex-1 overflow-hidden">
+              {chat.sessions.loading && threads.length === 0 ? (
+                <div className="text-sm text-fg-muted">Loading…</div>
+              ) : threads.length === 0 ? (
+                <div className="text-sm text-fg-muted">No chats yet.</div>
+              ) : (
+                <ScrollArea className="h-full">
+                  <div className="grid gap-2 pr-3">
+                    {threads.map((session) => {
+                      const isActive = chat.active.sessionId === session.session_id;
+                      return (
+                        <button
+                          key={session.session_id}
+                          type="button"
+                          data-testid={`chat-thread-${session.session_id}`}
+                          data-active={isActive ? "true" : undefined}
+                          className={cn(
+                            "w-full rounded-xl border px-3 py-2 text-left transition-colors",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+                            isActive
+                              ? "border-border bg-bg-subtle/80"
+                              : "border-border/50 bg-bg-card/40 hover:bg-bg-card/60",
+                          )}
+                          onClick={() => {
+                            void core.chatStore.openSession(session.session_id);
+                          }}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium text-fg">
+                                {session.title}
+                              </div>
+                              <div className="mt-1 truncate text-xs text-fg-muted">
+                                {session.preview || "—"}
+                              </div>
                             </div>
-                            <div className="mt-1 truncate text-xs text-fg-muted">
-                              {session.preview || "—"}
+                            <div className="shrink-0 text-xs text-fg-muted">
+                              {formatRelativeTime(session.updated_at)}
                             </div>
                           </div>
-                          <div className="shrink-0 text-xs text-fg-muted">
-                            {formatRelativeTime(session.updated_at)}
-                          </div>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </ScrollArea>
-            )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              )}
+            </div>
           </CardContent>
           <CardFooter className="justify-between gap-2">
             <Button
@@ -213,7 +218,7 @@ export function ChatPage({ core }: { core: OperatorCore }) {
           </CardFooter>
         </Card>
 
-        <Card className="flex min-h-[32rem] flex-col">
+        <Card className="flex h-full min-h-0 flex-col" data-testid="chat-conversation-panel">
           <CardHeader className="pb-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
@@ -223,17 +228,6 @@ export function ChatPage({ core }: { core: OperatorCore }) {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  data-testid="chat-compact"
-                  disabled={!active || chat.active.loading}
-                  onClick={() => {
-                    void core.chatStore.compactActive();
-                  }}
-                >
-                  Compact
-                </Button>
                 <Button
                   size="sm"
                   variant="danger"
@@ -249,7 +243,7 @@ export function ChatPage({ core }: { core: OperatorCore }) {
             </div>
           </CardHeader>
           <Separator />
-          <CardContent className="flex-1 overflow-hidden">
+          <CardContent className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden">
             {chat.active.error ? (
               <Alert
                 variant="error"
@@ -257,36 +251,38 @@ export function ChatPage({ core }: { core: OperatorCore }) {
                 description={chat.active.error.message}
               />
             ) : null}
-            <ScrollArea className="h-full" data-testid="chat-transcript">
-              <div className="grid gap-3 pr-3">
-                {activeTurns.length === 0 ? (
-                  <div className="text-sm text-fg-muted">
-                    {active ? "No messages yet." : "Pick a thread or start a new chat."}
-                  </div>
-                ) : (
-                  activeTurns.map((turn, index) => {
-                    const isUser = turn.role === "user";
-                    return (
-                      <div
-                        key={`${turn.role}-${index}`}
-                        className={cn("flex", isUser ? "justify-end" : "justify-start")}
-                      >
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <ScrollArea className="h-full" data-testid="chat-transcript">
+                <div className="grid gap-3 pr-3">
+                  {activeTurns.length === 0 ? (
+                    <div className="text-sm text-fg-muted">
+                      {active ? "No messages yet." : "Pick a thread or start a new chat."}
+                    </div>
+                  ) : (
+                    activeTurns.map((turn, index) => {
+                      const isUser = turn.role === "user";
+                      return (
                         <div
-                          className={cn(
-                            "max-w-[85%] rounded-2xl border px-4 py-3 text-sm whitespace-pre-wrap",
-                            isUser
-                              ? "border-border bg-bg-subtle/80 text-fg"
-                              : "border-border/50 bg-bg-card/40 text-fg",
-                          )}
+                          key={`${turn.role}-${index}`}
+                          className={cn("flex", isUser ? "justify-end" : "justify-start")}
                         >
-                          {turn.content}
+                          <div
+                            className={cn(
+                              "max-w-[85%] rounded-2xl border px-4 py-3 text-sm whitespace-pre-wrap",
+                              isUser
+                                ? "border-border bg-bg-subtle/80 text-fg"
+                                : "border-border/50 bg-bg-card/40 text-fg",
+                            )}
+                          >
+                            {turn.content}
+                          </div>
                         </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-            </ScrollArea>
+                      );
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
           </CardContent>
           <Separator />
           <CardFooter className="flex-col items-stretch gap-3">

--- a/packages/operator-ui/tests/layout/app-shell.test.ts
+++ b/packages/operator-ui/tests/layout/app-shell.test.ts
@@ -34,4 +34,44 @@ describe("AppShell", () => {
 
     cleanupTestRoot({ container, root });
   });
+
+  it.each([
+    { mode: "desktop", expectedHeightClass: "h-screen" },
+    { mode: "web", expectedHeightClass: "h-dvh" },
+  ] as const)(
+    "supports viewportLocked content in $mode mode without forwarding props to the DOM",
+    ({ mode, expectedHeightClass }) => {
+      const AppShell = (operatorUi as Record<string, unknown>)["AppShell"];
+      expect(AppShell).toBeDefined();
+
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const { container, root } = renderIntoDocument(
+        React.createElement(
+          AppShell as React.ComponentType,
+          {
+            mode,
+            viewportLocked: true,
+            sidebar: React.createElement("div", { "data-testid": "sidebar" }),
+            mobileNav: React.createElement("div", { "data-testid": "mobile-nav" }),
+          },
+          React.createElement("div", { "data-testid": "content" }),
+        ),
+      );
+
+      const outer = container.firstElementChild as HTMLDivElement | null;
+      const main = container.querySelector("main");
+      const contentWrapper = container.querySelector("main > div");
+
+      expect(consoleError).not.toHaveBeenCalled();
+      expect(outer?.className).toContain(expectedHeightClass);
+      expect(main?.className).toContain("min-h-0");
+      expect(main?.className).toContain("overflow-y-hidden");
+      expect(contentWrapper?.className).toContain("h-full");
+      expect(contentWrapper?.className).toContain("min-h-0");
+      expect(contentWrapper?.className).toContain("overflow-hidden");
+
+      cleanupTestRoot({ container, root });
+    },
+  );
 });

--- a/packages/operator-ui/tests/pages/chat-page.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page.test.ts
@@ -98,4 +98,69 @@ describe("ChatPage", () => {
 
     cleanupTestRoot(testRoot);
   });
+
+  it("keeps chat panels height-bound and removes the compact action", async () => {
+    const ws = {
+      sessionList: vi.fn().mockResolvedValue({
+        sessions: [
+          {
+            agent_id: "default",
+            session_id: "ui:thread-1",
+            channel: "ui",
+            thread_id: "ui-550e8400-e29b-41d4-a716-446655440000",
+            summary: "Conversation summary",
+            last_turn: { role: "assistant", content: "Assistant title\nMore details" },
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
+        next_cursor: null,
+      }),
+    };
+
+    const http = {};
+
+    const chatStore = createChatStore(ws as never, http as never);
+    await chatStore.refreshSessions();
+
+    const { store: connectionStore } = createStore({
+      status: "disconnected",
+      clientId: null,
+      lastDisconnect: null,
+      transportError: null,
+    });
+
+    const core = { connectionStore, chatStore } as unknown as OperatorCore;
+    const testRoot = renderIntoDocument(React.createElement(ChatPage, { core }));
+
+    const page = testRoot.container.querySelector<HTMLElement>('[data-testid="chat-page"]');
+    const panels = testRoot.container.querySelector<HTMLElement>('[data-testid="chat-panels"]');
+    const threadsPanel = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="chat-threads-panel"]',
+    );
+    const conversationPanel = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="chat-conversation-panel"]',
+    );
+    const transcript = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="chat-transcript"]',
+    );
+    const threadsScrollArea = threadsPanel?.querySelector<HTMLElement>("[data-scroll-area-root]");
+
+    expect(page?.className).toContain("h-full");
+    expect(page?.className).toContain("min-h-0");
+    expect(panels?.className).toContain("flex-1");
+    expect(panels?.className).toContain("grid-rows-[minmax(0,2fr)_minmax(0,3fr)]");
+    expect(threadsPanel?.className).toContain("h-full");
+    expect(threadsPanel?.className).toContain("min-h-0");
+    expect(conversationPanel?.className).toContain("h-full");
+    expect(conversationPanel?.className).toContain("min-h-0");
+    expect(threadsScrollArea?.parentElement?.className).toContain("min-h-0");
+    expect(threadsScrollArea?.parentElement?.className).toContain("flex-1");
+    expect(transcript?.parentElement?.className).toContain("min-h-0");
+    expect(transcript?.parentElement?.className).toContain("flex-1");
+    expect(testRoot.container.querySelector('[data-testid="chat-compact"]')).toBeNull();
+    expect(testRoot.container.querySelector('[data-testid="chat-delete"]')).not.toBeNull();
+
+    cleanupTestRoot(testRoot);
+  });
 });


### PR DESCRIPTION
Closes #1126

## Summary
- keep the Chat page constrained to the available window height in web and desktop
- make the Threads and Conversation regions scroll internally instead of growing the shell window
- remove the Conversation `Compact` action from the UI
- add focused layout and shell tests for the new viewport-locking behavior

## Testing
- `pnpm exec vitest run packages/operator-ui/tests/pages/chat-page.test.ts packages/operator-ui/tests/layout/app-shell.test.ts --reporter=dot`
- `pnpm exec vitest run packages/operator-ui/tests/operator-ui.a11y.test.ts --reporter=dot`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` currently fails in this checkout due unrelated gateway/desktop failures caused by missing module `verror`; the Chat/operator-ui tests above pass
