### PR TITLE
docs: align protocol docs and add surface readmes

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,35 @@
+# `@tyrum/web`
+
+Standalone Vite operator web app for Tyrum.
+
+## Purpose
+
+This app boots `@tyrum/operator-ui` in a browser environment and connects it to the gateway via
+`@tyrum/operator-core/browser`.
+
+The gateway can also serve a bundled operator UI at `/ui`. This app exists for standalone web
+development and browser-focused iteration.
+
+## Entry point
+
+- `apps/web/src/main.tsx`
+
+The app:
+
+- resolves gateway HTTP/WS URLs from local storage, Vite env vars, or the current origin
+- supports cookie auth by default and bearer-token bootstrap from URL auth handoff
+- creates the shared operator core manager and admin access controller
+- renders `OperatorUiApp` in `mode="web"`
+
+## Commands
+
+- `pnpm --filter @tyrum/web dev`
+- `pnpm --filter @tyrum/web build`
+- `pnpm --filter @tyrum/web typecheck`
+
+## Notes
+
+- Runtime UI state is primarily shared with other operator surfaces through
+  `@tyrum/operator-core` and `@tyrum/operator-ui`.
+- Gateway reconfiguration is stored in browser local storage (`tyrum-gateway-http`,
+  `tyrum-gateway-ws`).

--- a/docs/architecture/approvals.md
+++ b/docs/architecture/approvals.md
@@ -15,7 +15,7 @@ Approvals are **enforcement**, not prompt guidance.
 
 ## Approval lifecycle
 
-1. **Requested:** the gateway persists an approval request and emits an event.
+1. **Requested:** the gateway persists an approval request.
 2. **Resolved:** an operator approves/denies (or it expires).
 3. **Applied:** the waiting workflow/run resumes, cancels, or escalates.
 
@@ -28,13 +28,16 @@ Approvals are durable records in the StateStore and should behave correctly when
 - **Any gateway edge instance can serve the approval queue** (read from the StateStore) and accept resolution requests.
 - **Atomic resolution:** apply `pending → approved|denied|expired` transitions in a single durable write so double-submission is safe.
 - **Durable side effects:** engine resume/cancel is driven by a leased, durable action queue so retries and multi-instance deployments do not duplicate side effects.
-- **At-least-once events:** `approval.requested` / `approval.resolved` events may be delivered more than once; clients should dedupe using event ids. Re-emission of the same `approval.resolved` transition reuses the persisted `event_id`.
+- **At-least-once events:** `approval.updated` events may be delivered more than once; clients
+  should dedupe using event ids. Re-emission of the same approval transition reuses the persisted
+  `event_id`.
 
 ## Interfaces
 
 Approvals are exposed over:
 
-- WebSocket requests/responses plus server-push events (for real-time operator clients)
+- WebSocket requests/responses plus `approval.updated` server-push events (for real-time operator
+  clients)
 - HTTP APIs (for automation and operational tooling)
 
 ## Scoping
@@ -101,8 +104,7 @@ When a workflow step requires approval:
 
 Approvals should be observable via gateway-emitted events:
 
-- `approval.requested`
-- `approval.resolved`
+- `approval.updated`
 - `policy_override.created` (when `mode=always` creates an override)
 - `policy_override.revoked` / `policy_override.expired`
 - `run.paused` (with reason: approval)

--- a/docs/architecture/contracts.md
+++ b/docs/architecture/contracts.md
@@ -7,6 +7,10 @@ Contracts define the shapes and semantics of Tyrum interfaces. They are used to 
 - Plugin registration surfaces
 - Stored event payloads (so persisted data stays interpretable over time)
 
+For schema-backed interfaces, the exported contracts in `packages/schemas` are the authoritative
+source of truth. Architecture docs may summarize or explain those interfaces, but the schema
+definitions govern the actual wire and validation behavior.
+
 ## Contract formats
 
 Tyrum contracts are:

--- a/docs/architecture/gateway/index.md
+++ b/docs/architecture/gateway/index.md
@@ -64,3 +64,31 @@ flowchart TB
 - **Node interface:** WebSocket with pairing, capability advertisement, and capability RPC.
 - **Extensions:** tool schemas, plugin registration, and (optionally) MCP servers.
 - **Execution/approvals:** requests/events for starting runs, streaming progress, pausing for approval, and resuming with resume tokens.
