### PR TITLE
feat(operator-ui): allow skipping first-run onboarding

### DIFF
--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -61,9 +61,10 @@ Connect the desktop app to an existing gateway.
 Remote mode still keeps the same split locally: the UI connects as an operator client, and the
 desktop runtime connects separately as a node for local capabilities.
 
-After the desktop app connects, Tyrum automatically opens a guided setup wizard when the gateway
-still needs first-run configuration. That post-connect flow covers the basic operator setup steps
-and then returns you to the normal dashboard, configure, and agents pages.
+After the desktop app connects, Tyrum opens a guided setup wizard by default when the gateway
+still needs first-run configuration. You can skip that post-connect flow and configure the gateway
+manually from the normal dashboard, configure, and agents pages, then reopen the wizard later from
+the dashboard if you want to use it.
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ tyrum tokens issue-default-tenant-admin
 
 After you sign in, open `Configure -> Tokens` to manage tenant-scoped tokens in the UI. The page provides a filterable token list plus structured add/edit/revoke flows; newly minted token secrets are shown once in the issue result and cannot be read back later.
 
-If the gateway is missing first-run configuration, Tyrum now opens a guided setup wizard after sign-in. The wizard walks through admin access, provider setup, model presets, execution-profile assignments, and the default agent model before handing you back to the full UI.
+If the gateway is missing first-run configuration, Tyrum opens a guided setup wizard after sign-in by default. You can skip the wizard and configure providers, model presets, execution-profile assignments, and the default agent manually from the normal `Configure` and `Agents` pages, then resume the guided flow later from the dashboard if you want it.
 
 ## 4. Singleton agent routes (default on)
 

