### PR TITLE
fix: remove client entrypoint cycles and node loader edges

### DIFF
--- a/packages/client/src/browser.ts
+++ b/packages/client/src/browser.ts
@@ -29,8 +29,8 @@ import {
   type TyrumClientProtocolErrorKind,
 } from "./ws-client.js";
 import { normalizeFingerprint256 } from "./tls/fingerprint.js";
+import { VERSION } from "./version.js";
 
-export { VERSION } from "./index.js";
 export { autoExecute } from "./capability.js";
 export type { CapabilityProvider, TaskExecuteContext, TaskResult } from "./capability.js";
 export type {
@@ -178,3 +178,4 @@ export type {
   TyrumHttpFetch,
   TyrumRequestOptions,
 };
+export { VERSION };

--- a/packages/client/src/http/shared.ts
+++ b/packages/client/src/http/shared.ts
@@ -1,7 +1,7 @@
 import { z, type ZodType } from "zod";
 
-import { loadNodePinnedTransportModule } from "../node/load-pinned-transport.js";
 import { normalizeFingerprint256 } from "../tls/fingerprint.js";
+import { loadNodePinnedTransportModule } from "../load-node-pinned-transport.js";
 
 export const NonEmptyString = z.string().trim().min(1);
 const ErrorBodySchema = z

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 // Client SDK shared entry point
-export const VERSION = "0.1.0";
+export { VERSION } from "./version.js";
 
 export { autoExecute } from "./capability.js";
 export { normalizeFingerprint256 } from "./tls/fingerprint.js";

--- a/packages/client/src/load-node-pinned-transport.ts
+++ b/packages/client/src/load-node-pinned-transport.ts
@@ -1,0 +1,9 @@
+export type NodePinnedTransportModule = typeof import("./node/pinned-transport.js");
+
+export async function loadNodePinnedTransportModule(): Promise<NodePinnedTransportModule> {
+  const globalAny = globalThis as unknown as Record<PropertyKey, unknown>;
+  const specifier =
+    "./node/pinned-transport.js" +
+    String(globalAny[Symbol.for("tyrum:node-pinned-transport")] ?? "");
+  return (await import(specifier)) as NodePinnedTransportModule;
+}

--- a/packages/client/src/node.ts
+++ b/packages/client/src/node.ts
@@ -37,8 +37,8 @@ import {
   type TyrumClientProtocolErrorInfo,
   type TyrumClientProtocolErrorKind,
 } from "./ws-client.js";
+import { VERSION } from "./version.js";
 
-export { VERSION } from "./index.js";
 export { autoExecute } from "./capability.js";
 export type { CapabilityProvider, TaskExecuteContext, TaskResult } from "./capability.js";
 export type {
@@ -174,3 +174,4 @@ export type {
   TyrumHttpFetch,
   TyrumRequestOptions,
 };
+export { VERSION };

--- a/packages/client/src/node/load-pinned-transport.ts
+++ b/packages/client/src/node/load-pinned-transport.ts
@@ -1,8 +1,4 @@
-export type NodePinnedTransportModule = typeof import("./pinned-transport.js");
-
-export async function loadNodePinnedTransportModule(): Promise<NodePinnedTransportModule> {
-  const globalAny = globalThis as unknown as Record<PropertyKey, unknown>;
-  const specifier =
-    "./pinned-transport.js" + String(globalAny[Symbol.for("tyrum:node-pinned-transport")] ?? "");
-  return (await import(specifier)) as NodePinnedTransportModule;
-}
+export {
+  loadNodePinnedTransportModule,
+  type NodePinnedTransportModule,
+} from "../load-node-pinned-transport.js";

--- a/packages/client/src/version.ts
+++ b/packages/client/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.1.0";

--- a/packages/client/src/ws-client.transport.ts
+++ b/packages/client/src/ws-client.transport.ts
@@ -14,7 +14,7 @@ import {
   fromBase64Url,
   signProofWithPrivateKey,
 } from "./device-identity.js";
-import { loadNodePinnedTransportModule } from "./node/load-pinned-transport.js";
+import { loadNodePinnedTransportModule } from "./load-node-pinned-transport.js";
 import { normalizeFingerprint256 } from "./tls/fingerprint.js";
 import { TyrumClientProtocolCore } from "./ws-client.protocol.js";
 

--- a/packages/client/tests/entrypoints.test.ts
+++ b/packages/client/tests/entrypoints.test.ts
@@ -1,4 +1,9 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe("@tyrum/client entrypoints", () => {
   it("keeps browser-only storage helpers off the node entrypoint", async () => {
@@ -7,5 +12,29 @@ describe("@tyrum/client entrypoints", () => {
 
     expect(typeof browserEntry["createBrowserLocalStorageDeviceIdentityStorage"]).toBe("function");
     expect("createBrowserLocalStorageDeviceIdentityStorage" in nodeEntry).toBe(false);
+  });
+
+  it("re-exports the shared SDK version across public entrypoints", async () => {
+    const rootEntry = (await import("../src/index.js")) as Record<string, unknown>;
+    const browserEntry = (await import("../src/browser.js")) as Record<string, unknown>;
+    const nodeEntry = (await import("../src/node.js")) as Record<string, unknown>;
+
+    expect(rootEntry["VERSION"]).toBeTypeOf("string");
+    expect(browserEntry["VERSION"]).toBe(rootEntry["VERSION"]);
+    expect(nodeEntry["VERSION"]).toBe(rootEntry["VERSION"]);
+  });
+
+  it("avoids static entrypoint cycles and browser-facing node transport imports", async () => {
+    const [browserSource, nodeSource, httpSharedSource, wsTransportSource] = await Promise.all([
+      readFile(resolve(__dirname, "../src/browser.ts"), "utf8"),
+      readFile(resolve(__dirname, "../src/node.ts"), "utf8"),
+      readFile(resolve(__dirname, "../src/http/shared.ts"), "utf8"),
+      readFile(resolve(__dirname, "../src/ws-client.transport.ts"), "utf8"),
+    ]);
+
+    expect(browserSource).not.toContain('export { VERSION } from "./index.js";');
+    expect(nodeSource).not.toContain('export { VERSION } from "./index.js";');
+    expect(httpSharedSource).not.toContain('from "../node/load-pinned-transport.js"');
+    expect(wsTransportSource).not.toContain('from "./node/load-pinned-transport.js"');
   });
 });


### PR DESCRIPTION
## Summary
- move `@tyrum/client` VERSION into a dedicated module so root, browser, and node entrypoints do not depend on each other
- route browser-facing transport code through a runtime-neutral lazy loader so HTTP and WebSocket code no longer statically import the node loader path
- add entrypoint regressions covering shared VERSION exports and the source-shape constraints behind these fixes

## Validation
- `pnpm exec vitest run packages/client/tests/entrypoints.test.ts packages/client/tests/http-tls-pinning.test.ts packages/client/tests/tls-pinning.test.ts packages/client/tests/tls-pinning-dispatcher-cleanup.test.ts`
- `pnpm --filter @tyrum/client build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`