### PR TITLE
fix: constrain viewport-locked onboarding containers

### DIFF
--- a/apps/web/src/layout-harness-app.tsx
+++ b/apps/web/src/layout-harness-app.tsx
@@ -7,6 +7,7 @@ import { AiSdkChatPage } from "../../../packages/operator-ui/src/components/page
 import { ConfigurePage } from "../../../packages/operator-ui/src/components/pages/configure-page.js";
 import { DashboardPage } from "../../../packages/operator-ui/src/components/pages/dashboard-page.js";
 import { ExtensionsPage } from "../../../packages/operator-ui/src/components/pages/extensions-page.js";
+import { FirstRunOnboardingPage } from "../../../packages/operator-ui/src/components/pages/first-run-onboarding.js";
 import { NodeConfigurePage } from "../../../packages/operator-ui/src/components/pages/node-configure-page.js";
 import { PairingPage } from "../../../packages/operator-ui/src/components/pages/pairing-page.js";
 import { BrowserCapabilitiesPage } from "../../../packages/operator-ui/src/components/pages/platform/browser-capabilities-page.js";
@@ -21,6 +22,7 @@ import {
   createConfigureCore,
   createDashboardCore,
   createDesktopApi,
+  createOnboardingCore,
   createPairingCore,
   createWorkboardCore,
 } from "./layout-harness-route-fixtures.js";
@@ -35,7 +37,8 @@ type LayoutRoute =
   | "extensions"
   | "configure"
   | "browser"
