### PR TITLE
fix(operator-ui): restore PR 1124 primary navigation

### DIFF
--- a/packages/operator-ui/src/operator-routes.tsx
+++ b/packages/operator-ui/src/operator-routes.tsx
@@ -2,16 +2,13 @@ import type { OperatorCore } from "@tyrum/operator-core";
 import type { LucideIcon } from "lucide-react";
 import {
   Bot,
-  Database,
   Globe,
   LayoutGrid,
   Link2,
   MessageSquare,
   Monitor,
-  Play,
   Shield,
   ShieldCheck,
-  SlidersHorizontal,
   SquareKanban,
 } from "lucide-react";
 import { lazy, type LazyExoticComponent, type ComponentType, type ReactNode } from "react";
@@ -37,17 +34,9 @@ const ChatPage = lazyNamed<{ core: OperatorCore }>(
   () => import("./components/pages/chat-page.js"),
   "ChatPage",
 );
-const MemoryPage = lazyNamed<{ core: OperatorCore }>(
-  () => import("./components/pages/memory-page.js"),
-  "MemoryPage",
-);
 const ApprovalsPage = lazyNamed<{ core: OperatorCore }>(
   () => import("./components/pages/approvals-page.js"),
   "ApprovalsPage",
-);
-const RunsPage = lazyNamed<{ core: OperatorCore }>(
-  () => import("./components/pages/runs-page.js"),
-  "RunsPage",
 );
 const WorkBoardPage = lazyNamed<{ core: OperatorCore }>(
   () => import("./components/pages/workboard-page.js"),
@@ -65,10 +54,6 @@ const ConfigurePage = lazyNamed<{ core: OperatorCore }>(
   () => import("./components/pages/configure-page.js"),
   "ConfigurePage",
 );
-const SettingsPage = lazyNamed<{ core: OperatorCore; mode: OperatorUiMode }>(
-  () => import("./components/pages/settings-page.js"),
-  "SettingsPage",
-);
 const NodeConfigurePage = lazyNamed<{ onReloadPage?: () => void }>(
   () => import("./components/pages/node-configure-page.js"),
   "NodeConfigurePage",
@@ -81,14 +66,11 @@ const BrowserCapabilitiesPage = lazyNamed<Record<string, never>>(
 export type OperatorUiRouteId =
   | "dashboard"
   | "chat"
-  | "memory"
   | "approvals"
-  | "runs"
   | "workboard"
   | "agents"
   | "pairing"
   | "configure"
-  | "settings"
   | "node-configure"
   | "browser";
 
@@ -131,15 +113,6 @@ export const OPERATOR_ROUTE_DEFINITIONS: readonly OperatorRouteDefinition[] = [
     render: ({ core }) => <ChatPage core={core} />,
   },
   {
-    id: "memory",
-    label: "Memory",
-    icon: Database,
-    navGroup: "sidebar",
-    shortcut: true,
-    hostKinds: ["desktop", "web"],
-    render: ({ core }) => <MemoryPage core={core} />,
-  },
-  {
     id: "approvals",
     label: "Approvals",
     icon: ShieldCheck,
@@ -147,15 +120,6 @@ export const OPERATOR_ROUTE_DEFINITIONS: readonly OperatorRouteDefinition[] = [
     shortcut: true,
     hostKinds: ["desktop", "web"],
     render: ({ core }) => <ApprovalsPage core={core} />,
-  },
-  {
-    id: "runs",
-    label: "Runs",
-    icon: Play,
-    navGroup: "sidebar",
-    shortcut: true,
-    hostKinds: ["desktop", "web"],
-    render: ({ core }) => <RunsPage core={core} />,
   },
   {
     id: "workboard",
@@ -192,15 +156,6 @@ export const OPERATOR_ROUTE_DEFINITIONS: readonly OperatorRouteDefinition[] = [
     shortcut: true,
     hostKinds: ["desktop", "web"],
     render: ({ core }) => <ConfigurePage core={core} />,
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    icon: SlidersHorizontal,
-    navGroup: "sidebar",
-    shortcut: true,
-    hostKinds: ["desktop", "web"],
-    render: ({ core, mode }) => <SettingsPage core={core} mode={mode} />,
   },
   {
     id: "node-configure",

--- a/packages/operator-ui/tests/app-page-components.test.ts
+++ b/packages/operator-ui/tests/app-page-components.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { OPERATOR_ROUTE_DEFINITIONS } from "../src/operator-routes.js";
 
 describe("Operator UI app/page component structure", () => {
   it("exports each page from components/pages", async () => {
@@ -23,5 +24,21 @@ describe("Operator UI app/page component structure", () => {
       const mod = (await import(specifier)) as Record<string, unknown>;
       expect(mod[exportName]).toBeTypeOf("function");
     }
+  });
+
+  it("keeps the PR 1124 primary navigation shape in the shared route table", () => {
+    const sidebarShortcutIds = OPERATOR_ROUTE_DEFINITIONS.filter(
+      (route) => route.navGroup === "sidebar" && route.shortcut,
+    ).map((route) => route.id);
+
+    expect(sidebarShortcutIds).toEqual([
+      "dashboard",
+      "chat",
+      "approvals",
+      "workboard",
+      "agents",
+      "pairing",
+      "configure",
+    ]);
   });
 });

--- a/packages/operator-ui/tests/operator-ui.a11y.test.ts
+++ b/packages/operator-ui/tests/operator-ui.a11y.test.ts
@@ -206,13 +206,10 @@ type OperatorUiA11yRouteId =
   | "connect"
   | "dashboard"
   | "chat"
-  | "memory"
   | "approvals"
-  | "runs"
   | "agents"
   | "pairing"
   | "configure"
-  | "settings"
   | "node-configure"
   | "browser";
 
@@ -293,23 +290,17 @@ describe("operator-ui a11y", () => {
     { mode: "desktop", route: "connect" },
     { mode: "desktop", route: "dashboard" },
     { mode: "desktop", route: "chat" },
-    { mode: "desktop", route: "memory" },
     { mode: "desktop", route: "approvals" },
-    { mode: "desktop", route: "runs" },
     { mode: "desktop", route: "agents" },
     { mode: "desktop", route: "pairing" },
-    { mode: "desktop", route: "settings" },
     { mode: "desktop", route: "node-configure" },
     { mode: "desktop", route: "configure" },
     { mode: "web", route: "connect" },
     { mode: "web", route: "dashboard" },
     { mode: "web", route: "chat" },
-    { mode: "web", route: "memory" },
     { mode: "web", route: "approvals" },
-    { mode: "web", route: "runs" },
     { mode: "web", route: "agents" },
     { mode: "web", route: "pairing" },
-    { mode: "web", route: "settings" },
     { mode: "web", route: "configure" },
     { mode: "web", route: "browser" },
   ];

--- a/packages/operator-ui/tests/operator-ui.test.ts
+++ b/packages/operator-ui/tests/operator-ui.test.ts
@@ -2912,7 +2912,7 @@ describe("operator-ui", () => {
     }
   });
 
-  it("supports Cmd/Ctrl+1-9/0 page navigation shortcuts across the primary routes", async () => {
+  it("supports Cmd/Ctrl+1-7 page navigation shortcuts across the primary routes", async () => {
     const ws = new FakeWsClient();
     const { http } = createFakeHttpClient();
     const core = createOperatorCore({
@@ -2939,27 +2939,10 @@ describe("operator-ui", () => {
       await Promise.resolve();
     });
 
-    expect(container.querySelector('[data-testid="agents-tab-runs"]')).not.toBeNull();
-
-    await act(async () => {
-      window.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "9", ctrlKey: true, bubbles: true }),
-      );
-      await vi.dynamicImportSettled();
-      await Promise.resolve();
-    });
-
     expect(container.querySelector('[data-testid="configure-page"]')).not.toBeNull();
-
-    await act(async () => {
-      window.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "0", ctrlKey: true, bubbles: true }),
-      );
-      await vi.dynamicImportSettled();
-      await Promise.resolve();
-    });
-
-    expect(container.textContent).toContain("Settings");
+    expect(container.querySelector('[data-testid="nav-memory"]')).toBeNull();
+    expect(container.querySelector('[data-testid="nav-runs"]')).toBeNull();
+    expect(container.querySelector('[data-testid="nav-settings"]')).toBeNull();
 
     act(() => {
       root?.unmount();


### PR DESCRIPTION
## Summary
- restore the shared operator UI primary navigation to the PR #1124 route set
- remove standalone Memory, Runs, and Settings from the shared sidebar shortcuts while keeping desktop node configuration in the platform section
- add a route-table regression test so the restored nav shape does not drift again

## Testing
- `pnpm -w vitest run packages/operator-ui/tests/app-page-components.test.ts packages/operator-ui/tests/operator-ui.test.ts packages/operator-ui/tests/operator-ui.a11y.test.ts packages/operator-ui/tests/layout/mobile-nav.test.ts`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm --filter @tyrum/operator-ui build`
- pre-push hook: `pnpm lint`, workspace package builds, and `pnpm typecheck`

## Context
PR #1124 intentionally narrowed the main operator navigation to Dashboard, Chat, Approvals, Work, Agents, Pairings, and Configure. Later node-configure work reintroduced standalone Memory, Runs, and Settings, which made the current desktop/web UI diverge from the merged PR #1124 IA.
