### PR TITLE
fix(docs): align bootstrap docs and Helm config

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -78,14 +78,15 @@ jobs:
           set -euo pipefail
           LOG_FILE="$RUNNER_TEMP/tyrum.log"
           TYRUM_HOME="$RUNNER_TEMP/.tyrum-home"
+          PORT=18980
           mkdir -p "$TYRUM_HOME"
 
-          GATEWAY_PORT=18980 GATEWAY_HOST=127.0.0.1 TYRUM_HOME="$TYRUM_HOME" tyrum >"$LOG_FILE" 2>&1 &
+          tyrum --home "$TYRUM_HOME" --host 127.0.0.1 --port "$PORT" >"$LOG_FILE" 2>&1 &
           gateway_pid=$!
 
           ready=0
           for _ in $(seq 1 20); do
-            if grep -q "Gateway v" "$LOG_FILE"; then
+            if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
               ready=1
               break
             fi
@@ -97,7 +98,7 @@ jobs:
 
           if [[ "$ready" -ne 1 ]]; then
             cat "$LOG_FILE"
-            echo "Gateway did not start successfully."
+            echo "Gateway did not become healthy on the requested port."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,9 @@
   - `--migrations-dir` (override migrations directory for checks/tooling)
   - `--host` (default: `127.0.0.1`)
   - `--port` (default: `8788`)
-  - `--role` (`all|edge|worker|scheduler`)
+  - `--role` (`all|edge|worker|scheduler|desktop-runtime`)
+  - `--trusted-proxies`, `--tls-ready`, `--tls-self-signed`
+  - `--allow-insecure-http`, `--enable-engine-api`, `--enable-snapshot-import`
 
 ## Common commands
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Prereqs:
 - [Architecture overview](docs/architecture/index.md)
 - [Contributing](CONTRIBUTING.md)
 - [Desktop app](apps/desktop/README.md)
-- [Docs site](apps/docs/README.md)
 
 ## Workspace
 

--- a/apps/docs/tests/api-reference-docs.test.ts
+++ b/apps/docs/tests/api-reference-docs.test.ts
@@ -21,6 +21,7 @@ describe("API reference docs (Issue #842)", () => {
     const wsMessageHeadings = doc.match(/^#### `[^`]+`$/gm) ?? [];
     expect(wsMessageHeadings.length).toBeGreaterThanOrEqual(15);
 
+    expect(doc).toContain("/system/deployment-config");
     expect(doc).toMatch(/future automation/i);
   });
 });

