### PR TITLE
fix(gateway): skip policy gating for decide bootstrap

### DIFF
--- a/packages/gateway/src/modules/execution/engine/attempt-runner-helpers.ts
+++ b/packages/gateway/src/modules/execution/engine/attempt-runner-helpers.ts
@@ -23,6 +23,10 @@ export async function persistAttemptPolicyContext(
   deps: AttemptPolicyDeps,
   opts: AttemptPolicyContext,
 ): Promise<void> {
+  if (opts.action.type === "Decide") {
+    return;
+  }
+
   const run = await deps.db.get<{ policy_snapshot_id: string | null }>(
     "SELECT policy_snapshot_id FROM execution_runs WHERE tenant_id = ? AND run_id = ?",
     [opts.tenantId, opts.runId],

--- a/packages/gateway/src/modules/execution/engine/step-execution-queued-policy.ts
+++ b/packages/gateway/src/modules/execution/engine/step-execution-queued-policy.ts
@@ -50,6 +50,10 @@ export interface AttemptClaim {
   leaseTtlMs: number;
 }
 
+function isInternalControlAction(action: ActionPrimitiveT): boolean {
+  return action.type === "Decide";
+}
+
 export async function loadBudgetPolicyRowTx(
   tx: SqlDb,
   run: RunnableRunRow,
@@ -167,6 +171,9 @@ export async function maybeHandleSnapshotPolicyTx(
 ): Promise<StepClaimOutcome | undefined> {
   const policySnapshotId = budgetRow?.policy_snapshot_id ?? null;
   if (!policySnapshotId || !parsedAction) {
+    return undefined;
+  }
+  if (isInternalControlAction(parsedAction)) {
     return undefined;
   }
 

--- a/packages/gateway/tests/unit/execution-engine.policy-intent-test-support.ts
+++ b/packages/gateway/tests/unit/execution-engine.policy-intent-test-support.ts
@@ -98,6 +98,63 @@ function registerPolicyApprovalTests(fixture: { db: () => SqliteDb }): void {
     expect(runDone?.status).toBe("succeeded");
   });
 
+  it("does not approval-gate internal Decide steps under a policy snapshot", async () => {
+    const db = fixture.db();
+    const snapshotDal = new PolicySnapshotDal(db);
+    const snapshot = await snapshotDal.getOrCreate(
+      DEFAULT_TENANT_ID,
+      PolicyBundle.parse({
+        v: 1,
+        tools: { default: "require_approval", allow: [], require_approval: [], deny: [] },
+        network_egress: { default: "require_approval", allow: [], require_approval: [], deny: [] },
+      }),
+    );
+    const engine = new ExecutionEngine({ db });
+    await enqueuePlan(engine, {
+      key: "agent:default:main",
+      lane: "heartbeat",
+      planId: "plan-heartbeat-decide-1",
+      requestId: "req-heartbeat-decide-1",
+      policySnapshotId: snapshot.policy_snapshot_id,
+      steps: [
+        action("Decide", {
+          channel: "automation:default",
+          thread_id: "schedule-heartbeat-1",
+          message: "Review signals and act only if useful.",
+          metadata: {
+            automation: {
+              schedule_id: "heartbeat-1",
+              schedule_kind: "heartbeat",
+              delivery_mode: "quiet",
+            },
+          },
+        }),
+      ],
+    });
+    const executor: StepExecutor = {
+      execute: vi.fn(async (): Promise<StepResult> => ({ success: true, result: { ok: true } })),
+    };
+    await drain(engine, "w1", executor);
+    expect(mockCallCount(executor)).toBe(1);
+
+    const approvalCount = await db.get<{ n: number }>("SELECT COUNT(*) AS n FROM approvals");
+    expect(approvalCount?.n).toBe(0);
+
+    const run = await db.get<{ status: string; paused_reason: string | null }>(
+      "SELECT status, paused_reason FROM execution_runs LIMIT 1",
+    );
+    expect(run).toMatchObject({ status: "succeeded", paused_reason: null });
+
+    const attempt = await db.get<{
+      policy_snapshot_id?: string | null;
+      policy_decision_json?: string | null;
+      policy_applied_override_ids_json?: string | null;
+    }>("SELECT * FROM execution_attempts LIMIT 1");
+    expect(attempt?.policy_snapshot_id).toBe(snapshot.policy_snapshot_id);
+    expect(attempt?.policy_decision_json).toBeNull();
+    expect(attempt?.policy_applied_override_ids_json).toBeNull();
+  });
+
   it("fails the run when policy denies a step (cancels remaining steps + releases leases)", async () => {
     const db = fixture.db();
     const snapshotDal = new PolicySnapshotDal(db);


### PR DESCRIPTION
## Summary
Heartbeat automation schedules bootstrap execution with an internal `Decide` step. The queued-step policy layer was treating that control step as a normal policy-scoped tool call, which produced ambiguous `action.Decide` approvals before the agent turn could run.

This change skips snapshot tool-policy gating for internal `Decide` control steps and avoids persisting fake policy intent for those attempts. Real tool calls and connector sends inside the turn remain policy-gated.

Closes #1380.

## Testing
- `pnpm exec vitest run packages/gateway/tests/unit/execution-engine.test.ts`
- `pnpm lint`

## Notes
- `git push --no-verify` was used at user request because the repo pre-push hook was failing on unrelated timeout-heavy tests:
  - `packages/gateway/tests/unit/dist-heartbeat.test.ts`
  - `apps/desktop/tests/integration/embedded-gateway-startup.test.ts`
  - `apps/desktop/tests/integration/electron-process-smoke.test.ts`