### PR TITLE
fix: add explicit workboard tool schemas

### DIFF
--- a/packages/gateway/src/modules/agent/tool-catalog-workboard-schemas.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog-workboard-schemas.ts
@@ -1,0 +1,291 @@
+type JsonSchema = Record<string, unknown>;
+type ObjectProperties = Record<string, JsonSchema>;
+
+const STRING_SCHEMA = { type: "string" } as const;
+const NUMBER_SCHEMA = { type: "number" } as const;
+const ANY_JSON_VALUE_SCHEMA = {
+  description: "Any JSON value.",
+} as const satisfies JsonSchema;
+
+const WORK_ITEM_STATES = [
+  "backlog",
+  "ready",
+  "doing",
+  "blocked",
+  "done",
+  "failed",
+  "cancelled",
+] as const;
+const WORK_ITEM_TRANSITION_STATES = [
+  "backlog",
+  "ready",
+  "blocked",
+  "done",
+  "failed",
+  "cancelled",
+] as const;
+const WORK_ITEM_KINDS = ["action", "initiative"] as const;
+const TASK_STATES = [
+  "queued",
+  "leased",
+  "running",
+  "paused",
+  "completed",
+  "failed",
+  "cancelled",
+  "skipped",
+] as const;
+const ARTIFACT_KINDS = [
+  "candidate_plan",
+  "hypothesis",
+  "risk",
+  "tool_intent",
+  "verification_report",
+  "jury_opinion",
+  "result_summary",
+  "other",
+] as const;
+const SIGNAL_STATUSES = ["active", "paused", "fired", "resolved", "cancelled"] as const;
+const SIGNAL_TRIGGER_KINDS = ["time", "event"] as const;
+const SUBAGENT_STATUSES = ["running", "paused", "closing", "closed", "failed"] as const;
+const CLARIFICATION_STATUSES = ["open", "answered", "cancelled"] as const;
+const STATE_SCOPE_KINDS = ["agent", "work_item"] as const;
+
+const CURSOR_LIMIT_PROPERTIES = {
+  limit: NUMBER_SCHEMA,
+  cursor: STRING_SCHEMA,
+} as const satisfies ObjectProperties;
+
+const STATE_SCOPE_PROPERTIES = {
+  scope_kind: {
+    type: "string",
+    enum: [...STATE_SCOPE_KINDS],
+    description: "Use work_item when targeting a specific work item.",
+  },
+  work_item_id: {
+    type: "string",
+    description: "Required when scope_kind is work_item.",
+  },
+} as const satisfies ObjectProperties;
+
+function enumSchema(values: readonly string[]): JsonSchema {
+  return {
+    type: "string",
+    enum: [...values],
+  };
+}
+
+function arraySchema(items: JsonSchema): JsonSchema {
+  return {
+    type: "array",
+    items,
+  };
+}
+
+function objectSchema(properties: ObjectProperties, required: readonly string[] = []): JsonSchema {
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required: [...required] } : {}),
+    additionalProperties: false,
+  };
+}
+
+export const WORKBOARD_TOOL_INPUT_SCHEMAS = {
+  "workboard.capture": objectSchema({
+    kind: enumSchema(WORK_ITEM_KINDS),
+    title: STRING_SCHEMA,
+    priority: NUMBER_SCHEMA,
+    acceptance: ANY_JSON_VALUE_SCHEMA,
+    request: STRING_SCHEMA,
+    parent_work_item_id: STRING_SCHEMA,
+  }),
+  "workboard.item.list": objectSchema({
+    statuses: arraySchema(enumSchema(WORK_ITEM_STATES)),
+    kinds: arraySchema(enumSchema(WORK_ITEM_KINDS)),
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.item.get": objectSchema({ work_item_id: STRING_SCHEMA }, ["work_item_id"]),
+  "workboard.item.create": objectSchema({
+    kind: enumSchema(WORK_ITEM_KINDS),
+    title: STRING_SCHEMA,
+    priority: NUMBER_SCHEMA,
+    acceptance: ANY_JSON_VALUE_SCHEMA,
+    parent_work_item_id: STRING_SCHEMA,
+  }),
+  "workboard.item.delete": objectSchema({ work_item_id: STRING_SCHEMA }, ["work_item_id"]),
+  "workboard.item.update": objectSchema(
+    {
+      work_item_id: STRING_SCHEMA,
+      title: STRING_SCHEMA,
+      priority: NUMBER_SCHEMA,
+      acceptance: ANY_JSON_VALUE_SCHEMA,
+    },
+    ["work_item_id"],
+  ),
+  "workboard.item.transition": objectSchema(
+    {
+      work_item_id: STRING_SCHEMA,
+      status: enumSchema(WORK_ITEM_TRANSITION_STATES),
+      reason: STRING_SCHEMA,
+    },
+    ["work_item_id", "status"],
+  ),
+  "workboard.task.list": objectSchema({ work_item_id: STRING_SCHEMA }, ["work_item_id"]),
+  "workboard.task.get": objectSchema({ task_id: STRING_SCHEMA }, ["task_id"]),
+  "workboard.task.create": objectSchema(
+    {
+      work_item_id: STRING_SCHEMA,
+      status: enumSchema(TASK_STATES),
+      depends_on: arraySchema(STRING_SCHEMA),
+      execution_profile: STRING_SCHEMA,
+      side_effect_class: STRING_SCHEMA,
+      result_summary: STRING_SCHEMA,
+    },
+    ["work_item_id"],
+  ),
+  "workboard.task.delete": objectSchema({ task_id: STRING_SCHEMA }, ["task_id"]),
+  "workboard.task.update": objectSchema(
+    {
+      task_id: STRING_SCHEMA,
+      status: enumSchema(TASK_STATES),
+      result_summary: STRING_SCHEMA,
+    },
+    ["task_id"],
+  ),
+  "workboard.artifact.list": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.artifact.get": objectSchema({ artifact_id: STRING_SCHEMA }, ["artifact_id"]),
+  "workboard.artifact.create": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    kind: enumSchema(ARTIFACT_KINDS),
+    title: STRING_SCHEMA,
+    body_md: STRING_SCHEMA,
+    refs: arraySchema(STRING_SCHEMA),
+  }),
+  "workboard.artifact.delete": objectSchema({ artifact_id: STRING_SCHEMA }, ["artifact_id"]),
+  "workboard.decision.list": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.decision.get": objectSchema({ decision_id: STRING_SCHEMA }, ["decision_id"]),
+  "workboard.decision.create": objectSchema(
+    {
+      work_item_id: STRING_SCHEMA,
+      question: STRING_SCHEMA,
+      chosen: STRING_SCHEMA,
+      rationale_md: STRING_SCHEMA,
+      alternatives: arraySchema(STRING_SCHEMA),
+      input_artifact_ids: arraySchema(STRING_SCHEMA),
+    },
+    ["chosen", "rationale_md"],
+  ),
+  "workboard.decision.delete": objectSchema({ decision_id: STRING_SCHEMA }, ["decision_id"]),
+  "workboard.signal.list": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    statuses: arraySchema(enumSchema(SIGNAL_STATUSES)),
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.signal.get": objectSchema({ signal_id: STRING_SCHEMA }, ["signal_id"]),
+  "workboard.signal.create": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    trigger_kind: enumSchema(SIGNAL_TRIGGER_KINDS),
+    trigger_spec_json: ANY_JSON_VALUE_SCHEMA,
+    payload_json: ANY_JSON_VALUE_SCHEMA,
+    status: enumSchema(SIGNAL_STATUSES),
+  }),
+  "workboard.signal.delete": objectSchema({ signal_id: STRING_SCHEMA }, ["signal_id"]),
+  "workboard.signal.update": objectSchema(
+    {
+      signal_id: STRING_SCHEMA,
+      trigger_spec_json: ANY_JSON_VALUE_SCHEMA,
+      payload_json: ANY_JSON_VALUE_SCHEMA,
+      status: enumSchema(SIGNAL_STATUSES),
+    },
+    ["signal_id"],
+  ),
+  "workboard.state.list": objectSchema({
+    ...STATE_SCOPE_PROPERTIES,
+    prefix: STRING_SCHEMA,
+  }),
+  "workboard.state.get": objectSchema(
+    {
+      ...STATE_SCOPE_PROPERTIES,
+      key: STRING_SCHEMA,
+    },
+    ["key"],
+  ),
+  "workboard.state.delete": objectSchema(
+    {
+      ...STATE_SCOPE_PROPERTIES,
+      key: STRING_SCHEMA,
+    },
+    ["key"],
+  ),
+  "workboard.state.set": objectSchema(
+    {
+      ...STATE_SCOPE_PROPERTIES,
+      key: STRING_SCHEMA,
+      value_json: ANY_JSON_VALUE_SCHEMA,
+      provenance_json: ANY_JSON_VALUE_SCHEMA,
+    },
+    ["key"],
+  ),
+  "workboard.subagent.list": objectSchema({
+    statuses: arraySchema(enumSchema(SUBAGENT_STATUSES)),
+    work_item_id: STRING_SCHEMA,
+    work_item_task_id: STRING_SCHEMA,
+    execution_profile: STRING_SCHEMA,
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.subagent.get": objectSchema({ subagent_id: STRING_SCHEMA }, ["subagent_id"]),
+  "workboard.subagent.spawn": objectSchema(
+    {
+      message: STRING_SCHEMA,
+      execution_profile: STRING_SCHEMA,
+      work_item_id: STRING_SCHEMA,
+      work_item_task_id: STRING_SCHEMA,
+    },
+    ["message", "execution_profile"],
+  ),
+  "workboard.subagent.send": objectSchema(
+    {
+      subagent_id: STRING_SCHEMA,
+      message: STRING_SCHEMA,
+    },
+    ["subagent_id", "message"],
+  ),
+  "workboard.subagent.close": objectSchema(
+    {
+      subagent_id: STRING_SCHEMA,
+      reason: STRING_SCHEMA,
+    },
+    ["subagent_id"],
+  ),
+  "workboard.clarification.list": objectSchema({
+    work_item_id: STRING_SCHEMA,
+    statuses: arraySchema(enumSchema(CLARIFICATION_STATUSES)),
+    ...CURSOR_LIMIT_PROPERTIES,
+  }),
+  "workboard.clarification.request": objectSchema(
+    {
+      work_item_id: STRING_SCHEMA,
+      question: STRING_SCHEMA,
+    },
+    ["work_item_id", "question"],
+  ),
+  "workboard.clarification.answer": objectSchema(
+    {
+      clarification_id: STRING_SCHEMA,
+      answer_text: STRING_SCHEMA,
+    },
+    ["clarification_id", "answer_text"],
+  ),
+  "workboard.clarification.cancel": objectSchema({ clarification_id: STRING_SCHEMA }, [
+    "clarification_id",
+  ]),
+} as const satisfies Record<string, JsonSchema>;
+
+export type WorkboardToolId = keyof typeof WORKBOARD_TOOL_INPUT_SCHEMAS;

--- a/packages/gateway/src/modules/agent/tool-catalog-workboard.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog-workboard.ts
@@ -1,86 +1,162 @@
 import type { ToolDescriptor } from "./tools.js";
+import {
+  WORKBOARD_TOOL_INPUT_SCHEMAS,
+  type WorkboardToolId,
+} from "./tool-catalog-workboard-schemas.js";
 
-const WORKBOARD_GENERIC_INPUT_SCHEMA = {
-  type: "object",
-  additionalProperties: true,
-} as const;
+const DEFAULT_WORKBOARD_KEYWORDS = [
+  "workboard",
+  "task",
+  "subagent",
+  "clarification",
+  "state",
+] as const;
 
-function classifyWorkboardToolRisk(id: string): "low" | "medium" {
+const WORKBOARD_TOOL_METADATA = {
+  "workboard.capture": {
+    description:
+      "Create a backlog WorkItem and queue planner refinement. Use when work is multi-step, ambiguous, or should continue beyond the current turn.",
+    keywords: ["workboard", "capture", "backlog", "refine", "plan", "task"] as const,
+  },
+  "workboard.item.list": {
+    description: "List WorkItems in the current work scope.",
+  },
+  "workboard.item.get": {
+    description: "Fetch a single WorkItem by id.",
+  },
+  "workboard.item.create": {
+    description: "Create a WorkItem directly in the current work scope.",
+  },
+  "workboard.item.delete": {
+    description: "Delete a WorkItem from the current work scope.",
+  },
+  "workboard.item.update": {
+    description: "Update mutable WorkItem fields such as title, priority, or acceptance.",
+  },
+  "workboard.item.transition": {
+    description: "Transition a WorkItem to a new top-level state.",
+  },
+  "workboard.task.list": {
+    description: "List tasks for a WorkItem.",
+  },
+  "workboard.task.get": {
+    description: "Fetch a task for the current work scope by id.",
+  },
+  "workboard.task.create": {
+    description: "Create a task for a WorkItem.",
+  },
+  "workboard.task.delete": {
+    description: "Delete a task from the current work scope.",
+  },
+  "workboard.task.update": {
+    description: "Update a WorkItem task.",
+  },
+  "workboard.artifact.list": {
+    description: "List WorkBoard artifacts.",
+  },
+  "workboard.artifact.get": {
+    description: "Fetch a WorkBoard artifact by id.",
+  },
+  "workboard.artifact.create": {
+    description: "Create a WorkBoard artifact.",
+  },
+  "workboard.artifact.delete": {
+    description: "Delete a WorkBoard artifact by id.",
+  },
+  "workboard.decision.list": {
+    description: "List WorkBoard decisions.",
+  },
+  "workboard.decision.get": {
+    description: "Fetch a WorkBoard decision by id.",
+  },
+  "workboard.decision.create": {
+    description: "Create a WorkBoard decision.",
+  },
+  "workboard.decision.delete": {
+    description: "Delete a WorkBoard decision by id.",
+  },
+  "workboard.signal.list": {
+    description: "List WorkBoard signals.",
+  },
+  "workboard.signal.get": {
+    description: "Fetch a WorkBoard signal by id.",
+  },
+  "workboard.signal.create": {
+    description: "Create a WorkBoard signal.",
+  },
+  "workboard.signal.delete": {
+    description: "Delete a WorkBoard signal by id.",
+  },
+  "workboard.signal.update": {
+    description: "Update a WorkBoard signal.",
+  },
+  "workboard.state.list": {
+    description: "List WorkBoard state entries for the agent or a WorkItem.",
+  },
+  "workboard.state.get": {
+    description: "Fetch a WorkBoard state entry.",
+  },
+  "workboard.state.delete": {
+    description: "Delete a WorkBoard state entry.",
+  },
+  "workboard.state.set": {
+    description: "Set a WorkBoard state entry.",
+  },
+  "workboard.subagent.list": {
+    description: "List subagents for the current work scope.",
+  },
+  "workboard.subagent.get": {
+    description: "Fetch a subagent by id.",
+  },
+  "workboard.subagent.spawn": {
+    description: "Spawn a helper subagent and run a bounded prompt through it.",
+  },
+  "workboard.subagent.send": {
+    description: "Send another prompt to an existing subagent.",
+  },
+  "workboard.subagent.close": {
+    description: "Request subagent closure.",
+  },
+  "workboard.clarification.list": {
+    description: "List clarification requests for the current work scope.",
+  },
+  "workboard.clarification.request": {
+    description:
+      "Request clarification through the main user-facing agent and send a steer notification.",
+  },
+  "workboard.clarification.answer": {
+    description: "Answer a clarification request on behalf of the main user-facing agent.",
+  },
+  "workboard.clarification.cancel": {
+    description: "Cancel an open clarification request.",
+  },
+} as const satisfies Record<
+  WorkboardToolId,
+  {
+    description: string;
+    keywords?: readonly string[];
+  }
+>;
+
+function classifyWorkboardToolRisk(id: WorkboardToolId): "low" | "medium" {
   if (id.endsWith(".list") || id.endsWith(".get")) {
     return "low";
   }
   return "medium";
 }
 
-export const WORKBOARD_TOOL_REGISTRY: readonly ToolDescriptor[] = [
-  {
-    id: "workboard.capture",
-    description:
-      "Create a backlog WorkItem and queue planner refinement. Use when work is multi-step, ambiguous, or should continue beyond the current turn.",
-    risk: "medium",
-    requires_confirmation: false,
-    keywords: ["workboard", "capture", "backlog", "refine", "plan", "task"],
-    source: "builtin",
-    family: "workboard",
-    inputSchema: WORKBOARD_GENERIC_INPUT_SCHEMA,
-  },
-  ...(
-    [
-      ["workboard.item.list", "List WorkItems in the current work scope."],
-      ["workboard.item.get", "Fetch a single WorkItem by id."],
-      ["workboard.item.create", "Create a WorkItem directly in the current work scope."],
-      ["workboard.item.delete", "Delete a WorkItem from the current work scope."],
-      [
-        "workboard.item.update",
-        "Update mutable WorkItem fields such as title, priority, or acceptance.",
-      ],
-      ["workboard.item.transition", "Transition a WorkItem to a new top-level state."],
-      ["workboard.task.list", "List tasks for a WorkItem."],
-      ["workboard.task.get", "Fetch a task for the current work scope by id."],
-      ["workboard.task.create", "Create a task for a WorkItem."],
-      ["workboard.task.delete", "Delete a task from the current work scope."],
-      ["workboard.task.update", "Update a WorkItem task."],
-      ["workboard.artifact.list", "List WorkBoard artifacts."],
-      ["workboard.artifact.get", "Fetch a WorkBoard artifact by id."],
-      ["workboard.artifact.create", "Create a WorkBoard artifact."],
-      ["workboard.artifact.delete", "Delete a WorkBoard artifact by id."],
-      ["workboard.decision.list", "List WorkBoard decisions."],
-      ["workboard.decision.get", "Fetch a WorkBoard decision by id."],
-      ["workboard.decision.create", "Create a WorkBoard decision."],
-      ["workboard.decision.delete", "Delete a WorkBoard decision by id."],
-      ["workboard.signal.list", "List WorkBoard signals."],
-      ["workboard.signal.get", "Fetch a WorkBoard signal by id."],
-      ["workboard.signal.create", "Create a WorkBoard signal."],
-      ["workboard.signal.delete", "Delete a WorkBoard signal by id."],
-      ["workboard.signal.update", "Update a WorkBoard signal."],
-      ["workboard.state.list", "List WorkBoard state entries for the agent or a WorkItem."],
-      ["workboard.state.get", "Fetch a WorkBoard state entry."],
-      ["workboard.state.delete", "Delete a WorkBoard state entry."],
-      ["workboard.state.set", "Set a WorkBoard state entry."],
-      ["workboard.subagent.list", "List subagents for the current work scope."],
-      ["workboard.subagent.get", "Fetch a subagent by id."],
-      ["workboard.subagent.spawn", "Spawn a helper subagent and run a bounded prompt through it."],
-      ["workboard.subagent.send", "Send another prompt to an existing subagent."],
-      ["workboard.subagent.close", "Request subagent closure."],
-      ["workboard.clarification.list", "List clarification requests for the current work scope."],
-      [
-        "workboard.clarification.request",
-        "Request clarification through the main user-facing agent and send a steer notification.",
-      ],
-      [
-        "workboard.clarification.answer",
-        "Answer a clarification request on behalf of the main user-facing agent.",
-      ],
-      ["workboard.clarification.cancel", "Cancel an open clarification request."],
-    ] as const
-  ).map(([id, description]) => ({
+export const WORKBOARD_TOOL_REGISTRY: readonly ToolDescriptor[] = (
+  Object.keys(WORKBOARD_TOOL_METADATA) as WorkboardToolId[]
+).map((id) => {
+  const metadata = WORKBOARD_TOOL_METADATA[id];
+  return {
     id,
-    description,
+    description: metadata.description,
     risk: classifyWorkboardToolRisk(id),
     requires_confirmation: false,
-    keywords: ["workboard", "task", "subagent", "clarification", "state"],
-    source: "builtin" as const,
+    keywords: "keywords" in metadata ? metadata.keywords : DEFAULT_WORKBOARD_KEYWORDS,
+    source: "builtin",
     family: "workboard",
-    inputSchema: WORKBOARD_GENERIC_INPUT_SCHEMA,
-  })),
-] as const;
+    inputSchema: WORKBOARD_TOOL_INPUT_SCHEMAS[id],
+  };
+});

--- a/packages/gateway/tests/unit/agent-runtime-tool-schema-fallback.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-tool-schema-fallback.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayContainer } from "../../src/container.js";
 import { McpManager } from "../../src/modules/agent/mcp-manager.js";
+import { WORKBOARD_TOOL_REGISTRY } from "../../src/modules/agent/tool-catalog-workboard.js";
 import { buildBuiltinMemoryServerSpec } from "../../src/modules/memory/builtin-mcp.js";
 import {
   createToolSetBuilder,
@@ -122,5 +123,54 @@ describe("ToolSetBuilder schema fallback", () => {
     } finally {
       await mcpManager.shutdown();
     }
+  });
+
+  it("registers workboard artifact tools with explicit model-safe properties", async () => {
+    ({ homeDir, container } = await setupTestEnv());
+
+    const toolSetBuilder = createToolSetBuilder({
+      home: homeDir,
+      container,
+      policyService: {
+        isEnabled: () => false,
+        isObserveOnly: () => false,
+      },
+    });
+    const descriptor = WORKBOARD_TOOL_REGISTRY.find((tool) => tool.id === "workboard.artifact.get");
+    expect(descriptor).toBeDefined();
+    if (!descriptor) {
+      throw new Error("missing workboard.artifact.get descriptor");
+    }
+
+    const toolSet = toolSetBuilder.buildToolSet(
+      [descriptor],
+      {
+        execute: vi.fn(async () => ({
+          tool_call_id: "tc-workboard-artifact-get",
+          output: "ok",
+        })),
+      } as never,
+      new Set<string>(),
+      {
+        planId: "plan-workboard",
+        sessionId: "session-workboard",
+        channel: "test",
+        threadId: "thread-workboard",
+      },
+      makeContextReport() as never,
+    );
+
+    const modelTool = toolSet["workboard_artifact_get"] as {
+      inputSchema?: { jsonSchema?: Record<string, unknown> };
+    };
+
+    expect(modelTool.inputSchema?.jsonSchema).toMatchObject({
+      type: "object",
+      properties: {
+        artifact_id: { type: "string" },
+      },
+      required: ["artifact_id"],
+      additionalProperties: false,
+    });
   });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -303,6 +303,20 @@ describe("tool registry routes", () => {
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         source: "builtin",
+        canonical_id: "workboard.artifact.get",
+        input_schema: {
+          type: "object",
+          properties: {
+            artifact_id: { type: "string" },
+          },
+          required: ["artifact_id"],
+          additionalProperties: false,
+        },
+      }),
+    );
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
+        source: "builtin",
         canonical_id: "tool.automation.schedule.list",
         family: "automation",
       }),

