### PR TITLE
Fix operator input focus flash

### DIFF
--- a/packages/operator-ui/src/components/memory/memory-detail-panel.tsx
+++ b/packages/operator-ui/src/components/memory/memory-detail-panel.tsx
@@ -113,7 +113,7 @@ export function MemoryDetailPanel({
                 onChange={(event) => {
                   onSensitivityDraftChange(event.currentTarget.value as MemorySensitivity);
                 }}
-                className="flex h-9 w-full rounded-lg border border-border bg-bg px-3 py-1 text-sm text-fg transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
+                className="flex h-9 w-full rounded-lg border border-border bg-bg px-3 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
               >
                 {MEMORY_SENSITIVITIES.map((sensitivity) => (
                   <option key={sensitivity} value={sensitivity}>

--- a/packages/operator-ui/src/components/pages/admin-http-providers-dialog.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-providers-dialog.tsx
@@ -263,7 +263,7 @@ export function ProviderAccountDialog({
                       setProviderFilter(event.currentTarget.value);
                     }}
                     className={cn(
-                      "box-border flex h-8 w-full rounded-md border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-colors duration-150",
+                      "box-border flex h-8 w-full rounded-md border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
                       "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
                     )}
                   />

--- a/packages/operator-ui/src/components/pages/chat-page-parts.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-parts.tsx
@@ -292,7 +292,7 @@ export function ChatConversationPanel({
               }
             }}
             placeholder="Send a message…"
-            className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-bg px-2.5 py-2 text-sm text-fg outline-none transition focus:border-focus-ring"
+            className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-bg px-2.5 py-2 text-sm text-fg outline-none transition-[border-color,box-shadow] duration-150 focus:border-focus-ring"
           />
           <Button
             className="h-[44px] rounded-lg px-4"

--- a/packages/operator-ui/src/components/ui/input.tsx
+++ b/packages/operator-ui/src/components/ui/input.tsx
@@ -35,7 +35,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             aria-invalid={error ? "true" : undefined}
             aria-describedby={describedById}
             className={cn(
-              "box-border flex h-8 w-full rounded-lg border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-colors duration-150",
+              "box-border flex h-8 w-full rounded-lg border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
               "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
               "disabled:cursor-not-allowed disabled:opacity-50",
               error ? "border-error focus-visible:ring-error" : null,

--- a/packages/operator-ui/src/components/ui/select.tsx
+++ b/packages/operator-ui/src/components/ui/select.tsx
@@ -29,7 +29,7 @@ export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           aria-invalid={error ? "true" : undefined}
           aria-describedby={describedById}
           className={cn(
-            "box-border flex h-9 w-full rounded-lg border border-border bg-bg px-3 py-1 text-sm text-fg transition-colors duration-150",
+            "box-border flex h-9 w-full rounded-lg border border-border bg-bg px-3 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
             "disabled:cursor-not-allowed disabled:opacity-50",
             error ? "border-error focus-visible:ring-error" : null,

--- a/packages/operator-ui/src/components/ui/textarea.tsx
+++ b/packages/operator-ui/src/components/ui/textarea.tsx
@@ -29,7 +29,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           aria-invalid={error ? "true" : undefined}
           aria-describedby={describedById}
           className={cn(
-            "flex min-h-18 w-full rounded-lg border border-border bg-bg px-2.5 py-1.5 text-sm text-fg transition-colors duration-150",
+            "flex min-h-18 w-full rounded-lg border border-border bg-bg px-2.5 py-1.5 text-sm text-fg transition-[border-color,box-shadow] duration-150",
             "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
             "disabled:cursor-not-allowed disabled:opacity-50",
             error ? "border-error focus-visible:ring-error" : null,

--- a/packages/operator-ui/src/globals.css
+++ b/packages/operator-ui/src/globals.css
@@ -30,6 +30,23 @@
     cursor: pointer;
   }
 
+  input:is(
+    [type="email"],
+    [type="password"],
+    [type="search"],
+    [type="tel"],
+    [type="text"],
+    [type="url"],
+    :not([type])
+  ),
+  textarea {
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+  }
+
   ::view-transition-old(root) {
     animation: tyrum-fade-out 200ms ease-in both;
   }

--- a/packages/operator-ui/tests/globals-css.test.ts
+++ b/packages/operator-ui/tests/globals-css.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("globals.css", () => {
+  it("resets native chrome for plain text-entry controls", () => {
+    const css = readFileSync(join(process.cwd(), "packages/operator-ui/src/globals.css"), "utf8");
+
+    expect(css).toContain("input:is(");
+    expect(css).toContain('[type="text"]');
+    expect(css).toContain('[type="password"]');
+    expect(css).toContain('[type="url"]');
+    expect(css).toContain("textarea {");
+    expect(css).toContain("-webkit-appearance: none;");
+    expect(css).toContain("background-color: transparent;");
+  });
+});

--- a/packages/operator-ui/tests/ui/input.test.ts
+++ b/packages/operator-ui/tests/ui/input.test.ts
@@ -48,6 +48,25 @@ describe("Input", () => {
     cleanupTestRoot({ container, root });
   });
 
+  it("limits transitions to border and ring styles", () => {
+    const Input = (operatorUi as Record<string, unknown>)["Input"];
+    expect(Input).toBeDefined();
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(Input as React.ComponentType, {
+        id: "focus-target",
+        label: "Focus target",
+      }),
+    );
+
+    const input = container.querySelector<HTMLInputElement>("input#focus-target");
+    expect(input).not.toBeNull();
+    expect(input?.className).toContain("transition-[border-color,box-shadow]");
+    expect(input?.className).not.toContain("transition-colors");
+
+    cleanupTestRoot({ container, root });
+  });
+
   it("renders helper text when error is an empty string", () => {
     const Input = (operatorUi as Record<string, unknown>)["Input"];
     expect(Input).toBeDefined();

--- a/packages/operator-ui/tests/ui/textarea.test.ts
+++ b/packages/operator-ui/tests/ui/textarea.test.ts
@@ -44,6 +44,25 @@ describe("Textarea", () => {
     cleanupTestRoot({ container, root });
   });
 
+  it("limits transitions to border and ring styles", () => {
+    const Textarea = (operatorUi as Record<string, unknown>)["Textarea"];
+    expect(Textarea).toBeDefined();
+
+    const { container, root } = renderIntoDocument(
+      React.createElement(Textarea as React.ComponentType, {
+        id: "focus-target",
+        label: "Focus target",
+      }),
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea#focus-target");
+    expect(textarea).not.toBeNull();
+    expect(textarea?.className).toContain("transition-[border-color,box-shadow]");
+    expect(textarea?.className).not.toContain("transition-colors");
+
+    cleanupTestRoot({ container, root });
+  });
+
   it("renders helper text when error is an empty string", () => {
     const Textarea = (operatorUi as Record<string, unknown>)["Textarea"];
     expect(Textarea).toBeDefined();


### PR DESCRIPTION
## Summary
- reset native browser chrome for plain text-entry inputs and textareas in operator-ui
- stop animating form-control background color so focus styling only transitions border and ring states
- add regression coverage for the shared form controls and global CSS reset

## Why
Text-entry controls in the themed operator UI could briefly flash a white native background on focus before settling on the intended brown/beige theme color. The root cause was native `appearance` still being active on text-entry controls while the shared styles animated color changes.

Closes #1325.

## How to test
- `pnpm vitest run packages/operator-ui/tests/ui/input.test.ts packages/operator-ui/tests/ui/textarea.test.ts packages/operator-ui/tests/globals-css.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- open the web UI in light theme and focus the connect-page inputs; they should keep the themed background with no white flash
