### PR TITLE
fix browser UI request and approval resume regressions

### DIFF
--- a/packages/client/src/http/shared.ts
+++ b/packages/client/src/http/shared.ts
@@ -285,7 +285,10 @@ export class HttpTransport {
       }
       this.fetchImpl = options.fetch;
     } else if (!pinRaw && !allowSelfSigned && caCertPem === undefined) {
-      this.fetchImpl = fetch;
+      // Wrap the global fetch so browser calls retain the correct invocation
+      // shape. Calling a stored native Window method as an object property can
+      // throw "Illegal invocation" in Chromium.
+      this.fetchImpl = (input, init) => fetch(input, init);
     } else {
       if (!pinRaw) {
         if (allowSelfSigned) {

--- a/packages/client/tests/http-client.presence-modes.test.ts
+++ b/packages/client/tests/http-client.presence-modes.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createTestClient, jsonResponse, makeFetchMock } from "./http-client.test-support.js";
+
+describe("createTyrumHttpClient presence modes", () => {
+  it("accepts desktop and browser-node presence modes", async () => {
+    const fetch = makeFetchMock(async () =>
+      jsonResponse({
+        status: "ok",
+        generated_at: "2026-02-25T00:00:00.000Z",
+        entries: [
+          {
+            instance_id: "desktop-node-1",
+            role: "node",
+            host: "tyrum-desktop",
+            mode: "desktop",
+            last_seen_at: "2026-02-25T00:00:00.000Z",
+          },
+          {
+            instance_id: "browser-node-1",
+            role: "node",
+            host: "operator-ui browser node",
+            mode: "browser-node",
+            last_seen_at: "2026-02-25T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+    const client = createTestClient({ fetch });
+
+    const result = await client.presence.list();
+
+    expect(result.entries.map((entry) => entry.mode)).toEqual(["desktop", "browser-node"]);
+  });
+});

--- a/packages/client/tests/http-client.test-core-support.ts
+++ b/packages/client/tests/http-client.test-core-support.ts
@@ -230,6 +230,26 @@ export function registerHttpClientCoreTests(): void {
     expect(getHeader(init, "authorization")).toBeNull();
   });
 
+  it("wraps the global fetch so browser-native invocation stays valid", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn(async function (this: unknown) {
+      if (this && this !== globalThis) {
+        throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation");
+      }
+      return jsonResponse({ status: "ok", plugins: [] });
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    try {
+      const client = createTestClient();
+
+      await expect(client.plugins.list()).resolves.toEqual({ status: "ok", plugins: [] });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.stubGlobal("fetch", originalFetch);
+    }
+  });
+
   it("supports explicit none auth strategy", async () => {
     const fetch = mockJsonFetch({ status: "ok", plugins: [] });
     const client = createTestClient({ auth: { type: "none" }, fetch });

--- a/packages/gateway/src/bootstrap/runtime-builders.ts
+++ b/packages/gateway/src/bootstrap/runtime-builders.ts
@@ -6,6 +6,7 @@ import { NodeDispatchService } from "../modules/agent/node-dispatch-service.js";
 import { AgentRegistry } from "../modules/agent/registry.js";
 import { AuthAudit } from "../modules/auth/audit.js";
 import { SlidingWindowRateLimiter } from "../modules/auth/rate-limiter.js";
+import { deriveAgentIdFromKey } from "../modules/execution/gateway-step-executor-types.js";
 import { ApprovalEngineActionProcessor } from "../modules/approval/engine-action-processor.js";
 import { WsNotifier } from "../modules/approval/notifier.js";
 import { ConnectionDirectoryDal } from "../modules/backplane/connection-directory.js";
@@ -427,9 +428,30 @@ export function createWorkerLoop(
     nodeDispatchService: new NodeDispatchService(protocol.protocolDeps),
     fallback: toolExecutor,
   }) satisfies ExecutionStepExecutor;
+  const agents = protocol.protocolDeps.agents;
   const executor = createGatewayStepExecutor({
     container: context.container,
     toolExecutor: nodeDispatchExecutor,
+    decideExecutor: agents
+      ? async ({ request, planId, stepIndex, timeoutMs, context: executionContext }) => {
+          const runtime = await agents.getRuntime({
+            tenantId: executionContext.tenantId,
+            agentKey:
+              executionContext.agentId?.trim() || deriveAgentIdFromKey(executionContext.key),
+          });
+          const response = await runtime.executeDecideAction(request, {
+            timeoutMs,
+            execution: {
+              planId,
+              runId: executionContext.runId,
+              stepIndex,
+              stepId: executionContext.stepId,
+              stepApprovalId: executionContext.approvalId ?? undefined,
+            },
+          });
+          return { success: true, result: response };
+        }
+      : undefined,
   }) satisfies ExecutionStepExecutor;
 
   return startExecutionWorkerLoop({

--- a/packages/gateway/tests/unit/agent-runtime-worker-resume.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-worker-resume.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { MockLanguageModelV3 } from "ai/test";
+import { createContainer, type GatewayContainer } from "../../src/container.js";
+import { AgentRegistry } from "../../src/modules/agent/registry.js";
+import { AgentRuntime } from "../../src/modules/agent/runtime.js";
+import { createProtocolRuntime, createWorkerLoop } from "../../src/bootstrap/runtime-builders.js";
+import type { GatewayBootContext } from "../../src/bootstrap/runtime-shared.js";
+import {
+  DEFAULT_TENANT_ID,
+  fetch404,
+  migrationsDir,
+  seedAgentConfig,
+  teardownTestEnv,
+} from "./agent-runtime.test-helpers.js";
+
+describe("AgentRuntime worker approval resumes", () => {
+  let homeDir: string | undefined;
+  let container: GatewayContainer | undefined;
+
+  afterEach(async () => {
+    await teardownTestEnv({ homeDir, container });
+    container = undefined;
+    homeDir = undefined;
+  });
+
+  it("completes approved tool resumes when the background worker claims the decide step", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-"));
+    container = await createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+      tyrumHome: homeDir,
+    });
+
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { enabled: [] },
+        mcp: { enabled: [] },
+        tools: { allow: ["bash"] },
+        sessions: { ttl_days: 30, max_turns: 20 },
+        memory: { v1: { enabled: false } },
+      },
+    });
+
+    const usage = () => ({
+      inputTokens: {
+        total: 10,
+        noCache: 10,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 5,
+        text: 5,
+        reasoning: undefined,
+      },
+    });
+
+    let callCount = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            content: [
+              {
+                type: "tool-call" as const,
+                toolCallId: "tc-1",
+                toolName: "bash",
+                input: JSON.stringify({ command: "echo hi" }),
+              },
+            ],
+            finishReason: { unified: "tool-calls" as const, raw: undefined },
+            usage: usage(),
+            warnings: [],
+          };
+        }
+
+        return {
+          content: [{ type: "text" as const, text: "done" }],
+          finishReason: { unified: "stop" as const, raw: undefined },
+          usage: usage(),
+          warnings: [],
+        };
+      },
+    });
+
+    const logger = container.logger.child({ test: "agent-runtime-worker-resume" });
+    const secretProviderForTenant = (() => ({
+      list: async () => [],
+      resolve: async () => null,
+      store: async () => {
+        throw new Error("not implemented");
+      },
+      revoke: async () => false,
+    })) as GatewayBootContext["secretProviderForTenant"];
+    const context: GatewayBootContext = {
+      instanceId: "test-instance",
+      role: "all",
+      tyrumHome: homeDir,
+      host: "127.0.0.1",
+      port: 8788,
+      dbPath: ":memory:",
+      migrationsDir,
+      isLocalOnly: true,
+      shouldRunEdge: false,
+      shouldRunWorker: true,
+      deploymentConfig: container.deploymentConfig,
+      container,
+      logger,
+      authTokens: {} as GatewayBootContext["authTokens"],
+      secretProviderForTenant,
+      lifecycleHooks: [],
+    };
+
+    const protocol = await createProtocolRuntime(context, {
+      enabled: false,
+      shutdown: async () => undefined,
+    });
+    const agents = new AgentRegistry({
+      container,
+      baseHome: homeDir,
+      secretProviderForTenant,
+      defaultPolicyService: container.policyService,
+      defaultLanguageModel: model,
+      approvalNotifier: protocol.approvalNotifier,
+      protocolDeps: protocol.protocolDeps,
+      logger,
+    });
+    protocol.protocolDeps.agents = agents;
+
+    const workerLoop = createWorkerLoop(context, protocol);
+    expect(workerLoop).toBeDefined();
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      languageModel: model,
+      fetchImpl: fetch404,
+      approvalPollMs: 5_000,
+      turnEngineWaitMs: 10_000,
+    } as ConstructorParameters<typeof AgentRuntime>[0]);
+
+    try {
+      const turnPromise = runtime.turn({
+        channel: "test",
+        thread_id: "thread-1",
+        message: "run tool",
+      });
+
+      const deadlineMs = Date.now() + 2_000;
+      let approvalId: string | undefined;
+      while (Date.now() < deadlineMs) {
+        const pending = await container.approvalDal.getPending({ tenantId: DEFAULT_TENANT_ID });
+        if (pending.length > 0) {
+          approvalId = pending[0]!.approval_id;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      if (!approvalId) {
+        throw new Error("timed out waiting for pending approval");
+      }
+
+      await container.approvalDal.respond({
+        tenantId: DEFAULT_TENANT_ID,
+        approvalId,
+        decision: "approved",
+      });
+
+      const updated = await container.approvalDal.getById({
+        tenantId: DEFAULT_TENANT_ID,
+        approvalId,
+      });
+      expect(updated?.resume_token).toBeTruthy();
+
+      await (
+        runtime as AgentRuntime & {
+          executionEngine: { resumeRun: (token: string) => Promise<string | undefined> };
+        }
+      ).executionEngine.resumeRun(updated!.resume_token!);
+
+      const result = await turnPromise;
+      expect(result.reply).toBe("done");
+      expect(result.used_tools).toContain("bash");
+    } finally {
+      workerLoop?.stop();
+      await workerLoop?.done;
+      protocol.approvalEngineActionProcessor?.stop();
+      await agents.shutdown();
+    }
+  }, 15_000);
+});