+
+## Implementation map
+
+The current implementation is organized by gateway module rather than by a separate service per box
+in the diagrams:
+
+- **Edge/API surface:** `routes`, `ws`, `modules/auth`, `modules/authz`, `modules/ingress`
+- **Execution/work coordination:** `modules/execution`, `modules/approval`, `modules/workboard`,
+  `modules/playbook`, `modules/watcher`, `modules/automation`
+- **Durability/runtime state:** `modules/statestore`, `modules/artifact`, `modules/backplane`,
+  `modules/presence`, `modules/runtime-state`
+- **Agent/runtime support:** `modules/agent`, `modules/memory`, `modules/context`,
+  `modules/planner`, `modules/review`
+- **Device and node orchestration:** `modules/node`, `modules/desktop`, `modules/mobile`,
+  `modules/desktop-environments`
+
+## Integration map
+
+External integrations are also grouped into gateway modules:
+
+- **Models and provider auth:** `modules/models`, `routes/provider-config.ts`,
+  `routes/auth-profiles.ts`, `routes/provider-oauth.ts`
+- **Tools, plugins, and extensions:** `modules/plugins`, `modules/extensions`,
+  `routes/tool-registry.ts`, `routes/extensions.ts`
+- **Secrets and policy:** `modules/secret`, `modules/policy`, `routes/secret.ts`,
+  `routes/policy.ts`, `routes/policy-bundle.ts`
+- **Channels and external ingress:** `modules/channels`, `routes/ingress.ts`,
+  `routes/routing-config.ts`

--- a/docs/architecture/node.md
+++ b/docs/architecture/node.md
@@ -64,9 +64,9 @@ sequenceDiagram
   participant Client
 
   Node->>Gateway: connect.init/connect.proof (role=node, device, capabilities)
-  Gateway-->>Client: pairing.requested(node_id, identity)
+  Gateway-->>Client: pairing.updated(pairing.status=queued)
   Client->>Gateway: pairing.approve(node_id)
