### PR TITLE
fix: expose always approve for policy executions

### DIFF
--- a/packages/gateway/src/modules/execution/engine/step-execution-queued-policy.ts
+++ b/packages/gateway/src/modules/execution/engine/step-execution-queued-policy.ts
@@ -13,6 +13,7 @@ import {
 } from "../../policy/domain.js";
 import { normalizeDbDateTime } from "../../../utils/db-time.js";
 import { safeJsonParse } from "../../../utils/json.js";
+import { buildExecutionPolicyApprovalContext } from "../policy-approval-context.js";
 import { normalizePositiveInt } from "../normalize-positive-int.js";
 import { releaseLaneAndWorkspaceLeasesTx } from "./concurrency-manager.js";
 import { parsePlanIdFromTriggerJson } from "./db.js";
@@ -192,14 +193,15 @@ export async function maybeHandleSnapshotPolicyTx(
       kind: "policy",
       prompt: "Policy approval required to continue execution",
       detail: `policy requires approval for '${tool.toolId}' (${tool.matchTarget || "unknown"})`,
-      context: {
-        source: "execution-engine",
-        policy_snapshot_id: policySnapshotId,
-        tool_id: tool.toolId,
-        tool_match_target: tool.matchTarget,
+      context: buildExecutionPolicyApprovalContext({
+        policySnapshotId,
+        toolId: tool.toolId,
+        toolMatchTarget: tool.matchTarget,
         url: tool.url,
         decision,
-      },
+        agentId: ctx.run.agent_id,
+        workspaceId: ctx.run.workspace_id,
+      }),
     },
   );
   return { kind: "paused", reason: "policy", approvalId: paused.approvalId };

--- a/packages/gateway/src/modules/execution/local-step-executor-policy.ts
+++ b/packages/gateway/src/modules/execution/local-step-executor-policy.ts
@@ -6,6 +6,7 @@ import type { StepExecutionContext, StepResult } from "./engine.js";
 import { deriveAgentIdFromKey } from "./gateway-step-executor-types.js";
 import { resolveSecretScopesFromArgs } from "./gateway-step-executor-helpers.js";
 import { toolCallFromAction } from "./engine/tool-call.js";