--- a/apps/docs/tests/deployment-bootstrap-docs.test.ts
+++ b/apps/docs/tests/deployment-bootstrap-docs.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { readFile, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { listMarkdownFiles } from "./markdown-utils.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../..");
+const docsRoot = resolve(repoRoot, "docs");
+
+function extractMarkdownLinks(markdown: string): string[] {
+  const matches = markdown.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g);
+  return Array.from(matches, (match) => match[1] ?? "");
+}
+
+function isLocalMarkdownLink(target: string): boolean {
+  if (!target || target.startsWith("#")) return false;
+  if (/^(https?:|mailto:|tel:|data:)/i.test(target)) return false;
+  return true;
+}
+
+async function readRepoFile(path: string): Promise<string> {
+  return await readFile(resolve(repoRoot, path), "utf8");
+}
+
+describe("deployment bootstrap docs", () => {
+  it("removes stale env-driven gateway startup guidance from core docs", async () => {
+    const install = await readRepoFile("docs/install.md");
+    const gettingStarted = await readRepoFile("docs/getting-started.md");
+    const remote = await readRepoFile("docs/advanced/remote-gateway.md");
+    const multiNode = await readRepoFile("docs/advanced/multi-node.md");
+    const profiles = await readRepoFile("docs/advanced/deployment-profiles.md");
+
+    expect(install).not.toContain("TYRUM_AGENT_ENABLED");
+    expect(gettingStarted).not.toContain("TYRUM_AGENT_ENABLED");
+    expect(gettingStarted).not.toContain("GATEWAY_PORT=8789");
+    expect(remote).not.toContain("GATEWAY_HOST=0.0.0.0");
+    expect(remote).not.toContain("TYRUM_TLS_READY");
+    expect(remote).not.toContain("TYRUM_TLS_SELF_SIGNED");
+    expect(remote).not.toContain("TYRUM_ALLOW_INSECURE_HTTP");
+    expect(multiNode).not.toContain("TYRUM_HOME=");
+    expect(multiNode).not.toContain("GATEWAY_PORT=");
+    expect(profiles).not.toContain("env.GATEWAY_DB_PATH");
+  });
+
+  it("documents the deployment-config admin surface and valid canonical links", async () => {
+    const apiReference = await readRepoFile("docs/api-reference.md");
+
+    expect(apiReference).toContain("/system/deployment-config");
+  });
+
+  it("keeps local markdown links valid across source docs", async () => {
+    const markdownFiles = [
+      resolve(repoRoot, "README.md"),
+      resolve(repoRoot, "AGENTS.md"),
+      resolve(repoRoot, "apps/desktop/README.md"),
+      ...(await listMarkdownFiles(docsRoot)),
+    ];
+
+    for (const file of markdownFiles) {
+      const content = await readFile(file, "utf8");
+      const links = extractMarkdownLinks(content).filter(isLocalMarkdownLink);
+
+      for (const link of links) {
+        const linkPath = link.split("#", 1)[0]?.split("?", 1)[0] ?? "";
+        if (linkPath.length === 0) continue;
+
+        const targetPath = resolve(dirname(file), linkPath);
+        const info = await stat(targetPath);
+        expect(
+          info.isFile() || info.isDirectory(),
+          `broken local markdown link in ${file}: ${link}`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/charts/tyrum/templates/_helpers.tpl
+++ b/charts/tyrum/templates/_helpers.tpl
@@ -28,3 +28,33 @@ httpGet:
 {{- toYaml . | nindent 0 }}
 {{- end }}
 {{- end -}}
+
+{{- define "tyrum.startArgs" -}}
+{{- $root := .root -}}
+{{- $role := .role -}}
+- {{ $role | quote }}
+- "--home"
+- {{ $root.Values.runtime.home | quote }}
+- "--db"
+- {{ $root.Values.runtime.db | quote }}
+- "--host"
+- {{ $root.Values.runtime.host | quote }}
+- "--port"
+- {{ printf "%v" $root.Values.service.port | quote }}
+{{- with $root.Values.runtime.trustedProxies }}
+- "--trusted-proxies"
+- {{ . | quote }}
+{{- end }}
+{{- if $root.Values.runtime.tlsReady }}
+- "--tls-ready"
+{{- end }}
+{{- if $root.Values.runtime.tlsSelfSigned }}
+- "--tls-self-signed"
+{{- end }}
+{{- if $root.Values.runtime.allowInsecureHttp }}
+- "--allow-insecure-http"
+{{- end }}
+{{- if $root.Values.runtime.enableEngineApi }}
+- "--enable-engine-api"
+{{- end }}
+{{- end -}}

--- a/charts/tyrum/templates/deployment-single.yaml
+++ b/charts/tyrum/templates/deployment-single.yaml
@@ -31,7 +31,8 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["all"]
+          args:
+            {{- include "tyrum.startArgs" (dict "root" . "role" "all") | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -66,7 +67,7 @@ spec:
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: tyrum-data
-              mountPath: {{ .Values.env.TYRUM_HOME | quote }}
+              mountPath: {{ .Values.runtime.home | quote }}
           {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:

--- a/charts/tyrum/templates/deployment-split.yaml
+++ b/charts/tyrum/templates/deployment-split.yaml
@@ -1,6 +1,6 @@
 {{- if ne .Values.mode "single" }}
-{{- if not (regexMatch "(?i)^postgres(ql)?://" (trim (default "" .Values.env.GATEWAY_DB_PATH))) }}
-{{- fail "Split mode requires a PostgreSQL database. Please configure env.GATEWAY_DB_PATH with a postgres:// or postgresql:// URI." }}
+{{- if not (regexMatch "(?i)^postgres(ql)?://" (trim (default "" .Values.runtime.db))) }}
+{{- fail "Split mode requires a PostgreSQL database. Please configure runtime.db with a postgres:// or postgresql:// URI." }}
 {{- end }}
 {{- if not .Values.persistence.enabled }}
 {{- fail "Split mode requires persistence.enabled=true for durable agent workspaces (mounted only by ToolRunner jobs)." }}
@@ -39,7 +39,8 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["edge"]
+          args:
+            {{- include "tyrum.startArgs" (dict "root" . "role" "edge") | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -106,7 +107,8 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["worker"]
+          args:
+            {{- include "tyrum.startArgs" (dict "root" . "role" "worker") | nindent 12 }}
           env:
             {{- range $k, $v := .Values.env }}
             - name: {{ $k }}
@@ -176,7 +178,8 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["scheduler"]
+          args:
+            {{- include "tyrum.startArgs" (dict "root" . "role" "scheduler") | nindent 12 }}
           env:
             {{- range $k, $v := .Values.env }}
             - name: {{ $k }}

--- a/charts/tyrum/values.yaml
+++ b/charts/tyrum/values.yaml
@@ -14,19 +14,22 @@ gatewayToken:
   existingSecret: ""
   value: ""
 
-env:
-  TYRUM_HOME: /var/lib/tyrum
-  GATEWAY_HOST: 0.0.0.0
-  GATEWAY_PORT: "8788"
+runtime:
+  home: /var/lib/tyrum
+  db: /var/lib/tyrum/gateway.db
+  host: 0.0.0.0
   # Remote deployments should be fronted by TLS termination (Ingress/reverse proxy).
-  TYRUM_TLS_READY: "1"
+  tlsReady: true
+  tlsSelfSigned: false
   # Optional: trusted reverse proxy allowlist (comma-separated IPs/CIDRs).
   # When unset, the gateway ignores Forwarded/X-Forwarded-For/X-Real-IP headers
   # and derives the client IP from the socket.
-  GATEWAY_TRUSTED_PROXIES: ""
-  GATEWAY_DB_PATH: /var/lib/tyrum/gateway.db
+  trustedProxies: ""
+  allowInsecureHttp: false
   # Enable durable workflow APIs and engine-backed WS control plane.
-  TYRUM_ENGINE_API_ENABLED: "1"
+  enableEngineApi: true
+
+env:
   # Enterprise default per ADR-0007. Values: env|file|keychain
   TYRUM_SECRET_PROVIDER: env
   # Artifacts: default fs; set to s3 with the S3 env vars below.

--- a/config/deployments/helm-single.values.yaml
+++ b/config/deployments/helm-single.values.yaml
@@ -1,15 +1,16 @@
 # Reference values for `charts/tyrum` single-host mode.
 mode: single
 
-env:
-  TYRUM_HOME: /var/lib/tyrum
-  GATEWAY_HOST: 0.0.0.0
-  GATEWAY_PORT: "8788"
-  TYRUM_TLS_READY: "1"
+runtime:
+  home: /var/lib/tyrum
+  db: /var/lib/tyrum/gateway.db
+  host: 0.0.0.0
+  tlsReady: true
   # Optional: trusted reverse proxy allowlist (comma-separated IPs/CIDRs).
-  GATEWAY_TRUSTED_PROXIES: ""
-  GATEWAY_DB_PATH: /var/lib/tyrum/gateway.db
-  TYRUM_ENGINE_API_ENABLED: "1"
+  trustedProxies: ""
+  enableEngineApi: true
+
+env:
   TYRUM_SECRET_PROVIDER: env
 
 persistence:

--- a/config/deployments/helm-split-role.values.yaml
+++ b/config/deployments/helm-split-role.values.yaml
@@ -1,16 +1,16 @@
 # Reference values for `charts/tyrum` split-role mode.
 mode: split
 
-env:
-  TYRUM_HOME: /var/lib/tyrum
-  GATEWAY_HOST: 0.0.0.0
-  GATEWAY_PORT: "8788"
-  TYRUM_TLS_READY: "1"
+runtime:
+  home: /var/lib/tyrum
+  db: postgres://tyrum:REPLACE_ME@postgres.default.svc.cluster.local:5432/tyrum
+  host: 0.0.0.0
+  tlsReady: true
   # Optional: trusted reverse proxy allowlist (comma-separated IPs/CIDRs).
-  GATEWAY_TRUSTED_PROXIES: ""
-  # Split-role requires Postgres.
-  GATEWAY_DB_PATH: postgres://tyrum:REPLACE_ME@postgres.default.svc.cluster.local:5432/tyrum
-  TYRUM_ENGINE_API_ENABLED: "1"
+  trustedProxies: ""
+  enableEngineApi: true
+
+env:
   TYRUM_SECRET_PROVIDER: env
 
 persistence:

--- a/config/deployments/single-host.env.example
+++ b/config/deployments/single-host.env.example
@@ -1,26 +1,17 @@
 # single-host reference profile (SQLite, all roles in one process)
 #
-# Usage (local process):
-#   set -a && source config/deployments/single-host.env.example && set +a
-#   tyrum start
+# Intended usage (docker compose):
+#   cp config/deployments/single-host.env.example config/local.env
+#   docker compose --env-file config/local.env up -d --build tyrum
+#
+# Notes:
+# - Startup host/home/db/port are passed via explicit CLI flags in `docker-compose.yml`.
+# - Override those values by editing the compose command or by running `tyrum` with CLI flags directly.
+# - Do not commit secrets. `config/local.env` is gitignored.
 
-TYRUM_HOME=/var/lib/tyrum
-GATEWAY_HOST=127.0.0.1
-GATEWAY_PORT=8788
-GATEWAY_DB_PATH=/var/lib/tyrum/gateway.db
+# Optional: stable tenant admin token for compose-backed startup.
+# If unset, capture the printed bootstrap token from first startup instead.
+GATEWAY_TOKEN=
 
-# Optional: trusted reverse proxy allowlist (comma-separated IPs/CIDRs).
-# When unset, the gateway ignores Forwarded/X-Forwarded-For/X-Real-IP headers
-# and derives the client IP from the socket.
-# GATEWAY_TRUSTED_PROXIES=127.0.0.1,::1
-
-# Enable durable workflow APIs and engine-backed WS control plane.
-TYRUM_ENGINE_API_ENABLED=1
-
-# Secret provider (ADR-0007): env|file|keychain
-TYRUM_SECRET_PROVIDER=env
-
-# Optional: channel typing indicators (connectors that support it).
-# TYRUM_CHANNEL_TYPING_MODE=instant
-# TYRUM_CHANNEL_TYPING_REFRESH_MS=4000
-# TYRUM_CHANNEL_TYPING_AUTOMATION_ENABLED=0
+# Snapshot import is disabled by default. Set to `1` only when seeding fresh state.
+# TYRUM_SNAPSHOT_IMPORT_ENABLED=0

--- a/config/deployments/split-role.env.example
+++ b/config/deployments/split-role.env.example
@@ -13,12 +13,5 @@
 # If unset, capture the printed bootstrap token from first startup instead.
 GATEWAY_TOKEN=
 
-# Optional: trusted reverse proxy allowlist (comma-separated IPs/CIDRs).
-# When unset, the gateway ignores Forwarded/X-Forwarded-For/X-Real-IP headers
-# and derives the client IP from the socket.
-# GATEWAY_TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16
-
-# Optional: channel typing indicators (connectors that support it).
-# TYRUM_CHANNEL_TYPING_MODE=instant
-# TYRUM_CHANNEL_TYPING_REFRESH_MS=4000
-# TYRUM_CHANNEL_TYPING_AUTOMATION_ENABLED=0
+# Snapshot import is disabled by default. Set to `1` only when seeding fresh state.
+# TYRUM_SNAPSHOT_IMPORT_ENABLED=0

--- a/docs/advanced/deployment-profiles.md
+++ b/docs/advanced/deployment-profiles.md
@@ -7,7 +7,7 @@ Tyrum supports two operator-visible deployment profiles:
 
 Storage behavior is controlled by a separate runtime state profile:
 
-- `state.mode=local`: mutable runtime state lives under `TYRUM_HOME`
+- `state.mode=local`: mutable runtime state lives under the gateway home (`~/.tyrum` by default; override with `--home`)
 - `state.mode=shared`: mutable runtime state moves to shared stores (DB / artifacts / shared secret source)
 
 Recommended mapping:
@@ -59,11 +59,14 @@ For HA/shared cutover from an existing local home:
 4. Provide one shared secret key source for all instances (for example `TYRUM_SHARED_MASTER_KEY_B64` or an equivalent external secret source).
 5. Recreate mutable runtime config in the shared DB-backed operator/config surfaces before switching traffic. There is no filesystem import command.
 
-In shared mode, mutable runtime state must not depend on `TYRUM_HOME`. Bundled read-only assets remain valid.
+In shared mode, mutable runtime state must not depend on the local gateway home. Bundled read-only assets remain valid.
 
 ## Kubernetes deployments (Helm)
 
 The repo ships a Helm chart in `charts/tyrum`.
+
+Helm bootstrap settings live under `runtime.*`. Environment variables under `env.*` only cover process env inputs that the runtime still consumes.
+After first boot, persistent server/execution/agent changes live under `/system/deployment-config`.
 
 ### Single-host
 
@@ -79,6 +82,6 @@ Split-role requires Postgres:
 helm install tyrum charts/tyrum -f config/deployments/helm-split-role.values.yaml
 ```
 
-Replace `REPLACE_ME` in `config/deployments/helm-split-role.values.yaml` with your Postgres password (or set `env.GATEWAY_DB_PATH` to your full Postgres URI).
+Replace `REPLACE_ME` in `config/deployments/helm-split-role.values.yaml` with your Postgres password (or set `runtime.db` to your full Postgres URI).
 
-Once `env.GATEWAY_DB_PATH` contains real credentials, treat the resulting Helm values as sensitive (avoid committing it; prefer an untracked values file or a secret manager workflow).
+Once `runtime.db` contains real credentials, treat the resulting Helm values as sensitive (avoid committing it; prefer an untracked values file or a secret manager workflow).

--- a/docs/advanced/multi-node.md
+++ b/docs/advanced/multi-node.md
@@ -8,27 +8,27 @@ This guide explains the difference between running multiple independent local no
 
 Run each node with its own state directory and port.
 
-Use a unique `TYRUM_HOME` per node to keep databases and runtime state isolated.
+Use a unique gateway home per node to keep databases and runtime state isolated.
 
 ## Example: two local nodes
 
 Node A:
 
 ```bash
-TYRUM_HOME=$HOME/.tyrum-a GATEWAY_PORT=8788 tyrum
+tyrum --home "$HOME/.tyrum-a" --port 8788
 ```
 
 Node B:
 
 ```bash
-TYRUM_HOME=$HOME/.tyrum-b GATEWAY_PORT=8789 tyrum
+tyrum --home "$HOME/.tyrum-b" --port 8789
 ```
 
 This is still `state.mode=local`. Each node is independent.
 
 ### 2. HA / shared instances
 
-Do not share `TYRUM_HOME` across service instances.
+Do not share the same gateway home across service instances.
 
 For HA, use:
 
@@ -36,7 +36,7 @@ For HA, use:
 - shared Postgres
 - shared artifact storage
 - one shared secret key source across all instances
-- no mutable runtime fallbacks from `TYRUM_HOME`
+- no mutable runtime fallbacks from the local gateway home
 
 If you are moving from a local node, recreate mutable runtime config in the shared DB-backed surfaces before cutover. There is no filesystem import command.
 
@@ -48,8 +48,8 @@ If you are moving from a local node, recreate mutable runtime config in the shar
 
 ## Configuration strategy
 
-- Keep shared defaults in environment templates.
-- Override only per-node values (`TYRUM_HOME`, `GATEWAY_PORT`, host binding) for local-mode nodes.
+- Keep shared defaults in deployment config or explicit service definitions.
+- Override only per-node values (`--home`, `--port`, host binding) for local-mode nodes.
 - For shared mode, keep only instance-local cache/temp paths per node; durable state belongs in shared services.
 - Pin release versions during coordinated upgrades.
 
@@ -61,7 +61,7 @@ If you are moving from a local node, recreate mutable runtime config in the shar
 
 ## Common mistakes
 
-- Reusing the same `TYRUM_HOME` across nodes.
-- Treating `TYRUM_HOME` as shared durable state in HA mode.
+- Reusing the same gateway home across nodes.
+- Treating the local gateway home as shared durable state in HA mode.
 - Port collisions between nodes.
 - Upgrading all nodes at once without a canary.

--- a/docs/advanced/remote-gateway.md
+++ b/docs/advanced/remote-gateway.md
@@ -15,20 +15,18 @@ Use this when Tyrum needs to run on a different machine than your local workstat
 Example (TLS termination in front; recommended for larger deployments):
 
 ```bash
-GATEWAY_HOST=0.0.0.0 GATEWAY_PORT=8788 \
-  GATEWAY_TOKEN="$(openssl rand -hex 32)" \
-  TYRUM_TLS_READY=1 \
-  tyrum start
+GATEWAY_TOKEN="$(openssl rand -hex 32)" \
+  tyrum --host 0.0.0.0 --port 8788 --tls-ready
 ```
 
 Example (single gateway, secure by default via self-signed HTTPS/WSS):
 
 ```bash
-GATEWAY_HOST=0.0.0.0 GATEWAY_PORT=8788 \
-  GATEWAY_TOKEN="$(openssl rand -hex 32)" \
-  TYRUM_TLS_SELF_SIGNED=1 \
-  tyrum start
+GATEWAY_TOKEN="$(openssl rand -hex 32)" \
+  tyrum --host 0.0.0.0 --port 8788 --tls-self-signed
 ```
+
+Startup flags seed the first deployment-config revision. Persisted changes later live under `/system/deployment-config`.
 
 Notes:
 
@@ -44,15 +42,15 @@ Recommended minimum controls:
 - Allowlist source IPs.
 - Use TLS termination in front of the gateway.
 - Optionally configure **TLS certificate fingerprint pinning** for higher-assurance remote access.
-- If running behind a reverse proxy, configure `GATEWAY_TRUSTED_PROXIES` so the gateway only trusts `Forwarded` / `X-Forwarded-For` / `X-Real-IP` from known proxy addresses.
+- If running behind a reverse proxy, set deployment config `server.trustedProxies` so the gateway only trusts `Forwarded` / `X-Forwarded-For` / `X-Real-IP` from known proxy addresses. On first boot, you can seed it with `--trusted-proxies`.
 - Avoid direct internet exposure without access controls.
 - Rotate API keys used by external model providers.
 
-If you are operating in a trusted internal network without TLS (not recommended), you can acknowledge plaintext HTTP by setting `TYRUM_ALLOW_INSECURE_HTTP=1`.
+If you are operating in a trusted internal network without TLS (not recommended), you can acknowledge plaintext HTTP with `--allow-insecure-http` on first boot or by setting deployment config `server.allowInsecureHttp=true`.
 
 ## Operations checklist
 
-- Persist `TYRUM_HOME` on durable storage.
+- Persist the gateway home on durable storage (`~/.tyrum` by default, or the path passed via `--home`).
 - Keep Node.js and Tyrum updated.
 - Monitor process restarts and disk usage.
 
@@ -68,7 +66,7 @@ openssl s_client -connect example.com:443 -servername example.com < /dev/null 2>
   | openssl x509 -noout -fingerprint -sha256
 ```
 
-If you run the gateway with `TYRUM_TLS_SELF_SIGNED=1`, you can also use:
+If you run the gateway with `--tls-self-signed`, you can also use:
 
 ```bash
 tyrum tls fingerprint
@@ -91,5 +89,5 @@ Notes:
 
 ## Troubleshooting
 
-- Gateway unreachable: verify `GATEWAY_HOST`, firewall, and listening port.
+- Gateway unreachable: verify `--host`, firewall, and the listening port.
 - Slow responses: validate upstream model latency and local CPU/memory pressure.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -135,6 +135,37 @@ For device tokens, each WS request `type` is scope-checked via `packages/gateway
   - `200` Prometheus text format (content-type set by registry)
   - `401`, `403`
 
+### System administration
+
+These routes require a **system admin token** (`tenant_id === null`). Deployment config is revisioned and is the durable source of truth for server, execution, and agent feature gates.
+
+#### GET /system/deployment-config
+
+- Auth: Required (system token)
+- Request: None
+- Response:
+  - `200` JSON `{ revision, config, created_at, created_by, reason?, reverted_from_revision? }`
+  - Seeds the default revision on first read if the gateway has never stored deployment config before.
+  - `401`, `403`
+
+#### PUT /system/deployment-config
+
+- Auth: Required (system token)
+- Request: JSON `{ config, reason? }`
+- Response:
+  - `200` JSON `{ revision, config, created_at, created_by, reason?, reverted_from_revision? }`
+  - `400` invalid request
+  - `401`, `403`
+
+#### POST /system/deployment-config/revert
+
+- Auth: Required (system token)
+- Request: JSON `{ revision, reason? }`
+- Response:
+  - `200` JSON `{ revision, config, created_at, created_by, reason?, reverted_from_revision? }`
+  - `400` invalid request
+  - `401`, `403`
+
 #### GET /connections
 
 - Auth: Required (unless gateway auth is disabled)
@@ -772,7 +803,7 @@ Additional plugin-defined routers may be mounted under:
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.write`
-- Availability: Only when `TYRUM_ENGINE_API_ENABLED=1`
+- Availability: Only when deployment config `execution.engineApiEnabled=true` (fresh installs can seed this with `--enable-engine-api`)
 - Request: JSON `{ key, lane?, plan_id?, request_id?, steps: ActionPrimitive[], budgets? }`
 - Response:
   - `200` JSON `{ status: "ok", job_id, run_id, plan_id, request_id, key, lane, steps_count }`
@@ -783,7 +814,7 @@ Additional plugin-defined routers may be mounted under:
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.write`
-- Availability: Only when `TYRUM_ENGINE_API_ENABLED=1`
+- Availability: Only when deployment config `execution.engineApiEnabled=true`
 - Request: JSON `{ token: string }`
 - Response:
   - `200` JSON `{ status: "ok", run_id }`
@@ -794,7 +825,7 @@ Additional plugin-defined routers may be mounted under:
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.write`
-- Availability: Only when `TYRUM_ENGINE_API_ENABLED=1`
+- Availability: Only when deployment config `execution.engineApiEnabled=true`
 - Request: JSON `{ run_id: string, reason?: string }`
 - Response:
   - `200` JSON `{ status: "ok", run_id, cancelled: boolean }`
@@ -846,7 +877,7 @@ Additional plugin-defined routers may be mounted under:
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.write`
-- Availability: Only when `TYRUM_ENGINE_API_ENABLED=1`
+- Availability: Only when deployment config `execution.engineApiEnabled=true`
 - Request: JSON (optional overrides): `{ key?, lane?, plan_id?, request_id?, budgets? }`
 - Response:
   - `200` JSON `{ status: "ok", job_id, run_id, playbook_id, plan_id, request_id, key, lane, steps_count }`
@@ -1085,7 +1116,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.read`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: Optional query param `include_default` (default: `true`)
 - Response:
   - `200` JSON `{ agents: [{ agent_id, home?, has_config? }] }`
@@ -1095,7 +1126,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.read`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: Optional query param `agent_key` (default: `default`)
 - Response:
   - `200` JSON agent runtime status
@@ -1106,7 +1137,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.write`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: JSON `AgentTurnRequest`
 - Response:
   - `200` JSON agent turn result
@@ -1120,7 +1151,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.read`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: Optional query param `agent_key` (default: `default`)
 - Response:
   - `200` JSON `{ status: "ok", report }`
@@ -1131,7 +1162,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.read`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: Optional query params: `session_id`, `run_id`, `limit`
 - Response:
   - `200` JSON `{ status: "ok", reports: [...] }`
@@ -1141,7 +1172,7 @@ User-facing automation should prefer schedules over raw watchers. Schedule APIs 
 
 - Auth: Required (unless gateway auth is disabled)
 - Device scope: `operator.read`
-- Availability: Only when `TYRUM_AGENT_ENABLED=1`
+- Availability: Only when deployment config `agent.enabled=true` (default: enabled)
 - Request: Path param `:id`
 - Response:
   - `200` JSON `{ status: "ok", report }`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,6 +24,12 @@ tyrum
 
 By default, Tyrum runs local-first and binds to `127.0.0.1`.
 
+Override startup home/host/port with explicit CLI flags, for example:
+
+```bash
+tyrum --home "$HOME/.tyrum-demo" --port 8789
+```
+
 ## 3. Open the operator UI (`/ui`)
 
 Open:
@@ -48,26 +54,22 @@ After you sign in, open `Configure -> Tokens` to manage tenant-scoped tokens in 
 tyrum
 ```
 
-To disable singleton agent routes:
-
-```bash
-TYRUM_AGENT_ENABLED=0 tyrum
-```
+Singleton agent routes are enabled by default. Their durable availability is controlled by deployment config `agent.enabled`.
 
 ## 5. Common first-time checks
 
 - Verify Node.js 24.x: `node -v`
 - Verify command install path: `command -v tyrum`
-- If a port conflict occurs, set `GATEWAY_PORT`.
+- If a port conflict occurs, restart with `--port`.
 
 Example:
 
 ```bash
-GATEWAY_PORT=8789 tyrum
+tyrum --port 8789
 ```
 
 ## 6. Scaling later
 
-- `single-host` / desktop-style installs use local filesystem state under `TYRUM_HOME`.
+- `single-host` / desktop-style installs use local filesystem state under the gateway home (`~/.tyrum` by default, overridden with `--home`).
 - HA/shared deployments use `state.mode=shared` plus shared Postgres, shared artifact storage, and a shared secret key source.
 - Shared deployments do not provide a filesystem import path; configure durable state through the DB-backed operator/config surfaces before cutover.

--- a/docs/install.md
+++ b/docs/install.md
@@ -78,13 +78,7 @@ tyrum tokens issue-default-tenant-admin
 
 After login, open `Configure -> Tokens` to manage tenant tokens with a filterable list, structured add/edit/revoke dialogs, and one-time secret reveal on creation. Existing token secrets are not readable from the UI because the gateway stores token secrets hashed at rest; only freshly issued tokens are shown once in the issue result.
 
-Singleton agent routes are enabled by default.
-
-Disable singleton agent routes:
-
-```bash
-TYRUM_AGENT_ENABLED=0 tyrum
-```
+Singleton agent routes are enabled by default. Their durable availability is controlled by deployment config `agent.enabled`, not by a startup environment variable.
 
 ## Option 3: GitHub Releases
 

--- a/packages/gateway/src/bootstrap/cli-help.ts
+++ b/packages/gateway/src/bootstrap/cli-help.ts
@@ -1,7 +1,7 @@
 export const CLI_HELP_TEXT = `Tyrum gateway
 
 Usage:
-  tyrum [start|edge|worker|scheduler|desktop-runtime] [--home <path>] [--db <path|postgres-uri>] [--host <host>] [--port <port>] [--role <role>]
+  tyrum [start|edge|worker|scheduler|desktop-runtime] [--home <path>] [--db <path|postgres-uri>] [--host <host>] [--port <port>] [--role <role>] [--trusted-proxies <csv>] [--tls-ready|--tls-self-signed|--allow-insecure-http] [--enable-engine-api] [--enable-snapshot-import]
   tyrum check
   tyrum tokens issue-default-tenant-admin [--home <path>] [--db <path|postgres-uri>] [--migrations-dir <path>]
   tyrum tls fingerprint

--- a/packages/gateway/src/bootstrap/cli.ts
+++ b/packages/gateway/src/bootstrap/cli.ts
@@ -46,6 +46,14 @@ function parsePortFlag(value: string): number {
   return parsed;
 }
 
+function parseNonEmptyStringFlag(flag: string, value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${flag} requires a non-empty value`);
+  }
+  return trimmed;
+}
+
 function parseRoleFlag(value: string): GatewayRole {
   const normalized = value.trim().toLowerCase();
   if (
@@ -101,6 +109,9 @@ function parseStartFlags(
   let host: string | undefined;
   let port: number | undefined;
   let role: GatewayRole | undefined;
+  let trustedProxies: string | undefined;
+  let tlsReady: true | undefined;
+  let tlsSelfSigned: true | undefined;
   let allowInsecureHttp: true | undefined;
   let engineApiEnabled: true | undefined;
   let snapshotImportEnabled: true | undefined;
@@ -141,6 +152,24 @@ function parseStartFlags(
       continue;
     }
 
+    if (arg === "--trusted-proxies") {
+      const value = args[index + 1];
+      if (value === undefined) throw new Error("--trusted-proxies requires a value");
+      trustedProxies = parseNonEmptyStringFlag("--trusted-proxies", value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--tls-ready") {
+      tlsReady = true;
+      continue;
+    }
+
+    if (arg === "--tls-self-signed") {
+      tlsSelfSigned = true;
+      continue;
+    }
+
     if (arg === "--allow-insecure-http") {
       allowInsecureHttp = true;
       continue;
@@ -165,6 +194,9 @@ function parseStartFlags(
     host,
     port,
     role,
+    trustedProxies,
+    tlsReady,
+    tlsSelfSigned,
     migrationsDir: common.migrationsDir,
     allowInsecureHttp,
     engineApiEnabled,
@@ -240,6 +272,12 @@ export function parseCliArgs(argv: readonly string[]): CliCommand {
 
   if (first === "-h" || first === "--help") return { kind: "help" };
   if (first === "-v" || first === "--version" || first === "version") return { kind: "version" };
+
+  if (first.startsWith("-")) {
+    const flags = parseStartFlags(argv);
+    if ("kind" in flags) return flags;
+    return { kind: "start", ...flags };
+  }
 
   if (first === "start") {
     const flags = parseStartFlags(rest);
@@ -475,6 +513,9 @@ export async function runCli(argv: readonly string[] = process.argv.slice(2)): P
     db: command.db,
     host: command.host,
     port: command.port,
+    trustedProxies: command.trustedProxies,
+    tlsReady: command.tlsReady,
+    tlsSelfSigned: command.tlsSelfSigned,
     migrationsDir: command.migrationsDir,
     allowInsecureHttp: command.allowInsecureHttp,
     engineApiEnabled: command.engineApiEnabled,

--- a/packages/gateway/src/bootstrap/config.ts
+++ b/packages/gateway/src/bootstrap/config.ts
@@ -22,6 +22,9 @@ export type GatewayStartOptions = {
   host?: string;
   port?: number;
   migrationsDir?: string;
+  trustedProxies?: string;
+  tlsReady?: boolean;
+  tlsSelfSigned?: boolean;
   allowInsecureHttp?: boolean;
   engineApiEnabled?: boolean;
   snapshotImportEnabled?: boolean;
@@ -29,7 +32,12 @@ export type GatewayStartOptions = {
 
 export type StartCommandOverrides = Pick<
   GatewayStartOptions,
-  "allowInsecureHttp" | "engineApiEnabled" | "snapshotImportEnabled"
+  | "trustedProxies"
+  | "tlsReady"
+  | "tlsSelfSigned"
+  | "allowInsecureHttp"
+  | "engineApiEnabled"
+  | "snapshotImportEnabled"
 >;
 
 export function assertSplitRoleUsesPostgres(role: GatewayRole, dbPath: string): void {
@@ -132,6 +140,11 @@ function resolveTruthyEnvFlag(name: string): boolean {
   }
 }
 
+function resolveOptionalCliString(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
 export function resolveSnapshotImportEnabled(snapshotImportOverride?: boolean): boolean {
   return Boolean(snapshotImportOverride) || resolveTruthyEnvFlag("TYRUM_SNAPSHOT_IMPORT_ENABLED");
 }
@@ -141,6 +154,9 @@ export function buildStartupDefaultDeploymentConfig(
 ): DeploymentConfig {
   return DeploymentConfig.parse({
     server: {
+      trustedProxies: resolveOptionalCliString(overrides.trustedProxies),
+      tlsReady: Boolean(overrides.tlsReady),
+      tlsSelfSigned: Boolean(overrides.tlsSelfSigned),
       allowInsecureHttp: Boolean(overrides.allowInsecureHttp),
     },
     execution: {
@@ -156,10 +172,14 @@ export function applyStartCommandDeploymentOverrides(
   deploymentConfig: DeploymentConfig,
   overrides: StartCommandOverrides,
 ): DeploymentConfig {
+  const trustedProxies = resolveOptionalCliString(overrides.trustedProxies);
   return DeploymentConfig.parse({
     ...deploymentConfig,
     server: {
       ...deploymentConfig.server,
+      trustedProxies: deploymentConfig.server.trustedProxies ?? trustedProxies,
+      tlsReady: deploymentConfig.server.tlsReady || Boolean(overrides.tlsReady),
+      tlsSelfSigned: deploymentConfig.server.tlsSelfSigned || Boolean(overrides.tlsSelfSigned),
       allowInsecureHttp:
         deploymentConfig.server.allowInsecureHttp || Boolean(overrides.allowInsecureHttp),
     },

--- a/packages/gateway/src/bootstrap/runtime.ts
+++ b/packages/gateway/src/bootstrap/runtime.ts
@@ -153,6 +153,9 @@ async function createGatewayBootContext(
   const db = await openGatewayDb({ dbPath, migrationsDir });
   const deploymentConfigDal = new DeploymentConfigDal(db);
   const startupOverrides: StartCommandOverrides = {
+    trustedProxies: params.trustedProxies,
+    tlsReady: params.tlsReady,
+    tlsSelfSigned: params.tlsSelfSigned,
     allowInsecureHttp: params.allowInsecureHttp,
     engineApiEnabled: params.engineApiEnabled,
     snapshotImportEnabled: params.snapshotImportEnabled,

--- a/packages/gateway/tests/integration/agent.test.ts
+++ b/packages/gateway/tests/integration/agent.test.ts
@@ -49,13 +49,11 @@ args:
 describe("agent routes", () => {
   let homeDir: string | undefined;
   const originalTyrumHome = process.env["TYRUM_HOME"];
-  const originalAgentFlag = process.env["TYRUM_AGENT_ENABLED"];
 
   beforeEach(async () => {
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-"));
     await writeWorkspace(join(homeDir, "agents/default"));
     process.env["TYRUM_HOME"] = homeDir;
-    process.env["TYRUM_AGENT_ENABLED"] = "1";
   });
 
   afterEach(async () => {
@@ -64,12 +62,6 @@ describe("agent routes", () => {
       delete process.env["TYRUM_HOME"];
     } else {
       process.env["TYRUM_HOME"] = originalTyrumHome;
-    }
-
-    if (originalAgentFlag === undefined) {
-      delete process.env["TYRUM_AGENT_ENABLED"];
-    } else {
-      process.env["TYRUM_AGENT_ENABLED"] = originalAgentFlag;
     }
 
     if (homeDir) {

--- a/packages/gateway/tests/integration/approval-engine.test.ts
+++ b/packages/gateway/tests/integration/approval-engine.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/app.js";
 import {
   createTestContainer,
@@ -15,20 +15,6 @@ import { AuthTokenService } from "../../src/modules/auth/auth-token-service.js";
 import { ExecutionEngine } from "../../src/modules/execution/engine.js";
 
 describe("approval routes (engine integration)", () => {
-  const originalFlag = process.env["TYRUM_ENGINE_API_ENABLED"];
-
-  beforeEach(() => {
-    process.env["TYRUM_ENGINE_API_ENABLED"] = "1";
-  });
-
-  afterEach(() => {
-    if (originalFlag === undefined) {
-      delete process.env["TYRUM_ENGINE_API_ENABLED"];
-    } else {
-      process.env["TYRUM_ENGINE_API_ENABLED"] = originalFlag;
-    }
-  });
-
   it("resumes an engine-scoped paused run when an approval is approved", async () => {
     const container = await createTestContainer();
     const authTokens = new AuthTokenService(container.db);

--- a/packages/gateway/tests/unit/cli.test.ts
+++ b/packages/gateway/tests/unit/cli.test.ts
@@ -75,20 +75,35 @@ describe("gateway CLI argument parsing", () => {
     expect(parseCliArgs(["scheduler"])).toEqual({ kind: "start", role: "scheduler" });
   });
 
+  it("parses start flags without an explicit start subcommand", () => {
+    expect(parseCliArgs(["--home", "/tmp/home", "--port", "8789"])).toEqual({
+      kind: "start",
+      home: "/tmp/home",
+      port: 8789,
+    });
+  });
+
   it("parses boolean start flags", () => {
     expect(
       parseCliArgs([
         "all",
+        "--tls-ready",
+        "--tls-self-signed",
         "--allow-insecure-http",
         "--enable-engine-api",
         "--enable-snapshot-import",
+        "--trusted-proxies",
+        "10.0.0.0/8,192.168.0.0/16",
       ]),
     ).toEqual({
       kind: "start",
       role: "all",
+      tlsReady: true,
+      tlsSelfSigned: true,
       allowInsecureHttp: true,
       engineApiEnabled: true,
       snapshotImportEnabled: true,
+      trustedProxies: "10.0.0.0/8,192.168.0.0/16",
     });
   });
 
@@ -212,6 +227,62 @@ describe("snapshot import enablement", () => {
       if (previous === undefined) delete process.env["TYRUM_SNAPSHOT_IMPORT_ENABLED"];
       else process.env["TYRUM_SNAPSHOT_IMPORT_ENABLED"] = previous;
     }
+  });
+});
+
+describe("startup deployment-config overrides", () => {
+  it("seeds remote bootstrap flags into the initial deployment config", () => {
+    const config = buildStartupDefaultDeploymentConfig({
+      trustedProxies: "10.0.0.0/8,192.168.0.0/16",
+      tlsReady: true,
+      tlsSelfSigned: true,
+      allowInsecureHttp: true,
+      engineApiEnabled: true,
+    });
+
+    expect(config.server.trustedProxies).toBe("10.0.0.0/8,192.168.0.0/16");
+    expect(config.server.tlsReady).toBe(true);
+    expect(config.server.tlsSelfSigned).toBe(true);
+    expect(config.server.allowInsecureHttp).toBe(true);
+    expect(config.execution.engineApiEnabled).toBe(true);
+  });
+
+  it("does not overwrite persisted trusted proxies on restart", () => {
+    const persisted = applyStartCommandDeploymentOverrides(
+      DeploymentConfig.parse({
+        server: { trustedProxies: "203.0.113.0/24" },
+      }),
+      { trustedProxies: "10.0.0.0/8" },
+    );
+    expect(persisted.server.trustedProxies).toBe("203.0.113.0/24");
+  });
+
+  it("fills trusted proxies when the stored deployment config is empty", () => {
+    const persisted = applyStartCommandDeploymentOverrides(DeploymentConfig.parse({}), {
+      trustedProxies: "10.0.0.0/8",
+    });
+    expect(persisted.server.trustedProxies).toBe("10.0.0.0/8");
+  });
+
+  it("allows tls bootstrap flags to raise persisted server settings", () => {
+    const persisted = applyStartCommandDeploymentOverrides(
+      DeploymentConfig.parse({
+        server: {
+          tlsReady: false,
+          tlsSelfSigned: false,
+          allowInsecureHttp: false,
+        },
+      }),
+      {
+        tlsReady: true,
+        tlsSelfSigned: true,
+        allowInsecureHttp: true,
+      },
+    );
+
+    expect(persisted.server.tlsReady).toBe(true);
+    expect(persisted.server.tlsSelfSigned).toBe(true);
+    expect(persisted.server.allowInsecureHttp).toBe(true);
   });
 });
 

--- a/packages/gateway/tests/unit/helm-chart-probes.test.ts
+++ b/packages/gateway/tests/unit/helm-chart-probes.test.ts
@@ -88,17 +88,23 @@ describe("Helm chart probes", () => {
     expect(countOccurrences(split, "livenessProbe:")).toBe(1);
     expect(countOccurrences(split, "startupProbe:")).toBe(1);
 
+    expect(single).toContain('include "tyrum.startArgs"');
+    expect(single).toContain(".Values.runtime.home");
+
     const docs = split.split(/\n---\n/);
-    const edge = docs.find((doc) => doc.includes("-edge") && doc.includes('args: ["edge"]'));
-    const worker = docs.find((doc) => doc.includes("-worker") && doc.includes('args: ["worker"]'));
+    const edge = docs.find(
+      (doc) => doc.includes("-edge") && doc.includes('include "tyrum.startArgs"'),
+    );
+    const worker = docs.find(
+      (doc) => doc.includes("-worker") && doc.includes('include "tyrum.startArgs"'),
+    );
     const scheduler = docs.find(
-      (doc) => doc.includes("-scheduler") && doc.includes('args: ["scheduler"]'),
+      (doc) => doc.includes("-scheduler") && doc.includes('include "tyrum.startArgs"'),
     );
 
     expect(edge).toContain("startupProbe:");
     expect(edge).toContain("readinessProbe:");
     expect(edge).toContain("livenessProbe:");
-
     expect(worker).not.toContain("startupProbe:");
     expect(worker).not.toContain("readinessProbe:");
     expect(worker).not.toContain("livenessProbe:");
@@ -113,5 +119,18 @@ describe("Helm chart probes", () => {
 
     expect(helpers).toContain(`define "tyrum.probe"`);
     expect(helpers).toContain("path: /healthz");
+    expect(helpers).toContain(`define "tyrum.startArgs"`);
+    expect(helpers).toContain('"--home"');
+    expect(helpers).toContain(".Values.runtime.home");
+    expect(helpers).toContain('"--db"');
+    expect(helpers).toContain(".Values.runtime.db");
+    expect(helpers).toContain('"--host"');
+    expect(helpers).toContain(".Values.runtime.host");
+    expect(helpers).toContain('"--port"');
+    expect(helpers).toContain('"--trusted-proxies"');
+    expect(helpers).toContain('"--tls-ready"');
+    expect(helpers).toContain('"--tls-self-signed"');
+    expect(helpers).toContain('"--allow-insecure-http"');
+    expect(helpers).toContain('"--enable-engine-api"');
   });
 });

--- a/packages/gateway/tests/unit/reference-deployment-profiles.test.ts
+++ b/packages/gateway/tests/unit/reference-deployment-profiles.test.ts
@@ -37,8 +37,11 @@ describe("reference deployment profiles", () => {
       await expectFile("config/deployments/split-role.env.example"),
     );
 
-    expect(singleHostEnv.get("TYRUM_HOME")).toBeDefined();
-    expect(singleHostEnv.get("GATEWAY_DB_PATH")).toBeDefined();
+    const singleHostToken = singleHostEnv.get("GATEWAY_TOKEN");
+    expect(singleHostToken).toBeDefined();
+    expect(singleHostToken).toBe("");
+    expect(singleHostEnv.get("TYRUM_HOME")).toBeUndefined();
+    expect(singleHostEnv.get("GATEWAY_DB_PATH")).toBeUndefined();
 
     const splitRoleToken = splitRoleEnv.get("GATEWAY_TOKEN");
     expect(splitRoleToken).toBeDefined();
@@ -132,8 +135,14 @@ describe("reference deployment profiles", () => {
     expect(singleValues.mode).toBe("single");
     expect(splitValues.mode).toBe("split");
 
-    expect(splitValues.env?.GATEWAY_DB_PATH).toMatch(/^postgres(ql)?:\/\//u);
-    expect(splitValues.env?.GATEWAY_DB_PATH).toContain("REPLACE_ME");
+    expect(singleValues.runtime?.home).toBe("/var/lib/tyrum");
+    expect(singleValues.runtime?.host).toBe("0.0.0.0");
+    expect(singleValues.runtime?.tlsReady).toBe(true);
+    expect(singleValues.runtime?.enableEngineApi).toBe(true);
+    expect(singleValues.env?.GATEWAY_HOST).toBeUndefined();
+
+    expect(splitValues.runtime?.db).toMatch(/^postgres(ql)?:\/\//u);
+    expect(splitValues.runtime?.db).toContain("REPLACE_ME");
   });
 
   it("documents how to use the profiles", async () => {


### PR DESCRIPTION
Closes #1328

## Summary
- add CLI bootstrap flags for TLS readiness, self-signed certs, and trusted proxies
- move Helm startup bootstrap settings to `runtime.*` and keep `env.*` for real process env inputs
- update install, deployment, remote gateway, API, and operator docs to reflect DB-backed bootstrap intent
- add regression coverage for stale env-driven startup guidance and broken local markdown links

## Validation
- `git push -u origin 1328-align-bootstrap-docs-and-helm` (passed repo pre-push checks: lint, workspace typecheck, mobile typecheck)
- `pnpm exec vitest run packages/gateway/tests/unit/cli.test.ts packages/gateway/tests/unit/reference-deployment-profiles.test.ts packages/gateway/tests/unit/helm-chart-probes.test.ts apps/docs/tests/deployment-bootstrap-docs.test.ts apps/docs/tests/api-reference-docs.test.ts --reporter=dot`
- `pnpm exec vitest run apps/docs/tests --reporter=dot`
- `pnpm docs:public-check`
- `helm template tyrum charts/tyrum -f config/deployments/helm-single.values.yaml`
- `helm template tyrum charts/tyrum -f config/deployments/helm-split-role.values.yaml`
