### PR TITLE
fix: reflow dashboard from shell width

### DIFF
--- a/apps/web/tests/layout-regression.test.ts
+++ b/apps/web/tests/layout-regression.test.ts
@@ -233,6 +233,27 @@ async function assertNoInternalHorizontalClipping(page: Page, selectors: string[
   }
 }
 
+async function assertDashboardLayout(
+  page: Page,
+  expected: {
+    kpiColumns: "grid-cols-2" | "grid-cols-4";
+    summaryColumns: "grid-cols-1" | "grid-cols-2";
+  },
+): Promise<void> {
+  await page.waitForFunction(({ kpiColumns, summaryColumns }) => {
+    const kpiGrid = document.querySelector<HTMLElement>('[data-testid="dashboard-kpi-grid"]');
+    const summaryGrid = document.querySelector<HTMLElement>(
+      '[data-testid="dashboard-summary-grid"]',
+    );
+    const layoutContent = document.querySelector<HTMLElement>("[data-layout-content]");
+    return (
+      kpiGrid?.className.includes(kpiColumns) &&
+      summaryGrid?.className.includes(summaryColumns) &&
+      layoutContent?.getAttribute("data-layout-alignment") === "center"
+    );
+  }, expected);
+}
+
 describe("layout regression harness", () => {
   beforeAll(async () => {
     process.chdir(APP_ROOT);
@@ -333,6 +354,30 @@ describe("layout regression harness", () => {
         '[data-testid="chat-threads-panel"]',
         '[data-testid="chat-conversation-panel"]',
       ]);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("reflows dashboard when the sidebar collapses", { timeout: 30_000 }, async () => {
+    const page = await browser.newPage({ viewport: { width: 900, height: 700 } });
+    try {
+      await page.goto(`${baseUrl}?route=dashboard`, { waitUntil: "load" });
+      await page.waitForSelector('[data-testid="dashboard-kpi-grid"]');
+
+      await assertDashboardLayout(page, {
+        kpiColumns: "grid-cols-2",
+        summaryColumns: "grid-cols-1",
+      });
+      await assertNoHorizontalOverflow(page, ["[data-layout-content]"]);
+
+      await page.click('[data-testid="sidebar-collapse-toggle"]');
+
+      await assertDashboardLayout(page, {
+        kpiColumns: "grid-cols-4",
+        summaryColumns: "grid-cols-2",
+      });
+      await assertNoHorizontalOverflow(page, ["[data-layout-content]"]);
     } finally {
       await page.close();
     }

--- a/packages/operator-ui/src/components/pages/dashboard-page.tsx
+++ b/packages/operator-ui/src/components/pages/dashboard-page.tsx
@@ -3,6 +3,7 @@ import type { ActivityEvent, ActivityWorkstream, OperatorCore } from "@tyrum/ope
 import * as React from "react";
 import { Bot, Inbox, Play, ShieldCheck, SquareKanban } from "lucide-react";
 import { AppPage } from "../layout/app-page.js";
+import { useAppShellMinWidth } from "../layout/app-shell.js";
 import { Alert } from "../ui/alert.js";
 import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
@@ -28,6 +29,7 @@ import {
 import { useNodeInventory } from "./pairing-page.inventory.js";
 
 type ConfigHealthIssue = NonNullable<StatusResponse["config_health"]>["issues"][number];
+const DASHBOARD_WIDE_CONTENT_WIDTH_PX = 768;
 
 function getConfigHealthAction(issue: ConfigHealthIssue): {
   label: "Configure" | "Agents";
@@ -73,6 +75,7 @@ export function DashboardPage({
   onNavigate,
   connectionRouteId = "configure",
 }: DashboardPageProps) {
+  const wideDashboard = useAppShellMinWidth(DASHBOARD_WIDE_CONTENT_WIDTH_PX);
   const status = useOperatorStore(core.statusStore);
   const connection = useOperatorStore(core.connectionStore);
   const approvals = useOperatorStore(core.approvalsStore);
@@ -276,7 +279,10 @@ export function DashboardPage({
       ) : null}
 
       {/* KPI Grid */}
-      <div className="grid min-w-0 grid-cols-2 gap-3 sm:grid-cols-4">
+      <div
+        data-testid="dashboard-kpi-grid"
+        className={cn("grid min-w-0 gap-3", wideDashboard ? "grid-cols-4" : "grid-cols-2")}
+      >
         <KpiCard
           icon={ShieldCheck}
           value={String(approvals.pendingIds.length)}
@@ -317,7 +323,10 @@ export function DashboardPage({
       </div>
 
       {/* System Status + Security */}
-      <div className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
+      <div
+        data-testid="dashboard-summary-grid"
+        className={cn("grid min-w-0 gap-3", wideDashboard ? "grid-cols-2" : "grid-cols-1")}
+      >
         <Card>
           <CardHeader className="pb-0">
             <h3 className="text-sm font-semibold">System Status</h3>

--- a/packages/operator-ui/tests/pages/dashboard-page.test.ts
+++ b/packages/operator-ui/tests/pages/dashboard-page.test.ts
@@ -1,15 +1,21 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import React, { act } from "react";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { OperatorCore } from "../../../operator-core/src/index.js";
 import { createStore } from "../../../operator-core/src/store.js";
 import type { ActivityState } from "../../../operator-core/src/stores/activity-store.js";
+import { AppShell } from "../../src/components/layout/app-shell.js";
 import { DashboardPage } from "../../src/components/pages/dashboard-page.js";
 import { sampleNodeInventoryResponse } from "../operator-ui.http-fixture-data.js";
-import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+import {
+  cleanupTestRoot,
+  renderIntoDocument,
+  stubAppShellContentWidth,
+  stubMatchMedia,
+} from "../test-utils.js";
 
 const emptyActivityState: ActivityState = {
   agentsById: {},
@@ -103,6 +109,10 @@ function createMockCore(overrides?: Partial<Record<string, unknown>>) {
 }
 
 describe("DashboardPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("does not use the old precomputed tokens text pattern", () => {
     const source = readFileSync(
       join(process.cwd(), "packages/operator-ui/src/components/pages/dashboard-page.tsx"),
@@ -112,17 +122,52 @@ describe("DashboardPage", () => {
     expect(source).not.toContain('value={typeof tokensUsed === "number" ? tokensUsedText : "-"}');
   });
 
-  it("uses a responsive KPI grid layout with system status and security cards", () => {
-    const source = readFileSync(
-      join(process.cwd(), "packages/operator-ui/src/components/pages/dashboard-page.tsx"),
-      "utf8",
-    );
+  it("reflows the dashboard grids based on app shell content width", () => {
+    const matchMedia = stubMatchMedia("(min-width: 768px)", false);
+    const measurements = stubAppShellContentWidth(700);
+    const { core } = createMockCore();
+    let testRoot: ReturnType<typeof renderIntoDocument> | null = null;
 
-    expect(source).toContain("KpiCard");
-    expect(source).toContain("sm:grid-cols-4");
-    expect(source).toContain("sm:grid-cols-2");
-    expect(source).toContain("System Status");
-    expect(source).toContain("Security");
+    try {
+      testRoot = renderIntoDocument(
+        React.createElement(
+          AppShell,
+          {
+            mode: "desktop",
+            sidebar: React.createElement("div"),
+            mobileNav: null,
+          },
+          React.createElement(DashboardPage, { core }),
+        ),
+      );
+
+      const kpiGrid = testRoot.container.querySelector("[data-testid='dashboard-kpi-grid']");
+      const summaryGrid = testRoot.container.querySelector(
+        "[data-testid='dashboard-summary-grid']",
+      );
+      const layoutContent = testRoot.container.querySelector("[data-layout-content]");
+
+      expect(kpiGrid?.className).toContain("grid-cols-2");
+      expect(kpiGrid?.className).not.toContain("grid-cols-4");
+      expect(summaryGrid?.className).toContain("grid-cols-1");
+      expect(summaryGrid?.className).not.toContain("grid-cols-2");
+      expect(layoutContent?.getAttribute("data-layout-alignment")).toBe("center");
+
+      measurements.setWidth(820);
+      measurements.notifyResize();
+
+      expect(kpiGrid?.className).toContain("grid-cols-4");
+      expect(kpiGrid?.className).not.toContain("grid-cols-2");
+      expect(summaryGrid?.className).toContain("grid-cols-2");
+      expect(summaryGrid?.className).not.toContain("grid-cols-1");
+      expect(layoutContent?.getAttribute("data-layout-alignment")).toBe("center");
+    } finally {
+      if (testRoot) {
+        cleanupTestRoot(testRoot);
+      }
+      matchMedia.cleanup();
+      measurements.cleanup();
+    }
   });
 
   it("pulses the connection dot only while connecting", () => {

--- a/packages/operator-ui/tests/test-utils.ts
+++ b/packages/operator-ui/tests/test-utils.ts
@@ -142,3 +142,77 @@ export function stubMatchMedia(
     },
   };
 }
+
+export function stubAppShellContentWidth(initialWidth: number) {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeObserverCallback: ResizeObserverCallback | null = null;
+  let observedElement: Element | null = null;
+  let measuredWidth = initialWidth;
+
+  const isMeasuredElement = (element: unknown): element is HTMLElement =>
+    element instanceof HTMLElement &&
+    typeof element.className === "string" &&
+    element.className.includes("min-w-0 flex-1 flex-col overflow-hidden");
+
+  globalThis.ResizeObserver = class ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverCallback = callback;
+    }
+
+    observe(target: Element): void {
+      observedElement = target;
+    }
+
+    unobserve(_target: Element): void {}
+
+    disconnect(): void {}
+  };
+
+  vi.spyOn(window, "getComputedStyle").mockImplementation(
+    (_element: Element) =>
+      ({
+        paddingLeft: "0px",
+        paddingRight: "0px",
+      }) as CSSStyleDeclaration,
+  );
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    return isMeasuredElement(this) ? measuredWidth : 0;
+  });
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(function (this: Element) {
+    return {
+      width: isMeasuredElement(this) ? measuredWidth : 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  });
+
+  return {
+    setWidth(nextWidth: number) {
+      measuredWidth = nextWidth;
+    },
+    notifyResize() {
+      act(() => {
+        resizeObserverCallback?.(
+          [
+            {
+              target: observedElement as Element,
+              contentRect: { width: measuredWidth } as DOMRectReadOnly,
+            } as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      });
+    },
+    cleanup() {
+      globalThis.ResizeObserver = originalResizeObserver;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- make Dashboard reflow from app-shell content width instead of viewport `sm:` breakpoints
- keep Dashboard centered while switching KPI and summary sections between compact and wide layouts
- add unit and browser regression coverage for sidebar-open vs collapsed resize behavior

## Testing
- pnpm vitest packages/operator-ui/tests/pages/dashboard-page.test.ts --run
- pnpm vitest apps/web/tests/layout-regression.test.ts --run
- pnpm lint
- pnpm typecheck

Closes #1321