-  Gateway-->>Node: pairing.approved(scoped_token)
+  Gateway-->>Node: pairing.updated(scoped_token)
   Node-->>Gateway: capability.ready(...)
   Node-->>Gateway: attempt.evidence(...)
 ```

--- a/docs/architecture/protocol/events.md
+++ b/docs/architecture/protocol/events.md
@@ -6,8 +6,11 @@ The wire shapes are defined by shared, versioned contracts (see [Contracts](../c
 
 ## Event envelope
 
-- `event_id`: unique id for dedupe. For `approval.resolved`, `pairing.resolved`, and `policy_override.created`, the gateway persists event identity so re-emission of the same transition reuses the same `event_id`.
-- `type`: event name (for example `run.updated`, `approval.requested`, `artifact.created`, `capability.ready`, `attempt.evidence`).
+For current event names and payloads, treat the schema exports in `packages/schemas` as
+authoritative. This page mirrors that contract for operator and implementation guidance.
+
+- `event_id`: unique id for dedupe. For `approval.updated`, `pairing.updated`, and `policy_override.created`, the gateway persists event identity so re-emission of the same transition reuses the same `event_id`.
+- `type`: event name (for example `run.updated`, `approval.updated`, `artifact.created`, `capability.ready`, `attempt.evidence`).
 - `occurred_at`: timestamp.
 - `scope`: routing scope (global, agent, session key/lane, run, node, or client).
 - `payload`: typed fields defined by a contract.
@@ -16,9 +19,9 @@ The wire shapes are defined by shared, versioned contracts (see [Contracts](../c
 
 - **Connection lifecycle:** connected/disconnected, heartbeat timeouts.
 - **Presence:** gateway/client/node presence upserts, prunes, and snapshots (see [Presence](../presence.md)).
-- **Pairing:** node requested/approved/denied/revoked.
+- **Pairing:** node pairing state changes, including approval and revocation.
 - **Node capability readiness:** nodes report capability readiness (for example `capability.ready`).
-- **Approvals:** requests/resolutions, expiry.
+- **Approvals:** approval state changes, expiry, and linked policy override lifecycle.
 - **Execution engine:** run queued/started/paused/resumed/completed/failed; step started/completed; retries and budget events.
 - **Evidence:** artifacts captured/attached; postconditions passed/failed.
 - **Agent runtime:** plan/workflow selection and high-level intent updates.
@@ -29,12 +32,12 @@ The wire shapes are defined by shared, versioned contracts (see [Contracts](../c
 
 ## Event catalog (v1)
 
-This is the canonical list of `type` values and payload contracts for the v1 WebSocket event stream (protocol revision `2`).
+This is the documented list of `type` values and payload contracts for the v1 WebSocket event
+stream (protocol revision `2`), aligned to the current exported schemas.
 
 ### Approvals and policy
 
-- `approval.requested` — `{ approval: Approval }`
-- `approval.resolved` — `{ approval: Approval }`
+- `approval.updated` — `{ approval: Approval }`
 - `policy_override.created` — `{ override: PolicyOverride }`
 - `policy_override.revoked` — `{ override: PolicyOverride }`
 - `policy_override.expired` — `{ override: PolicyOverride }`
@@ -72,9 +75,7 @@ This is the canonical list of `type` values and payload contracts for the v1 Web
 
 ### Pairing and presence
 
-- `pairing.requested` — `{ pairing: NodePairingRequest }`
-- `pairing.approved` — `{ pairing: NodePairingRequest, scoped_token }`
-- `pairing.resolved` — `{ pairing: NodePairingRequest }`
+- `pairing.updated` — `{ pairing: NodePairingRequest, scoped_token? }`
 - `presence.upserted` — `{ entry: PresenceEntry }`
 - `presence.pruned` — `{ instance_id }`
 
@@ -101,11 +102,12 @@ This is the canonical list of `type` values and payload contracts for the v1 Web
 
 ## Notes
 
-- Some gateway→peer interactions are modeled as **requests** (with responses) rather than events, for example `task.execute` and `approval.request`.
+- Some gateway→peer interactions are modeled as **requests** (with responses) rather than events,
+  for example `task.execute` and `approval.resolve`.
 - Events are **tenant-scoped**. The gateway delivers an event only to peers authenticated within the same `tenant_id`.
 - Stable event identity is currently persisted for:
-  - `approval.resolved` (per approval transition)
-  - `pairing.resolved` (per pairing transition/status)
+  - `approval.updated` (per approval transition/status)
+  - `pairing.updated` (per pairing transition/status)
   - `policy_override.created` (per override)
 
 ## Delivery expectations
@@ -113,7 +115,9 @@ This is the canonical list of `type` values and payload contracts for the v1 Web
 - Events are delivered **at-least-once**. Consumers must tolerate duplicates and implement idempotent handling.
 - Consumers should tolerate **unknown `type` values** (forward-compat) and ignore events they don't recognize.
 - Deduplicate using `event_id` (and treat `occurred_at` as informational, not a strict ordering guarantee).
-- Re-emitting the same `approval.resolved`, `pairing.resolved`, or `policy_override.created` transition preserves the original `event_id`; other event types may still receive fresh ids when independently re-emitted.
+- Re-emitting the same `approval.updated`, `pairing.updated`, or `policy_override.created`
+  transition preserves the original `event_id`; other event types may still receive fresh ids when
+  independently re-emitted.
 - Clients should tolerate reconnect and resubscribe without losing safety invariants; durable state in the StateStore remains the source of truth.
 
 ### Client SDK semantics

--- a/docs/architecture/protocol/handshake.md
+++ b/docs/architecture/protocol/handshake.md
@@ -94,4 +94,8 @@ After a connection is authenticated, the gateway authorizes what the peer can do
 
 Nodes require pairing approval before they can execute capabilities. Pairing binds a node device identity to a trust level and a scoped capability allowlist, and it can be revoked at any time.
 
-On approval, the gateway issues a node-scoped access token and delivers it to the node via a `pairing.approved` event (`payload.scoped_token`). Nodes can persist this token and use it for WS upgrade authentication (for example via `tyrum-auth.<base64url(token)>`) to reduce bootstrap-token usage during normal operation. Revocation invalidates this scoped token immediately.
+On approval, the gateway issues a node-scoped access token and delivers it to the node via a
+`pairing.updated` event when the pairing transitions to `approved` (`payload.scoped_token`). Nodes
+can persist this token and use it for WS upgrade authentication (for example via
+`tyrum-auth.<base64url(token)>`) to reduce bootstrap-token usage during normal operation.
+Revocation invalidates this scoped token immediately.

--- a/docs/architecture/protocol/index.md
+++ b/docs/architecture/protocol/index.md
@@ -8,11 +8,15 @@ Tyrum uses a typed WebSocket protocol between the gateway, clients, and nodes. T
 
 The wire shapes are defined by shared, versioned contracts (see [Contracts](../contracts.md)).
 
+For wire-level behavior, the exported schemas in `packages/schemas` are the source of truth. The
+architecture docs explain intent and usage, but schema-backed request/response/event names win when
+they disagree with prose examples.
+
 The protocol is the primary interface for:
 
 - interactive chat sessions
 - workflow execution progress (runs/steps)
-- approvals (requested/resolved) and resume control
+- approvals and resume control
 - node pairing and capability RPC
 
 ## Transport

--- a/docs/architecture/protocol/requests-responses.md
+++ b/docs/architecture/protocol/requests-responses.md
@@ -59,4 +59,6 @@ Distributed systems lose packets and drop connections; retries are expected. Tyr
 
 - Resolution is an atomic state transition on the durable approval record (`pending → approved|denied|expired`).
 - Only the first successful transition enqueues a durable engine action (resume/cancel). Duplicate resolve attempts for an already-resolved approval do not enqueue additional actions.
-- `approval.resolved` is emitted once per approval transition, and any re-emission of that same transition reuses the persisted `event_id`; delivery is still at-least-once, so consumers should dedupe using `event_id`.
+- `approval.updated` is emitted for each approval transition/status change, and re-emission of that
+  same transition reuses the persisted `event_id`; delivery is still at-least-once, so consumers
+  should dedupe using `event_id`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,34 @@
+# `@tyrum/cli`
+
+Command-line operator client for Tyrum.
+
+## Purpose
+
+This package provides scripted and terminal-friendly access to common operator workflows without
+running the full desktop or web UI.
+
+## Entry points
+
+- library: `packages/cli/src/index.ts`
+- CLI runtime: `packages/cli/src/run-cli.ts`
+- binary: `tyrum-cli`
+
+## Current command areas
+
+- approvals
+- pairing
+- workflow run/resume/cancel
+- elevated mode
+- policy bundle and policy overrides
+- secrets
+- operator config and device identity
+
+## Commands
+
+- `pnpm --filter @tyrum/cli build`
+- `pnpm --filter @tyrum/cli start -- --help`
+
+## Notes
+
+- The CLI uses the shared client stack from `@tyrum/client` and `@tyrum/cli-utils`.
+- It is an operator client, not a capability node. Device automation stays behind paired nodes.

--- a/packages/desktop-node/README.md
+++ b/packages/desktop-node/README.md
@@ -1,0 +1,38 @@
+# `@tyrum/desktop-node`
+
+Desktop capability-provider runtime for Tyrum.
+
+## Purpose
+
+This package connects to the gateway as a `role: node` peer and exposes desktop-local capabilities
+such as desktop automation, accessibility-backed inspection, and OCR-assisted query support.
+
+It is used both by the standalone desktop-node CLI and by desktop-oriented Tyrum environments.
+
+## Entry points
+
+- library: `packages/desktop-node/src/index.ts`
+- CLI runtime: `packages/desktop-node/src/cli/run-cli.ts`
+- binary: `tyrum-desktop-node`
+
+## Runtime shape
+
+The node runtime:
+
+- loads or creates a device identity under `$TYRUM_HOME/desktop-node`
+- connects to the gateway over WebSocket using node auth
+- advertises desktop capabilities and listens for pairing updates
+- executes desktop actions through the provider/backends in `src/providers`
+
+## Commands
+
+- `pnpm --filter @tyrum/desktop-node build`
+- `pnpm --filter @tyrum/desktop-node start -- --help`
+- `pnpm --filter @tyrum/desktop-node test`
+
+## Notes
+
+- Default gateway WS URL: `ws://127.0.0.1:8788/ws`
+- Tokens can be passed directly or loaded from a token file/environment.
+- This package is a node runtime, not an operator client. Approval, policy, and pairing decisions
+  still live in the gateway and operator surfaces.