-  | "desktop";
+  | "desktop"
+  | "onboarding";
 
 function HarnessIcon({ className }: { className?: string }) {
   return (
@@ -69,6 +72,22 @@ function createDesktopRoute(): React.ReactNode {
     <OperatorUiHostProvider value={{ kind: "desktop", api: createDesktopApi() }}>
       <NodeConfigurePage />
     </OperatorUiHostProvider>
+  );
+}
+
+function createOnboardingRoute(): React.ReactNode {
+  const core = createOnboardingCore();
+  return (
+    <AdminAccessProvider core={core} mode="desktop">
+      <FirstRunOnboardingPage
+        core={core}
+        issueSignature="no_provider_accounts:deployment"
+        onClose={() => undefined}
+        onDismiss={() => undefined}
+        onMarkCompleted={() => undefined}
+        onNavigate={() => undefined}
+      />
+    </AdminAccessProvider>
   );
 }
 
@@ -106,6 +125,8 @@ function renderRoute(route: LayoutRoute): React.ReactNode {
       return createBrowserRoute();
     case "desktop":
       return createDesktopRoute();
+    case "onboarding":
+      return createOnboardingRoute();
     default:
       return null;
   }
@@ -125,6 +146,7 @@ export function LayoutHarnessApp() {
     { id: "configure", label: "Configure", icon: HarnessIcon },
     { id: "browser", label: "Browser", icon: HarnessIcon },
     { id: "desktop", label: "Desktop", icon: HarnessIcon },
+    { id: "onboarding", label: "Onboarding", icon: HarnessIcon },
   ];
 
   return (

--- a/apps/web/src/layout-harness-route-fixtures.tsx
+++ b/apps/web/src/layout-harness-route-fixtures.tsx
@@ -2,6 +2,7 @@ import {
   createElevatedModeStore,
   type OperatorCore,
 } from "../../../packages/operator-core/src/index.js";
+import { createStore } from "../../../packages/operator-core/src/store.js";
 import type { DesktopApi } from "../../../packages/operator-ui/src/desktop-api.js";
 import {
   createActivityStore,
@@ -30,6 +31,100 @@ function createNodeConfig(overrides: Record<string, unknown> = {}): Record<strin
     web: { allowedDomains: [], headless: true },
     ...overrides,
   };
+}
+
+function createOnboardingStatusStore() {
+  return createStore({
+    status: {
+      status: "ok" as const,
+      version: "1.0.0",
+      instance_id: "layout-harness",
+      role: "all" as const,
+      db_kind: "sqlite" as const,
+      is_exposed: false,
+      otel_enabled: false,
+      auth: { enabled: true },
+      ws: null,
+      policy: null,
+      model_auth: null,
+      catalog_freshness: null,
+      session_lanes: {},
+      queue_depth: null,
+      sandbox: null,
+      config_health: {
+        status: "issues" as const,
+        issues: [
+          {
+            code: "no_provider_accounts" as const,
+            severity: "error" as const,
+            message: "No active provider accounts are configured.",
+            target: { kind: "deployment" as const, id: null },
+          },
+        ],
+      },
+    },
+    usage: null,
+    presenceByInstanceId: {},
+    loading: { status: false, usage: false, presence: false },
+    error: { status: null, usage: null, presence: null },
+    lastSyncedAt: "2026-03-08T00:00:00.000Z",
+  }).store;
+}
+
+function createOnboardingAgentConfigResponse() {
+  return {
+    revision: 1,
+    tenant_id: "tenant-1",
+    agent_id: "11111111-1111-4111-8111-111111111111",
+    agent_key: "default",
+    config: {
+      model: { model: null },
+      persona: {
+        name: "Default Agent",
+        tone: "direct",
+        palette: "graphite",
+        character: "architect",
+      },
+      memory: {
+        enabled: true,
+        strategy: "summary",
+      },
+      instructions: "",
+      mcp: {
+        pre_turn_tools: [],
+        server_settings: {},
+      },
+    },
+    persona: {
+      name: "Default Agent",
+      tone: "direct",
+      palette: "graphite",
+      character: "architect",
+    },
+    config_sha256: "e".repeat(64),
+    created_at: "2026-03-01T00:00:00.000Z",
+    created_by: { kind: "tenant.token" as const, token_id: "token-1" },
+    reason: null,
+    reverted_from_revision: null,
+  };
+}
+
+function createUnassignedAssignments() {
+  return [
+    "interaction",
+    "explorer_ro",
+    "reviewer_ro",
+    "planner",
+    "jury",
+    "executor_rw",
+    "integrator",
+  ].map((execution_profile_id) => ({
+    execution_profile_id,
+    preset_key: null,
+    preset_display_name: null,
+    provider_key: null,
+    model_id: null,
+  }));
 }
 
 export function createDesktopApi(): DesktopApi {
@@ -148,5 +243,73 @@ export function createConfigureCore(): OperatorCore {
   return {
     elevatedModeStore: createElevatedModeStore(),
     http: createHarnessConfigureHttpFixtures(),
+  } as unknown as OperatorCore;
+}
+
+export function createOnboardingCore(): OperatorCore {
+  const elevatedModeStore = createElevatedModeStore();
+  elevatedModeStore.enter({
+    elevatedToken: "layout-harness-elevated-token",
+    expiresAt: "2099-01-01T00:00:00.000Z",
+  });
+
+  const onboardingRegistry = [
+    {
+      provider_key: "openai",
+      name: "OpenAI",
+      doc: null,
+      supported: true,
+      accounts: [],
+      methods: [
+        {
+          method_key: "api_key",
+          label: "API key",
+          type: "api_key",
+          fields: [
+            {
+              key: "api_key",
+              label: "API key",
+              description: "Primary secret used for the provider account.",
+              kind: "secret",
+              input: "password",
+              required: true,
+            },
+            ...Array.from({ length: 12 }, (_, index) => ({
+              key: `config_${String(index + 1)}`,
+              label: `Config field ${String(index + 1)}`,
+              description:
+                "Extra fixture field to force the onboarding provider step to scroll within its card body.",
+              kind: "config" as const,
+              input: "text" as const,
+              required: false,
+            })),
+          ],
+        },
+      ],
+    },
+  ];
+
+  return {
+    httpBaseUrl: "http://127.0.0.1:8788/",
+    elevatedModeStore,
+    statusStore: createOnboardingStatusStore(),
+    http: {
+      providerConfig: {
+        listRegistry: async () => ({ status: "ok" as const, providers: onboardingRegistry }),
+        listProviders: async () => ({ status: "ok" as const, providers: [] }),
+      },
+      modelConfig: {
+        listPresets: async () => ({ status: "ok" as const, presets: [] }),
+        listAvailable: async () => ({ status: "ok" as const, models: [] }),
+        listAssignments: async () => ({
+          status: "ok" as const,
+          assignments: createUnassignedAssignments(),
+        }),
+      },
+      agentConfig: {
+        get: async () => createOnboardingAgentConfigResponse(),
+      },
+    },
+    syncAllNow: async () => {},
   } as unknown as OperatorCore;
 }

--- a/apps/web/tests/layout-regression.test.ts
+++ b/apps/web/tests/layout-regression.test.ts
@@ -18,6 +18,8 @@ type LayoutCase = {
   route: string;
   clicks?: string[];
   selectors: string[];
+  constrainedSelectors?: string[];
+  verticallyScrollableSelectors?: string[];
   viewport?: {
     width: number;
     height: number;
@@ -165,6 +167,18 @@ const cases: LayoutCase[] = [
     clicks: ['[role="tab"]:has-text("Web")'],
     selectors: ["[data-layout-content]", '[role="tabpanel"][data-state="active"]'],
   },
+  {
+    name: "onboarding",
+    route: "onboarding",
+    selectors: [
+      '[data-testid="first-run-onboarding"]',
+      '[data-testid="first-run-onboarding-card"]',
+      '[data-testid="first-run-onboarding-card-body"]',
+    ],
+    constrainedSelectors: ['[data-testid="first-run-onboarding-card"]'],
+    verticallyScrollableSelectors: ['[data-testid="first-run-onboarding-card-body"]'],
+    viewport: { width: 1280, height: 720 },
+  },
 ];
 
 async function assertNoHorizontalOverflow(page: Page, selectors: string[]): Promise<void> {
@@ -224,6 +238,57 @@ async function assertNoInternalHorizontalClipping(page: Page, selectors: string[
       measurement.clippedBy,
       `${measurement.selector} clipped ${measurement.clippedBy}px of horizontal content`,
     ).toBeLessThanOrEqual(1);
+  }
+}
+
+async function assertWithinViewportHeight(page: Page, selectors: string[]): Promise<void> {
+  const result = await page.evaluate((candidateSelectors) => {
+    const viewportHeight = window.innerHeight;
+    return candidateSelectors.map((selector) => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) {
+        return { selector, found: false, bottom: null, overflow: null };
+      }
+      const rect = element.getBoundingClientRect();
+      return {
+        selector,
+        found: true,
+        bottom: rect.bottom,
+        overflow: Math.max(0, rect.bottom - viewportHeight),
+      };
+    });
+  }, selectors);
+
+  for (const measurement of result) {
+    expect(measurement.found, `${measurement.selector} should exist`).toBe(true);
+    expect(
+      measurement.overflow,
+      `${measurement.selector} overflowed vertically by ${measurement.overflow}px`,
+    ).toBeLessThanOrEqual(1);
+  }
+}
+
+async function assertHasVerticalScrollCapacity(page: Page, selectors: string[]): Promise<void> {
+  const result = await page.evaluate((candidateSelectors) => {
+    return candidateSelectors.map((selector) => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) {
+        return { selector, found: false, overflowBy: null };
+      }
+      return {
+        selector,
+        found: true,
+        overflowBy: Math.max(0, element.scrollHeight - element.clientHeight),
+      };
+    });
+  }, selectors);
+
+  for (const measurement of result) {
+    expect(measurement.found, `${measurement.selector} should exist`).toBe(true);
+    expect(
+      measurement.overflowBy,
+      `${measurement.selector} should own vertical overflow`,
+    ).toBeGreaterThan(1);
   }
 }
 
