### PR TITLE
fix: surface workboard captures across scopes

### DIFF
--- a/apps/web/src/layout-harness-route-fixtures.tsx
+++ b/apps/web/src/layout-harness-route-fixtures.tsx
@@ -236,6 +236,13 @@ export function createWorkboardCore(): OperatorCore {
     ws: {
       ...createEventWsStub(),
     },
+    http: {
+      agents: {
+        list: async () => ({
+          agents: [{ agent_key: "default", persona: { name: "Default Agent" } }],
+        }),
+      },
+    },
     connect() {},
     disconnect() {},
   } as unknown as OperatorCore;

--- a/apps/web/src/layout-harness-store-fixtures.ts
+++ b/apps/web/src/layout-harness-store-fixtures.ts
@@ -159,12 +159,17 @@ export function createWorkboardStore() {
         },
       ],
       tasksByWorkItemId: {},
+      scopeKeys: {
+        agent_key: "default",
+        workspace_key: "default",
+      },
       supported: true,
       loading: false,
       error: null,
       lastSyncedAt: "2026-03-08T00:00:00.000Z",
     }).store,
     refreshList: async () => {},
+    setScopeKeys: () => {},
     resetSupportProbe: () => {},
     upsertWorkItem: () => {},
   };

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
@@ -296,6 +296,7 @@ export async function prepareTurn(
     nodeCapabilityInspectionService,
     memoryToolRuntime,
     deps.opts.protocolDeps?.agents,
+    deps.opts.protocolDeps,
   );
   const toolExecutionContext = {
     tenantId: session.tenant_id,

--- a/packages/gateway/src/modules/agent/tool-executor-workboard-tools-shared.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-workboard-tools-shared.ts
@@ -2,12 +2,14 @@ import type { AgentRegistry } from "./registry.js";
 import type { ToolResult, WorkspaceLeaseConfig } from "./tool-executor-shared.js";
 import type { SqlDb } from "../../statestore/types.js";
 import type { WorkScope } from "@tyrum/schemas";
+import type { WorkboardBroadcastDeps } from "../workboard/item-broadcast.js";
 import { WorkboardDal } from "../workboard/dal.js";
 export { resolveAgentKeyById, runSubagentTurn } from "../workboard/subagent-runtime-support.js";
 
 export type WorkboardToolExecutorContext = {
   workspaceLease?: WorkspaceLeaseConfig;
   agents?: AgentRegistry;
+  broadcastDeps?: WorkboardBroadcastDeps;
 };
 
 export function asRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/gateway/src/modules/agent/tool-executor-workboard-tools.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-workboard-tools.ts
@@ -1,5 +1,6 @@
 import { LaneQueueSignalDal } from "../lanes/queue-signal-dal.js";
 import { WorkboardDal } from "../workboard/dal.js";
+import { broadcastWorkItemCreated } from "../workboard/item-broadcast.js";
 import { SubagentService } from "../workboard/subagent-service.js";
 import { requireHelperExecutionProfile } from "./subagent-helper-profiles.js";
 import type { ToolExecutionAudit, ToolResult } from "./tool-executor-shared.js";
@@ -77,6 +78,7 @@ async function createCapture(
       source_session_key: createdFromSessionKey,
     },
   });