--- a/packages/operator-core/README.md
+++ b/packages/operator-core/README.md
@@ -1,6 +1,7 @@
 # `@tyrum/operator-core`
 
 Shared, renderer-agnostic operator state + actions built on top of `@tyrum/client` (WS + HTTP).
+This package is the client-side foundation used by the web app, desktop app, mobile app, and TUI.
 
 ## Usage
 
@@ -123,6 +124,44 @@ const connection = useSyncExternalStore(
 - `refreshStatus()`
 - `refreshUsage(query?)`
 - `refreshPresence()`
+
+### `workboardStore`
+
+Tracks WorkBoard items, tasks, drilldown records, and selection state for the operator work view.
+
+### `chatStore`
+
+Tracks session/chat threads, active session state, and live AI SDK chat updates used by operator
+clients.
+
+### `agentStatusStore`
+
+Tracks agent inventory and high-level status summaries used by the operator dashboard and agent
+management surfaces.
+
+### `desktopEnvironmentHostsStore` / `desktopEnvironmentsStore`
+
+Track gateway-managed desktop environment hosts, lifecycle state, logs, and related admin actions.
+
+### `elevatedModeStore`
+
+Tracks time-bounded elevated mode used to unlock admin or mutating operations from operator
+surfaces.
+
+### `autoSyncStore`
+
+Tracks background sync work scheduled after reconnects and explicit refreshes.
+
+## Surface summary
+
+`createOperatorCore()` returns a single object that owns:
+
+- WebSocket + HTTP clients
+- connection lifecycle controls
+- elevated-mode state
+- approvals, runs, pairing, status, workboard, chat, activity, and agent-status stores
+- desktop-environment stores for operator/admin surfaces
+- reconnect-driven best-effort resync via `syncAllNow()`
 
 ## Reconnect semantics
 

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -1,0 +1,36 @@
+# `@tyrum/tui`
+
+Ink-based terminal UI client for Tyrum.
+
+## Purpose
+
+This package provides a live terminal operator surface backed by `@tyrum/operator-core`.
+
+It is aimed at operators who want a persistent terminal workflow rather than the browser or desktop
+app.
+
+## Entry points
+
+- library: `packages/tui/src/index.ts`
+- CLI runtime: `packages/tui/src/cli.ts`
+- binary: `tyrum-tui`
+
+## Runtime shape
+
+The TUI:
+
+- resolves gateway URLs, auth token, and device identity from CLI args and environment
+- creates a shared operator-core-backed runtime
+- renders the Ink app defined in `packages/tui/src/app.tsx`
+
+## Commands
+
+- `pnpm --filter @tyrum/tui build`
+- `pnpm --filter @tyrum/tui start -- --help`
+- `pnpm --filter @tyrum/tui test`
+
+## Notes
+
+- Default gateway URL: `http://127.0.0.1:8788`
+- Default Tyrum home: `~/.tyrum`
+- The TUI is an operator client only; it does not execute node capability calls itself.


### PR DESCRIPTION
## Summary

- align approval and pairing protocol docs to the current `approval.updated` / `pairing.updated` event model
- make `packages/schemas` the explicit source of truth for wire-level protocol behavior in the docs
- refresh `@tyrum/operator-core` docs and add missing READMEs for the web app, CLI, TUI, and desktop node
- add concise gateway implementation and integration maps for contributors

Closes #1394.

## Testing

- `pnpm docs:public-check`
- `pnpm format:check`
- `pnpm --filter @tyrum/docs build`
- pre-push hook: `pnpm lint`
- pre-push hook: `pnpm typecheck`
- pre-push hook: `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- pre-push hook: `pnpm test`

## Risk

Docs-only change. No runtime, schema, route, or protocol behavior changes.

## Rollback

Revert commit `a7a4341d`.
