### PR TITLE
Fix elevated-mode admin client refresh churn

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-shared.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-shared.tsx
@@ -27,13 +27,14 @@ export function isAdminAccessHttpError(error: unknown): boolean {
 function createElevatedAdminHttpClient(input: {
   core: OperatorCore;
   mode: ReturnType<typeof useElevatedModeUiContext>["mode"];
-  elevatedMode: ElevatedModeState;
+  elevatedStatus: ElevatedModeState["status"];
+  elevatedToken: ElevatedModeState["elevatedToken"];
 }): AdminHttpClient | null {
-  if (input.elevatedMode.status !== "active" || !input.elevatedMode.elevatedToken) return null;
+  if (input.elevatedStatus !== "active" || !input.elevatedToken) return null;
 
   return createTyrumHttpClient({
     baseUrl: input.core.httpBaseUrl,
-    auth: { type: "bearer", token: input.elevatedMode.elevatedToken },
+    auth: { type: "bearer", token: input.elevatedToken },
     fetch: resolveTyrumHttpFetch(input.mode),
   });
 }
@@ -59,9 +60,17 @@ export function useAdminHttpClient(options?: {
   const { core, mode } = useElevatedModeUiContext();
   const access = options?.access ?? "read";
   const elevatedMode = useOperatorStore(core.elevatedModeStore);
+  const elevatedStatus = elevatedMode.status;
+  const elevatedToken = elevatedMode.elevatedToken;
   const elevatedHttp = useMemo(
-    () => createElevatedAdminHttpClient({ core, mode, elevatedMode }),
-    [core, elevatedMode, mode],
+    () =>
+      createElevatedAdminHttpClient({
+        core,
+        mode,
+        elevatedStatus,
+        elevatedToken,
+      }),
+    [core.httpBaseUrl, elevatedStatus, elevatedToken, mode],
   );
 
   if (access === "strict") {
@@ -74,10 +83,18 @@ export function useAdminHttpClient(options?: {
 export function useAdminMutationHttpClient(): AdminHttpClient | null {
   const { core, mode } = useElevatedModeUiContext();
   const elevatedMode = useOperatorStore(core.elevatedModeStore);
+  const elevatedStatus = elevatedMode.status;
+  const elevatedToken = elevatedMode.elevatedToken;
 
   return useMemo(
-    () => createElevatedAdminHttpClient({ core, mode, elevatedMode }),
-    [core, elevatedMode, mode],
+    () =>
+      createElevatedAdminHttpClient({
+        core,
+        mode,
+        elevatedStatus,
+        elevatedToken,
+      }),
+    [core.httpBaseUrl, elevatedStatus, elevatedToken, mode],
   );
 }
 

--- a/packages/operator-ui/tests/pages/admin-http-shared.hook.test.tsx
+++ b/packages/operator-ui/tests/pages/admin-http-shared.hook.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 
 import React, { act } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createElevatedModeStore, type OperatorCore } from "@tyrum/operator-core";
 import { ElevatedModeProvider } from "../../src/elevated-mode.js";
 import { useAdminHttpClient } from "../../src/components/pages/admin-http-shared.js";
 import { cleanupTestRoot, renderIntoDocument, type TestRoot } from "../test-utils.js";
 
-function createTestCore() {
-  const baseStore = createElevatedModeStore({ tickIntervalMs: 0 });
+function createTestCore(options?: { tickIntervalMs?: number }) {
+  const baseStore = createElevatedModeStore({ tickIntervalMs: options?.tickIntervalMs ?? 0 });
   let subscribeCalls = 0;
   const elevatedModeStore = {
     ...baseStore,
@@ -33,6 +33,7 @@ function createTestCore() {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   document.body.innerHTML = "";
 });
 
@@ -99,6 +100,66 @@ describe("useAdminHttpClient", () => {
       });
 
       expect(hasStrictClient).toBe(true);
+    } finally {
+      if (testRoot) cleanupTestRoot(testRoot);
+      baseStore.dispose();
+    }
+  });
+
+  it("keeps the elevated client stable across countdown ticks, recreates it for a new token, and falls back on exit", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+
+    const { baseStore, core, readHttp } = createTestCore({ tickIntervalMs: 1_000 });
+    let testRoot: TestRoot | null = null;
+    let resolvedClient: OperatorCore["http"] | null = null;
+
+    function ReadProbe() {
+      resolvedClient = useAdminHttpClient();
+      return null;
+    }
+
+    try {
+      testRoot = renderIntoDocument(
+        <ElevatedModeProvider core={core} mode="web">
+          <ReadProbe />
+        </ElevatedModeProvider>,
+      );
+
+      expect(resolvedClient).toBe(readHttp);
+
+      act(() => {
+        baseStore.enter({
+          elevatedToken: "token-1",
+          expiresAt: "2026-03-01T00:01:00.000Z",
+        });
+      });
+
+      const firstElevatedClient = resolvedClient;
+      expect(firstElevatedClient).not.toBeNull();
+      expect(firstElevatedClient).not.toBe(readHttp);
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+
+      expect(resolvedClient).toBe(firstElevatedClient);
+
+      act(() => {
+        baseStore.enter({
+          elevatedToken: "token-2",
+          expiresAt: "2026-03-01T00:02:00.000Z",
+        });
+      });
+
+      expect(resolvedClient).not.toBe(firstElevatedClient);
+      expect(resolvedClient).not.toBe(readHttp);
+
+      act(() => {
+        baseStore.exit();
+      });
+
+      expect(resolvedClient).toBe(readHttp);
     } finally {
       if (testRoot) cleanupTestRoot(testRoot);
       baseStore.dispose();

--- a/packages/operator-ui/tests/pages/admin-page.http.providers.elevated-mode.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.providers.elevated-mode.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setNativeValue } from "../test-utils.js";
+import {
+  cleanupAdminHttpPage,
+  flush,
+  getByTestId,
+  getLabeledInput,
+  renderAdminHttpConfigurePage,
+  switchHttpTab,
+} from "./admin-page.http.test-support.js";
+import { TEST_TIMESTAMP, createAdminHttpTestCore } from "./admin-page.http-fixture-support.js";
+import { createElevatedModeStore } from "../../../operator-core/src/index.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ConfigurePage (HTTP) providers elevated mode", () => {
+  it("does not refetch providers on elevated countdown ticks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse(TEST_TIMESTAMP));
+
+    const { core } = createAdminHttpTestCore();
+    core.elevatedModeStore.dispose();
+    core.elevatedModeStore = createElevatedModeStore();
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2026-03-01T00:01:00.000Z",
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url === "http://example.test/config/providers/registry") {
+        return new Response(
+          JSON.stringify({
+            status: "ok",
+            providers: [
+              {
+                provider_key: "openai",
+                name: "OpenAI",
+                doc: null,
+                supported: true,
+                methods: [
+                  {
+                    method_key: "api_key",
+                    label: "API key",
+                    type: "api_key",
+                    fields: [
+                      {
+                        key: "api_key",
+                        label: "API key",
+                        description: null,
+                        kind: "secret",
+                        input: "password",
+                        required: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+
+      if (method === "GET" && url === "http://example.test/config/providers") {
+        return new Response(JSON.stringify({ status: "ok", providers: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const page = renderAdminHttpConfigurePage(core);
+    try {
+      await switchHttpTab(page.container, "admin-http-tab-providers");
+      await flush();
+      await flush();
+
+      const initialProviderReads = fetchMock.mock.calls.filter(([input, init]) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
+        const method = init?.method ?? "GET";
+        return (
+          method === "GET" &&
+          (url === "http://example.test/config/providers/registry" ||
+            url === "http://example.test/config/providers")
+        );
+      });
+      expect(initialProviderReads).toHaveLength(2);
+
+      const addProviderButton = getByTestId<HTMLButtonElement>(
+        page.container,
+        "providers-add-open",
+      );
+      await act(async () => {
+        addProviderButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      const dialog = getByTestId<HTMLElement>(document.body, "providers-account-dialog");
+      const displayNameInput = getLabeledInput(dialog, "Display name");
+
+      act(() => {
+        setNativeValue(displayNameInput, "Team account");
+      });
+      expect(displayNameInput.value).toBe("Team account");
+
+      await act(async () => {
+        vi.advanceTimersByTime(1_000);
+        await Promise.resolve();
+      });
+      await flush();
+      await flush();
+
+      const providerReadsAfterTick = fetchMock.mock.calls.filter(([input, init]) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : "";
+        const method = init?.method ?? "GET";
+        return (
+          method === "GET" &&
+          (url === "http://example.test/config/providers/registry" ||
+            url === "http://example.test/config/providers")
+        );
+      });
+      expect(providerReadsAfterTick).toHaveLength(2);
+      expect(displayNameInput.value).toBe("Team account");
+    } finally {
+      cleanupAdminHttpPage(page);
+      core.elevatedModeStore.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stabilize the elevated admin HTTP client so countdown ticks do not recreate it every second
- add a hook regression to verify the client stays stable across countdown ticks and falls back on exit
- add a Configure -> Providers regression to prove the dialog no longer refetches and resets while elevated mode is active

Closes #1398

## How to test
- pnpm exec vitest run packages/operator-ui/tests/pages/admin-http-shared.hook.test.tsx packages/operator-ui/tests/pages/admin-page.http.providers.elevated-mode.test.ts
- pnpm exec vitest run packages/operator-ui/tests/pages/admin-page.http.policy.elevated-mode.test.ts
- pnpm exec oxlint packages/operator-ui/src/components/pages/admin-http-shared.tsx packages/operator-ui/tests/pages/admin-http-shared.hook.test.tsx packages/operator-ui/tests/pages/admin-page.http.providers.elevated-mode.test.ts
- pnpm exec tsc -b packages/operator-core packages/operator-ui --pretty false
- git push -u origin 1398-fix-elevated-mode-admin-refresh

## Risk and rollback
- low-risk UI-only change in the shared admin HTTP hook
- rollback is reverting this branch or commit, which restores the prior client recreation behavior
