### PR TITLE
chore: refresh workspace before pre-push checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,8 @@
 set -eu
 
 echo "Running pre-push checks..."
+pnpm clean
+pnpm install --frozen-lockfile
 pnpm lint
 pnpm typecheck
 pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json


### PR DESCRIPTION
## Summary
- run `pnpm clean` before the repo-local pre-push validation sequence
- run `pnpm install --frozen-lockfile` before lint, typecheck, desktop typecheck, and tests
- keep the existing validation commands intact after the workspace refresh

## Testing
- `git push -u origin 1378-refresh-pre-push-validations`

Closes #1378