--- a/packages/schemas/src/presence.ts
+++ b/packages/schemas/src/presence.ts
@@ -4,7 +4,17 @@ import { DateTimeSchema } from "./common.js";
 export const PresenceRole = z.enum(["gateway", "client", "node"]);
 export type PresenceRole = z.infer<typeof PresenceRole>;
 
-export const PresenceMode = z.enum(["ui", "web", "cli", "node", "backend", "probe", "test"]);
+export const PresenceMode = z.enum([
+  "ui",
+  "web",
+  "cli",
+  "node",
+  "backend",
+  "probe",
+  "test",
+  "desktop",
+  "browser-node",
+]);
 export type PresenceMode = z.infer<typeof PresenceMode>;
 
 export const PresenceReason = z.enum(["self", "connect", "periodic", "node-connected", "prune"]);


### PR DESCRIPTION
Closes #1215.

## Summary
- wrap browser-native `fetch` usage so `/ui` HTTP-backed views do not fail with `Illegal invocation`
- accept `desktop` and `browser-node` presence modes emitted by the gateway
- route resumed execution-engine `Decide` steps back through the agent runtime so approved chat turns finish when the background worker claims them

## Test plan
- [x] `pnpm vitest run packages/client/tests/http-client.test.ts packages/client/tests/http-client.presence-modes.test.ts packages/gateway/tests/unit/agent-runtime-engine-isolation.test.ts packages/gateway/tests/unit/agent-runtime-worker-resume.test.ts`
- [x] manually reproduced the `/ui` chat approval flow before the fix and verified it succeeds after restart