### PR TITLE
fix(operator-ui): prevent inactive tab panels from contributing layout spacing

### DIFF
--- a/packages/operator-ui/src/components/ui/tabs.tsx
+++ b/packages/operator-ui/src/components/ui/tabs.tsx
@@ -49,7 +49,7 @@ export const TabsContent = React.forwardRef<
     <TabsPrimitive.Content
       ref={ref}
       className={cn(
-        "pt-2",
+        "pt-2 data-[state=inactive]:hidden!",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         className,
       )}


### PR DESCRIPTION
## Summary
- Inactive Radix `TabsContent` panels in the Node Configuration page were taking up layout space because the `grid` class passed via `className` overrode the `hidden` attribute's `display: none`
- Added `data-[state=inactive]:hidden!` to the `TabsContent` component so inactive panels are always removed from layout regardless of display classes

Closes #1199

## Test plan
- [ ] Open Node Configuration page
- [ ] Click through each tab (General → Desktop → Browser → Shell → Web)
- [ ] Verify spacing above tab content is consistent across all tabs
- [ ] Verify the Audit panel tabs (which use `forceMount`) still work correctly