### PR TITLE
fix(operator-ui): scope chat agents error overlay

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page.tsx
@@ -432,7 +432,7 @@ export function ChatPage({ core }: { core: OperatorCore }) {
 
   return (
     <div
-      className="flex h-full flex-1 w-full flex-col overflow-hidden bg-bg"
+      className="relative flex h-full flex-1 w-full flex-col overflow-hidden bg-bg"
       data-testid="chat-page"
     >
       {chat.agents.error ? (

--- a/packages/operator-ui/tests/pages/chat-page.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page.test.ts
@@ -159,6 +159,49 @@ describe("ChatPage", () => {
     cleanupTestRoot(testRoot);
   });
 
+  it("keeps the agents error alert positioned within the chat page", async () => {
+    const ws = {
+      sessionList: vi.fn().mockResolvedValue({
+        sessions: [],
+        next_cursor: null,
+      }),
+    };
+    const http = {
+      agentList: {
+        get: vi.fn().mockRejectedValue(new Error("agent list failed")),
+      },
+    };
+
+    const chatStore = createChatStore(ws as never, http as never);
+    const { store: connectionStore } = createStore({
+      status: "connected",
+      clientId: "client-1",
+      lastDisconnect: null,
+      transportError: null,
+    });
+
+    const matchMedia = stubMatchMedia("(min-width: 1024px)", true);
+    const core = { connectionStore, chatStore } as unknown as OperatorCore;
+    const testRoot = renderIntoDocument(React.createElement(ChatPage, { core }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const page = testRoot.container.querySelector<HTMLElement>('[data-testid="chat-page"]');
+    const alerts = Array.from(testRoot.container.querySelectorAll<HTMLElement>('[role="alert"]'));
+    const agentErrorAlert = alerts.find((alert) =>
+      alert.textContent?.includes("Failed to load agents"),
+    );
+
+    expect(page?.className).toContain("relative");
+    expect(agentErrorAlert?.textContent).toContain("agent list failed");
+
+    matchMedia.cleanup();
+    cleanupTestRoot(testRoot);
+  });
+
   it("uses master-detail navigation on narrow screens", async () => {
     const ws = {
       sessionList: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary
- add a local positioning context to `chat-page` so the agents error alert is anchored to the page itself
- add a regression test that forces `refreshAgents()` to fail and verifies the error path remains scoped correctly
- close the positioning bug reported for the absolute error overlay before surrounding layout changes can expose it

Closes #1189

## Test plan
- [x] `pnpm exec vitest run packages/operator-ui/tests/pages/chat-page.test.ts`
- [x] `pnpm --filter @tyrum/operator-ui build`
- [x] pre-push checks passed (`lint`, workspace builds, `tsc -b`)