### PR TITLE
fix: keep AppPage content left aligned until fully visible

### DIFF
--- a/packages/operator-ui/src/components/layout/app-page.tsx
+++ b/packages/operator-ui/src/components/layout/app-page.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import { cn } from "../../lib/cn.js";
 import { ScrollArea } from "../ui/scroll-area.js";
 
+function contentFitsViewport(element: HTMLElement): boolean {
+  return element.scrollWidth - element.clientWidth <= 1;
+}
+
 export interface AppPageToolbarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   title?: React.ReactNode;
   actions?: React.ReactNode;
@@ -38,13 +42,45 @@ export function AppPageContent({
   scrollAreaRef,
   ...props
 }: AppPageContentProps) {
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const [centerContent, setCenterContent] = React.useState(true);
+
+  const updateAlignment = React.useCallback(() => {
+    const element = contentRef.current;
+    if (!element) return;
+    const nextCentered = contentFitsViewport(element);
+    setCenterContent((current) => (current === nextCentered ? current : nextCentered));
+  }, []);
+
+  React.useLayoutEffect(() => {
+    updateAlignment();
+  });
+
+  React.useLayoutEffect(() => {
+    const element = contentRef.current;
+    if (!element || typeof ResizeObserver !== "function") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      updateAlignment();
+    });
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [updateAlignment]);
+
   return (
     <div className={cn("min-h-0 flex-1 overflow-hidden", className)} {...props}>
       <ScrollArea ref={scrollAreaRef} className={cn("h-full", scrollAreaClassName)}>
         <div
+          ref={contentRef}
           data-layout-content=""
+          data-layout-alignment={centerContent ? "center" : "start"}
           className={cn(
-            "mx-auto grid box-border w-full max-w-5xl gap-5 px-4 py-4 md:px-5 md:py-5",
+            "grid box-border w-full max-w-5xl gap-5 px-4 py-4 md:px-5 md:py-5",
+            centerContent ? "mx-auto" : "ml-0 mr-auto",
             contentClassName,
           )}
         >

--- a/packages/operator-ui/tests/layout/app-page.test.ts
+++ b/packages/operator-ui/tests/layout/app-page.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { AppPageContent } from "../../src/components/layout/app-page.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+function isLayoutContentElement(element: unknown): element is HTMLElement {
+  return element instanceof HTMLElement && element.hasAttribute("data-layout-content");
+}
+
+function installLayoutContentMeasurements(input: { clientWidth: number; scrollWidth: number }) {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeObserverCallback: ResizeObserverCallback | null = null;
+  let observedElement: Element | null = null;
+
+  let clientWidth = input.clientWidth;
+  let scrollWidth = input.scrollWidth;
+
+  globalThis.ResizeObserver = class ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverCallback = callback;
+    }
+
+    observe(target: Element): void {
+      observedElement = target;
+    }
+
+    unobserve(_target: Element): void {}
+
+    disconnect(): void {}
+  };
+
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    return isLayoutContentElement(this) ? clientWidth : 0;
+  });
+  vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    return isLayoutContentElement(this) ? scrollWidth : 0;
+  });
+
+  return {
+    setWidths(next: { clientWidth?: number; scrollWidth?: number }) {
+      if (typeof next.clientWidth === "number") {
+        clientWidth = next.clientWidth;
+      }
+      if (typeof next.scrollWidth === "number") {
+        scrollWidth = next.scrollWidth;
+      }
+    },
+    notifyResize() {
+      act(() => {
+        resizeObserverCallback?.(
+          [
+            {
+              target: observedElement as Element,
+              contentRect: { width: clientWidth } as DOMRectReadOnly,
+            } as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      });
+    },
+    restore() {
+      globalThis.ResizeObserver = originalResizeObserver;
+    },
+  };
+}
+
+describe("AppPageContent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("left aligns the content box while its children still overflow horizontally", () => {
+    const measurements = installLayoutContentMeasurements({ clientWidth: 900, scrollWidth: 1200 });
+    let testRoot: ReturnType<typeof renderIntoDocument> | null = null;
+
+    try {
+      testRoot = renderIntoDocument(
+        React.createElement(
+          AppPageContent,
+          null,
+          React.createElement("div", { style: { minWidth: "1200px" } }, "Wide content"),
+        ),
+      );
+
+      const content = testRoot.container.querySelector("[data-layout-content]");
+      expect(content?.getAttribute("data-layout-alignment")).toBe("start");
+      expect(content?.className).toContain("ml-0");
+      expect(content?.className).toContain("mr-auto");
+      expect(content?.className).not.toContain("mx-auto");
+    } finally {
+      if (testRoot) {
+        cleanupTestRoot(testRoot);
+      }
+      measurements.restore();
+    }
+  });
+
+  it("recenters the content box after the overflow clears", () => {
+    const measurements = installLayoutContentMeasurements({ clientWidth: 900, scrollWidth: 1200 });
+    let testRoot: ReturnType<typeof renderIntoDocument> | null = null;
+
+    try {
+      testRoot = renderIntoDocument(
+        React.createElement(
+          AppPageContent,
+          null,
+          React.createElement("div", { style: { minWidth: "1200px" } }, "Wide content"),
+        ),
+      );
+
+      measurements.setWidths({ scrollWidth: 900 });
+      measurements.notifyResize();
+
+      const content = testRoot.container.querySelector("[data-layout-content]");
+      expect(content?.getAttribute("data-layout-alignment")).toBe("center");
+      expect(content?.className).toContain("mx-auto");
+      expect(content?.className).not.toContain("ml-0");
+    } finally {
+      if (testRoot) {
+        cleanupTestRoot(testRoot);
+      }
+      measurements.restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep shared `AppPage` content left-aligned while its children still overflow horizontally
- recenter the page content automatically once the horizontal clipping clears
- add regression coverage for both the left-aligned and recentered states

## Why
Some desktop pages started adding empty space on the left as the window widened even though right-most page content was still not fully visible. The shared page container was centering too early.

## Testing
- `pnpm vitest run packages/operator-ui/tests/layout/app-page.test.ts`
- `pnpm vitest run apps/web/tests/layout-regression.test.ts`
- `pnpm lint`
- `pnpm typecheck`

## Risk
Low. The change is isolated to shared `AppPage` alignment behavior and only switches between left-aligned and centered layout based on measured horizontal fit.

## Rollback
Revert this PR to restore the previous always-centered `AppPage` behavior.

Closes #1319
