### PR TITLE
fix(operator-ui): reduce agent selection panel width

### DIFF
--- a/packages/operator-ui/src/components/pages/agents-page.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page.tsx
@@ -275,7 +275,7 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
 
       <div className="flex min-h-0 flex-1">
         <div
-          className="hidden h-full w-[260px] shrink-0 flex-col border-r border-border bg-bg-subtle/30 lg:flex"
+          className="hidden h-full w-[180px] shrink-0 flex-col border-r border-border bg-bg-subtle/30 lg:flex"
           data-testid="agents-list-panel"
         >
           <div className="flex h-14 shrink-0 items-center border-b border-border px-3">


### PR DESCRIPTION
## Summary
- Narrowed the agent list sidebar from 260px to 180px (~30% reduction) for a tighter layout on the Agents page.

Closes #1195

## Test plan
- [ ] Open the Agents page and verify the agent selection panel is visibly narrower
- [ ] Confirm agent names and status indicators still display correctly without overflow
- [ ] Verify the panel is still hidden on smaller viewports (below `lg` breakpoint)