--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -167,7 +167,7 @@ function OperatorUiAppRoot({
               core={core}
               issueSignature={onboarding.issueSignature}
               onClose={onboarding.close}
-              onDismiss={onboarding.dismiss}
+              onSkip={onboarding.skip}
               onMarkCompleted={onboarding.markCompleted}
               onNavigate={(routeId) => {
                 viewModel.navigate(routeId);

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
@@ -6,7 +6,6 @@ import { formatErrorMessage } from "../../utils/format-error-message.js";
 import { useAdminHttpClient } from "./admin-http-shared.js";
 import {
   buildOnboardingIssueSignature,
-  clearOnboardingStoredState,
   getRelevantOnboardingIssues,
   readOnboardingStoredState,
   supportsFirstRunOnboarding,
@@ -39,7 +38,7 @@ export type FirstRunOnboardingController = {
   issueSignature: string;
   close: () => void;
   open: () => void;
-  dismiss: () => void;
+  skip: () => void;
   markCompleted: () => void;
 };
 
@@ -154,13 +153,12 @@ export function useFirstRunOnboardingController(input: {
     if (!isConnectedForOnboarding(connection)) return;
     if (status.status === null && status.loading.status) return;
     if (issues.length === 0) {
-      clearOnboardingStoredState(input.scopeKey);
       return;
     }
     if (issueSignature.length === 0) return;
 
     const storedState = readOnboardingStoredState(input.scopeKey);
-    if (storedState && storedState.issueSignature === issueSignature) {
+    if (storedState?.status === "skipped") {
       return;
     }
     setIsOpen(true);
@@ -185,23 +183,19 @@ export function useFirstRunOnboardingController(input: {
       open() {
         setIsOpen(true);
       },
-      dismiss() {
+      skip() {
         const persistedSignature = issueSignature || lastNonEmptySignatureRef.current;
-        if (persistedSignature.length > 0) {
-          writeOnboardingStoredState(input.scopeKey, {
-            issueSignature: persistedSignature,
-            status: "dismissed",
-          });
-        }
+        writeOnboardingStoredState(input.scopeKey, {
+          ...(persistedSignature.length > 0 ? { issueSignature: persistedSignature } : {}),
+          status: "skipped",
+        });
         setIsOpen(false);
       },
       markCompleted() {
-        if (issueSignature.length > 0) {
-          writeOnboardingStoredState(input.scopeKey, {
-            issueSignature,
-            status: "completed",
-          });
-        }
+        writeOnboardingStoredState(input.scopeKey, {
+          ...(issueSignature.length > 0 ? { issueSignature } : {}),
+          status: "completed",
+        });
       },
     }),
     [available, input.scopeKey, isOpen, issueSignature],

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.shared.ts
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.shared.ts
@@ -34,8 +34,8 @@ export type FirstRunOnboardingStepId =
   | "agent"
   | "done";
 export type FirstRunOnboardingStoredState = {
-  issueSignature: string;
-  status: "dismissed" | "completed";
+  issueSignature?: string;
+  status: "skipped" | "completed";
 };
 
 export function supportsFirstRunOnboarding(hostKind: "desktop" | "mobile" | "web"): boolean {
@@ -65,9 +65,16 @@ export function readOnboardingStoredState(scopeKey: string): FirstRunOnboardingS
     }
     const issueSignature = (parsed as { issueSignature?: unknown }).issueSignature;
     const status = (parsed as { status?: unknown }).status;
-    if (typeof issueSignature !== "string") return null;
-    if (status !== "dismissed" && status !== "completed") return null;
-    return { issueSignature, status };
+    if (status === "dismissed") {
+      return typeof issueSignature === "string"
+        ? { issueSignature, status: "skipped" }
+        : { status: "skipped" };
+    }
+    if (status !== "skipped" && status !== "completed") return null;
+    if (typeof issueSignature === "string") {
+      return { issueSignature, status };
+    }
+    return { status };
   } catch {
     return null;
   }

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -44,14 +44,14 @@ export function FirstRunOnboardingPage({
   core,
   issueSignature,
   onClose,
-  onDismiss,
+  onSkip,
   onMarkCompleted,
   onNavigate,
 }: {
   core: OperatorCore;
   issueSignature: string;
   onClose: () => void;
-  onDismiss: () => void;
+  onSkip: () => void;
   onMarkCompleted: () => void;
   onNavigate: (routeId: "agents" | "configure" | "dashboard") => void;
 }) {
@@ -294,7 +294,8 @@ export function FirstRunOnboardingPage({
                 <h2 className="text-lg font-semibold text-fg">Initial Setup</h2>
               </div>
               <div className="text-sm text-fg-muted">
-                Finish the first-run configuration so Tyrum can use its default runtime paths.
+                Follow the guided setup or skip it and configure providers, models, and agents
+                manually.
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -310,10 +311,10 @@ export function FirstRunOnboardingPage({
                     onClose();
                     return;
                   }
-                  onDismiss();
+                  onSkip();
                 }}
               >
-                {step === "done" ? "Close" : "Dismiss"}
+                {step === "done" ? "Close" : "Skip setup"}
               </Button>
             </div>
           </div>

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts
@@ -248,7 +248,8 @@ export function registerFirstRunOnboardingFlowTests(): void {
     expect(
       await waitForSelector(container, '[data-testid="first-run-onboarding-step-done"]'),
     ).not.toBeNull();
-    expect(local.size).toBe(0);
+    expect(local.size).toBe(1);
+    expect(Array.from(local.values())[0]).toContain('"status":"completed"');
 
     cleanup(root, container);
   });

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-state-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-state-test-support.ts
@@ -25,7 +25,7 @@ import {
 } from "./operator-ui.first-run-onboarding.helpers.js";
 
 export function registerFirstRunOnboardingStateTests(): void {
-  it("auto-opens setup when config health has first-run issues and resumes after dismissal", async () => {
+  it("auto-opens setup when config health has first-run issues and resumes after skipping", async () => {
     const { local } = stubPersistentStorage();
     const ws = new FakeWsClient();
     const { http, statusGet } = createFakeHttpClient();
@@ -58,10 +58,10 @@ export function registerFirstRunOnboardingStateTests(): void {
 
     await waitForSelector(container, '[data-testid="first-run-onboarding"]');
 
-    const dismissButton = findButtonByText(container, "Dismiss");
-    expect(dismissButton).not.toBeNull();
+    const skipButton = findButtonByText(container, "Skip setup");
+    expect(skipButton).not.toBeNull();
     await act(async () => {
-      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      skipButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await Promise.resolve();
     });
 
@@ -71,7 +71,7 @@ export function registerFirstRunOnboardingStateTests(): void {
     );
     const storedValues = Array.from(local.values());
     expect(storedValues).toHaveLength(1);
-    expect(storedValues[0]).toContain('"status":"dismissed"');
+    expect(storedValues[0]).toContain('"status":"skipped"');
 
     await act(async () => {
       resumeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -201,7 +201,7 @@ export function registerFirstRunOnboardingStateTests(): void {
     cleanup(root, container);
   });
 
-  it("reopens onboarding when the unresolved issue signature changes after dismissal", async () => {
+  it("keeps onboarding skipped when the unresolved issue signature changes", async () => {
     stubPersistentStorage();
     let issues: Parameters<typeof buildIssueStatusResponse>[0] = [
       {
@@ -232,10 +232,10 @@ export function registerFirstRunOnboardingStateTests(): void {
     });
 
     await waitForSelector(container, '[data-testid="first-run-onboarding"]');
-    const dismissButton = findButtonByText(container, "Dismiss");
-    expect(dismissButton).not.toBeNull();
+    const skipButton = findButtonByText(container, "Skip setup");
+    expect(skipButton).not.toBeNull();
     await act(async () => {
-      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      skipButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await Promise.resolve();
     });
 
@@ -251,12 +251,18 @@ export function registerFirstRunOnboardingStateTests(): void {
       await core.syncAllNow();
     });
 
-    expect(await waitForSelector(container, '[data-testid="first-run-onboarding"]')).not.toBeNull();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="first-run-onboarding"]')).toBeNull();
+    expect(
+      await waitForSelector(container, '[data-testid="dashboard-resume-setup"]'),
+    ).not.toBeNull();
 
     cleanup(root, container);
   });
 
-  it("clears dismissed state once config health becomes clean and reopens for the same issue later", async () => {
+  it("keeps skipped state when config health becomes clean and suppresses the same issue later", async () => {
     const { local } = stubPersistentStorage();
     let issues: Parameters<typeof buildIssueStatusResponse>[0] = [
       {
@@ -289,19 +295,19 @@ export function registerFirstRunOnboardingStateTests(): void {
     });
 
     await waitForSelector(container, '[data-testid="first-run-onboarding"]');
-    const dismissButton = findButtonByText(container, "Dismiss");
-    expect(dismissButton).not.toBeNull();
+    const skipButton = findButtonByText(container, "Skip setup");
+    expect(skipButton).not.toBeNull();
     await act(async () => {
-      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      skipButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await Promise.resolve();
     });
-    expect(Array.from(local.values())[0]).toContain('"status":"dismissed"');
+    expect(Array.from(local.values())[0]).toContain('"status":"skipped"');
 
     issues = [];
     await act(async () => {
       await core.syncAllNow();
     });
-    expect(local.size).toBe(0);
+    expect(local.size).toBe(1);
 
     issues = [
       {
@@ -315,7 +321,76 @@ export function registerFirstRunOnboardingStateTests(): void {
       await core.syncAllNow();
     });
 
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="first-run-onboarding"]')).toBeNull();
+    expect(
+      await waitForSelector(container, '[data-testid="dashboard-resume-setup"]'),
+    ).not.toBeNull();
+
+    const resumeButton = findButtonByText(container, "Resume Setup");
+    expect(resumeButton).not.toBeNull();
+    await act(async () => {
+      resumeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
     expect(await waitForSelector(container, '[data-testid="first-run-onboarding"]')).not.toBeNull();
+
+    cleanup(root, container);
+  });
+
+  it("treats legacy dismissed storage as skipped onboarding", async () => {
+    const scopeKey = "desktop:http://example.test:";
+    stubPersistentStorage({
+      local: new Map<string, string>([
+        [
+          `tyrum.first-run-onboarding:${scopeKey}`,
+          JSON.stringify({
+            issueSignature: "no_provider_accounts:deployment:",
+            status: "dismissed",
+          }),
+        ],
+      ]),
+    });
+    const ws = new FakeWsClient();
+    const { http, statusGet } = createFakeHttpClient();
+    statusGet.mockResolvedValue(
+      buildIssueStatusResponse([
+        {
+          code: "no_provider_accounts",
+          severity: "error",
+          message: "No active provider accounts are configured.",
+          target: { kind: "deployment", id: null },
+        },
+      ]),
+    );
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("test"),
+      deps: { ws, http },
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="first-run-onboarding"]')).toBeNull();
+    expect(
+      await waitForSelector(container, '[data-testid="dashboard-resume-setup"]'),
+    ).not.toBeNull();
 
     cleanup(root, container);
   });


### PR DESCRIPTION
## Summary
- allow the operator first-run onboarding wizard to be skipped persistently per gateway/device scope
- keep manual resume available from the dashboard and preserve guided completion tracking
- update onboarding docs for web and desktop to explain manual configuration and resume behavior

## Testing
- pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts
- pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json
- pnpm exec oxlint packages/operator-ui/src/components/pages/first-run-onboarding.shared.ts packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts packages/operator-ui/src/components/pages/first-run-onboarding.tsx packages/operator-ui/src/app.tsx packages/operator-ui/tests/operator-ui.first-run-onboarding-state-test-support.ts packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts
- pre-commit hooks during git commit
- pre-push checks: lint, typecheck, desktop tsconfig check, full test suite with coverage

Closes #1357