### PR TITLE
fix: align workboard kanban columns at breakpoint

### DIFF
--- a/packages/operator-ui/src/components/pages/workboard-page.tsx
+++ b/packages/operator-ui/src/components/pages/workboard-page.tsx
@@ -41,7 +41,11 @@ const DESKTOP_BOARD_GRID_STYLE = {
   gridTemplateColumns: `repeat(${WORK_ITEM_STATUSES.length}, minmax(0, 1fr))`,
 } as const;
 
-const WORKBOARD_DESKTOP_CONTENT_WIDTH_PX = 1120;
+const WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX = 1120;
+const WORKBOARD_DESKTOP_CONTENT_WIDTH_PX = WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX + 40;
+const DESKTOP_BOARD_MIN_WIDTH_STYLE = {
+  minWidth: WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX,
+} as const;
 
 function makeAgentScope(): WorkStateKVScope {
   return { kind: "agent", ...DEFAULT_SCOPE_KEYS };
@@ -355,7 +359,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
                 <div
                   data-testid="workboard-board-header"
                   className="grid border-b border-border bg-bg-subtle"
-                  style={DESKTOP_BOARD_GRID_STYLE}
+                  style={{ ...DESKTOP_BOARD_GRID_STYLE, ...DESKTOP_BOARD_MIN_WIDTH_STYLE }}
                 >
                   {WORK_ITEM_STATUSES.map((status) => (
                     <div
@@ -371,7 +375,10 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
                     </div>
                   ))}
                 </div>
-                <div className="min-w-[70rem] grid" style={DESKTOP_BOARD_GRID_STYLE}>
+                <div
+                  className="grid"
+                  style={{ ...DESKTOP_BOARD_GRID_STYLE, ...DESKTOP_BOARD_MIN_WIDTH_STYLE }}
+                >
                   {WORK_ITEM_STATUSES.map((status) => (
                     <div
                       key={status}

--- a/packages/operator-ui/tests/pages/workboard-page.test.ts
+++ b/packages/operator-ui/tests/pages/workboard-page.test.ts
@@ -38,7 +38,7 @@ describe("WorkBoardPage", () => {
 
   it("uses a status selector on narrow screens without horizontal board scrolling", () => {
     const { core } = createCore("connected");
-    const matchMedia = stubMatchMedia("(min-width: 1120px)", false);
+    const matchMedia = stubMatchMedia("(min-width: 1160px)", false);
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
 
     try {
@@ -59,7 +59,7 @@ describe("WorkBoardPage", () => {
 
   it("renders an aligned board header on large screens", () => {
     const { core } = createCore("connected");
-    const matchMedia = stubMatchMedia("(min-width: 1120px)", true);
+    const matchMedia = stubMatchMedia("(min-width: 1160px)", true);
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
 
     try {
@@ -73,6 +73,11 @@ describe("WorkBoardPage", () => {
       expect(boardHeader).not.toBeNull();
       expect(boardHeader?.style.gridTemplateColumns).toBe(
         `repeat(${WORK_ITEM_STATUSES.length}, minmax(0, 1fr))`,
+      );
+      expect(boardHeader?.style.minWidth).toBe("1120px");
+      expect(boardHeader?.nextElementSibling).not.toBeNull();
+      expect((boardHeader?.nextElementSibling as HTMLElement | null)?.style.minWidth).toBe(
+        "1120px",
       );
     } finally {
       matchMedia.cleanup();
@@ -157,7 +162,7 @@ describe("WorkBoardPage", () => {
       },
     );
 
-    const matchMedia = stubMatchMedia("(min-width: 1120px)", true);
+    const matchMedia = stubMatchMedia("(min-width: 1160px)", true);
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
     try {
       await flushEffects();
@@ -346,7 +351,7 @@ describe("WorkBoardPage", () => {
       error: "WorkBoard is not supported by this gateway (database not configured).",
     });
 
-    const matchMedia = stubMatchMedia("(min-width: 1120px)", true);
+    const matchMedia = stubMatchMedia("(min-width: 1160px)", true);
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
     try {
       await flushEffects();


### PR DESCRIPTION
## Summary
- delay the desktop workboard switch until the padded content area can fit the full kanban board
- give the kanban header row and body grid the same minimum width so column edges stay aligned near the breakpoint
- update the page tests to cover the new threshold and shared width contract

## Test plan
- [x] `pnpm exec vitest run packages/operator-ui/tests/pages/workboard-page.test.ts`
- [x] pre-commit formatting and lint hooks passed during `git commit`

Fixes #1211