--- a/packages/gateway/tests/unit/workboard-tool-metadata.test.ts
+++ b/packages/gateway/tests/unit/workboard-tool-metadata.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { getExecutionProfile } from "../../src/modules/agent/execution-profiles.js";
 import { WORKBOARD_TOOL_REGISTRY } from "../../src/modules/agent/tool-catalog-workboard.js";
+import { WORKBOARD_TOOL_INPUT_SCHEMAS } from "../../src/modules/agent/tool-catalog-workboard-schemas.js";
+import type { ToolDescriptor } from "../../src/modules/agent/tools.js";
 
 function toolRisk(id: string): "low" | "medium" | undefined {
   return WORKBOARD_TOOL_REGISTRY.find((tool) => tool.id === id)?.risk;
+}
+
+function toolSchema(id: string): Record<string, unknown> | undefined {
+  return WORKBOARD_TOOL_REGISTRY.find((tool) => tool.id === id)?.inputSchema;
+}
+
+function expectToolSchema(id: string): Record<string, unknown> {
+  const schema = toolSchema(id);
+  expect(schema).toBeDefined();
+  return schema as Record<string, unknown>;
 }
 
 describe("WorkBoard tool metadata", () => {
@@ -25,5 +37,60 @@ describe("WorkBoard tool metadata", () => {
 
   it("keeps the interaction profile wildcard allowlist minimal", () => {
     expect(getExecutionProfile("interaction").tool_allowlist).toEqual(["*"]);
+  });
+
+  it("keeps registry ids and explicit schema ids in exact sync", () => {
+    expect(WORKBOARD_TOOL_REGISTRY.map((tool) => tool.id).toSorted()).toEqual(
+      Object.keys(WORKBOARD_TOOL_INPUT_SCHEMAS).toSorted(),
+    );
+  });
+
+  it("defines explicit object properties for every workboard tool schema", () => {
+    for (const tool of WORKBOARD_TOOL_REGISTRY) {
+      expect(tool.inputSchema).toMatchObject({
+        type: "object",
+        properties: expect.any(Object),
+        additionalProperties: false,
+      } satisfies Partial<ToolDescriptor["inputSchema"]>);
+    }
+  });
+
+  it("keeps representative workboard schemas aligned with executor inputs", () => {
+    expect(expectToolSchema("workboard.artifact.get")).toMatchObject({
+      properties: {
+        artifact_id: { type: "string" },
+      },
+      required: ["artifact_id"],
+      additionalProperties: false,
+    });
+    expect(expectToolSchema("workboard.item.transition")).toMatchObject({
+      properties: {
+        work_item_id: { type: "string" },
+        status: {
+          type: "string",
+          enum: ["backlog", "ready", "blocked", "done", "failed", "cancelled"],
+        },
+      },
+      required: ["work_item_id", "status"],
+    });
+    expect(expectToolSchema("workboard.state.set")).toMatchObject({
+      properties: {
+        key: { type: "string" },
+        scope_kind: { type: "string", enum: ["agent", "work_item"] },
+        work_item_id: { type: "string" },
+        value_json: expect.any(Object),
+        provenance_json: expect.any(Object),
+      },
+      required: ["key"],
+    });
+    expect(expectToolSchema("workboard.subagent.spawn")).toMatchObject({
+      properties: {
+        message: { type: "string" },
+        execution_profile: { type: "string" },
+        work_item_id: { type: "string" },
+        work_item_task_id: { type: "string" },
+      },
+      required: ["message", "execution_profile"],
+    });
   });
 });


### PR DESCRIPTION
Closes #1382

## What changed
- replace the generic WorkBoard tool input schema with explicit per-tool schemas that match executor arguments
- make the WorkBoard tool registry exhaustive so every registered tool has explicit metadata and schema coverage
- add regression tests for schema metadata, the `workboard_artifact_get` model alias path, and the tool registry route surface

## How to test
- `pnpm install`
- `pnpm lint`
- `pnpm exec vitest run packages/gateway/tests/unit/workboard-tool-metadata.test.ts packages/gateway/tests/unit/agent-runtime-tool-schema-fallback.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts`
- `pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json`
- `pnpm typecheck`

## Risk
- low; this changes the advertised WorkBoard tool schema surface without changing executor behavior

## Rollback
- revert commit `7e32d202129b71f93ba69173626b89a27273df33`