### PR TITLE
Tighten chat tool call transcript bubbles

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/tool-set-builder-helpers.ts
+++ b/packages/gateway/src/modules/agent/runtime/tool-set-builder-helpers.ts
@@ -109,6 +109,7 @@ export type ApprovalDecisionResult = {
 
 export type ApprovalStatusUpdate = {
   approvalId: string;
+  toolCallId?: string;
   status: ApprovalStatus;
   prompt: string;
   createdAt: string;
@@ -180,6 +181,7 @@ export async function awaitApprovalForToolExecution(
   deps.approvalNotifier.notify(approval);
   await onStatusUpdate?.({
     approvalId: approval.approval_id,
+    toolCallId,
     status: approval.status,
     prompt: approval.prompt,
     createdAt: approval.created_at,
@@ -194,6 +196,7 @@ export async function awaitApprovalForToolExecution(
     if (!current) {
       await onStatusUpdate?.({
         approvalId: approval.approval_id,
+        toolCallId,
         status: "expired",
         prompt: approval.prompt,
         createdAt: approval.created_at,
@@ -210,6 +213,7 @@ export async function awaitApprovalForToolExecution(
       const reason = extractApprovalReason(current);
       await onStatusUpdate?.({
         approvalId: current.approval_id,
+        toolCallId,
         status: current.status,
         prompt: current.prompt,
         createdAt: current.created_at,
@@ -226,6 +230,7 @@ export async function awaitApprovalForToolExecution(
       const reason = extractApprovalReason(current);
       await onStatusUpdate?.({
         approvalId: current.approval_id,
+        toolCallId,
         status: current.status,
         prompt: current.prompt,
         createdAt: current.created_at,
@@ -250,6 +255,7 @@ export async function awaitApprovalForToolExecution(
   const reason = extractApprovalReason(expired) ?? "approval timed out";
   await onStatusUpdate?.({
     approvalId: approval.approval_id,
+    toolCallId,
     status: "expired",
     prompt: approval.prompt,
     createdAt: approval.created_at,

--- a/packages/gateway/src/modules/agent/runtime/tool-set-builder-lifecycle.ts
+++ b/packages/gateway/src/modules/agent/runtime/tool-set-builder-lifecycle.ts
@@ -64,6 +64,7 @@ export async function upsertApprovalTranscript(
       kind: "approval",
       id: input.update.approvalId,
       approval_id: input.update.approvalId,
+      tool_call_id: input.update.toolCallId,
       status: input.update.status,
       title: "Approval required",
       detail: input.update.reason?.trim() || input.update.prompt,

--- a/packages/operator-core/src/stores/chat-store.transcript.ts
+++ b/packages/operator-core/src/stores/chat-store.transcript.ts
@@ -153,6 +153,12 @@ export function toApprovalTranscriptItem(
   const status = typeof record["status"] === "string" ? record["status"].trim() : "";
   const prompt = typeof record["prompt"] === "string" ? record["prompt"] : "";
   if (!approvalId || !status || !prompt) return null;
+  const context =
+    typeof record["context"] === "object" &&
+    record["context"] !== null &&
+    !Array.isArray(record["context"])
+      ? (record["context"] as Record<string, unknown>)
+      : null;
   const scope =
     typeof record["scope"] === "object" &&
     record["scope"] !== null &&
@@ -171,6 +177,9 @@ export function toApprovalTranscriptItem(
         ? record["created_at"]
         : occurredAt,
     updated_at: occurredAt,
+    ...(typeof context?.["tool_call_id"] === "string" && context["tool_call_id"].trim().length > 0
+      ? { tool_call_id: context["tool_call_id"] as string }
+      : {}),
     ...(typeof scope?.["run_id"] === "string" ? { run_id: scope["run_id"] as string } : {}),
   };
 }

--- a/packages/operator-core/tests/chat-store-transcript-compat.test.ts
+++ b/packages/operator-core/tests/chat-store-transcript-compat.test.ts
@@ -117,6 +117,9 @@ describe("chat-store-transcript compatibility helpers", () => {
             approval_id: "approval-compat",
             status: "approved",
             prompt: "Proceed",
+            context: {
+              tool_call_id: "tool-call-compat",
+            },
             scope: {
               run_id: "run-compat",
             },
@@ -126,6 +129,7 @@ describe("chat-store-transcript compatibility helpers", () => {
       ),
     ).toMatchObject({
       approval_id: "approval-compat",
+      tool_call_id: "tool-call-compat",
       status: "approved",
       detail: "Proceed",
       run_id: "run-compat",

--- a/packages/operator-core/tests/chat-store-transcript.test.ts
+++ b/packages/operator-core/tests/chat-store-transcript.test.ts
@@ -164,6 +164,9 @@ describe("chat-store transcript helpers", () => {
             status: "pending",
             prompt: "Approve deployment?",
             created_at: "2026-03-09T00:00:01.000Z",
+            context: {
+              tool_call_id: "tool-call-1",
+            },
             scope: {
               run_id: "run-1",
             },
@@ -175,6 +178,7 @@ describe("chat-store transcript helpers", () => {
       kind: "approval",
       id: "approval-1",
       approval_id: "approval-1",
+      tool_call_id: "tool-call-1",
       status: "pending",
       title: "Approval required",
       detail: "Approve deployment?",

--- a/packages/operator-ui/src/components/pages/chat-page-parts.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-parts.tsx
@@ -1,24 +1,22 @@
-import type {
-  Approval,
-  SessionTranscriptApprovalItem,
-  SessionTranscriptItem,
-  SessionTranscriptTextItem,
-  SessionTranscriptToolItem,
-} from "@tyrum/client";
+import type { Approval } from "@tyrum/client";
 import type { ResolveApprovalInput } from "@tyrum/operator-core";
-import { ChevronLeft, Copy, Hammer, Send, ShieldCheck, Trash2 } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { ChevronLeft, Send, Trash2 } from "lucide-react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { cn } from "../../lib/cn.js";
-import { formatRelativeTime } from "../../utils/format-relative-time.js";
-import { ApprovalActions } from "./approval-actions.js";
 import { Alert } from "../ui/alert.js";
-import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
 import { Spinner } from "../ui/spinner.js";
 import { ChatThreadsPanel, type ChatThreadSummary } from "./chat-page-threads.js";
+import {
+  buildTranscriptDisplayItems,
+  ChatApprovalItem,
+  ChatReasoningItem,
+  ChatTextItem,
+  ChatToolItem,
+  isActiveToolStatus,
+  type ChatTranscriptItem,
+  type ReasoningDisplayMode,
+} from "./chat-page-transcript.js";
 
 const CHAT_AUTOSCROLL_THRESHOLD_PX = 40;
 
@@ -45,64 +43,8 @@ export function isBottomLocked(element: HTMLElement): boolean {
   );
 }
 
-function transcriptTimestamp(item: ChatTranscriptItem): string {
-  return item.kind === "text" ? item.created_at : item.updated_at;
-}
-
-function formatToolStatus(status: SessionTranscriptToolItem["status"]): string {
-  return status === "awaiting_approval" ? "awaiting approval" : status;
-}
-
-function toolBadgeVariant(
-  status: SessionTranscriptToolItem["status"],
-): React.ComponentProps<typeof Badge>["variant"] {
-  switch (status) {
-    case "completed":
-      return "success";
-    case "failed":
-      return "danger";
-    case "awaiting_approval":
-      return "warning";
-    default:
-      return "outline";
-  }
-}
-
-function approvalBadgeVariant(
-  status: SessionTranscriptApprovalItem["status"],
-): React.ComponentProps<typeof Badge>["variant"] {
-  switch (status) {
-    case "approved":
-      return "success";
-    case "denied":
-    case "expired":
-    case "cancelled":
-      return "danger";
-    default:
-      return "warning";
-  }
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await globalThis.navigator.clipboard.writeText(text);
-    toast.success("Copied to clipboard");
-  } catch {
-    toast.error("Failed to copy to clipboard");
-  }
-}
-
 export { ChatThreadsPanel, type ChatThreadSummary };
-
-export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
-type ChatReasoningItem = {
-  kind: "reasoning";
-  id: string;
-  content: string;
-  created_at: string;
-  updated_at: string;
-};
-type ChatTranscriptItem = SessionTranscriptItem | ChatReasoningItem;
+export type { ReasoningDisplayMode } from "./chat-page-transcript.js";
 
 function MarkdownToggle({
   value,
@@ -156,141 +98,6 @@ function ReasoningToggle({
   );
 }
 
-function ChatTextItem({
-  item,
-  renderMode,
-}: {
-  item: SessionTranscriptTextItem;
-  renderMode: "markdown" | "text";
-}) {
-  return (
-    <div
-      className={cn(
-        "group relative rounded-xl border px-4 py-3 shadow-sm",
-        item.role === "assistant"
-          ? "border-border bg-bg"
-          : item.role === "system"
-            ? "border-amber-200/70 bg-amber-50/70"
-            : "border-border bg-bg-subtle/70",
-      )}
-    >
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-fg-muted">
-          <span>{item.role}</span>
-          <span>•</span>
-          <span>{formatRelativeTime(item.created_at)}</span>
-        </div>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 w-7 p-0 text-fg-muted opacity-0 transition-opacity hover:text-fg group-hover:opacity-100"
-          onClick={() => {
-            void copyToClipboard(item.content);
-          }}
-          title="Copy message"
-        >
-          <Copy className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-      {renderMode === "markdown" ? (
-        <div className="prose prose-sm max-w-none text-fg prose-headings:text-fg prose-p:text-fg prose-strong:text-fg prose-code:text-fg prose-pre:bg-bg-subtle">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.content}</ReactMarkdown>
-        </div>
-      ) : (
-        <pre className="whitespace-pre-wrap break-words text-sm text-fg">{item.content}</pre>
-      )}
-    </div>
-  );
-}
-
-function ChatToolItem({ item }: { item: SessionTranscriptToolItem }) {
-  return (
-    <div className="rounded-xl border border-border bg-bg-subtle/50 px-4 py-3">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-sm font-medium text-fg">
-          <Hammer className="h-4 w-4" />
-          <span>{item.tool_id}</span>
-        </div>
-        <Badge variant={toolBadgeVariant(item.status)}>{formatToolStatus(item.status)}</Badge>
-      </div>
-      <div className="text-sm text-fg-muted">{item.summary || "Working…"}</div>
-      {item.error ? <div className="mt-2 text-sm text-danger-700">{item.error}</div> : null}
-      <div className="mt-2 text-xs text-fg-muted">
-        {formatRelativeTime(transcriptTimestamp(item))}
-        {typeof item.duration_ms === "number" ? ` • ${item.duration_ms} ms` : ""}
-      </div>
-    </div>
-  );
-}
-
-function ChatReasoningItem({
-  item,
-  mode,
-}: {
-  item: ChatReasoningItem;
-  mode: Exclude<ReasoningDisplayMode, "hidden">;
-}) {
-  const [open, setOpen] = useState(mode === "expanded");
-
-  useEffect(() => {
-    setOpen(mode === "expanded");
-  }, [mode]);
-
-  return (
-    <details
-      className="rounded-xl border border-border/70 bg-bg-subtle/30 px-4 py-3"
-      open={open}
-      onToggle={(event) => {
-        setOpen(event.currentTarget.open);
-      }}
-    >
-      <summary className="cursor-pointer text-sm font-medium text-fg-muted">
-        Model reasoning
-      </summary>
-      <pre className="mt-3 whitespace-pre-wrap break-words text-sm text-fg-muted">
-        {item.content}
-      </pre>
-      <div className="mt-2 text-xs text-fg-muted">{formatRelativeTime(item.updated_at)}</div>
-    </details>
-  );
-}
-
-function ChatApprovalItem({
-  item,
-  approval,
-  onResolve,
-  resolvingState,
-}: {
-  item: SessionTranscriptApprovalItem;
-  approval?: Approval | null;
-  onResolve: (input: ResolveApprovalInput) => void;
-  resolvingState?: "approved" | "denied" | "always";
-}) {
-  const actionable = item.status === "pending";
-  return (
-    <div className="rounded-xl border border-warning-300 bg-warning-50/80 px-4 py-3">
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-sm font-medium text-warning-900">
-          <ShieldCheck className="h-4 w-4" />
-          <span>{item.title}</span>
-        </div>
-        <Badge variant={approvalBadgeVariant(item.status)}>{item.status}</Badge>
-      </div>
-      <div className="text-sm text-warning-950">{item.detail}</div>
-      {actionable ? (
-        <ApprovalActions
-          approvalId={item.approval_id}
-          approval={approval}
-          resolvingState={resolvingState}
-          onResolve={onResolve}
-          className="mt-3 flex flex-wrap gap-2"
-        />
-      ) : null}
-      <div className="mt-2 text-xs text-warning-900/80">{formatRelativeTime(item.updated_at)}</div>
-    </div>
-  );
-}
-
 export function ChatConversationPanel({
   activeThreadId,
   transcript,
@@ -336,6 +143,14 @@ export function ChatConversationPanel({
 }) {
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const wasBottomLockedRef = useRef(true);
+  const displayItems = buildTranscriptDisplayItems(transcript, approvalsById);
+  const visibleItems =
+    reasoningMode === "hidden"
+      ? displayItems.filter((item) => item.kind !== "reasoning")
+      : displayItems;
+  const showInlineWorking =
+    working &&
+    !displayItems.some((item) => item.kind === "tool" && isActiveToolStatus(item.item.status));
 
   useEffect(() => {
     const element = transcriptRef.current;
@@ -356,7 +171,7 @@ export function ChatConversationPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col" data-testid="chat-conversation-panel">
-      <div className="flex h-14 shrink-0 items-center justify-between border-b border-border px-4">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           {onBack ? (
             <Button
@@ -392,48 +207,66 @@ export function ChatConversationPanel({
       </div>
 
       {loadError ? (
-        <div className="p-4">
+        <div className="p-3">
           <Alert variant="error" title="Failed to load conversation" description={loadError} />
         </div>
       ) : null}
 
       <div
         ref={transcriptRef}
-        className="min-h-0 flex-1 overflow-y-auto p-4"
+        className="min-h-0 flex-1 overflow-y-auto px-3 py-3"
         data-testid="chat-transcript"
       >
-        {transcript.length === 0 ? (
+        {visibleItems.length === 0 ? (
           <div className="text-sm text-fg-muted">No messages yet.</div>
         ) : (
-          <div className="grid gap-3">
-            {transcript.map((item) => {
+          <div className="grid gap-2">
+            {visibleItems.map((item) => {
               if (item.kind === "text") {
-                return <ChatTextItem key={item.id} item={item} renderMode={renderMode} />;
+                return <ChatTextItem key={item.item.id} item={item.item} renderMode={renderMode} />;
               }
               if (item.kind === "reasoning") {
-                return reasoningMode === "hidden" ? null : (
-                  <ChatReasoningItem key={item.id} item={item} mode={reasoningMode} />
+                return (
+                  <ChatReasoningItem
+                    key={item.item.id}
+                    item={item.item}
+                    mode={reasoningMode === "hidden" ? "collapsed" : reasoningMode}
+                  />
                 );
               }
               if (item.kind === "tool") {
-                return <ChatToolItem key={item.id} item={item} />;
+                return (
+                  <ChatToolItem
+                    key={item.item.id}
+                    item={item.item}
+                    approvalItem={item.approvalItem}
+                    approval={item.approval}
+                    onResolve={onResolveApproval}
+                    resolvingState={
+                      item.approvalItem &&
+                      resolvingApproval?.approvalId === item.approvalItem.approval_id
+                        ? resolvingApproval.state
+                        : undefined
+                    }
+                  />
+                );
               }
               return (
                 <ChatApprovalItem
-                  key={item.id}
-                  item={item}
-                  approval={approvalsById[item.approval_id] ?? null}
+                  key={item.item.id}
+                  item={item.item}
+                  approval={item.approval}
                   onResolve={onResolveApproval}
                   resolvingState={
-                    resolvingApproval?.approvalId === item.approval_id
+                    resolvingApproval?.approvalId === item.item.approval_id
                       ? resolvingApproval.state
                       : undefined
                   }
                 />
               );
             })}
-            {working ? (
-              <div className="inline-flex items-center gap-2 rounded-xl border border-border bg-bg-subtle/40 px-4 py-3 text-sm text-fg-muted">
+            {showInlineWorking ? (
+              <div className="inline-flex items-center gap-2 px-1 py-0.5 text-xs text-fg-muted">
                 <Spinner className="h-4 w-4" />
                 Agent is working
               </div>
@@ -442,9 +275,9 @@ export function ChatConversationPanel({
         )}
       </div>
 
-      <div className="border-t border-border p-4">
+      <div className="border-t border-border p-3">
         {sendError ? (
-          <div className="mb-3">
+          <div className="mb-2.5">
             <Alert variant="error" title="Failed to send" description={sendError} />
           </div>
         ) : null}
@@ -459,10 +292,10 @@ export function ChatConversationPanel({
               }
             }}
             placeholder="Send a message…"
-            className="min-h-[52px] flex-1 resize-none rounded-xl border border-border bg-bg px-4 py-3 text-sm text-fg outline-none transition focus:border-focus-ring"
+            className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-bg px-3 py-2.5 text-sm text-fg outline-none transition focus:border-focus-ring"
           />
           <Button
-            className="h-[52px] rounded-xl px-4"
+            className="h-[44px] rounded-lg px-4"
             onClick={() => {
               void send();
             }}

--- a/packages/operator-ui/src/components/pages/chat-page-transcript.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-transcript.tsx
@@ -1,0 +1,398 @@
+import type {
+  Approval,
+  SessionTranscriptApprovalItem,
+  SessionTranscriptItem,
+  SessionTranscriptTextItem,
+  SessionTranscriptToolItem,
+} from "@tyrum/client";
+import type { ResolveApprovalInput } from "@tyrum/operator-core";
+import { Copy, Hammer, ShieldCheck } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { formatRelativeTime } from "../../utils/format-relative-time.js";
+import { ApprovalActions } from "./approval-actions.js";
+import { Badge } from "../ui/badge.js";
+import { Button } from "../ui/button.js";
+
+export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
+
+type ChatReasoningItem = {
+  kind: "reasoning";
+  id: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ChatTranscriptItem = SessionTranscriptItem | ChatReasoningItem;
+
+export type ChatDisplayItem =
+  | { kind: "text"; item: SessionTranscriptTextItem }
+  | { kind: "reasoning"; item: ChatReasoningItem }
+  | {
+      kind: "tool";
+      item: SessionTranscriptToolItem;
+      approvalItem: SessionTranscriptApprovalItem | null;
+      approval: Approval | null;
+    }
+  | {
+      kind: "approval";
+      item: SessionTranscriptApprovalItem;
+      approval: Approval | null;
+    };
+
+function transcriptTimestamp(item: ChatTranscriptItem): string {
+  return item.kind === "text" ? item.created_at : item.updated_at;
+}
+
+function formatToolStatus(status: SessionTranscriptToolItem["status"]): string {
+  return status === "awaiting_approval" ? "awaiting approval" : status;
+}
+
+function toolBadgeVariant(
+  status: SessionTranscriptToolItem["status"],
+): React.ComponentProps<typeof Badge>["variant"] {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+      return "danger";
+    case "awaiting_approval":
+      return "warning";
+    default:
+      return "outline";
+  }
+}
+
+function approvalBadgeVariant(
+  status: SessionTranscriptApprovalItem["status"],
+): React.ComponentProps<typeof Badge>["variant"] {
+  switch (status) {
+    case "approved":
+      return "success";
+    case "denied":
+    case "expired":
+    case "cancelled":
+      return "danger";
+    default:
+      return "warning";
+  }
+}
+
+export function formatApprovalStatus(status: SessionTranscriptApprovalItem["status"]): string {
+  switch (status) {
+    case "pending":
+      return "Pending";
+    case "approved":
+      return "Approved";
+    case "denied":
+      return "Denied";
+    case "expired":
+      return "Expired";
+    case "cancelled":
+      return "Cancelled";
+  }
+}
+
+export function isActiveToolStatus(status: SessionTranscriptToolItem["status"]): boolean {
+  return status === "queued" || status === "running" || status === "awaiting_approval";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readApprovalToolCallId(
+  item: SessionTranscriptApprovalItem,
+  approval: Approval | null | undefined,
+): string | null {
+  if (typeof item.tool_call_id === "string" && item.tool_call_id.trim().length > 0) {
+    return item.tool_call_id;
+  }
+  const context = isRecord(approval?.context) ? approval.context : null;
+  const toolCallId = typeof context?.["tool_call_id"] === "string" ? context["tool_call_id"] : "";
+  return toolCallId.trim().length > 0 ? toolCallId : null;
+}
+
+function approvalResolutionNote(
+  item: SessionTranscriptApprovalItem,
+  approval: Approval | null,
+): string | null {
+  const resolution = isRecord(approval?.resolution) ? approval.resolution : null;
+  const reason = typeof resolution?.["reason"] === "string" ? resolution["reason"].trim() : "";
+  if (reason) return reason;
+  const prompt = typeof approval?.prompt === "string" ? approval.prompt.trim() : "";
+  const detail = item.detail.trim();
+  if (!detail || detail === prompt) return null;
+  return detail;
+}
+
+export function buildTranscriptDisplayItems(
+  transcript: ChatTranscriptItem[],
+  approvalsById: Record<string, Approval>,
+): ChatDisplayItem[] {
+  const toolCallIds = new Set<string>();
+  for (const item of transcript) {
+    if (item.kind === "tool") {
+      toolCallIds.add(item.tool_call_id);
+    }
+  }
+
+  const linkedApprovals = new Map<
+    string,
+    { item: SessionTranscriptApprovalItem; approval: Approval | null }
+  >();
+  for (const item of transcript) {
+    if (item.kind !== "approval") continue;
+    const approval = approvalsById[item.approval_id] ?? null;
+    const toolCallId = readApprovalToolCallId(item, approval);
+    if (!toolCallId || !toolCallIds.has(toolCallId)) continue;
+    const existing = linkedApprovals.get(toolCallId);
+    if (!existing || item.updated_at >= existing.item.updated_at) {
+      linkedApprovals.set(toolCallId, { item, approval });
+    }
+  }
+
+  const displayItems: ChatDisplayItem[] = [];
+  for (const item of transcript) {
+    if (item.kind === "text") {
+      displayItems.push({ kind: "text", item });
+      continue;
+    }
+    if (item.kind === "reasoning") {
+      displayItems.push({ kind: "reasoning", item });
+      continue;
+    }
+    if (item.kind === "tool") {
+      const linkedApproval = linkedApprovals.get(item.tool_call_id);
+      displayItems.push({
+        kind: "tool",
+        item,
+        approvalItem: linkedApproval?.item ?? null,
+        approval: linkedApproval?.approval ?? null,
+      });
+      continue;
+    }
+
+    const approval = approvalsById[item.approval_id] ?? null;
+    const toolCallId = readApprovalToolCallId(item, approval);
+    if (toolCallId && toolCallIds.has(toolCallId)) continue;
+    displayItems.push({ kind: "approval", item, approval });
+  }
+
+  return displayItems;
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await globalThis.navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  } catch {
+    toast.error("Failed to copy to clipboard");
+  }
+}
+
+export function ChatTextItem({
+  item,
+  renderMode,
+}: {
+  item: SessionTranscriptTextItem;
+  renderMode: "markdown" | "text";
+}) {
+  return (
+    <div
+      className={
+        item.role === "assistant"
+          ? "group relative rounded-lg border border-border bg-bg px-3 py-2.5"
+          : item.role === "system"
+            ? "group relative rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2.5"
+            : "group relative rounded-lg border border-border bg-bg-subtle/70 px-3 py-2.5"
+      }
+    >
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-fg-muted">
+          <span>{item.role}</span>
+          <span>•</span>
+          <span>{formatRelativeTime(item.created_at)}</span>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 w-6 p-0 text-fg-muted opacity-0 transition-opacity hover:text-fg group-hover:opacity-100"
+          onClick={() => {
+            void copyToClipboard(item.content);
+          }}
+          title="Copy message"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {renderMode === "markdown" ? (
+        <div className="prose prose-sm max-w-none text-fg prose-headings:mb-2 prose-headings:mt-3 prose-headings:text-fg prose-p:my-2 prose-p:text-fg prose-ul:my-2 prose-ol:my-2 prose-strong:text-fg prose-code:text-fg prose-pre:my-2 prose-pre:bg-bg-subtle">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.content}</ReactMarkdown>
+        </div>
+      ) : (
+        <pre className="whitespace-pre-wrap break-words text-[13px] leading-5 text-fg">
+          {item.content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export function ChatToolItem({
+  item,
+  approvalItem,
+  approval,
+  onResolve,
+  resolvingState,
+}: {
+  item: SessionTranscriptToolItem;
+  approvalItem: SessionTranscriptApprovalItem | null;
+  approval: Approval | null;
+  onResolve: (input: ResolveApprovalInput) => void;
+  resolvingState?: "approved" | "denied" | "always";
+}) {
+  const approvalStatus = approval?.status ?? approvalItem?.status ?? "pending";
+  const approvalNote = approvalItem ? approvalResolutionNote(approvalItem, approval) : null;
+
+  return (
+    <div
+      className="rounded-lg border border-border bg-bg-subtle/40 px-3 py-2.5"
+      data-testid={`chat-tool-card-${item.tool_call_id}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm font-medium text-fg">
+            <Hammer className="h-4 w-4 shrink-0" />
+            <span className="truncate">{item.tool_id}</span>
+          </div>
+          <div className="mt-1 text-sm text-fg-muted">{item.summary || "Working…"}</div>
+          {item.error ? <div className="mt-1.5 text-sm text-danger-700">{item.error}</div> : null}
+        </div>
+        <Badge variant={toolBadgeVariant(item.status)}>{formatToolStatus(item.status)}</Badge>
+      </div>
+      {approvalItem && approvalStatus === "pending" ? (
+        <div
+          className="mt-2 rounded-md border border-warning-300/70 bg-warning-50/70 px-2.5 py-2"
+          data-testid={`chat-tool-approval-${approvalItem.approval_id}`}
+        >
+          <div className="mb-1.5 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-warning-900">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              <span>{approvalItem.title}</span>
+            </div>
+            <Badge variant={approvalBadgeVariant(approvalStatus)}>
+              {formatApprovalStatus(approvalStatus)}
+            </Badge>
+          </div>
+          <div className="text-sm text-warning-950">{approvalItem.detail}</div>
+          <ApprovalActions
+            approvalId={approvalItem.approval_id}
+            approval={approval}
+            resolvingState={resolvingState}
+            onResolve={onResolve}
+            className="mt-2 flex flex-wrap gap-2"
+          />
+        </div>
+      ) : approvalItem ? (
+        <div
+          className="mt-2 flex flex-wrap items-center gap-2 text-xs text-fg-muted"
+          data-testid={`chat-tool-approval-note-${approvalItem.approval_id}`}
+        >
+          <div className="inline-flex items-center gap-1.5">
+            <ShieldCheck className="h-3.5 w-3.5 text-fg-muted" />
+            <span>Approval</span>
+          </div>
+          <Badge variant={approvalBadgeVariant(approvalStatus)}>
+            {formatApprovalStatus(approvalStatus)}
+          </Badge>
+          {approvalNote ? <span className="truncate">{approvalNote}</span> : null}
+        </div>
+      ) : null}
+      <div className="mt-2 text-[11px] text-fg-muted">
+        {formatRelativeTime(transcriptTimestamp(item))}
+        {typeof item.duration_ms === "number" ? ` • ${item.duration_ms} ms` : ""}
+      </div>
+    </div>
+  );
+}
+
+export function ChatReasoningItem({
+  item,
+  mode,
+}: {
+  item: ChatReasoningItem;
+  mode: Exclude<ReasoningDisplayMode, "hidden">;
+}) {
+  const [open, setOpen] = useState(mode === "expanded");
+
+  useEffect(() => {
+    setOpen(mode === "expanded");
+  }, [mode]);
+
+  return (
+    <details
+      className="rounded-lg border border-border/70 bg-bg-subtle/30 px-3 py-2.5"
+      open={open}
+      onToggle={(event) => {
+        setOpen(event.currentTarget.open);
+      }}
+    >
+      <summary className="cursor-pointer text-sm font-medium text-fg-muted">
+        Model reasoning
+      </summary>
+      <pre className="mt-2 whitespace-pre-wrap break-words text-[13px] leading-5 text-fg-muted">
+        {item.content}
+      </pre>
+      <div className="mt-2 text-[11px] text-fg-muted">{formatRelativeTime(item.updated_at)}</div>
+    </details>
+  );
+}
+
+export function ChatApprovalItem({
+  item,
+  approval,
+  onResolve,
+  resolvingState,
+}: {
+  item: SessionTranscriptApprovalItem;
+  approval?: Approval | null;
+  onResolve: (input: ResolveApprovalInput) => void;
+  resolvingState?: "approved" | "denied" | "always";
+}) {
+  const approvalStatus = approval?.status ?? item.status;
+  const actionable = approvalStatus === "pending";
+
+  return (
+    <div
+      className="rounded-lg border border-warning-300 bg-warning-50/80 px-3 py-2.5"
+      data-testid={`chat-approval-card-${item.approval_id}`}
+    >
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-sm font-medium text-warning-900">
+          <ShieldCheck className="h-4 w-4" />
+          <span>{item.title}</span>
+        </div>
+        <Badge variant={approvalBadgeVariant(approvalStatus)}>
+          {formatApprovalStatus(approvalStatus)}
+        </Badge>
+      </div>
+      <div className="text-sm text-warning-950">{item.detail}</div>
+      {actionable ? (
+        <ApprovalActions
+          approvalId={item.approval_id}
+          approval={approval}
+          resolvingState={resolvingState}
+          onResolve={onResolve}
+          className="mt-2 flex flex-wrap gap-2"
+        />
+      ) : null}
+      <div className="mt-2 text-[11px] text-warning-900/80">
+        {formatRelativeTime(item.updated_at)}
+      </div>
+    </div>
+  );
+}

--- a/packages/operator-ui/tests/pages/chat-page-tool-bubble.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-tool-bubble.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { ChatConversationPanel } from "../../src/components/pages/chat-page-parts.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+describe("ChatPage tool call bubbles", () => {
+  it("fades in the transcript copy button on hover", () => {
+    const testRoot = renderIntoDocument(
+      React.createElement(ChatConversationPanel, {
+        activeThreadId: "thread-1",
+        transcript: [
+          {
+            kind: "text",
+            id: "turn-1",
+            role: "assistant",
+            content: "Copied text",
+            created_at: new Date().toISOString(),
+          },
+        ],
+        renderMode: "markdown",
+        onRenderModeChange: () => {},
+        reasoningMode: "collapsed",
+        onReasoningModeChange: () => {},
+        loadError: null,
+        sendError: null,
+        deleteDisabled: false,
+        onDelete: () => {},
+        draft: "",
+        setDraft: () => {},
+        send: async () => {},
+        sendBusy: false,
+        canSend: false,
+        working: false,
+        approvalsById: {},
+        onResolveApproval: () => {},
+        resolvingApproval: null,
+      }),
+    );
+
+    const copyButton = testRoot.container.querySelector<HTMLButtonElement>(
+      'button[title="Copy message"]',
+    );
+
+    expect(copyButton).not.toBeNull();
+    expect(copyButton?.className).toContain("opacity-0");
+    expect(copyButton?.className).toContain("group-hover:opacity-100");
+    expect(copyButton?.className).toContain("transition-opacity");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("groups linked tool approvals into a single tool card", () => {
+    const approvalId = "11111111-1111-1111-1111-111111111111";
+    const toolCallId = "tool-call-1";
+    const approval = {
+      approval_id: approvalId,
+      approval_key: "approval:1",
+      kind: "workflow_step",
+      status: "pending",
+      prompt: "Allow the tool call?",
+      context: {
+        tool_call_id: toolCallId,
+      },
+      created_at: "2026-03-10T00:00:00.000Z",
+      expires_at: null,
+      resolution: null,
+    } as const;
+
+    const testRoot = renderIntoDocument(
+      React.createElement(ChatConversationPanel, {
+        activeThreadId: "thread-1",
+        transcript: [
+          {
+            kind: "tool",
+            id: toolCallId,
+            tool_id: "shell.exec",
+            tool_call_id: toolCallId,
+            status: "awaiting_approval",
+            summary: "Waiting for approval",
+            created_at: "2026-03-10T00:00:00.000Z",
+            updated_at: "2026-03-10T00:00:01.000Z",
+          },
+          {
+            kind: "approval",
+            id: approvalId,
+            approval_id: approvalId,
+            status: "pending",
+            title: "Approval required",
+            detail: approval.prompt,
+            created_at: approval.created_at,
+            updated_at: "2026-03-10T00:00:01.000Z",
+          },
+        ],
+        renderMode: "markdown",
+        onRenderModeChange: () => {},
+        reasoningMode: "collapsed",
+        onReasoningModeChange: () => {},
+        loadError: null,
+        sendError: null,
+        deleteDisabled: false,
+        onDelete: () => {},
+        draft: "",
+        setDraft: () => {},
+        send: async () => {},
+        sendBusy: false,
+        canSend: false,
+        working: true,
+        approvalsById: { [approvalId]: approval },
+        onResolveApproval: () => {},
+        resolvingApproval: null,
+      }),
+    );
+
+    const toolCard = testRoot.container.querySelector<HTMLElement>(
+      `[data-testid="chat-tool-card-${toolCallId}"]`,
+    );
+
+    expect(toolCard).not.toBeNull();
+    expect(toolCard?.textContent).toContain("Allow the tool call?");
+    expect(
+      toolCard?.querySelector(`[data-testid="approval-approve-${approvalId}"]`),
+    ).not.toBeNull();
+    expect(
+      testRoot.container.querySelector(`[data-testid="chat-approval-card-${approvalId}"]`),
+    ).toBeNull();
+    expect(testRoot.container.textContent).not.toContain("Agent is working");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("shows resolved approval history inline within the tool card", () => {
+    const approvalId = "22222222-2222-2222-2222-222222222222";
+    const toolCallId = "tool-call-2";
+    const testRoot = renderIntoDocument(
+      React.createElement(ChatConversationPanel, {
+        activeThreadId: "thread-1",
+        transcript: [
+          {
+            kind: "tool",
+            id: toolCallId,
+            tool_id: "shell.exec",
+            tool_call_id: toolCallId,
+            status: "completed",
+            summary: "Command finished",
+            created_at: "2026-03-10T00:00:00.000Z",
+            updated_at: "2026-03-10T00:00:03.000Z",
+          },
+          {
+            kind: "approval",
+            id: approvalId,
+            approval_id: approvalId,
+            tool_call_id: toolCallId,
+            status: "approved",
+            title: "Approval required",
+            detail: "Allow the tool call?",
+            created_at: "2026-03-10T00:00:00.000Z",
+            updated_at: "2026-03-10T00:00:02.000Z",
+          },
+        ],
+        renderMode: "markdown",
+        onRenderModeChange: () => {},
+        reasoningMode: "collapsed",
+        onReasoningModeChange: () => {},
+        loadError: null,
+        sendError: null,
+        deleteDisabled: false,
+        onDelete: () => {},
+        draft: "",
+        setDraft: () => {},
+        send: async () => {},
+        sendBusy: false,
+        canSend: false,
+        working: false,
+        approvalsById: {
+          [approvalId]: {
+            approval_id: approvalId,
+            approval_key: "approval:2",
+            kind: "workflow_step",
+            status: "approved",
+            prompt: "Allow the tool call?",
+            context: {
+              tool_call_id: toolCallId,
+            },
+            created_at: "2026-03-10T00:00:00.000Z",
+            expires_at: null,
+            resolution: {
+              decision: "approved",
+              resolved_at: "2026-03-10T00:00:02.000Z",
+              reason: "Approved for this command",
+            },
+          },
+        },
+        onResolveApproval: () => {},
+        resolvingApproval: null,
+      }),
+    );
+
+    const note = testRoot.container.querySelector<HTMLElement>(
+      `[data-testid="chat-tool-approval-note-${approvalId}"]`,
+    );
+
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain("Approved");
+    expect(note?.textContent).toContain("Approved for this command");
+    expect(
+      testRoot.container.querySelector(`[data-testid="approval-approve-${approvalId}"]`),
+    ).toBeNull();
+    expect(
+      testRoot.container.querySelector(`[data-testid="chat-approval-card-${approvalId}"]`),
+    ).toBeNull();
+
+    cleanupTestRoot(testRoot);
+  });
+});

--- a/packages/operator-ui/tests/pages/chat-page.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page.test.ts
@@ -6,7 +6,6 @@ import type { OperatorCore } from "../../../operator-core/src/index.js";
 import { createChatStore } from "../../../operator-core/src/stores/chat-store.js";
 import { createStore } from "../../../operator-core/src/store.js";
 import { ChatPage } from "../../src/components/pages/chat-page.js";
-import { ChatConversationPanel } from "../../src/components/pages/chat-page-parts.js";
 import { cleanupTestRoot, click, renderIntoDocument, stubMatchMedia } from "../test-utils.js";
 
 function createApprovalsStoreStub() {
@@ -24,51 +23,6 @@ function createApprovalsStoreStub() {
 }
 
 describe("ChatPage", () => {
-  it("fades in the transcript copy button on hover", () => {
-    const testRoot = renderIntoDocument(
-      React.createElement(ChatConversationPanel, {
-        activeThreadId: "thread-1",
-        transcript: [
-          {
-            kind: "text",
-            id: "turn-1",
-            role: "assistant",
-            content: "Copied text",
-            created_at: new Date().toISOString(),
-          },
-        ],
-        renderMode: "markdown",
-        onRenderModeChange: () => {},
-        reasoningMode: "collapsed",
-        onReasoningModeChange: () => {},
-        loadError: null,
-        sendError: null,
-        deleteDisabled: false,
-        onDelete: () => {},
-        draft: "",
-        setDraft: () => {},
-        send: async () => {},
-        sendBusy: false,
-        canSend: false,
-        working: false,
-        approvalsById: {},
-        onResolveApproval: () => {},
-        resolvingApproval: null,
-      }),
-    );
-
-    const copyButton = testRoot.container.querySelector<HTMLButtonElement>(
-      'button[title="Copy message"]',
-    );
-
-    expect(copyButton).not.toBeNull();
-    expect(copyButton?.className).toContain("opacity-0");
-    expect(copyButton?.className).toContain("group-hover:opacity-100");
-    expect(copyButton?.className).toContain("transition-opacity");
-
-    cleanupTestRoot(testRoot);
-  });
-
   it("uses the persisted session title instead of deriving it from the last turn", async () => {
     const ws = {
       on: vi.fn(),

--- a/packages/schemas/src/session-transcript.ts
+++ b/packages/schemas/src/session-transcript.ts
@@ -65,6 +65,7 @@ export const SessionTranscriptApprovalItem = z
     kind: z.literal("approval"),
     id: z.string().trim().min(1),
     approval_id: z.string().trim().min(1),
+    tool_call_id: z.string().trim().min(1).optional(),
     status: ApprovalStatus,
     title: z.string().default("Approval required"),
     detail: z.string().default(""),


### PR DESCRIPTION
## Summary
- tighten the chat transcript layout so message and tool cards use less vertical space
- consolidate linked tool approvals into the same tool-call bubble and remove the redundant working bubble
- persist optional approval-to-tool linkage for live and fetched transcript rendering

## Testing
- pnpm exec vitest run packages/operator-core/tests/chat-store-transcript.test.ts packages/operator-core/tests/chat-store-transcript-compat.test.ts packages/operator-ui/tests/pages/chat-page.test.ts packages/operator-ui/tests/pages/chat-page-tool-bubble.test.ts packages/operator-ui/tests/pages/chat-page-reasoning.test.ts packages/operator-ui/tests/pages/chat-page-send-error.test.ts
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm format:check

Closes #1283
