### PR TITLE
fix(gateway): reduce prompt and node metadata exposure

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/prompts.ts
+++ b/packages/gateway/src/modules/agent/runtime/prompts.ts
@@ -74,7 +74,6 @@ export function formatRuntimePrompt(input: {
   gitRoot?: string;
   stateMode: string;
   model: string;
-  approvalWorkflowAvailable: boolean;
 }): string {
   return [
     "Runtime:",
@@ -87,7 +86,6 @@ export function formatRuntimePrompt(input: {
     `Gateway cwd: ${input.cwd}`,
     `Workspace path: ${input.home}`,
     `Git repo root: ${input.gitRoot ?? "none detected"}`,
-    `Approval workflow available: ${String(input.approvalWorkflowAvailable)}`,
     `Agent id: ${input.agentId}`,
     `Workspace id: ${input.workspaceId}`,
     `Session id: ${input.sessionId}`,
@@ -127,9 +125,5 @@ export function formatToolPrompt(tools: readonly ToolDescriptor[]): string {
     return "No tools are allowed for this agent configuration.";
   }
 
-  return tools
-    .map((tool) => {
-      return `${tool.id}: ${tool.description} (risk=${tool.risk}, confirmation=${tool.requires_confirmation})`;
-    })
-    .join("\n");
+  return tools.map((tool) => `${tool.id}: ${tool.description}`).join("\n");
 }

--- a/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
@@ -15,8 +15,6 @@ import type { ModelMessage } from "ai";
 import { coerceModelMessages } from "../../ai-sdk/message-utils.js";
 import { coerceRecord } from "../../util/coerce.js";
 import { buildAgentTurnKey } from "../turn-key.js";
-import type { PolicyService } from "../../policy/service.js";
-import { deriveElevatedExecutionAvailableFromPolicyBundle } from "../../sandbox/elevated-execution.js";
 import { renderEnvelopeMessageText } from "../session-message-text.js";
 import type { LaneQueueScope } from "./turn-engine-bridge.js";
 
@@ -113,36 +111,8 @@ export function extractToolApprovalResumeState(
   return { approval_id: approvalId, messages, used_tools: usedTools, steps_used: stepsUsed };
 }
 
-export async function deriveElevatedExecutionAvailable(
-  policyService: PolicyService,
-  scope: { tenantId: string; agentId?: string },
-): Promise<boolean | null> {
-  try {
-    const effective = await policyService.loadEffectiveBundle(scope);
-    return deriveElevatedExecutionAvailableFromPolicyBundle(effective.bundle);
-  } catch {
-    // Intentional: policy bundle may be unavailable; treat elevated execution as unknown.
-    return null;
-  }
-}
-
-export async function buildSandboxPrompt(input: {
-  policyService: PolicyService;
-  hardeningProfile: string;
-  tenantId: string;
-  agentId?: string;
-}): Promise<string> {
-  const elevatedExecutionAvailable = await deriveElevatedExecutionAvailable(input.policyService, {
-    tenantId: input.tenantId,
-    agentId: input.agentId,
-  });
-  return [
-    "Sandbox:",
-    `Hardening profile: ${input.hardeningProfile}`,
-    `Elevated execution available: ${
-      elevatedExecutionAvailable === null ? "unknown" : String(elevatedExecutionAvailable)
-    }`,
-  ].join("\n");
+export function buildSandboxPrompt(): string {
+  return ["Sandbox:", "Execution constraints are enforced by the gateway."].join("\n");
 }
 
 export function resolveAgentId(): string {

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
@@ -131,7 +131,6 @@ export async function buildRuntimePrompt(input: {
   home: string;
   stateMode: "local" | "shared";
   model: string;
-  approvalWorkflowAvailable: boolean;
 }): Promise<string> {
   return formatRuntimePrompt({
     ...input,
@@ -320,8 +319,7 @@ export async function resolveToolsAndMemory(
   );
   const filteredTools = toolCandidates
     .filter((tool) => isToolAllowed(executionProfile.profile.tool_allowlist, tool.id))
-    .filter((tool) => ctx.config.memory.v1.enabled || !tool.id.startsWith("memory."))
-    .slice(0, 8);
+    .filter((tool) => ctx.config.memory.v1.enabled || !tool.id.startsWith("memory."));
 
   return { memoryDigestResult, toolSetBuilder, filteredTools };
 }

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
@@ -32,7 +32,6 @@ import { NodeDispatchService } from "../node-dispatch-service.js";
 import { ToolExecutor } from "../tool-executor.js";
 import { NodeCapabilityInspectionService } from "../../node/capability-inspection-service.js";
 import { NodeInventoryService } from "../../node/inventory-service.js";
-import { resolveSandboxHardeningProfile } from "../../sandbox/hardening.js";
 import { LaneQueueSignalDal } from "../../lanes/queue-signal-dal.js";
 import { resolveGatewayStateMode } from "../../runtime-state/mode.js";
 import type { SecretProvider } from "../../secret/provider.js";
@@ -160,9 +159,6 @@ export async function prepareTurn(
           },
         });
   const workFocusText = `Work focus digest:\n${workFocusDigest}`;
-  const hardeningProfile = resolveSandboxHardeningProfile(
-    deps.opts.container.deploymentConfig.toolrunner.hardeningProfile,
-  );
   const runtimePrompt = await buildRuntimePrompt({
     nowIso: new Date().toISOString(),
     agentId: session.agent_id,
@@ -173,7 +169,6 @@ export async function prepareTurn(
     home: deps.home,
     stateMode: resolveGatewayStateMode(deps.opts.container.deploymentConfig),
     model: executionProfile.profile.model_id ?? executionProfile.id,
-    approvalWorkflowAvailable: true,
   });
 
   const {
@@ -187,12 +182,7 @@ export async function prepareTurn(
     automationTriggerText,
   } = assemblePrompts(ctx, session, memoryDigestResult, filteredTools, automation, runtimePrompt);
 
-  const sandboxPrompt = await buildSandboxPrompt({
-    policyService: deps.policyService,
-    hardeningProfile,
-    tenantId: deps.tenantId,
-    agentId: session.agent_id,
-  });
+  const sandboxPrompt = buildSandboxPrompt();
   const systemPrompt = `${identityPrompt}\n\n${runtimePromptText}\n\n${safetyPrompt}\n\n${sandboxPrompt}`;
 
   const automationDigestText = automation

--- a/packages/gateway/src/modules/agent/tool-executor-node-dispatch.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-node-dispatch.ts
@@ -45,6 +45,45 @@ type NodeDispatchAudit = {
   policy_snapshot_id?: string;
 };
 
+function stripNodeListControlState(payload: ReturnType<typeof NodeInventoryResponse.parse>) {
+  return {
+    status: payload.status,
+    generated_at: payload.generated_at,
+    ...(payload.key ? { key: payload.key } : {}),
+    ...(payload.lane ? { lane: payload.lane } : {}),
+    nodes: payload.nodes.map((node) => ({
+      node_id: node.node_id,
+      ...(node.label ? { label: node.label } : {}),
+      ...(node.mode ? { mode: node.mode } : {}),
+      ...(node.version ? { version: node.version } : {}),
+      connected: node.connected,
+      ...(node.last_seen_at ? { last_seen_at: node.last_seen_at } : {}),
+      capabilities: node.capabilities.map((capabilitySummary) => ({
+        capability: capabilitySummary.capability,
+        capability_version: capabilitySummary.capability_version,
+        connected: capabilitySummary.connected,
+        supported_action_count: capabilitySummary.supported_action_count,
+        enabled_action_count: capabilitySummary.enabled_action_count,
+        available_action_count: capabilitySummary.available_action_count,
+        unknown_action_count: capabilitySummary.unknown_action_count,
+      })),
+    })),
+  };
+}
+
+function stripNodeInspectionControlState(payload: NodeCapabilityInspectionResponseT) {
+  return {
+    status: payload.status,
+    generated_at: payload.generated_at,
+    node_id: payload.node_id,
+    capability: payload.capability,
+    capability_version: payload.capability_version,
+    connected: payload.connected,
+    source_of_truth: payload.source_of_truth,
+    actions: payload.actions,
+  };
+}
+
 type DispatchExecutionContext = {
   tenantId: string;
   nodeDispatchService: NodeDispatchService;
@@ -260,12 +299,14 @@ export async function executeNodeInspectTool(
   }
 
   try {
-    const payload = await context.inspectionService.inspect({
-      tenantId,
-      nodeId,
-      capabilityId: capability,
-      includeDisabled: false,
-    });
+    const payload = stripNodeInspectionControlState(
+      await context.inspectionService.inspect({
+        tenantId,
+        nodeId,
+        capabilityId: capability,
+        includeDisabled: false,
+      }),
+    );
     const tagged = tagContent(JSON.stringify(payload), "tool");
     return {
       tool_call_id: toolCallId,
@@ -317,18 +358,19 @@ export async function executeNodeListTool(
     };
   }
 
-  const payload = NodeInventoryResponse.parse({
-    status: "ok",
-    generated_at: new Date().toISOString(),
-    ...(await context.nodeInventoryService.list({
-      tenantId,
-      capability,
-      dispatchableOnly,
-      key,
-      lane,
-    })),
-  });
-
+  const payload = stripNodeListControlState(
+    NodeInventoryResponse.parse({
+      generated_at: new Date().toISOString(),
+      status: "ok",
+      ...(await context.nodeInventoryService.list({
+        tenantId,
+        capability,
+        dispatchableOnly,
+        key,
+        lane,
+      })),
+    }),
+  );
   const tagged = tagContent(JSON.stringify(payload), "tool");
   return {
     tool_call_id: toolCallId,

--- a/packages/gateway/tests/unit/agent-runtime-execution-profiles.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-execution-profiles.test.ts
@@ -140,4 +140,67 @@ describe("AgentRuntime (execution profiles)", () => {
     expect(executorTools).toContain("write");
     expect(executorTools).toContain("bash");
   });
+
+  it("exposes the full post-gating tool set without truncation", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-tools-"));
+    container = await createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    await new AgentConfigDal(container.db).set({
+      tenantId: DEFAULT_TENANT_ID,
+      agentId: DEFAULT_AGENT_ID,
+      config: AgentConfig.parse({
+        model: { model: "openai/gpt-4.1" },
+        skills: { enabled: [] },
+        mcp: { enabled: [] },
+        tools: {
+          allow: [
+            "read",
+            "write",
+            "edit",
+            "apply_patch",
+            "bash",
+            "glob",
+            "grep",
+            "websearch",
+            "webfetch",
+            "codesearch",
+          ],
+        },
+        sessions: { ttl_days: 30, max_turns: 20 },
+        memory: { v1: { enabled: false } },
+      }),
+      createdBy: { kind: "test" },
+      reason: "test",
+    });
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      languageModel: createStubLanguageModel("ok"),
+      fetchImpl: fetch404,
+      turnEngineWaitMs: 30_000,
+    });
+
+    await runtime.turn({
+      channel: "test",
+      thread_id: "thread-tools",
+      message: "hello",
+    });
+
+    expect(runtime.getLastContextReport()?.selected_tools).toEqual([
+      "glob",
+      "grep",
+      "read",
+      "apply_patch",
+      "bash",
+      "codesearch",
+      "edit",
+      "webfetch",
+      "websearch",
+      "write",
+    ]);
+  });
 });

--- a/packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createContainer, type GatewayContainer } from "../../src/container.js";
+import { AgentRuntime } from "../../src/modules/agent/runtime.js";
+import { createStubLanguageModel } from "./stub-language-model.js";
+import {
+  seedAgentConfig,
+  fetch404,
+  migrationsDir,
+  teardownTestEnv,
+} from "./agent-runtime.test-helpers.js";
+
+describe("AgentRuntime MCP tool exposure", () => {
+  let homeDir: string | undefined;
+  let container: GatewayContainer | undefined;
+
+  afterEach(async () => {
+    await teardownTestEnv({ homeDir, container });
+    container = undefined;
+    homeDir = undefined;
+  });
+
+  it("exposes all enabled MCP tools to the model tool set", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-mcp-tools-"));
+    container = await createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    await mkdir(join(homeDir, "mcp/calendar"), { recursive: true });
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { enabled: [] },
+        mcp: { enabled: ["calendar"] },
+        tools: { allow: ["read", "mcp.*"] },
+        sessions: { ttl_days: 30, max_turns: 20 },
+        memory: { v1: { enabled: false } },
+      },
+    });
+    await writeFile(
+      join(homeDir, "mcp/calendar/server.yml"),
+      `id: calendar\nname: Calendar MCP\nenabled: true\ntransport: stdio\ncommand: node\nargs: []\n`,
+      "utf-8",
+    );
+
+    const mcpManager = {
+      listToolDescriptors: vi.fn(async () => [
+        {
+          id: "mcp.calendar.events_list",
+          description: "List calendar events.",
+          risk: "medium" as const,
+          requires_confirmation: true,
+          keywords: ["calendar", "events"],
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        {
+          id: "mcp.calendar.events_create",
+          description: "Create calendar events.",
+          risk: "medium" as const,
+          requires_confirmation: true,
+          keywords: ["calendar", "create"],
+          inputSchema: {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      ]),
+      shutdown: vi.fn(async () => {}),
+    };
+
+    const runtime = new AgentRuntime({
+      container,
+      home: homeDir,
+      languageModel: createStubLanguageModel("hello"),
+      fetchImpl: fetch404,
+      mcpManager: mcpManager as unknown as ConstructorParameters<
+        typeof AgentRuntime
+      >[0]["mcpManager"],
+    });
+
+    await runtime.turn({
+      channel: "test",
+      thread_id: "thread-mcp",
+      message: "calendar",
+    });
+
+    expect(runtime.getLastContextReport()?.selected_tools).toEqual([
+      "mcp.calendar.events_create",
+      "mcp.calendar.events_list",
+      "read",
+    ]);
+  });
+});

--- a/packages/gateway/tests/unit/agent-runtime-sandbox-prompt.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-sandbox-prompt.test.ts
@@ -25,7 +25,7 @@ describe("AgentRuntime system prompt sandbox section", () => {
     }
   });
 
-  it("includes hardening profile and elevated execution availability", async () => {
+  it("uses a neutral sandbox prompt", async () => {
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-sandbox-prompt-"));
     container = createContainer(
       {
@@ -110,13 +110,12 @@ describe("AgentRuntime system prompt sandbox section", () => {
 
     expect(result.reply).toBe("hello");
     expect(capturedSystem).toContain("Sandbox:");
-    expect(capturedSystem).toContain("Hardening profile: hardened");
-    expect(capturedSystem).toContain("Elevated execution available: true");
-    expect(capturedSystem?.match(/Elevated execution available:/g)).toHaveLength(1);
-    expect(capturedSystem?.match(/Hardening profile:/g)).toHaveLength(1);
+    expect(capturedSystem).toContain("Execution constraints are enforced by the gateway.");
+    expect(capturedSystem).not.toContain("Hardening profile:");
+    expect(capturedSystem).not.toContain("Elevated execution available:");
   });
 
-  it("reports unknown elevated execution availability when policy resolution fails", async () => {
+  it("keeps the sandbox prompt stable when policy resolution fails", async () => {
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-sandbox-prompt-unknown-"));
     container = createContainer(
       {
@@ -194,7 +193,8 @@ describe("AgentRuntime system prompt sandbox section", () => {
 
     expect(result.reply).toBe("hello");
     expect(capturedSystem).toContain("Sandbox:");
-    expect(capturedSystem).toContain("Hardening profile: hardened");
-    expect(capturedSystem).toContain("Elevated execution available: unknown");
+    expect(capturedSystem).toContain("Execution constraints are enforced by the gateway.");
+    expect(capturedSystem).not.toContain("Hardening profile:");
+    expect(capturedSystem).not.toContain("Elevated execution available:");
   });
 });

--- a/packages/gateway/tests/unit/runtime-prompts.test.ts
+++ b/packages/gateway/tests/unit/runtime-prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatSkillsPrompt } from "../../src/modules/agent/runtime/prompts.js";
+import { formatSkillsPrompt, formatToolPrompt } from "../../src/modules/agent/runtime/prompts.js";
 
 describe("formatSkillsPrompt", () => {
   it("includes inline skill instructions with provenance metadata", () => {
@@ -47,5 +47,21 @@ describe("formatSkillsPrompt", () => {
     expect(prompt).toContain("DB Skill (skill-db@2.0.0)");
     expect(prompt).toContain("file=db://runtime-packages/skill/skill-db");
     expect(prompt).toContain("Escalate approval requests before running deploy actions.");
+  });
+
+  it("omits risk and confirmation metadata from tool summaries", () => {
+    const prompt = formatToolPrompt([
+      {
+        id: "bash",
+        description: "Execute shell commands on the local machine.",
+        risk: "high",
+        requires_confirmation: true,
+        keywords: [],
+      },
+    ]);
+
+    expect(prompt).toBe("bash: Execute shell commands on the local machine.");
+    expect(prompt).not.toContain("risk=");
+    expect(prompt).not.toContain("confirmation=");
   });
 });

--- a/packages/gateway/tests/unit/tool-executor.node-dispatch-test-support.ts
+++ b/packages/gateway/tests/unit/tool-executor.node-dispatch-test-support.ts
@@ -346,6 +346,7 @@ export function registerToolExecutorNodeDispatchTests(home: HomeDirState): void 
               connected: true,
               paired_status: "approved",
               attached_to_requested_lane: true,
+              source_client_device_id: "client-1",
               capabilities: [
                 {
                   capability: "tyrum.desktop.snapshot",
@@ -387,7 +388,11 @@ export function registerToolExecutorNodeDispatchTests(home: HomeDirState): void 
       });
       expect(result.error).toBeUndefined();
       expect(result.output).toContain('"status":"ok"');
-      expect(result.output).toContain('"attached_to_requested_lane":true');
+      expect(result.output).not.toContain('"attached_to_requested_lane":true');
+      expect(result.output).not.toContain('"paired_status":"approved"');
+      expect(result.output).not.toContain('"source_client_device_id":"client-1"');
+      expect(result.output).not.toContain('"dispatchable":true');
+      expect(result.output).not.toContain('"paired":true');
     } finally {
       await db.close();
     }

--- a/packages/gateway/tests/unit/turn-preparation-runtime.test.ts
+++ b/packages/gateway/tests/unit/turn-preparation-runtime.test.ts
@@ -94,9 +94,9 @@ describe("turn preparation runtime helpers", () => {
       home: "/workspace-prompt",
       stateMode: "local",
       model: "model-1",
-      approvalWorkflowAvailable: true,
     });
 
     expect(prompt).toContain("Git repo root: /repo-root");
+    expect(prompt).not.toContain("Approval workflow available:");
   });
 });


### PR DESCRIPTION
## Summary
- remove prompt metadata that is not actionable for the model, including approval workflow, tool risk/confirmation tags, and sandbox hardening/elevated execution details
- stop truncating the post-gating tool set so enabled tools remain visible to the runtime context report and model tool set
- strip control-plane-only fields from `tool.node.list` and `tool.node.inspect` responses

## Testing
- `pnpm exec vitest run packages/gateway/tests/unit/agent-runtime-execution-profiles.test.ts packages/gateway/tests/unit/agent-runtime-sandbox-prompt.test.ts packages/gateway/tests/unit/runtime-prompts.test.ts packages/gateway/tests/unit/turn-preparation-runtime.test.ts packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts packages/gateway/tests/unit/tool-executor.test.ts --reporter=verbose`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`

Closes #1307
