### PR TITLE
fix: send chat composer draft on enter

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -3,7 +3,7 @@ import type { ResolveApprovalInput } from "@tyrum/operator-core";
 import { useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { ChevronLeft, Send, Trash2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { toast } from "sonner";
 import type {
   createTyrumAiSdkChatSessionClient,
@@ -168,6 +168,24 @@ export function AiSdkConversation({
   const working = chat.status === "submitted" || chat.status === "streaming";
   const canSend = draft.trim().length > 0 && chat.status !== "submitted";
 
+  const handleDraftKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>): void => {
+    if (
+      event.key !== "Enter" ||
+      event.shiftKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.nativeEvent.isComposing
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (!canSend) {
+      return;
+    }
+    void send();
+  };
+
   return (
     <div
       className="flex h-full min-h-0 min-w-0 flex-1 flex-col"
@@ -229,6 +247,7 @@ export function AiSdkConversation({
             onChange={(event) => {
               setDraft(event.currentTarget.value);
             }}
+            onKeyDown={handleDraftKeyDown}
             placeholder="Send a message"
             value={draft}
           />

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
@@ -41,6 +41,16 @@ async function flushEffects(): Promise<void> {
   });
 }
 
+function dispatchDraftKeyDown(draft: HTMLTextAreaElement, init: KeyboardEventInit): boolean {
+  return draft.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    }),
+  );
+}
+
 describe("AiSdkConversation", () => {
   beforeEach(() => {
     useChatMock.mockReset();
@@ -178,6 +188,167 @@ describe("AiSdkConversation", () => {
     expect(sessionClient.get).toHaveBeenCalledWith({ session_id: "session-1" });
     expect(chatState.setMessages).toHaveBeenCalledWith(reloadedMessages);
     expect(onSessionMessages).toHaveBeenCalledWith(reloadedMessages);
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("sends the draft on plain Enter", async () => {
+    const chatState = makeUseChatState();
+    useChatMock.mockReturnValue(chatState);
+
+    const resolveAttachedNodeId = vi.fn(async () => null);
+    const sessionClient = {
+      get: vi.fn(async () => ({
+        session_id: "session-1",
+        messages: [],
+      })),
+    };
+
+    const { AiSdkConversation } =
+      await import("../../src/components/pages/chat-page-ai-sdk-conversation.js");
+    const testRoot = renderIntoDocument(
+      e(AiSdkConversation, {
+        approvalsById: {},
+        onDelete: vi.fn(),
+        onResolveApproval: vi.fn(),
+        onRenderModeChange: vi.fn(),
+        onReasoningModeChange: vi.fn(),
+        onSessionMessages: vi.fn(),
+        renderMode: "markdown",
+        resolvingApproval: null,
+        resolveAttachedNodeId,
+        reasoningMode: "collapsed",
+        session: {
+          session_id: "session-1",
+          thread_id: "thread-1",
+          messages: [],
+        },
+        sessionClient,
+        transport: { transport: true },
+      } as never),
+    );
+
+    const draft = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-draft']",
+    ) as HTMLTextAreaElement;
+    setNativeValue(draft, "hello world");
+
+    let eventAllowed = true;
+    act(() => {
+      eventAllowed = dispatchDraftKeyDown(draft, { key: "Enter" });
+    });
+    await flushEffects();
+
+    expect(eventAllowed).toBe(false);
+    expect(resolveAttachedNodeId).toHaveBeenCalledOnce();
+    expect(chatState.sendMessage).toHaveBeenCalledWith({ text: "hello world" }, undefined);
+    expect(draft.value).toBe("");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("keeps Shift+Enter as a newline action", async () => {
+    const chatState = makeUseChatState();
+    useChatMock.mockReturnValue(chatState);
+
+    const sessionClient = {
+      get: vi.fn(async () => ({
+        session_id: "session-1",
+        messages: [],
+      })),
+    };
+
+    const { AiSdkConversation } =
+      await import("../../src/components/pages/chat-page-ai-sdk-conversation.js");
+    const testRoot = renderIntoDocument(
+      e(AiSdkConversation, {
+        approvalsById: {},
+        onDelete: vi.fn(),
+        onResolveApproval: vi.fn(),
+        onRenderModeChange: vi.fn(),
+        onReasoningModeChange: vi.fn(),
+        onSessionMessages: vi.fn(),
+        renderMode: "markdown",
+        resolvingApproval: null,
+        resolveAttachedNodeId: vi.fn(async () => null),
+        reasoningMode: "collapsed",
+        session: {
+          session_id: "session-1",
+          thread_id: "thread-1",
+          messages: [],
+        },
+        sessionClient,
+        transport: { transport: true },
+      } as never),
+    );
+
+    const draft = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-draft']",
+    ) as HTMLTextAreaElement;
+    setNativeValue(draft, "line 1\nline 2");
+
+    let eventAllowed = true;
+    act(() => {
+      eventAllowed = dispatchDraftKeyDown(draft, { key: "Enter", shiftKey: true });
+    });
+    await flushEffects();
+
+    expect(eventAllowed).toBe(true);
+    expect(chatState.sendMessage).not.toHaveBeenCalled();
+    expect(draft.value).toBe("line 1\nline 2");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("does not send on Enter while composing IME input", async () => {
+    const chatState = makeUseChatState();
+    useChatMock.mockReturnValue(chatState);
+
+    const sessionClient = {
+      get: vi.fn(async () => ({
+        session_id: "session-1",
+        messages: [],
+      })),
+    };
+
+    const { AiSdkConversation } =
+      await import("../../src/components/pages/chat-page-ai-sdk-conversation.js");
+    const testRoot = renderIntoDocument(
+      e(AiSdkConversation, {
+        approvalsById: {},
+        onDelete: vi.fn(),
+        onResolveApproval: vi.fn(),
+        onRenderModeChange: vi.fn(),
+        onReasoningModeChange: vi.fn(),
+        onSessionMessages: vi.fn(),
+        renderMode: "markdown",
+        resolvingApproval: null,
+        resolveAttachedNodeId: vi.fn(async () => null),
+        reasoningMode: "collapsed",
+        session: {
+          session_id: "session-1",
+          thread_id: "thread-1",
+          messages: [],
+        },
+        sessionClient,
+        transport: { transport: true },
+      } as never),
+    );
+
+    const draft = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-draft']",
+    ) as HTMLTextAreaElement;
+    setNativeValue(draft, "hello");
+
+    let eventAllowed = true;
+    act(() => {
+      eventAllowed = dispatchDraftKeyDown(draft, { key: "Enter", isComposing: true });
+    });
+    await flushEffects();
+
+    expect(eventAllowed).toBe(true);
+    expect(chatState.sendMessage).not.toHaveBeenCalled();
+    expect(draft.value).toBe("hello");
 
     cleanupTestRoot(testRoot);
   });


### PR DESCRIPTION
## Summary
- send the shared AI SDK chat composer draft on plain `Enter`
- preserve multiline input on `Shift+Enter` and ignore IME composition
- add focused regression coverage for keyboard submit behavior

## Testing
- pnpm exec vitest run packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts

Closes #1356
