### PR TITLE
fix: verify file-type patch activation on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "ci": "pnpm ci:ubuntu",
     "ci:ubuntu": "pnpm install --frozen-lockfile && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm lint && pnpm format:check && pnpm build && pnpm --filter tyrum-desktop exec playwright install chromium && xvfb-run -a --server-args=\"-screen 0 1920x1080x24\" pnpm test --coverage.enabled --coverage.reporter=text-summary",
-    "prepare": "node scripts/setup-githooks.mjs",
+    "prepare": "node scripts/setup-githooks.mjs && node scripts/check-file-type-patch.mjs",
     "setup:githooks": "node scripts/setup-githooks.mjs",
     "pretypecheck": "pnpm --filter @tyrum/schemas build && pnpm --filter @tyrum/client build && pnpm --filter @tyrum/desktop-node build && pnpm --filter @tyrum/operator-core build && pnpm --filter @tyrum/operator-ui build && node -e \"const fs=require('node:fs'); fs.rmSync('packages/schemas/tsconfig.tsbuildinfo',{force:true}); fs.rmSync('packages/gateway/tsconfig.tsbuildinfo',{force:true})\"",
     "build": "pnpm -r run build",

--- a/scripts/check-file-type-patch.mjs
+++ b/scripts/check-file-type-patch.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+function fail(reason, remediation, err) {
+  const lines = [
+    "Patched dependency check failed: file-type ASF loop guard is inactive.",
+    "",
+    reason,
+    "",
+    "Remediation:",
+    ...remediation.map((line) => `- ${line}`),
+  ];
+
+  if (err instanceof Error && err.message) {
+    lines.push("", "Underlying error:", err.message);
+  }
+
+  console.error(lines.join("\n"));
+  process.exit(1);
+}
+
+try {
+  const desktopNodePackageJson = require.resolve("../packages/desktop-node/package.json");
+  const nutJsPackageJson = require.resolve("@nut-tree-fork/nut-js/package.json", {
+    paths: [dirname(desktopNodePackageJson)],
+  });
+  const jimpPackageJson = require.resolve("jimp/package.json", {
+    paths: [dirname(nutJsPackageJson)],
+  });
+  const jimpCorePackageJson = require.resolve("@jimp/core/package.json", {
+    paths: [dirname(jimpPackageJson)],
+  });
+  const fileTypeCorePath = require.resolve("file-type/core", {
+    paths: [dirname(jimpCorePackageJson)],
+  });
+  const source = readFileSync(fileTypeCorePath, "utf8");
+
+  const hasLoopGuard =
+    source.includes("const previousPosition = tokenizer.position;") &&
+    source.includes("if (tokenizer.position <= previousPosition) {");
+
+  if (!hasLoopGuard) {
+    fail(
+      `Expected patched file-type source at ${fileTypeCorePath}.`,
+      [
+        "Refresh patched dependencies: pnpm install --force",
+        "If the problem persists, clear node_modules and reinstall: rm -rf node_modules && pnpm install",
+      ],
+      undefined,
+    );
+  }
+} catch (err) {
+  fail(
+    "Unable to resolve the transitive file-type package used by @tyrum/desktop-node.",
+    [
+      "Install dependencies: pnpm install",
+      "If dependencies were already installed, refresh the virtual store: pnpm install --force",
+    ],
+    err instanceof Error ? err : new Error(String(err)),
+  );
+}


### PR DESCRIPTION
## Summary
- add an install-time check that resolves the transitive `file-type` copy used by `@tyrum/desktop-node` and verifies the ASF loop guard is present
- run that check from the root `prepare` hook so stale pnpm virtual-store state fails fast with remediation
- keep the existing regression test as the runtime proof that malformed ASF input no longer hangs

## Why
A stale pnpm virtual store can leave `file-type@16.5.4` effectively unpatched even though the repo already carries `patches/file-type@16.5.4.patch`. This change turns that silent failure mode into an immediate install error.

## How To Test
- `node scripts/check-file-type-patch.mjs`
- `pnpm vitest run packages/desktop-node/tests/file-type-audit-patch.test.ts`
- `pnpm exec oxlint scripts/check-file-type-patch.mjs`
- `pnpm exec prettier --check package.json scripts/check-file-type-patch.mjs`
- `pnpm install`

## Risk
Low. The change only adds an install-time verification step and does not change runtime behavior when dependencies are installed correctly.

## Rollback
Remove `scripts/check-file-type-patch.mjs` and the `prepare` hook addition in `package.json`.

Closes #1317