+import { buildExecutionPolicyApprovalContext } from "./policy-approval-context.js";
 
 export async function maybeEnforceLocalExecutorPolicy(input: {
   action: ActionPrimitiveT;
@@ -112,14 +113,15 @@ export async function maybeEnforceLocalExecutorPolicy(input: {
         kind: "policy",
         prompt: "Policy approval required to continue execution",
         detail: `policy requires approval for '${tool.toolId}' (${tool.matchTarget || "unknown"})`,
-        context: {
-          source: "execution-engine",
-          policy_snapshot_id: policySnapshotId,
-          tool_id: tool.toolId,
-          tool_match_target: tool.matchTarget,
+        context: buildExecutionPolicyApprovalContext({
+          policySnapshotId,
+          toolId: tool.toolId,
+          toolMatchTarget: tool.matchTarget,
           url: tool.url,
           decision: decision.decision,
-        },
+          agentId,
+          workspaceId: input.context.workspaceId,
+        }),
       },
     };
   }

--- a/packages/gateway/src/modules/execution/policy-approval-context.ts
+++ b/packages/gateway/src/modules/execution/policy-approval-context.ts
@@ -1,0 +1,47 @@
+import { suggestedOverridesForToolCall } from "../policy/suggested-overrides.js";
+
+export function buildExecutionPolicyApprovalContext(input: {
+  policySnapshotId: string;
+  toolId: string;
+  toolMatchTarget: string;
+  decision: string;
+  workspaceId?: string | null;
+  agentId?: string | null;
+  url?: string;
+}): Record<string, unknown> {
+  const policy: Record<string, unknown> = {
+    policy_snapshot_id: input.policySnapshotId,
+  };
+
+  const agentId = input.agentId?.trim();
+  if (agentId) {
+    policy["agent_id"] = agentId;
+  }
+
+  const workspaceId = input.workspaceId?.trim();
+  if (workspaceId) {
+    policy["workspace_id"] = workspaceId;
+  }
+
+  const matchTarget = input.toolMatchTarget.trim();
+  if (workspaceId && matchTarget) {
+    const suggestedOverrides = suggestedOverridesForToolCall({
+      toolId: input.toolId,
+      matchTarget,
+      workspaceId,
+    });
+    if (suggestedOverrides && suggestedOverrides.length > 0) {
+      policy["suggested_overrides"] = suggestedOverrides;
+    }
+  }
+
+  return {
+    source: "execution-engine",
+    policy_snapshot_id: input.policySnapshotId,
+    tool_id: input.toolId,
+    tool_match_target: input.toolMatchTarget,
+    ...(input.url ? { url: input.url } : {}),
+    decision: input.decision,
+    policy,
+  };
+}

--- a/packages/gateway/tests/unit/execution-engine.policy-intent-test-support.ts
+++ b/packages/gateway/tests/unit/execution-engine.policy-intent-test-support.ts
@@ -65,6 +65,27 @@ function registerPolicyApprovalTests(fixture: { db: () => SqliteDb }): void {
     expect(approval?.kind).toBe("policy");
     expect(approval?.resume_token).toBeTruthy();
     const approvalDal = new ApprovalDal(db);
+    const pendingApproval = await approvalDal.getById({
+      tenantId: DEFAULT_TENANT_ID,
+      approvalId: approval!.approval_id,
+    });
+    expect(pendingApproval?.context).toMatchObject({
+      source: "execution-engine",
+      tool_id: "webfetch",
+      tool_match_target: "https://example.com/",
+      decision: "require_approval",
+      policy: {
+        policy_snapshot_id: snapshot.policy_snapshot_id,
+        workspace_id: DEFAULT_WORKSPACE_ID,
+        suggested_overrides: [
+          {
+            tool_id: "webfetch",
+            pattern: "https://example.com/",
+            workspace_id: DEFAULT_WORKSPACE_ID,
+          },
+        ],
+      },
+    });
     await approvalDal.respond({
       tenantId: DEFAULT_TENANT_ID,
       approvalId: approval!.approval_id,

--- a/packages/gateway/tests/unit/local-step-executor-policy.test.ts
+++ b/packages/gateway/tests/unit/local-step-executor-policy.test.ts
@@ -6,7 +6,7 @@ import type { SecretHandle } from "@tyrum/schemas";
 import { ActionPrimitive } from "@tyrum/schemas";
 import type { GatewayContainer } from "../../src/container.js";
 import { createLocalStepExecutor } from "../../src/modules/execution/local-step-executor.js";
-import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
+import { DEFAULT_TENANT_ID, DEFAULT_WORKSPACE_ID } from "../../src/modules/identity/scope.js";
 import type { SecretProvider } from "../../src/modules/secret/provider.js";
 
 describe("LocalStepExecutor policy enforcement", () => {
@@ -71,7 +71,7 @@ describe("LocalStepExecutor policy enforcement", () => {
       agentId: "00000000-0000-4000-8000-000000000002",
       key: "agent:test",
       lane: "main",
-      workspaceId: "default",
+      workspaceId: DEFAULT_WORKSPACE_ID,
       policySnapshotId: "policy-1",
     };
   }
@@ -177,5 +177,46 @@ describe("LocalStepExecutor policy enforcement", () => {
       expect.objectContaining({ secretScopes: ["db:billing"] }),
     );
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("includes suggested overrides in policy approval pauses for tool-matched steps", async () => {
+    const { executor } = await makeMockedPolicyExecutor({
+      secretsDecision: "allow",
+      toolDecision: "require_approval",
+    });
+
+    const result = await executor.execute(
+      ActionPrimitive.parse({
+        type: "Http",
+        args: { url: "https://example.com/data", method: "GET" },
+      }),
+      "plan-policy-approval-context",
+      0,
+      5_000,
+      policyContext(null),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.pause).toMatchObject({
+      kind: "policy",
+      prompt: "Policy approval required to continue execution",
+      context: {
+        source: "execution-engine",
+        tool_id: "webfetch",
+        tool_match_target: "https://example.com/data",
+        decision: "require_approval",
+        policy: {
+          policy_snapshot_id: "policy-1",
+          workspace_id: DEFAULT_WORKSPACE_ID,
+          suggested_overrides: [
+            {
+              tool_id: "webfetch",
+              pattern: "https://example.com/data",
+              workspace_id: DEFAULT_WORKSPACE_ID,
+            },
+          ],
+        },
+      },
+    });
   });
 });

--- a/packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts
+++ b/packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts
@@ -136,4 +136,89 @@ describe("ApprovalsPage always approve", () => {
       cleanupTestRoot({ container, root });
     }
   });
+
+  it("shows always approve for execution-engine policy approvals", async () => {
+    const approval = {
+      approval_id: "55555555-5555-4555-8555-555555555555",
+      approval_key: "approval:2",
+      kind: "policy",
+      status: "pending",
+      prompt: "Policy approval required to continue execution",
+      context: {
+        source: "execution-engine",
+        tool_id: "webfetch",
+        tool_match_target: "https://example.com/data",
+        decision: "require_approval",
+        policy: {
+          policy_snapshot_id: "66666666-6666-4666-8666-666666666666",
+          workspace_id: "22222222-2222-4222-8222-222222222222",
+          suggested_overrides: [
+            {
+              tool_id: "webfetch",
+              pattern: "https://example.com/data",
+              workspace_id: "22222222-2222-4222-8222-222222222222",
+            },
+          ],
+        },
+      },
+      scope: {
+        key: "agent:default:main",
+        lane: "heartbeat",
+        run_id: "77777777-7777-4777-8777-777777777777",
+        step_id: "88888888-8888-4888-8888-888888888888",
+      },
+      created_at: "2026-03-10T18:25:06.000Z",
+      expires_at: null,
+      resolution: null,
+    } as const;
+    const resolve = vi.fn(async () => ({
+      approval: { ...approval, status: "approved" },
+      createdOverrides: [],
+    }));
+
+    const { store: approvalsBaseStore } = createStore({
+      byId: { [approval.approval_id]: approval },
+      pendingIds: [approval.approval_id],
+      loading: false,
+      error: null,
+      lastSyncedAt: null,
+    });
+    const approvalsStore = {
+      ...approvalsBaseStore,
+      resolve,
+    };
+
+    const { store: pairingStore } = createStore({
+      byId: {},
+      pendingIds: [],
+      loading: false,
+      error: null,
+      lastSyncedAt: null,
+    });
+    const { store: runsStore } = createStore({
+      runsById: {},
+      stepsById: {},
+      attemptsById: {},
+      stepIdsByRunId: {},
+      attemptIdsByStepId: {},
+    });
+
+    const core = {
+      approvalsStore,
+      pairingStore,
+      runsStore,
+    } as unknown as OperatorCore;
+
+    const { container, root } = renderIntoDocument(React.createElement(ApprovalsPage, { core }));
+
+    try {
+      expect(container.textContent).toContain("Policy approval required to continue execution");
+      const alwaysButton = container.querySelector<HTMLButtonElement>(
+        `[data-testid="approval-always-${approval.approval_id}"]`,
+      );
+      expect(alwaysButton).not.toBeNull();
+    } finally {
+      cleanupTestRoot({ container, root });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared execution policy approval context builder that attaches safe `policy.suggested_overrides`
- use that builder for execution-engine and local executor policy approval pauses
- cover the backend context and approvals page behavior with regression tests

Closes #1246

## How to test
- `pnpm exec vitest run packages/gateway/tests/unit/local-step-executor-policy.test.ts packages/gateway/tests/unit/execution-engine.test.ts --testNamePattern "policy|LocalStepExecutor policy enforcement"`
- `pnpm exec vitest run packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts`
- `pnpm lint`
- `pnpm typecheck`

## Risk
Low. This only enriches policy approval context for already-paused execution flows and reuses the existing always-approve UI path.

## Rollback
Revert commit `56e6a90b`.