+  broadcastWorkItemCreated({ item, deps: context.broadcastDeps });
 
   return jsonResult(toolCallId, {
     work_item_id: item.work_item_id,

--- a/packages/gateway/src/modules/agent/tool-executor.ts
+++ b/packages/gateway/src/modules/agent/tool-executor.ts
@@ -23,6 +23,7 @@ import type { McpManager } from "./mcp-manager.js";
 import type { NodeDispatchService } from "./node-dispatch-service.js";
 import type { NodeCapabilityInspectionService } from "../node/capability-inspection-service.js";
 import type { AgentRegistry } from "./registry.js";
+import type { WorkboardBroadcastDeps } from "../workboard/item-broadcast.js";
 import {
   DEFAULT_DNS_LOOKUP,
   type DnsLookupFn,
@@ -59,6 +60,7 @@ export class ToolExecutor {
     private readonly nodeCapabilityInspectionService?: NodeCapabilityInspectionService,
     private readonly memoryToolRuntime?: AgentMemoryToolRuntime,
     private readonly agents?: AgentRegistry,
+    private readonly workboardBroadcastDeps?: WorkboardBroadcastDeps,
   ) {}
 
   private workspaceLeaseOwner(toolCallId: string): string {
@@ -262,6 +264,7 @@ export class ToolExecutor {
       {
         workspaceLease: this.workspaceLease,
         agents: this.agents,
+        broadcastDeps: this.workboardBroadcastDeps,
       },
       toolId,
       toolCallId,

--- a/packages/gateway/src/modules/workboard/item-broadcast.ts
+++ b/packages/gateway/src/modules/workboard/item-broadcast.ts
@@ -1,0 +1,36 @@
+import type { WorkItem } from "@tyrum/schemas";
+import { broadcastWsEvent } from "../../ws/broadcast.js";
+import type { ProtocolDeps } from "../../ws/protocol.js";
+import { WORKBOARD_WS_AUDIENCE } from "../../ws/workboard-audience.js";
+
+export type WorkboardBroadcastDeps = Pick<
+  ProtocolDeps,
+  "connectionManager" | "cluster" | "logger" | "maxBufferedBytes"
+>;
+
+export function broadcastWorkItemCreated(input: {
+  item: WorkItem;
+  deps?: WorkboardBroadcastDeps;
+}): void {
+  if (!input.deps) {
+    return;
+  }
+
+  broadcastWsEvent(
+    input.item.tenant_id,
+    {
+      event_id: crypto.randomUUID(),
+      type: "work.item.created",
+      occurred_at: new Date().toISOString(),
+      scope: { kind: "agent", agent_id: input.item.agent_id },
+      payload: { item: input.item },
+    },
+    {
+      connectionManager: input.deps.connectionManager,
+      cluster: input.deps.cluster,
+      logger: input.deps.logger,
+      maxBufferedBytes: input.deps.maxBufferedBytes,
+    },
+    WORKBOARD_WS_AUDIENCE,
+  );
+}

--- a/packages/gateway/src/ws/protocol/workboard-handlers.ts
+++ b/packages/gateway/src/ws/protocol/workboard-handlers.ts
@@ -60,6 +60,7 @@ import {
   type WorkScope,
   type TransitionItem,
 } from "./workboard-handlers-shared.js";
+import { broadcastWorkItemCreated } from "../../modules/workboard/item-broadcast.js";
 import { maybeEmitWorkItemOverlapWarningArtifact } from "./workboard-overlap-warning.js";
 
 async function maybeEnqueueTransitionNotification(params: {
@@ -103,7 +104,7 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
         item: payload.item,
         createdFromSessionKey: `agent:${keys.agentKey}:main`,
       });
-      broadcastAgentEvent(scope.tenant_id, "work.item.created", item.agent_id, { item }, deps);
+      broadcastWorkItemCreated({ item, deps });
       await maybeEmitWorkItemOverlapWarningArtifact({ dal, scope, item, deps });
       return okResult(msg, WsWorkCreateResult.parse({ item }));
     },

--- a/packages/gateway/tests/unit/workboard-orchestration-tools.test.ts
+++ b/packages/gateway/tests/unit/workboard-orchestration-tools.test.ts
@@ -13,7 +13,9 @@ import { WorkboardOrchestrator } from "../../src/modules/workboard/orchestrator.
 import { WorkboardDal } from "../../src/modules/workboard/dal.js";
 import type { AgentRegistry } from "../../src/modules/agent/registry.js";
 import { SessionLaneNodeAttachmentDal } from "../../src/modules/agent/session-lane-node-attachment-dal.js";
+import { ConnectionManager } from "../../src/ws/connection-manager.js";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { makeClient } from "./ws-workboard.test-support.js";
 
 function createFakeAgents(reply: string): AgentRegistry {
   return {
@@ -173,6 +175,112 @@ describe("WorkBoard tools and orchestration", () => {
         "workboard.subagent.spawn",
       ),
     ).toBe(false);
+  });
+
+  it("broadcasts work.item.created when workboard.capture adds backlog work", async () => {
+    db = openTestSqliteDb();
+    const cm = new ConnectionManager();
+    const { ws } = makeClient(cm);
+    const scope = {
+      tenant_id: DEFAULT_TENANT_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      workspace_id: DEFAULT_WORKSPACE_ID,
+    } as const;
+
+    const result = await executeWorkboardTool(
+      {
+        workspaceLease: {
+          db,
+          tenantId: DEFAULT_TENANT_ID,
+          agentId: DEFAULT_AGENT_ID,
+          workspaceId: DEFAULT_WORKSPACE_ID,
+        },
+        broadcastDeps: { connectionManager: cm },
+      },
+      "workboard.capture",
+      "tool-call-capture-1",
+      { title: "Captured with broadcast" },
+      { work_session_key: "agent:default:test:default:channel:thread-capture-broadcast" },
+    );
+
+    expect(result?.error).toBeUndefined();
+    const output = JSON.parse(result?.output ?? "{}") as {
+      work_item_id?: string;
+      status?: string;
+      refinement_phase?: string;
+    };
+    expect(output.work_item_id).toBeTruthy();
+    expect(output.refinement_phase).toBe("new");
+
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const event = JSON.parse(String(ws.send.mock.calls[0]?.[0] ?? "{}")) as {
+      type?: string;
+      payload?: { item?: { work_item_id?: string; title?: string; status?: string } };
+    };
+    expect(event.type).toBe("work.item.created");
+    expect(event.payload?.item?.work_item_id).toBe(output.work_item_id);
+    expect(event.payload?.item?.title).toBe("Captured with broadcast");
+    expect(event.payload?.item?.status).toBe(output.status);
+
+    const workboard = new WorkboardDal(db);
+    const item = await workboard.getItem({
+      scope,
+      work_item_id: output.work_item_id ?? "",
+    });
+    expect(item?.title).toBe("Captured with broadcast");
+    const tasks = await workboard.listTasks({
+      scope,
+      work_item_id: output.work_item_id ?? "",
+    });
+    expect(
+      tasks.some((task) => task.execution_profile === "planner" && task.status === "queued"),
+    ).toBe(true);
+  });
+
+  it("still captures work when broadcast deps are unavailable", async () => {
+    db = openTestSqliteDb();
+    const scope = {
+      tenant_id: DEFAULT_TENANT_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      workspace_id: DEFAULT_WORKSPACE_ID,
+    } as const;
+
+    const result = await executeWorkboardTool(
+      {
+        workspaceLease: {
+          db,
+          tenantId: DEFAULT_TENANT_ID,
+          agentId: DEFAULT_AGENT_ID,
+          workspaceId: DEFAULT_WORKSPACE_ID,
+        },
+      },
+      "workboard.capture",
+      "tool-call-capture-2",
+      { title: "Captured without broadcast" },
+      { work_session_key: "agent:default:test:default:channel:thread-capture-without-broadcast" },
+    );
+
+    expect(result?.error).toBeUndefined();
+    const output = JSON.parse(result?.output ?? "{}") as {
+      work_item_id?: string;
+      refinement_phase?: string;
+    };
+    expect(output.work_item_id).toBeTruthy();
+    expect(output.refinement_phase).toBe("new");
+
+    const workboard = new WorkboardDal(db);
+    const item = await workboard.getItem({
+      scope,
+      work_item_id: output.work_item_id ?? "",
+    });
+    expect(item?.title).toBe("Captured without broadcast");
+    const tasks = await workboard.listTasks({
+      scope,
+      work_item_id: output.work_item_id ?? "",
+    });
+    expect(
+      tasks.some((task) => task.execution_profile === "planner" && task.status === "queued"),
+    ).toBe(true);
   });
 
   it("creates one planner subagent per backlog item and completes planner tasks", async () => {

--- a/packages/operator-core/src/index.ts
+++ b/packages/operator-core/src/index.ts
@@ -88,7 +88,11 @@ export type {
 export type { Pairing, PairingState, PairingStore } from "./stores/pairing-store.js";
 export type { RunsState, RunsStore } from "./stores/runs-store.js";
 export type { OperatorPresenceEntry, StatusState, StatusStore } from "./stores/status-store.js";
-export type { WorkboardState, WorkboardStore } from "./stores/workboard-store.js";
+export type {
+  WorkboardScopeKeys,
+  WorkboardState,
+  WorkboardStore,
+} from "./stores/workboard-store.js";
 export type {
   ChatActiveSessionState,
   ChatAgent,

--- a/packages/operator-core/src/stores/workboard-store.ts
+++ b/packages/operator-core/src/stores/workboard-store.ts
@@ -12,6 +12,7 @@ import {
 export interface WorkboardState {
   items: WorkItem[];
   tasksByWorkItemId: WorkTasksByWorkItemId;
+  scopeKeys: WorkboardScopeKeys;
   supported: boolean | null;
   loading: boolean;
   error: string | null;
@@ -20,14 +21,29 @@ export interface WorkboardState {
 
 export interface WorkboardStore extends ExternalStore<WorkboardState> {
   refreshList(): Promise<void>;
+  setScopeKeys(scopeKeys: Partial<WorkboardScopeKeys>): void;
   upsertWorkItem(item: WorkItem): void;
   resetSupportProbe(): void;
 }
 
-const DEFAULT_SCOPE_KEYS = {
+export interface WorkboardScopeKeys {
+  agent_key: string;
+  workspace_key: string;
+}
+
+const DEFAULT_SCOPE_KEYS: WorkboardScopeKeys = {
   agent_key: "default",
   workspace_key: "default",
 } as const;
+
+function normalizeScopeKeys(scopeKeys?: Partial<WorkboardScopeKeys>): WorkboardScopeKeys {
+  const agentKey = scopeKeys?.agent_key?.trim() || DEFAULT_SCOPE_KEYS.agent_key;
+  const workspaceKey = scopeKeys?.workspace_key?.trim() || DEFAULT_SCOPE_KEYS.workspace_key;
+  return {
+    agent_key: agentKey,
+    workspace_key: workspaceKey,
+  };
+}
 
 function isUnsupportedRequestForWorkList(errorMessage: string): boolean {
   return errorMessage.includes("work.list failed: unsupported_request");
@@ -41,6 +57,7 @@ export function createWorkboardStore(ws: OperatorWsClient): {
   const { store, setState } = createStore<WorkboardState>({
     items: [],
     tasksByWorkItemId: {},
+    scopeKeys: DEFAULT_SCOPE_KEYS,
     supported: null,
     loading: false,
     error: null,
@@ -55,6 +72,31 @@ export function createWorkboardStore(ws: OperatorWsClient): {
     setState((prev) => {
       if (prev.supported !== false) return prev;
       return { ...prev, supported: null, error: null };
+    });
+  }
+
+  function setScopeKeys(scopeKeys: Partial<WorkboardScopeKeys>): void {
+    const nextScopeKeys = normalizeScopeKeys(scopeKeys);
+    refreshRunId += 1;
+    activeRefreshRunId = null;
+    bufferedWorkItemUpserts = new Map<string, WorkItem>();
+
+    setState((prev) => {
+      if (
+        prev.scopeKeys.agent_key === nextScopeKeys.agent_key &&
+        prev.scopeKeys.workspace_key === nextScopeKeys.workspace_key
+      ) {
+        return prev;
+      }
+      return {
+        ...prev,
+        items: [],
+        tasksByWorkItemId: {},
+        scopeKeys: nextScopeKeys,
+        loading: false,
+        error: null,
+        lastSyncedAt: null,
+      };
     });
   }
 
@@ -89,7 +131,8 @@ export function createWorkboardStore(ws: OperatorWsClient): {
     }));
 
     try {
-      const result = await ws.workList({ ...DEFAULT_SCOPE_KEYS, limit: 200 });
+      const scopeKeys = store.getSnapshot().scopeKeys;
+      const result = await ws.workList({ ...scopeKeys, limit: 200 });
       if (activeRefreshRunId !== runId) return;
       const buffered = bufferedWorkItemUpserts;
 
@@ -137,6 +180,7 @@ export function createWorkboardStore(ws: OperatorWsClient): {
     store: {
       ...store,
       refreshList,
+      setScopeKeys,
       upsertWorkItem: handleWorkItemUpsert,
       resetSupportProbe,
     },

--- a/packages/operator-core/tests/workboard-store.test.ts
+++ b/packages/operator-core/tests/workboard-store.test.ts
@@ -41,11 +41,39 @@ describe("workboard-store", () => {
       workspace_key: "default",
       limit: 200,
     });
+    expect(snapshot.scopeKeys).toEqual({
+      agent_key: "default",
+      workspace_key: "default",
+    });
     expect(snapshot.supported).toBe(true);
     expect(snapshot.loading).toBe(false);
     expect(snapshot.error).toBe(null);
     expect(snapshot.lastSyncedAt).toEqual(expect.any(String));
     expect(snapshot.items.map((item) => item.work_item_id)).toEqual(["w-buffered", "w1"]);
+  });
+
+  it("uses updated scope keys after a scope change", async () => {
+    const ws = {
+      workList: vi.fn(async () => ({ items: [] })),
+    } as any;
+
+    const { store } = createWorkboardStore(ws);
+    store.setScopeKeys({ agent_key: "planner", workspace_key: "ops" });
+
+    const scopedSnapshot = store.getSnapshot();
+    expect(scopedSnapshot.scopeKeys).toEqual({
+      agent_key: "planner",
+      workspace_key: "ops",
+    });
+    expect(scopedSnapshot.items).toEqual([]);
+
+    await store.refreshList();
+
+    expect(ws.workList).toHaveBeenCalledWith({
+      agent_key: "planner",
+      workspace_key: "ops",
+      limit: 200,
+    });
   });
 
   it("marks WorkBoard as unsupported on the gateway unsupported_request error", async () => {

--- a/packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx
+++ b/packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx
@@ -1,0 +1,191 @@
+import type { OperatorCore, WorkboardScopeKeys } from "@tyrum/operator-core";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "../ui/button.js";
+import { Input } from "../ui/input.js";
+import { Select } from "../ui/select.js";
+import { StatusDot, type StatusDotVariant } from "../ui/status-dot.js";
+
+type WorkboardScopeControlsProps = {
+  core: OperatorCore;
+  isConnected: boolean;
+  scopeKeys: WorkboardScopeKeys;
+};
+
+type WorkboardToolbarActionsProps = WorkboardScopeControlsProps & {
+  connectionStatus: string;
+};
+
+type AgentOption = {
+  agentKey: string;
+  label: string;
+};
+
+const DEFAULT_SCOPE_KEYS: WorkboardScopeKeys = {
+  agent_key: "default",
+  workspace_key: "default",
+} as const;
+
+function normalizeScopeKeys(scopeKeys: Partial<WorkboardScopeKeys>): WorkboardScopeKeys {
+  return {
+    agent_key: scopeKeys.agent_key?.trim() || DEFAULT_SCOPE_KEYS.agent_key,
+    workspace_key: scopeKeys.workspace_key?.trim() || DEFAULT_SCOPE_KEYS.workspace_key,
+  };
+}
+
+function normalizeAgentOptions(agents: unknown): AgentOption[] {
+  if (!Array.isArray(agents)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const options: AgentOption[] = [];
+  for (const agent of agents) {
+    if (!agent || typeof agent !== "object") {
+      continue;
+    }
+    const record = agent as { agent_key?: unknown; persona?: { name?: unknown } | null };
+    const agentKey =
+      typeof record.agent_key === "string" && record.agent_key.trim().length > 0
+        ? record.agent_key.trim()
+        : "";
+    if (!agentKey || seen.has(agentKey)) {
+      continue;
+    }
+    seen.add(agentKey);
+    const personaName =
+      typeof record.persona?.name === "string" && record.persona.name.trim().length > 0
+        ? record.persona.name.trim()
+        : "";
+    options.push({
+      agentKey,
+      label:
+        personaName && personaName.toLowerCase() !== agentKey.toLowerCase()
+          ? `${agentKey} · ${personaName}`
+          : agentKey,
+    });
+  }
+  options.sort((left, right) => left.agentKey.localeCompare(right.agentKey));
+  return options;
+}
+
+export function WorkboardScopeControls({
+  core,
+  isConnected,
+  scopeKeys,
+}: WorkboardScopeControlsProps) {
+  const [scopeDraft, setScopeDraft] = useState<WorkboardScopeKeys>(scopeKeys);
+  const [agentOptions, setAgentOptions] = useState<AgentOption[]>([]);
+
+  useEffect(() => {
+    setScopeDraft(scopeKeys);
+  }, [scopeKeys]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadAgentOptions = async (): Promise<void> => {
+      try {
+        const response = await core.http.agents.list();
+        if (cancelled) return;
+        setAgentOptions(normalizeAgentOptions((response as { agents?: unknown })?.agents));
+      } catch {
+        if (!cancelled) {
+          setAgentOptions([]);
+        }
+      }
+    };
+
+    void loadAgentOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [core.http]);
+
+  const visibleAgentOptions = useMemo(() => {
+    if (agentOptions.some((option) => option.agentKey === scopeDraft.agent_key)) {
+      return agentOptions;
+    }
+    return [{ agentKey: scopeDraft.agent_key, label: scopeDraft.agent_key }, ...agentOptions];
+  }, [agentOptions, scopeDraft.agent_key]);
+
+  const applyScope = useCallback(async (): Promise<void> => {
+    const nextScopeKeys = normalizeScopeKeys(scopeDraft);
+    core.workboardStore.setScopeKeys(nextScopeKeys);
+    if (!isConnected) return;
+    await core.workboardStore.refreshList();
+  }, [core.workboardStore, isConnected, scopeDraft]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Select
+        data-testid="workboard-scope-agent"
+        aria-label="Workboard agent scope"
+        className="min-w-44"
+        value={scopeDraft.agent_key}
+        onChange={(event) =>
+          setScopeDraft((prev) => ({ ...prev, agent_key: event.currentTarget.value }))
+        }
+      >
+        {visibleAgentOptions.map((option) => (
+          <option key={option.agentKey} value={option.agentKey}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+      <Input
+        data-testid="workboard-scope-workspace"
+        aria-label="Workboard workspace scope"
+        className="w-36"
+        value={scopeDraft.workspace_key}
+        onChange={(event) =>
+          setScopeDraft((prev) => ({ ...prev, workspace_key: event.currentTarget.value }))
+        }
+      />
+      <Button
+        data-testid="workboard-scope-apply"
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          void applyScope();
+        }}
+      >
+        Load scope
+      </Button>
+    </div>
+  );
+}
+
+export function WorkboardToolbarActions({
+  connectionStatus,
+  core,
+  isConnected,
+  scopeKeys,
+}: WorkboardToolbarActionsProps) {
+  const connectionDotVariant: StatusDotVariant =
+    connectionStatus === "connected"
+      ? "success"
+      : connectionStatus === "connecting"
+        ? "warning"
+        : "neutral";
+
+  return (
+    <>
+      <WorkboardScopeControls core={core} isConnected={isConnected} scopeKeys={scopeKeys} />
+      <div className="flex items-center gap-2 text-sm text-fg-muted">
+        <StatusDot variant={connectionDotVariant} pulse={connectionStatus === "connecting"} />
+        {connectionStatus}
+      </div>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => {
+          core.disconnect();
+          core.connect();
+        }}
+      >
+        Reconnect
+      </Button>
+    </>
+  );
+}

--- a/packages/operator-ui/src/components/pages/workboard-page.tsx
+++ b/packages/operator-ui/src/components/pages/workboard-page.tsx
@@ -12,9 +12,7 @@ import { formatErrorMessage } from "../../utils/format-error-message.js";
 import { useAppShellMinWidth } from "../layout/app-shell.js";
 import { AppPageToolbar } from "../layout/app-page.js";
 import { Alert } from "../ui/alert.js";
-import { Button } from "../ui/button.js";
 import { ScrollArea } from "../ui/scroll-area.js";
-import { StatusDot, type StatusDotVariant } from "../ui/status-dot.js";
 import {
   WORK_ITEM_STATUSES,
   groupWorkItemsByStatus,
@@ -27,38 +25,35 @@ import {
   type WorkStateKvEntry,
 } from "../workboard/workboard-store.js";
 import { WorkBoardDrilldown } from "./workboard-page-drilldown.js";
+import { WorkboardToolbarActions } from "./workboard-page-scope-controls.js";
 import { STATUS_LABELS, WorkStatusList, WorkStatusPanel } from "./workboard-page.shared.js";
 
-export type WorkBoardPageProps = {
-  core: OperatorCore;
-};
+export type WorkBoardPageProps = { core: OperatorCore };
 
-const DEFAULT_SCOPE_KEYS = {
-  agent_key: "default",
-  workspace_key: "default",
-} as const;
 const DESKTOP_BOARD_GRID_STYLE = {
   gridTemplateColumns: `repeat(${WORK_ITEM_STATUSES.length}, minmax(0, 1fr))`,
 } as const;
 
 const WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX = 1120;
 const WORKBOARD_DESKTOP_CONTENT_WIDTH_PX = WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX + 40;
-const DESKTOP_BOARD_MIN_WIDTH_STYLE = {
-  minWidth: WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX,
-} as const;
+const DESKTOP_BOARD_MIN_WIDTH_STYLE = { minWidth: WORKBOARD_DESKTOP_BOARD_MIN_WIDTH_PX } as const;
 
-function makeAgentScope(): WorkStateKVScope {
-  return { kind: "agent", ...DEFAULT_SCOPE_KEYS };
+function makeAgentScope(scopeKeys: { agent_key: string; workspace_key: string }): WorkStateKVScope {
+  return { kind: "agent", ...scopeKeys };
 }
 
-function makeWorkItemScope(workItemId: string): WorkStateKVScope {
-  return { kind: "work_item", ...DEFAULT_SCOPE_KEYS, work_item_id: workItemId };
+function makeWorkItemScope(
+  scopeKeys: { agent_key: string; workspace_key: string },
+  workItemId: string,
+): WorkStateKVScope {
+  return { kind: "work_item", ...scopeKeys, work_item_id: workItemId };
 }
 
 export function WorkBoardPage({ core }: WorkBoardPageProps) {
   const connection = useOperatorStore(core.connectionStore);
   const isConnected = connection.status === "connected";
   const workboard = useOperatorStore(core.workboardStore);
+  const currentScopeKeys = workboard.scopeKeys;
   const desktopBoard = useAppShellMinWidth(WORKBOARD_DESKTOP_CONTENT_WIDTH_PX);
 
   const selectedIdRef = useRef<string | null>(null);
@@ -76,6 +71,10 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
   const [signals, setSignals] = useState<WorkSignal[]>([]);
   const [agentKvEntries, setAgentKvEntries] = useState<WorkStateKvEntry[]>([]);
   const [workItemKvEntries, setWorkItemKvEntries] = useState<WorkStateKvEntry[]>([]);
+
+  useEffect(() => {
+    setSelectedWorkItemId(null);
+  }, [currentScopeKeys.agent_key, currentScopeKeys.workspace_key]);
 
   useEffect(() => {
     selectedIdRef.current = selectedWorkItemId;
@@ -105,11 +104,6 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
     });
   }, [selectedWorkItemId, workboard.items]);
 
-  const reconnect = useCallback(() => {
-    core.disconnect();
-    core.connect();
-  }, [core]);
-
   const transitionSelected = useCallback(
     async (status: WorkItem["status"], reason: string): Promise<void> => {
       if (!isConnected) return;
@@ -119,7 +113,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       setDrilldownError(null);
       try {
         const res = await core.ws.workTransition({
-          ...DEFAULT_SCOPE_KEYS,
+          ...currentScopeKeys,
           work_item_id: selectedWorkItemId,
           status,
           reason,
@@ -136,7 +130,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
         setTransitionTarget(null);
       }
     },
-    [core.ws, core.workboardStore, isConnected, selectedWorkItemId],
+    [core.ws, core.workboardStore, currentScopeKeys, isConnected, selectedWorkItemId],
   );
 
   useEffect(() => {
@@ -173,7 +167,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       const selectedId = selectedIdRef.current;
       if (!selectedId) return;
       void core.ws
-        .workSignalGet({ ...DEFAULT_SCOPE_KEYS, signal_id: event.payload.signal_id })
+        .workSignalGet({ ...currentScopeKeys, signal_id: event.payload.signal_id })
         .then((res) => {
           if (disposed) return;
           if (res.signal.work_item_id !== selectedIdRef.current) return;
@@ -219,7 +213,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       core.ws.off("work.signal.fired", onWorkSignalFired);
       core.ws.off("work.state_kv.updated", onWorkStateKvUpdated);
     };
-  }, [core.ws, isConnected]);
+  }, [core.ws, currentScopeKeys, isConnected]);
 
   useEffect(() => {
     if (!isConnected || !selectedWorkItemId) {
@@ -242,24 +236,26 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       try {
         const [workItemRes, artifactsRes, decisionsRes, signalsRes, agentKvRes, workItemKvRes] =
           await Promise.all([
-            core.ws.workGet({ ...DEFAULT_SCOPE_KEYS, work_item_id: selectedWorkItemId }),
+            core.ws.workGet({ ...currentScopeKeys, work_item_id: selectedWorkItemId }),
             core.ws.workArtifactList({
-              ...DEFAULT_SCOPE_KEYS,
+              ...currentScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
             core.ws.workDecisionList({
-              ...DEFAULT_SCOPE_KEYS,
+              ...currentScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
             core.ws.workSignalList({
-              ...DEFAULT_SCOPE_KEYS,
+              ...currentScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
-            core.ws.workStateKvList({ scope: makeAgentScope() }),
-            core.ws.workStateKvList({ scope: makeWorkItemScope(selectedWorkItemId) }),
+            core.ws.workStateKvList({ scope: makeAgentScope(currentScopeKeys) }),
+            core.ws.workStateKvList({
+              scope: makeWorkItemScope(currentScopeKeys, selectedWorkItemId),
+            }),
           ]);
 
         if (cancelled) return;
@@ -284,7 +280,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [core.ws, isConnected, selectedWorkItemId]);
+  }, [core.ws, currentScopeKeys, isConnected, selectedWorkItemId]);
 
   const tasksForSelected = selectTasksForSelectedWorkItem(
     workboard.tasksByWorkItemId,
@@ -306,13 +302,6 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
     [taskList],
   );
 
-  const connectionDotVariant: StatusDotVariant =
-    connection.status === "connected"
-      ? "success"
-      : connection.status === "connecting"
-        ? "warning"
-        : "neutral";
-
   const canMarkReadySelected = selectedItem?.status === "backlog";
   const canResumeSelected = selectedItem?.status === "blocked";
   const canCancelSelected =
@@ -320,21 +309,18 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
     selectedItem?.status === "doing" ||
     selectedItem?.status === "blocked";
 
-  const toolbarActions = (
-    <>
-      <div className="flex items-center gap-2 text-sm text-fg-muted">
-        <StatusDot variant={connectionDotVariant} pulse={connection.status === "connecting"} />
-        {connection.status}
-      </div>
-      <Button variant="secondary" size="sm" onClick={reconnect}>
-        Reconnect
-      </Button>
-    </>
-  );
-
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-bg">
-      <AppPageToolbar actions={toolbarActions} />
+      <AppPageToolbar
+        actions={
+          <WorkboardToolbarActions
+            connectionStatus={connection.status}
+            core={core}
+            isConnected={isConnected}
+            scopeKeys={currentScopeKeys}
+          />
+        }
+      />
 
       {desktopBoard ? (
         <div className="min-h-0 flex-1 overflow-hidden">

--- a/packages/operator-ui/tests/pages/workboard-page.test-support.ts
+++ b/packages/operator-ui/tests/pages/workboard-page.test-support.ts
@@ -21,6 +21,7 @@ function createWorkboardStore(snapshot?: Partial<Record<string, unknown>>) {
   let state = {
     items: [],
     tasksByWorkItemId: {},
+    scopeKeys: { ...DEFAULT_SCOPE_KEYS },
     supported: null,
     loading: false,
     error: null,
@@ -37,6 +38,26 @@ function createWorkboardStore(snapshot?: Partial<Record<string, unknown>>) {
     },
     getSnapshot: () => state,
     refreshList: vi.fn(async () => {}),
+    setScopeKeys: vi.fn((scopeKeys: Record<string, unknown>) => {
+      state = {
+        ...state,
+        items: [],
+        tasksByWorkItemId: {},
+        scopeKeys: {
+          agent_key:
+            typeof scopeKeys.agent_key === "string" && scopeKeys.agent_key.trim().length > 0
+              ? scopeKeys.agent_key.trim()
+              : DEFAULT_SCOPE_KEYS.agent_key,
+          workspace_key:
+            typeof scopeKeys.workspace_key === "string" && scopeKeys.workspace_key.trim().length > 0
+              ? scopeKeys.workspace_key.trim()
+              : DEFAULT_SCOPE_KEYS.workspace_key,
+        },
+        error: null,
+        lastSyncedAt: null,
+      };
+      for (const listener of listeners) listener();
+    }),
     resetSupportProbe: vi.fn(() => {}),
     upsertWorkItem: (item: any) => {
       state = {
@@ -131,14 +152,22 @@ export function createCore(
 ) {
   const ws = createWsStub(wsOverrides);
   const workboard = createWorkboardStore(workboardSnapshot);
+  const http = {
+    agents: {
+      list: vi.fn(async () => ({
+        agents: [{ agent_key: "default", persona: { name: "Default" } }],
+      })),
+    },
+  };
   const core = {
     connectionStore: createConnectionStore(status),
     workboardStore: workboard.store,
+    http,
     ws,
     connect: vi.fn(),
     disconnect: vi.fn(),
   } as unknown as OperatorCore;
-  return { core, ws, workboard };
+  return { core, ws, workboard, http };
 }
 
 export async function flushEffects(): Promise<void> {

--- a/packages/operator-ui/tests/pages/workboard-page.test.ts
+++ b/packages/operator-ui/tests/pages/workboard-page.test.ts
@@ -345,6 +345,58 @@ describe("WorkBoardPage", () => {
     }
   });
 
+  it("uses the current workboard scope for drilldown requests", async () => {
+    const workItem = makeWorkItem({
+      work_item_id: "wi-scope",
+      agent_id: "agent-scope",
+      workspace_id: "workspace-scope",
+    });
+    const { core, ws } = createCore(
+      "connected",
+      {
+        workGet: vi.fn(async () => ({ item: workItem })),
+        workArtifactList: vi.fn(async () => ({ artifacts: [] })),
+        workDecisionList: vi.fn(async () => ({ decisions: [] })),
+        workSignalList: vi.fn(async () => ({ signals: [] })),
+        workStateKvList: vi.fn(async () => ({ entries: [] })),
+      },
+      {
+        items: [workItem],
+        scopeKeys: { agent_key: "planner", workspace_key: "ops" },
+        supported: true,
+      },
+    );
+
+    const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
+    try {
+      await flushEffects();
+
+      const scopedCard = testRoot.container.querySelector<HTMLButtonElement>(
+        '[data-testid="work-item-wi-scope"]',
+      );
+      expect(scopedCard).not.toBeNull();
+
+      await act(async () => {
+        scopedCard!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      expect(ws.workGet).toHaveBeenCalledWith({
+        agent_key: "planner",
+        workspace_key: "ops",
+        work_item_id: "wi-scope",
+      });
+      expect(ws.workArtifactList).toHaveBeenCalledWith({
+        agent_key: "planner",
+        workspace_key: "ops",
+        work_item_id: "wi-scope",
+        limit: 200,
+      });
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
   it("shows unsupported-request message when work.list is not available", async () => {
     const { core } = createCore("connected", undefined, {
       supported: false,


### PR DESCRIPTION
## Summary
- make the operator Workboard store and page scope-aware instead of hard-coding `default/default`
- broadcast `work.item.created` from `workboard.capture` using the same event shape as `work.create`
- update the web layout harness fixtures for the new Workboard scope state so regression coverage remains valid

## Problem
The operator Workboard could stay empty even after a successful `workboard.capture` because the UI only queried `default/default` scope while captures could land in another agent/workspace scope. Tool-driven captures also did not emit the live `work.item.created` event, so same-scope operator clients would not update immediately.

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm format:check`
- `pnpm test`
- `pnpm exec vitest run packages/gateway/tests/unit/workboard-orchestration-tools.test.ts packages/gateway/tests/unit/ws-workboard.test.ts`
- `pnpm exec vitest run apps/web/tests/layout-regression.test.ts packages/operator-ui/tests/pages/workboard-page.test.ts`

Closes #1399.
