### PR TITLE
Replace elevated mode border frame with slim top bar

### DIFF
--- a/packages/operator-ui/src/components/elevated-mode/elevated-mode-chrome.tsx
+++ b/packages/operator-ui/src/components/elevated-mode/elevated-mode-chrome.tsx
@@ -4,8 +4,6 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useOperatorStore } from "../../use-operator-store.js";
 import { formatErrorMessage } from "../../utils/format-error-message.js";
-import { Button } from "../ui/button.js";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip.js";
 import { useElevatedModeUiContext } from "./elevated-mode-provider.js";
 
 export function ElevatedModeChrome() {
@@ -16,40 +14,30 @@ export function ElevatedModeChrome() {
   if (!isElevatedModeActive(elevatedMode)) return null;
 
   return (
-    <>
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 z-40 border-4 border-error shadow-[inset_0_0_0_1px_rgba(127,29,29,0.35)]"
-        data-testid="elevated-mode-frame"
-      />
-      <div className="absolute right-3 top-3 z-50 md:right-4 md:top-4">
-        <TooltipProvider delayDuration={0}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label="Exit Elevated Mode"
-                className="h-8 w-8 rounded-full border border-error/40 bg-bg-card/90 p-0 text-error backdrop-blur hover:bg-error/10"
-                data-testid="elevated-mode-exit"
-                disabled={busy}
-                variant="ghost"
-                onClick={() => {
-                  setBusy(true);
-                  void exitElevatedMode()
-                    .catch((error) => {
-                      toast.error(formatErrorMessage(error));
-                    })
-                    .finally(() => {
-                      setBusy(false);
-                    });
-                }}
-              >
-                <X aria-hidden="true" className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Exit Elevated Mode</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-    </>
+    <div
+      className="z-40 flex h-8 shrink-0 items-center justify-between border-b border-error/30 bg-error/15 px-3 text-xs font-medium text-error"
+      data-testid="elevated-mode-frame"
+    >
+      <span>Elevated Mode</span>
+      <button
+        aria-label="Exit Elevated Mode"
+        className="flex h-5 w-5 items-center justify-center rounded text-error/70 transition-colors hover:bg-error/15 hover:text-error"
+        data-testid="elevated-mode-exit"
+        disabled={busy}
+        type="button"
+        onClick={() => {
+          setBusy(true);
+          void exitElevatedMode()
+            .catch((error) => {
+              toast.error(formatErrorMessage(error));
+            })
+            .finally(() => {
+              setBusy(false);
+            });
+        }}
+      >
+        <X aria-hidden="true" className="h-3.5 w-3.5" />
+      </button>
+    </div>
   );
 }

--- a/scripts/lint/oxlint-ratchet.mjs
+++ b/scripts/lint/oxlint-ratchet.mjs
@@ -27,7 +27,8 @@ function loadBaseline() {
 }
 
 function runOxlintJson() {
-  const result = spawnSync("pnpm", ["exec", "oxlint", "-f", "json", "."], {
+  const oxlintBin = path.join(repoRoot, "node_modules", ".bin", "oxlint");
+  const result = spawnSync(oxlintBin, ["-f", "json", "."], {
     cwd: repoRoot,
     encoding: "utf8",
   });


### PR DESCRIPTION
## Summary
- Replace the full-viewport red `border-4` overlay with a slim 32px top bar using subtle error-tinted background and bottom border, following the AWS/Vercel environment indicator pattern
- Remove unused `Button` and `Tooltip` imports from the chrome component
- Fix `oxlint-ratchet.mjs` to call oxlint directly instead of via `pnpm exec`, avoiding engine warnings corrupting JSON output

## Test plan
- [x] All 69 `operator-ui` tests pass (including all elevated mode tests)
- [x] Build succeeds
- [x] Lint and typecheck pass
- [ ] Visually verify the slim top bar appears when elevated mode is active
- [ ] Verify the exit button works from the top bar

Closes #1232