### PR TITLE
fix: show chat agent names and wrap long messages

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -169,7 +169,10 @@ export function AiSdkConversation({
   const canSend = draft.trim().length > 0 && chat.status !== "submitted";
 
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col" data-testid="chat-conversation-panel">
+    <div
+      className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
+      data-testid="chat-conversation-panel"
+    >
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           {onBack ? (

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
@@ -172,13 +172,15 @@ function textFromMessage(message: UIMessage): string {
 function TextBlock({ value, renderMode }: { value: string; renderMode: "markdown" | "text" }) {
   if (renderMode === "markdown") {
     return (
-      <div className="prose prose-sm max-w-none text-fg prose-headings:mb-2 prose-headings:mt-3 prose-headings:text-fg prose-p:my-2 prose-p:text-fg prose-ul:my-2 prose-ol:my-2 prose-strong:text-fg prose-code:text-fg prose-pre:my-2 prose-pre:bg-bg-subtle">
+      <div className="prose prose-sm min-w-0 max-w-none break-words text-fg [overflow-wrap:anywhere] prose-headings:mb-2 prose-headings:mt-3 prose-headings:text-fg prose-p:my-2 prose-p:break-words prose-p:text-fg prose-ul:my-2 prose-ol:my-2 prose-strong:text-fg prose-code:break-words prose-code:text-fg prose-code:[overflow-wrap:anywhere] prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:bg-bg-subtle prose-pre:[overflow-wrap:anywhere]">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
       </div>
     );
   }
   return (
-    <pre className="whitespace-pre-wrap break-words text-[13px] leading-5 text-fg">{value}</pre>
+    <pre className="whitespace-pre-wrap break-words text-[13px] leading-5 text-fg [overflow-wrap:anywhere]">
+      {value}
+    </pre>
   );
 }
 
@@ -218,7 +220,7 @@ function ToolPartCard({
       {"input" in part && part.input !== undefined ? (
         <div className="mt-2">
           <div className="mb-1 text-[11px] uppercase tracking-wide text-fg-muted">Input</div>
-          <pre className="overflow-x-auto rounded-md bg-bg px-2 py-1.5 text-xs text-fg">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-bg px-2 py-1.5 text-xs text-fg [overflow-wrap:anywhere]">
             {stringifyPart(part.input)}
           </pre>
         </div>
@@ -227,14 +229,16 @@ function ToolPartCard({
       {"output" in part && part.output !== undefined ? (
         <div className="mt-2">
           <div className="mb-1 text-[11px] uppercase tracking-wide text-fg-muted">Output</div>
-          <pre className="overflow-x-auto rounded-md bg-bg px-2 py-1.5 text-xs text-fg">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-bg px-2 py-1.5 text-xs text-fg [overflow-wrap:anywhere]">
             {stringifyPart(part.output)}
           </pre>
         </div>
       ) : null}
 
       {"errorText" in part && typeof part.errorText === "string" ? (
-        <div className="mt-2 text-sm text-danger-700">{part.errorText}</div>
+        <div className="mt-2 break-words text-sm text-danger-700 [overflow-wrap:anywhere]">
+          {part.errorText}
+        </div>
       ) : null}
 
       {showApprovalDetails && "approval" in part && part.approval ? (
@@ -346,12 +350,12 @@ export function MessageCard({
   return (
     <div
       className={cn(
-        "group relative rounded-lg px-2 py-1.5",
+        "group relative w-full min-w-0 rounded-lg px-2 py-1.5",
         messageContainerClassName(message.role),
       )}
     >
-      <div className="mb-1.5 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-fg-muted">
+      <div className="mb-1.5 flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0 flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-fg-muted">
           <span>{message.role}</span>
           {createdAt ? (
             <>
@@ -438,7 +442,7 @@ export function MessageCard({
                 <div className="mb-1 text-[11px] uppercase tracking-wide text-fg-muted">
                   {part.type}
                 </div>
-                <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs text-fg">
+                <pre className="overflow-x-auto whitespace-pre-wrap break-words text-xs text-fg [overflow-wrap:anywhere]">
                   {stringifyPart(part.data)}
                 </pre>
               </div>

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
@@ -59,13 +59,13 @@ export function AiSdkChatMessageList({
   return (
     <div
       ref={transcriptRef}
-      className="min-h-0 flex-1 overflow-y-auto p-2"
+      className="min-h-0 min-w-0 flex-1 overflow-y-auto p-2"
       data-testid="ai-sdk-chat-transcript"
     >
       {messages.length === 0 ? (
         <div className="text-sm text-fg-muted">No messages yet.</div>
       ) : (
-        <div className="grid gap-1.5">
+        <div className="grid min-w-0 gap-1.5">
           {messages.map((message) => (
             <MessageCard
               key={message.id}

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
@@ -28,7 +28,45 @@ import type { ReasoningDisplayMode } from "./chat-page-ai-sdk-types.js";
 
 const CHAT_TWO_PANEL_CONTENT_WIDTH_PX = 800;
 
-type ChatAgentOption = { agent_id: string };
+type ChatAgentOption = {
+  agent_id: string;
+  label: string;
+};
+
+function formatChatAgentLabel(input: {
+  agent_id: string;
+  agent_key?: string;
+  persona?: { name?: string };
+}): string {
+  const agentId = input.agent_id.trim();
+  const agentKey = input.agent_key?.trim() ?? "";
+  const displayName = input.persona?.name?.trim() || agentKey || agentId;
+  if (!agentKey || displayName === agentKey) {
+    return displayName;
+  }
+  return `${displayName} (${agentKey})`;
+}
+
+function normalizeChatAgentOptions(
+  input: Array<{
+    agent_id: string;
+    agent_key?: string;
+    persona?: { name?: string };
+  }>,
+): ChatAgentOption[] {
+  const byId = new Map<string, ChatAgentOption>();
+  for (const agent of input) {
+    const agentId = agent.agent_id.trim();
+    if (!agentId || byId.has(agentId)) {
+      continue;
+    }
+    byId.set(agentId, {
+      agent_id: agentId,
+      label: formatChatAgentLabel(agent),
+    });
+  }
+  return [...byId.values()];
+}
 
 type SessionListState = {
   error: string | null;
@@ -108,7 +146,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
         if (cancelled) {
           return;
         }
-        const nextAgents = result.agents.map((agent) => ({ agent_id: agent.agent_id }));
+        const nextAgents = normalizeChatAgentOptions(result.agents);
         setAgents(nextAgents);
         const firstAgent = nextAgents[0];
         if (firstAgent) {

--- a/packages/operator-ui/src/components/pages/chat-page-threads.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-threads.tsx
@@ -45,7 +45,7 @@ export function ChatThreadsPanel({
   canLoadMore: boolean;
   onOpenThread: (sessionId: string) => void;
   agentId: string;
-  agents: Array<{ agent_id: string }>;
+  agents: Array<{ agent_id: string; label: string }>;
   onAgentChange: (value: string) => void;
   onNewChat: () => void;
 }) {
@@ -71,7 +71,7 @@ export function ChatThreadsPanel({
           ) : (
             agents.map((agent) => (
               <option key={agent.agent_id} value={agent.agent_id}>
-                {agent.agent_id}
+                {agent.label}
               </option>
             ))
           )}

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
@@ -90,6 +90,11 @@ describe("AiSdkConversation", () => {
     await flushEffects();
     expect(onSessionMessages).toHaveBeenCalledWith([]);
 
+    const conversationPanel = testRoot.container.querySelector(
+      "[data-testid='chat-conversation-panel']",
+    ) as HTMLElement | null;
+    expect(conversationPanel?.className).toContain("min-w-0");
+
     const draft = testRoot.container.querySelector(
       "[data-testid='ai-sdk-chat-draft']",
     ) as HTMLTextAreaElement;

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { UIMessage } from "ai";
+import { MessageCard } from "../../src/components/pages/chat-page-ai-sdk-message-card.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+const e = React.createElement;
+
+describe("MessageCard", () => {
+  it("applies wrap-safe classes to long markdown text blocks", () => {
+    const testRoot = renderIntoDocument(
+      e(MessageCard, {
+        approvalsById: {},
+        message: {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "averylongtokenwithoutspaces".repeat(10) }],
+        } as unknown as UIMessage,
+        onResolveApproval: vi.fn(),
+        reasoningMode: "collapsed",
+        renderMode: "markdown",
+        resolvingApproval: null,
+      }),
+    );
+
+    const card = testRoot.container.firstElementChild as HTMLElement | null;
+    const proseBlock = testRoot.container.querySelector("div.prose") as HTMLElement | null;
+
+    expect(card?.className).toContain("w-full");
+    expect(card?.className).toContain("min-w-0");
+    expect(proseBlock?.className).toContain("break-words");
+    expect(proseBlock?.className).toContain("[overflow-wrap:anywhere]");
+    expect(proseBlock?.className).toContain("prose-pre:whitespace-pre-wrap");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("wraps structured data blocks instead of forcing bubble overflow", () => {
+    const testRoot = renderIntoDocument(
+      e(MessageCard, {
+        approvalsById: {},
+        message: {
+          id: "assistant-2",
+          role: "assistant",
+          parts: [
+            {
+              type: "data-debug",
+              data: { payload: "0123456789".repeat(30) },
+            },
+          ],
+        } as unknown as UIMessage,
+        onResolveApproval: vi.fn(),
+        reasoningMode: "collapsed",
+        renderMode: "text",
+        resolvingApproval: null,
+      }),
+    );
+
+    const dataPre = testRoot.container.querySelector("pre") as HTMLElement | null;
+
+    expect(dataPre?.className).toContain("whitespace-pre-wrap");
+    expect(dataPre?.className).toContain("break-words");
+    expect(dataPre?.className).toContain("[overflow-wrap:anywhere]");
+
+    cleanupTestRoot(testRoot);
+  });
+});

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
@@ -188,7 +188,10 @@ describe("AiSdkChatPage integration", () => {
     createSessionClientMock.mockReturnValue(sessionClient);
 
     const agentsList = vi.fn(async () => ({
-      agents: [{ agent_id: "default" }, { agent_id: "other" }],
+      agents: [
+        { agent_id: "default", agent_key: "default", persona: { name: "Default" } },
+        { agent_id: "other", agent_key: "other", persona: { name: "Other" } },
+      ],
     }));
     const { store: connectionStore } = createStore({
       status: "connected",

--- a/packages/operator-ui/tests/pages/chat-page-threads.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-threads.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatThreadsPanel } from "../../src/components/pages/chat-page-threads.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+const e = React.createElement;
+
+describe("ChatThreadsPanel", () => {
+  it("renders agent names in the selector while keeping agent ids as option values", () => {
+    const testRoot = renderIntoDocument(
+      e(ChatThreadsPanel, {
+        splitView: true,
+        connected: true,
+        loading: false,
+        agentsLoading: false,
+        errorMessage: null,
+        threads: [],
+        activeSessionId: null,
+        onRefresh: vi.fn(),
+        onLoadMore: vi.fn(),
+        canLoadMore: false,
+        onOpenThread: vi.fn(),
+        agentId: "writer-agent",
+        agents: [
+          { agent_id: "writer-agent", label: "Writer (writer)" },
+          { agent_id: "reviewer-agent", label: "Reviewer (reviewer)" },
+        ],
+        onAgentChange: vi.fn(),
+        onNewChat: vi.fn(),
+      }),
+    );
+
+    const select = testRoot.container.querySelector(
+      "[data-testid='chat-agent-select']",
+    ) as HTMLSelectElement | null;
+    const options = Array.from(select?.querySelectorAll("option") ?? []);
+
+    expect(options.map((option) => option.value)).toEqual(["writer-agent", "reviewer-agent"]);
+    expect(options.map((option) => option.textContent)).toEqual([
+      "Writer (writer)",
+      "Reviewer (reviewer)",
+    ]);
+
+    cleanupTestRoot(testRoot);
+  });
+});


### PR DESCRIPTION
## Summary
- show human-readable agent labels in the chat selector while preserving `agent_id` selection
- constrain the conversation/message layout so long markdown, text, tool, and data content wraps inside the available width
- add regression tests for selector labels and wrap-safe message rendering

## Testing
- pre-commit: `pnpm format:check-staged`
- pre-commit: `pnpm lint`
- focused: `pnpm exec vitest run "packages/operator-ui/tests/pages/chat-page-threads.test.ts" "packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts" "packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts" "packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts"`
- focused: `pnpm exec prettier --check packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx packages/operator-ui/src/components/pages/chat-page-threads.tsx packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx packages/operator-ui/tests/pages/chat-page-threads.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts`
- focused: `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- pre-push: `pnpm lint`
- pre-push: workspace build/typecheck chain
- pre-push: `pnpm test --coverage.enabled --coverage.reporter=text-summary`

Closes #1346