### PR TITLE
fix(operator-ui): prevent scroll area content from overflowing viewport width

### DIFF
--- a/packages/operator-ui/src/components/ui/scroll-area.tsx
+++ b/packages/operator-ui/src/components/ui/scroll-area.tsx
@@ -15,7 +15,7 @@ export const ScrollArea = React.forwardRef<
     >
       <ScrollAreaPrimitive.Viewport
         data-scroll-area-viewport=""
-        className="h-full w-full rounded-[inherit]"
+        className="h-full w-full rounded-[inherit] [&>div]:!block"
         onScroll={onScroll}
       >
         {children}


### PR DESCRIPTION
## Summary

- Override Radix ScrollArea viewport's internal `display: table` wrapper with `display: block` so page content shrinks to fit narrow windows instead of being clipped on the right edge.

## Root cause

Radix UI's `ScrollArea.Viewport` wraps children in a div with inline `display: table` for content measurement. Table layout expands to fit content's natural width rather than being constrained by the parent. Since all `ScrollArea` usages in the operator UI are vertical-only, horizontal overflow was silently clipped by `overflow-hidden` ancestors.

## Test plan

- [ ] Resize operator UI window to narrow widths and verify dashboard row values (connection status, counts) are fully visible
- [ ] Verify vertical scrolling still works correctly on all pages (dashboard, workboard, agents, chat, approvals)
- [ ] Confirm scrollbar thumb sizing is unaffected

Closes #1193