### PR TITLE
fix(operator-ui): align sidebar footer rows

### DIFF
--- a/packages/operator-ui/src/components/layout/sidebar.tsx
+++ b/packages/operator-ui/src/components/layout/sidebar.tsx
@@ -274,12 +274,7 @@ function SidebarStatusControls({ collapsed, connectionStatus }: SidebarStatusCon
                   />
                 }
               >
-                <span
-                  data-testid="connection-status-label"
-                  className="min-w-0 break-words leading-5 [overflow-wrap:anywhere]"
-                >
-                  {connectionDisplay.label}
-                </span>
+                <span data-testid="connection-status-label">{connectionDisplay.label}</span>
               </SidebarFooterRowContent>
             </span>
           </TooltipTrigger>


### PR DESCRIPTION
## Summary
- align the sidebar footer rows to a shared icon and label grid
- keep the footer controls full-width so `Sync now`, connection status, and `Collapse` start at the same text column
- close #1181

## Test plan
- [x] `pnpm exec vitest run packages/operator-ui/tests/layout/sidebar.test.ts`