@@ -289,6 +354,12 @@ describe("layout regression harness", () => {
         }
 
         await assertNoHorizontalOverflow(page, testCase.selectors);
+        if (testCase.constrainedSelectors) {
+          await assertWithinViewportHeight(page, testCase.constrainedSelectors);
+        }
+        if (testCase.verticallyScrollableSelectors) {
+          await assertHasVerticalScrollCapacity(page, testCase.verticallyScrollableSelectors);
+        }
         if (testCase.name === "workboard") {
           await assertNoInternalHorizontalClipping(page, ['[data-testid="workboard-board"]']);
         }

--- a/packages/operator-ui/src/components/layout/app-page.tsx
+++ b/packages/operator-ui/src/components/layout/app-page.tsx
@@ -29,6 +29,7 @@ export function AppPageToolbar({ title, actions, className, ...props }: AppPageT
 }
 
 export interface AppPageContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  contentLayout?: "stack" | "fill";
   contentClassName?: string;
   scrollAreaClassName?: string;
   scrollAreaRef?: React.Ref<React.ElementRef<typeof ScrollArea>>;
@@ -37,6 +38,7 @@ export interface AppPageContentProps extends React.HTMLAttributes<HTMLDivElement
 export function AppPageContent({
   children,
   className,
+  contentLayout = "stack",
   contentClassName,
   scrollAreaClassName,
   scrollAreaRef,
@@ -71,21 +73,35 @@ export function AppPageContent({
     };
   }, [updateAlignment]);
 
+  const content = (
+    <div
+      ref={contentRef}
+      data-layout-content=""
+      data-layout-alignment={centerContent ? "center" : "start"}
+      data-layout-mode={contentLayout}
+      className={cn(
+        "box-border w-full max-w-5xl gap-5 px-4 py-4 md:px-5 md:py-5",
+        contentLayout === "fill" ? "flex h-full min-h-0 min-w-0 flex-col" : "grid min-h-fit",
+        centerContent ? "mx-auto" : "ml-0 mr-auto",
+        contentClassName,
+      )}
+    >
+      {children}
+    </div>
+  );
+
+  if (contentLayout === "fill") {
+    return (
+      <div className={cn("min-h-0 flex-1 overflow-hidden", className)} {...props}>
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div className={cn("min-h-0 flex-1 overflow-hidden", className)} {...props}>
       <ScrollArea ref={scrollAreaRef} className={cn("h-full", scrollAreaClassName)}>
-        <div
-          ref={contentRef}
-          data-layout-content=""
-          data-layout-alignment={centerContent ? "center" : "start"}
-          className={cn(
-            "grid box-border w-full max-w-5xl gap-5 px-4 py-4 md:px-5 md:py-5",
-            centerContent ? "mx-auto" : "ml-0 mr-auto",
-            contentClassName,
-          )}
-        >
-          {children}
-        </div>
+        {content}
       </ScrollArea>
     </div>
   );
@@ -94,6 +110,7 @@ export function AppPageContent({
 export interface AppPageProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
   title?: React.ReactNode;
   actions?: React.ReactNode;
+  contentLayout?: "stack" | "fill";
   contentClassName?: string;
   scrollAreaClassName?: string;
   scrollAreaRef?: React.Ref<React.ElementRef<typeof ScrollArea>>;
@@ -105,6 +122,7 @@ export function AppPage({
   actions,
   children,
   className,
+  contentLayout,
   contentClassName,
   scrollAreaClassName,
   scrollAreaRef,
@@ -119,6 +137,7 @@ export function AppPage({
       {title || actions ? <AppPageToolbar title={title} actions={actions} /> : null}
       <AppPageContent
         className={bodyClassName}
+        contentLayout={contentLayout}
         contentClassName={contentClassName}
         scrollAreaClassName={scrollAreaClassName}
         scrollAreaRef={scrollAreaRef}

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -284,9 +284,16 @@ export function FirstRunOnboardingPage({
   };
 
   return (
-    <AppPage contentClassName="max-w-4xl gap-5" data-testid="first-run-onboarding">
-      <Card>
-        <CardHeader className="pb-3">
+    <AppPage
+      contentLayout="fill"
+      contentClassName="max-w-4xl gap-5"
+      data-testid="first-run-onboarding"
+    >
+      <Card
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        data-testid="first-run-onboarding-card"
+      >
+        <CardHeader className="shrink-0 pb-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="grid gap-2">
               <div className="flex items-center gap-2">
@@ -318,7 +325,10 @@ export function FirstRunOnboardingPage({
             </div>
           </div>
         </CardHeader>
-        <CardContent className="grid gap-4">
+        <CardContent
+          className="grid min-h-0 flex-1 gap-4 overflow-auto"
+          data-testid="first-run-onboarding-card-body"
+        >
           {data.errorMessage ? (
             <Alert
               variant="error"
@@ -347,7 +357,7 @@ export function FirstRunOnboardingPage({
           ) : null}
           {renderStep()}
         </CardContent>
-        <CardFooter className="justify-between">
+        <CardFooter className="shrink-0 justify-between">
           <div className="text-xs text-fg-muted">
             Status is refreshed against the live gateway after each step.
           </div>

--- a/packages/operator-ui/tests/layout/app-page.test.ts
+++ b/packages/operator-ui/tests/layout/app-page.test.ts
@@ -128,4 +128,58 @@ describe("AppPageContent", () => {
       measurements.restore();
     }
   });
+
+  it("keeps stack layout as the default mode", () => {
+    const measurements = installLayoutContentMeasurements({ clientWidth: 900, scrollWidth: 900 });
+    let testRoot: ReturnType<typeof renderIntoDocument> | null = null;
+
+    try {
+      testRoot = renderIntoDocument(
+        React.createElement(
+          AppPageContent,
+          null,
+          React.createElement("div", null, "Document content"),
+        ),
+      );
+
+      const content = testRoot.container.querySelector("[data-layout-content]");
+      expect(content?.getAttribute("data-layout-mode")).toBe("stack");
+      expect(content?.className).toContain("grid");
+      expect(content?.className).toContain("min-h-fit");
+      expect(content?.className).not.toContain("flex-col");
+    } finally {
+      if (testRoot) {
+        cleanupTestRoot(testRoot);
+      }
+      measurements.restore();
+    }
+  });
+
+  it("supports fill layout mode for viewport-constrained pages", () => {
+    const measurements = installLayoutContentMeasurements({ clientWidth: 900, scrollWidth: 900 });
+    let testRoot: ReturnType<typeof renderIntoDocument> | null = null;
+
+    try {
+      testRoot = renderIntoDocument(
+        React.createElement(
+          AppPageContent,
+          { contentLayout: "fill" },
+          React.createElement("div", null, "Constrained content"),
+        ),
+      );
+
+      const content = testRoot.container.querySelector("[data-layout-content]");
+      expect(content?.getAttribute("data-layout-mode")).toBe("fill");
+      expect(content?.className).toContain("flex");
+      expect(content?.className).toContain("flex-col");
+      expect(content?.className).toContain("h-full");
+      expect(content?.className).toContain("min-h-0");
+      expect(content?.className).not.toContain("grid");
+    } finally {
+      if (testRoot) {
+        cleanupTestRoot(testRoot);
+      }
+      measurements.restore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add an opt-in `contentLayout="fill"` mode to `AppPage` / `AppPageContent` for viewport-constrained pages
- apply the constrained layout pattern to the first-run onboarding `Initial Setup` card so the card body owns vertical overflow
- extend the browser layout harness to cover onboarding and fail on vertical overflow regressions

Closes #1360

## Testing
- `pnpm vitest run packages/operator-ui/tests/layout/app-page.test.ts`
- `pnpm vitest run packages/operator-ui/tests/layout/app-shell.test.ts`
- `pnpm vitest run apps/web/tests/layout-regression.test.ts`
- `pnpm vitest run packages/operator-ui/tests/operator-ui.test.ts -t onboarding`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `git push -u origin 1360-prevent-viewport-container-overflow` (passed pre-push: lint, typecheck, desktop tsc, full test suite with coverage)

## Risk / rollback
Risk is limited to viewport-locked page layout behavior because the new fill-height mode is opt-in and only onboarding uses it in this change. Rollback is a small revert of the `AppPage` fill mode and onboarding card classes.
