### PR TITLE
build: split Vite vendor chunks

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { createTyrumManualChunk } from "../../scripts/vite/manual-chunks.mjs";
 
 export default defineConfig({
   root: "src/renderer",
@@ -9,5 +10,10 @@ export default defineConfig({
   build: {
     outDir: "../../dist/renderer",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: createTyrumManualChunk,
+      },
+    },
   },
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { createTyrumManualChunk } from "../../scripts/vite/manual-chunks.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../..");
@@ -35,5 +36,10 @@ export default defineConfig({
   build: {
     outDir: "../dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: createTyrumManualChunk,
+      },
+    },
   },
 });

--- a/scripts/vite/manual-chunks.mjs
+++ b/scripts/vite/manual-chunks.mjs
@@ -1,0 +1,45 @@
+export function createTyrumManualChunk(id) {
+  const normalizedId = id.split("?")[0]?.replaceAll("\\", "/");
+  if (!normalizedId?.includes("/node_modules/")) {
+    return undefined;
+  }
+
+  const packageName = getNodeModulePackageName(normalizedId);
+  if (!packageName) {
+    return undefined;
+  }
+  if (PACKAGES_WITH_EMPTY_CHUNKS.has(packageName)) {
+    return undefined;
+  }
+
+  return `vendor-${packageName.replace("@", "").replace(/[/.]/g, "-")}`;
+}
+
+const PACKAGES_WITH_EMPTY_CHUNKS = new Set([
+  "detect-node-es",
+  "micromark-extension-gfm-tagfilter",
+  "micromark-util-encode",
+  "zwitch",
+]);
+
+function getNodeModulePackageName(id) {
+  const nodeModulesMarker = "/node_modules/";
+  const nodeModulesIndex = id.lastIndexOf(nodeModulesMarker);
+  if (nodeModulesIndex === -1) {
+    return null;
+  }
+
+  const packagePath = id.slice(nodeModulesIndex + nodeModulesMarker.length);
+  const segments = packagePath.split("/");
+  const firstSegment = segments[0];
+  if (!firstSegment) {
+    return null;
+  }
+
+  if (firstSegment.startsWith("@")) {
+    const secondSegment = segments[1];
+    return secondSegment ? `${firstSegment}/${secondSegment}` : null;
+  }
+
+  return firstSegment;
+}


### PR DESCRIPTION
## Summary
- add a shared Vite manual chunk helper for web and desktop renderer builds
- split third-party packages into deterministic vendor chunks to remove bundle-size warnings
- avoid empty chunk outputs for known no-op packages

## Testing
- pnpm --filter @tyrum/web build
- pnpm --filter tyrum-desktop build
- pnpm build
- pnpm lint
- pnpm format:check

Closes #1230
