### PR TITLE
fix(operator-ui): align onboarding provider picker

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-providers-dialog.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-providers-dialog.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { cn } from "../../lib/cn.js";
 import { formatErrorMessage } from "../../utils/format-error-message.js";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
@@ -13,35 +12,24 @@ import {
   DialogTitle,
 } from "../ui/dialog.js";
 import { Input } from "../ui/input.js";
-import { Label } from "../ui/label.js";
-import { ScrollArea } from "../ui/scroll-area.js";
 import { Select } from "../ui/select.js";
 import type { AdminHttpClient } from "./admin-http-shared.js";
 import {
   buildProviderPayload,
   emptyFormState,
+  getBooleanConfigDefaults,
   getFieldBooleanValue,
   getFieldStringValue,
   normalizeFormState,
-  syncDisplayNameOnProviderChange,
+  reconcileProviderFormState,
+  selectProviderFormState,
   validateProviderForm,
   type ConfiguredProviderAccount,
   type ConfiguredProviderGroup,
-  type ProviderMethod,
   type ProviderFormState,
   type ProviderRegistryEntry,
 } from "./admin-http-providers.shared.js";
-
-const PROVIDER_PICKER_VISIBLE_COUNT = 5;
-const PROVIDER_PICKER_ROW_REM = 4.25;
-
-function getBooleanConfigDefaults(method: ProviderMethod | undefined): Record<string, boolean> {
-  return Object.fromEntries(
-    (method?.fields ?? [])
-      .filter((field) => field.kind === "config" && field.input === "boolean")
-      .map((field) => [field.key, false]),
-  );
-}
+import { ProviderPickerField } from "./provider-picker-field.js";
 
 export function ProviderAccountDialog({
   open,
@@ -69,7 +57,6 @@ export function ProviderAccountDialog({
   const [saving, setSaving] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [autoSelectReady, setAutoSelectReady] = React.useState(false);
-  const providerFilterId = React.useId();
 
   const supportedProviders = React.useMemo(
     () => registry.filter((provider) => provider.supported && provider.methods.length > 0),
@@ -98,12 +85,6 @@ export function ProviderAccountDialog({
     selectedProvider?.methods.find((method) => method.method_key === state.methodKey) ??
     selectedProvider?.methods[0];
   const mode = account ? "edit" : "create";
-  const providerPickerHeightRem =
-    Math.min(Math.max(filteredSupportedProviders.length, 1), PROVIDER_PICKER_VISIBLE_COUNT) *
-    PROVIDER_PICKER_ROW_REM;
-  const selectedProviderConfiguredCount = state.providerKey
-    ? (configuredCounts.get(state.providerKey) ?? 0)
-    : 0;
 
   React.useEffect(() => {
     if (!open) {
@@ -130,25 +111,12 @@ export function ProviderAccountDialog({
 
   const applyProviderSelection = React.useCallback(
     (providerKey: string) => {
-      const nextProvider = supportedProviders.find(
-        (provider) => provider.provider_key === providerKey,
-      );
       setState((current) => {
-        const currentProviderName = supportedProviders.find(
-          (provider) => provider.provider_key === current.providerKey,
-        )?.name;
-        const nextMethod = nextProvider?.methods[0];
-        return {
-          providerKey: nextProvider?.provider_key ?? "",
-          methodKey: nextMethod?.method_key ?? "",
-          displayName: syncDisplayNameOnProviderChange({
-            currentDisplayName: current.displayName,
-            currentProviderName,
-            nextProviderName: nextProvider?.name,
-          }),
-          configValues: getBooleanConfigDefaults(nextMethod),
-          secretValues: {},
-        };
+        return selectProviderFormState({
+          currentState: current,
+          providerKey,
+          supportedProviders,
+        });
       });
     },
     [supportedProviders],
@@ -156,44 +124,14 @@ export function ProviderAccountDialog({
 
   React.useEffect(() => {
     if (!open || account || !autoSelectReady) return;
-    if (
-      filteredSupportedProviders.some((provider) => provider.provider_key === state.providerKey)
-    ) {
-      return;
-    }
-    const firstVisibleProvider = filteredSupportedProviders[0];
-    if (firstVisibleProvider) {
-      applyProviderSelection(firstVisibleProvider.provider_key);
-      return;
-    }
     setState((current) =>
-      current.providerKey || current.methodKey || Object.keys(current.secretValues).length > 0
-        ? (() => {
-            const currentProviderName = supportedProviders.find(
-              (provider) => provider.provider_key === current.providerKey,
-            )?.name;
-            const shouldClearDisplayName =
-              !current.displayName.trim() || current.displayName === (currentProviderName ?? "");
-            return {
-              ...current,
-              providerKey: "",
-              methodKey: "",
-              displayName: shouldClearDisplayName ? "" : current.displayName,
-              configValues: {},
-              secretValues: {},
-            };
-          })()
-        : current,
+      reconcileProviderFormState({
+        currentState: current,
+        filteredProviders: filteredSupportedProviders,
+        supportedProviders,
+      }),
     );
-  }, [
-    account,
-    applyProviderSelection,
-    autoSelectReady,
-    filteredSupportedProviders,
-    open,
-    state.providerKey,
-    supportedProviders,
-  ]);
+  }, [account, autoSelectReady, filteredSupportedProviders, open, supportedProviders]);
 
   const formError = validateProviderForm(state, selectedMethod, mode);
 
@@ -246,104 +184,14 @@ export function ProviderAccountDialog({
 
         <div className="grid gap-4">
           {!account ? (
-            <div className="grid gap-1.5">
-              <Label htmlFor={providerFilterId} required>
-                Provider
-              </Label>
-              <div className="overflow-hidden rounded-lg border border-border bg-bg-card/40">
-                <div className="border-b border-border/70 p-2">
-                  <input
-                    id={providerFilterId}
-                    type="text"
-                    value={providerFilter}
-                    data-testid="providers-filter-input"
-                    aria-label="Filter providers"
-                    placeholder="Filter providers by name or key"
-                    onChange={(event) => {
-                      setProviderFilter(event.currentTarget.value);
-                    }}
-                    className={cn(
-                      "box-border flex h-8 w-full rounded-md border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
-                      "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
-                    )}
-                  />
-                </div>
-                <ScrollArea
-                  className="w-full"
-                  data-testid="providers-provider-picker"
-                  style={{ height: `${providerPickerHeightRem}rem` }}
-                >
-                  <div className="grid gap-1 p-2" role="radiogroup" aria-label="Provider">
-                    {filteredSupportedProviders.length > 0 ? (
-                      filteredSupportedProviders.map((provider) => {
-                        const active = provider.provider_key === state.providerKey;
-                        const configuredCount = configuredCounts.get(provider.provider_key) ?? 0;
-                        const accountLabel =
-                          configuredCount === 1
-                            ? "1 account configured"
-                            : `${configuredCount} accounts configured`;
-
-                        return (
-                          <button
-                            key={provider.provider_key}
-                            type="button"
-                            role="radio"
-                            aria-checked={active}
-                            data-testid={`providers-provider-option-${provider.provider_key}`}
-                            className={cn(
-                              "flex w-full items-start justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors",
-                              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
-                              active
-                                ? "border-primary bg-bg text-fg"
-                                : "border-border bg-bg hover:bg-bg-subtle",
-                            )}
-                            onClick={() => {
-                              applyProviderSelection(provider.provider_key);
-                            }}
-                          >
-                            <div className="grid gap-0.5">
-                              <span className="text-sm font-medium text-fg">{provider.name}</span>
-                              <span className="text-xs text-fg-muted">{provider.provider_key}</span>
-                            </div>
-                            <div className="grid justify-items-end gap-1 text-xs text-fg-muted">
-                              {configuredCount > 0 ? (
-                                <span
-                                  className={cn(
-                                    "rounded-full border px-2 py-0.5",
-                                    active
-                                      ? "border-primary/50 bg-primary/10 text-fg"
-                                      : "border-border bg-bg-card/60",
-                                  )}
-                                >
-                                  {accountLabel}
-                                </span>
-                              ) : (
-                                <span>Not configured</span>
-                              )}
-                              {provider.methods.length > 1 ? (
-                                <span>{provider.methods.length} auth methods</span>
-                              ) : null}
-                            </div>
-                          </button>
-                        );
-                      })
-                    ) : (
-                      <div className="rounded-md border border-dashed border-border px-3 py-4 text-sm text-fg-muted">
-                        No providers match this filter.
-                      </div>
-                    )}
-                  </div>
-                </ScrollArea>
-              </div>
-              <p className="text-sm text-fg-muted">
-                Type to narrow the list. Up to five providers stay visible before scrolling.
-              </p>
-              {selectedProviderConfiguredCount > 0 ? (
-                <p className="text-sm text-fg-muted">
-                  This provider is already configured. Saving will add another account.
-                </p>
-              ) : null}
-            </div>
+            <ProviderPickerField
+              configuredProviders={configuredProviders}
+              filteredProviders={filteredSupportedProviders}
+              onProviderFilterChange={setProviderFilter}
+              onSelectProvider={applyProviderSelection}
+              providerFilter={providerFilter}
+              selectedProviderKey={state.providerKey}
+            />
           ) : null}
 
           {account ? (

--- a/packages/operator-ui/src/components/pages/admin-http-providers.shared.ts
+++ b/packages/operator-ui/src/components/pages/admin-http-providers.shared.ts
@@ -80,6 +80,101 @@ export function syncDisplayNameOnProviderChange(input: {
   return input.currentDisplayName;
 }
 
+export function getBooleanConfigDefaults(
+  method: ProviderMethod | undefined,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    (method?.fields ?? [])
+      .filter((field) => field.kind === "config" && field.input === "boolean")
+      .map((field) => [field.key, false]),
+  );
+}
+
+export function selectProviderFormState(input: {
+  currentState: ProviderFormState;
+  providerKey: string;
+  supportedProviders: readonly ProviderRegistryEntry[];
+}): ProviderFormState {
+  const nextProvider = input.supportedProviders.find(
+    (provider) => provider.provider_key === input.providerKey,
+  );
+  const currentProviderName = input.supportedProviders.find(
+    (provider) => provider.provider_key === input.currentState.providerKey,
+  )?.name;
+  const nextMethod = nextProvider?.methods[0];
+
+  return {
+    providerKey: nextProvider?.provider_key ?? "",
+    methodKey: nextMethod?.method_key ?? "",
+    displayName: syncDisplayNameOnProviderChange({
+      currentDisplayName: input.currentState.displayName,
+      currentProviderName,
+      nextProviderName: nextProvider?.name,
+    }),
+    configValues: getBooleanConfigDefaults(nextMethod),
+    secretValues: {},
+  };
+}
+
+function clearProviderFormState(input: {
+  currentState: ProviderFormState;
+  supportedProviders: readonly ProviderRegistryEntry[];
+}): ProviderFormState {
+  if (
+    !input.currentState.providerKey &&
+    !input.currentState.methodKey &&
+    Object.keys(input.currentState.configValues).length === 0 &&
+    Object.keys(input.currentState.secretValues).length === 0
+  ) {
+    return input.currentState;
+  }
+
+  const currentProviderName = input.supportedProviders.find(
+    (provider) => provider.provider_key === input.currentState.providerKey,
+  )?.name;
+  const shouldClearDisplayName =
+    !input.currentState.displayName.trim() ||
+    input.currentState.displayName === (currentProviderName ?? "");
+
+  return {
+    ...input.currentState,
+    providerKey: "",
+    methodKey: "",
+    displayName: shouldClearDisplayName ? "" : input.currentState.displayName,
+    configValues: {},
+    secretValues: {},
+  };
+}
+
+export function reconcileProviderFormState(input: {
+  currentState: ProviderFormState;
+  filteredProviders: readonly ProviderRegistryEntry[];
+  supportedProviders: readonly ProviderRegistryEntry[];
+}): ProviderFormState {
+  if (
+    input.currentState.providerKey &&
+    input.filteredProviders.some(
+      (provider) => provider.provider_key === input.currentState.providerKey,
+    )
+  ) {
+    return input.currentState;
+  }
+
+  const firstVisibleProvider = input.filteredProviders[0];
+  if (firstVisibleProvider) {
+    return selectProviderFormState({
+      currentState: input.currentState,
+      providerKey: firstVisibleProvider.provider_key,
+      supportedProviders: input.supportedProviders,
+    });
+  }
+
+  return clearProviderFormState({
+    currentState: input.currentState,
+    supportedProviders: input.supportedProviders,
+  });
+}
+
 export function normalizeFormState(input: {
   registry: ProviderRegistryEntry[];
   providerKey?: string;

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
@@ -26,7 +26,7 @@ import {
 import {
   buildProviderPayload,
   emptyFormState,
-  normalizeFormState,
+  reconcileProviderFormState,
   type ConfiguredProviderGroup,
   type ProviderFormState,
   type ProviderRegistryEntry,
@@ -289,17 +289,18 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
     selectedProvider?.methods[0];
 
   React.useEffect(() => {
-    setProviderState((current) => {
-      if (
-        current.providerKey &&
-        supportedProviders.some((provider) => provider.provider_key === current.providerKey)
-      ) {
-        return current;
-      }
-      return normalizeFormState({ registry: data.registry });
-    });
+    setProviderState((current) =>
+      reconcileProviderFormState({
+        currentState: current,
+        filteredProviders,
+        supportedProviders,
+      }),
+    );
+  }, [filteredProviders, supportedProviders]);
+
+  React.useEffect(() => {
     setProviderFilter("");
-  }, [data.registry, supportedProviders]);
+  }, [data.registry]);
 
   React.useEffect(() => {
     setModelState((current) => {

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.sections.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.sections.tsx
@@ -6,8 +6,10 @@ import { Checkbox } from "../ui/checkbox.js";
 import { Input } from "../ui/input.js";
 import { Select } from "../ui/select.js";
 import {
+  getBooleanConfigDefaults,
   getFieldBooleanValue,
   getFieldStringValue,
+  type ConfiguredProviderGroup,
   type ProviderFormState,
   type ProviderRegistryEntry,
 } from "./admin-http-providers.shared.js";
@@ -20,6 +22,7 @@ import {
   type ModelPreset,
 } from "./admin-http-models.shared.js";
 import { OnboardingStepFrame } from "./first-run-onboarding.parts.js";
+import { ProviderPickerField } from "./provider-picker-field.js";
 
 export function OnboardingDoneStep({
   onClose,
@@ -94,6 +97,7 @@ export function OnboardingAdminStep({
 export function OnboardingProviderStep({
   busy,
   canSave,
+  configuredProviders,
   filteredProviders,
   onProviderFilterChange,
   onProviderSave,
@@ -107,6 +111,7 @@ export function OnboardingProviderStep({
 }: {
   busy: boolean;
   canSave: boolean;
+  configuredProviders: ConfiguredProviderGroup[];
   filteredProviders: ProviderRegistryEntry[];
   onProviderFilterChange: (value: string) => void;
   onProviderSave: () => void;
@@ -121,24 +126,15 @@ export function OnboardingProviderStep({
   return (
     <OnboardingStepFrame stepId="provider">
       <div className="grid gap-4" data-testid="first-run-onboarding-step-provider">
+        <ProviderPickerField
+          configuredProviders={configuredProviders}
+          filteredProviders={filteredProviders}
+          onProviderFilterChange={onProviderFilterChange}
+          onSelectProvider={onProviderSelectionChange}
+          providerFilter={providerFilter}
+          selectedProviderKey={providerState.providerKey}
+        />
         <div className="grid gap-4 md:grid-cols-2">
-          <Input
-            label="Filter providers"
-            value={providerFilter}
-            onChange={(event) => onProviderFilterChange(event.currentTarget.value)}
-            placeholder="Search providers"
-          />
-          <Select
-            label="Provider"
-            value={providerState.providerKey}
-            onChange={(event) => onProviderSelectionChange(event.currentTarget.value)}
-          >
-            {filteredProviders.map((provider) => (
-              <option key={provider.provider_key} value={provider.provider_key}>
-                {provider.name}
-              </option>
-            ))}
-          </Select>
           <Select
             label="Authentication method"
             value={providerState.methodKey}
@@ -149,13 +145,7 @@ export function OnboardingProviderStep({
               onProviderStateChange((current) => ({
                 ...current,
                 methodKey: event.currentTarget.value,
-                configValues: nextMethod
-                  ? Object.fromEntries(
-                      nextMethod.fields
-                        .filter((field) => field.kind === "config" && field.input === "boolean")
-                        .map((field) => [field.key, false]),
-                    )
-                  : {},
+                configValues: getBooleanConfigDefaults(nextMethod),
                 secretValues: {},
               }));
             }}
@@ -177,6 +167,13 @@ export function OnboardingProviderStep({
             }}
           />
         </div>
+        {!selectedProvider ? (
+          <Alert
+            variant="warning"
+            title="No supported providers available"
+            description="The model catalog does not currently expose any supported provider setup flows."
+          />
+        ) : null}
         {(selectedRegistryProvider?.fields ?? []).map((field) => {
           if (field.kind === "config" && field.input === "boolean") {
             return (

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -9,10 +9,7 @@ import { Button } from "../ui/button.js";
 import { Card, CardContent } from "../ui/card.js";
 import { useElevatedModeUiContext } from "../elevated-mode/elevated-mode-provider.js";
 import { useAdminMutationAccess, useAdminMutationHttpClient } from "./admin-http-shared.js";
-import {
-  syncDisplayNameOnProviderChange,
-  validateProviderForm,
-} from "./admin-http-providers.shared.js";
+import { selectProviderFormState, validateProviderForm } from "./admin-http-providers.shared.js";
 import { modelRefFor } from "./admin-http-models.shared.js";
 import {
   buildDefaultAgentConfigUpdate,
@@ -100,25 +97,12 @@ export function FirstRunOnboardingPage({
 
   const applyProviderSelection = React.useCallback(
     (providerKey: string) => {
-      const nextProvider = drafts.supportedProviders.find(
-        (provider) => provider.provider_key === providerKey,
-      );
       drafts.setProviderState((current) => {
-        const currentProviderName = drafts.supportedProviders.find(
-          (provider) => provider.provider_key === current.providerKey,
-        )?.name;
-        const nextMethod = nextProvider?.methods[0];
-        return {
-          providerKey: nextProvider?.provider_key ?? "",
-          methodKey: nextMethod?.method_key ?? "",
-          displayName: syncDisplayNameOnProviderChange({
-            currentDisplayName: current.displayName,
-            currentProviderName,
-            nextProviderName: nextProvider?.name,
-          }),
-          configValues: {},
-          secretValues: {},
-        };
+        return selectProviderFormState({
+          currentState: current,
+          providerKey,
+          supportedProviders: drafts.supportedProviders,
+        });
       });
     },
     [drafts],
@@ -172,6 +156,7 @@ export function FirstRunOnboardingPage({
         <OnboardingProviderStep
           busy={submitBusy}
           canSave={Boolean(mutationHttp)}
+          configuredProviders={data.providers}
           filteredProviders={drafts.filteredProviders}
           onProviderFilterChange={drafts.setProviderFilter}
           onProviderSave={() => {

--- a/packages/operator-ui/src/components/pages/provider-picker-field.tsx
+++ b/packages/operator-ui/src/components/pages/provider-picker-field.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import { cn } from "../../lib/cn.js";
+import { Label } from "../ui/label.js";
+import { ScrollArea } from "../ui/scroll-area.js";
+import type {
+  ConfiguredProviderGroup,
+  ProviderRegistryEntry,
+} from "./admin-http-providers.shared.js";
+
+const PROVIDER_PICKER_VISIBLE_COUNT = 5;
+const PROVIDER_PICKER_ROW_REM = 4.25;
+
+export function ProviderPickerField({
+  configuredProviders,
+  filteredProviders,
+  onProviderFilterChange,
+  onSelectProvider,
+  providerFilter,
+  selectedProviderKey,
+}: {
+  configuredProviders: readonly ConfiguredProviderGroup[];
+  filteredProviders: readonly ProviderRegistryEntry[];
+  onProviderFilterChange: (value: string) => void;
+  onSelectProvider: (providerKey: string) => void;
+  providerFilter: string;
+  selectedProviderKey: string;
+}): React.ReactElement {
+  const providerFilterId = React.useId();
+  const configuredCounts = React.useMemo(
+    () =>
+      new Map(
+        configuredProviders.map((provider) => [provider.provider_key, provider.accounts.length]),
+      ),
+    [configuredProviders],
+  );
+  const providerPickerHeightRem =
+    Math.min(Math.max(filteredProviders.length, 1), PROVIDER_PICKER_VISIBLE_COUNT) *
+    PROVIDER_PICKER_ROW_REM;
+  const selectedProviderConfiguredCount = selectedProviderKey
+    ? (configuredCounts.get(selectedProviderKey) ?? 0)
+    : 0;
+
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={providerFilterId} required>
+        Provider
+      </Label>
+      <div className="overflow-hidden rounded-lg border border-border bg-bg-card/40">
+        <div className="border-b border-border/70 p-2">
+          <input
+            id={providerFilterId}
+            type="text"
+            value={providerFilter}
+            data-testid="providers-filter-input"
+            aria-label="Filter providers"
+            placeholder="Filter providers by name or key"
+            onChange={(event) => {
+              onProviderFilterChange(event.currentTarget.value);
+            }}
+            className={cn(
+              "box-border flex h-8 w-full rounded-md border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
+              "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
+            )}
+          />
+        </div>
+        <ScrollArea
+          className="w-full"
+          data-testid="providers-provider-picker"
+          style={{ height: `${providerPickerHeightRem}rem` }}
+        >
+          <div className="grid gap-1 p-2" role="radiogroup" aria-label="Provider">
+            {filteredProviders.length > 0 ? (
+              filteredProviders.map((provider) => {
+                const active = provider.provider_key === selectedProviderKey;
+                const configuredCount = configuredCounts.get(provider.provider_key) ?? 0;
+                const accountLabel =
+                  configuredCount === 1
+                    ? "1 account configured"
+                    : `${configuredCount} accounts configured`;
+
+                return (
+                  <button
+                    key={provider.provider_key}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    data-testid={`providers-provider-option-${provider.provider_key}`}
+                    className={cn(
+                      "flex w-full items-start justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
+                      active
+                        ? "border-primary bg-bg text-fg"
+                        : "border-border bg-bg hover:bg-bg-subtle",
+                    )}
+                    onClick={() => {
+                      onSelectProvider(provider.provider_key);
+                    }}
+                  >
+                    <div className="grid gap-0.5">
+                      <span className="text-sm font-medium text-fg">{provider.name}</span>
+                      <span className="text-xs text-fg-muted">{provider.provider_key}</span>
+                    </div>
+                    <div className="grid justify-items-end gap-1 text-xs text-fg-muted">
+                      {configuredCount > 0 ? (
+                        <span
+                          className={cn(
+                            "rounded-full border px-2 py-0.5",
+                            active
+                              ? "border-primary/50 bg-primary/10 text-fg"
+                              : "border-border bg-bg-card/60",
+                          )}
+                        >
+                          {accountLabel}
+                        </span>
+                      ) : (
+                        <span>Not configured</span>
+                      )}
+                      {provider.methods.length > 1 ? (
+                        <span>{provider.methods.length} auth methods</span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="rounded-md border border-dashed border-border px-3 py-4 text-sm text-fg-muted">
+                No providers match this filter.
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+      <p className="text-sm text-fg-muted">
+        Type to narrow the list. Up to five providers stay visible before scrolling.
+      </p>
+      {selectedProviderConfiguredCount > 0 ? (
+        <p className="text-sm text-fg-muted">
+          This provider is already configured. Saving will add another account.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-provider-picker-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-provider-picker-test-support.ts
@@ -1,0 +1,285 @@
+import { expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createBearerTokenAuth, createOperatorCore } from "../../operator-core/src/index.js";
+import { OperatorUiApp } from "../src/index.js";
+import { stubAdminHttpFetch } from "./admin-http-fetch-test-support.js";
+import {
+  TEST_DEVICE_IDENTITY,
+  requestInfoToUrl,
+  setControlledInputValue,
+  stubPersistentStorage,
+  waitForSelector,
+} from "./operator-ui.test-support.js";
+import { FakeWsClient, createFakeHttpClient } from "./operator-ui.test-fixtures.js";
+import {
+  buildIssueStatusResponse,
+  cleanup,
+  createConfiguredProviderGroup,
+  findButtonByText,
+  getInputByLabel,
+  setInputByLabel,
+} from "./operator-ui.first-run-onboarding.helpers.js";
+
+function createRegistryProvider(providerKey: string, name: string) {
+  return {
+    provider_key: providerKey,
+    name,
+    doc: null,
+    supported: true,
+    methods: [
+      {
+        method_key: "api_key",
+        label: "API key",
+        type: "api_key",
+        fields: [
+          {
+            key: "api_key",
+            label: "API key",
+            description: null,
+            kind: "secret",
+            input: "password",
+            required: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function registerFirstRunOnboardingProviderPickerTests(): void {
+  it("filters providers, auto-selects OpenAI, and saves the visible provider selection", async () => {
+    stubPersistentStorage();
+    const ws = new FakeWsClient();
+    const { http, statusGet } = createFakeHttpClient();
+    let providers: ReturnType<typeof createConfiguredProviderGroup>[] = [];
+    let savedBody: {
+      config: Record<string, unknown>;
+      display_name: string;
+      provider_key: string;
+      method_key: string;
+      secrets: Record<string, string>;
+    } | null = null;
+
+    http.providerConfig.listRegistry = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [
+        createRegistryProvider("302ai", "302.AI"),
+        createRegistryProvider("openai", "OpenAI"),
+      ],
+    }));
+    http.providerConfig.listProviders = vi.fn(async () => ({
+      status: "ok" as const,
+      providers,
+    }));
+    http.modelConfig.listPresets = vi.fn(async () => ({ status: "ok" as const, presets: [] }));
+
+    statusGet.mockImplementation(async () => {
+      if (providers.length === 0) {
+        return buildIssueStatusResponse([
+          {
+            code: "no_provider_accounts",
+            severity: "error",
+            message: "No active provider accounts are configured.",
+            target: { kind: "deployment", id: null },
+          },
+        ]);
+      }
+      return buildIssueStatusResponse([
+        {
+          code: "no_model_presets",
+          severity: "error",
+          message: "No model presets are configured.",
+          target: { kind: "deployment", id: null },
+        },
+      ]);
+    });
+
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deviceIdentity: TEST_DEVICE_IDENTITY,
+      deps: { ws, http },
+    });
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    stubAdminHttpFetch(core, async (input, init) => {
+      const url = requestInfoToUrl(input);
+      if (!url.endsWith("/config/providers/accounts")) {
+        throw new Error(`Unexpected fetch call: ${url}`);
+      }
+
+      savedBody = JSON.parse(String(init?.body)) as typeof savedBody;
+      const providerGroup = createConfiguredProviderGroup();
+      providers = [
+        {
+          ...providerGroup,
+          provider_key: savedBody!.provider_key,
+          name: savedBody!.display_name,
+          accounts: [
+            {
+              ...providerGroup.accounts[0],
+              display_name: savedBody!.display_name,
+              provider_key: savedBody!.provider_key,
+              method_key: savedBody!.method_key,
+            },
+          ],
+        },
+      ];
+
+      return new Response(JSON.stringify({ status: "ok", account: providers[0]!.accounts[0] }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await waitForSelector(container, '[data-testid="first-run-onboarding-step-provider"]');
+    const filterInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="providers-filter-input"]',
+    );
+    const displayNameInput = getInputByLabel(container, "Display name");
+
+    expect(filterInput).not.toBeNull();
+    expect(displayNameInput).not.toBeNull();
+    expect(displayNameInput?.value).toBe("302.AI");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "open");
+      await Promise.resolve();
+    });
+
+    const openaiOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="providers-provider-option-openai"]',
+    );
+    expect(container.querySelector('[data-testid="providers-provider-option-302ai"]')).toBeNull();
+    expect(openaiOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("OpenAI");
+
+    setInputByLabel(container, "API key", "sk-openai");
+    await act(async () => {
+      findButtonByText(container, "Save provider account")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(savedBody).toEqual({
+      config: {},
+      display_name: "OpenAI",
+      provider_key: "openai",
+      method_key: "api_key",
+      secrets: { api_key: "sk-openai" },
+    });
+    expect(
+      await waitForSelector(container, '[data-testid="first-run-onboarding-step-preset"]'),
+    ).not.toBeNull();
+
+    cleanup(root, container);
+  });
+
+  it("preserves a custom display name across onboarding provider filter changes", async () => {
+    stubPersistentStorage();
+    const ws = new FakeWsClient();
+    const { http, statusGet } = createFakeHttpClient();
+
+    http.providerConfig.listRegistry = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [
+        createRegistryProvider("302ai", "302.AI"),
+        createRegistryProvider("openai", "OpenAI"),
+      ],
+    }));
+    statusGet.mockResolvedValue(
+      buildIssueStatusResponse([
+        {
+          code: "no_provider_accounts",
+          severity: "error",
+          message: "No active provider accounts are configured.",
+          target: { kind: "deployment", id: null },
+        },
+      ]),
+    );
+
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deviceIdentity: TEST_DEVICE_IDENTITY,
+      deps: { ws, http },
+    });
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    stubAdminHttpFetch(core);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await waitForSelector(container, '[data-testid="first-run-onboarding-step-provider"]');
+    const filterInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="providers-filter-input"]',
+    );
+    const displayNameInput = getInputByLabel(container, "Display name");
+
+    expect(filterInput).not.toBeNull();
+    expect(displayNameInput).not.toBeNull();
+
+    await act(async () => {
+      setControlledInputValue(displayNameInput!, "Team account");
+      setControlledInputValue(filterInput!, "open");
+      await Promise.resolve();
+    });
+
+    const openaiOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="providers-provider-option-openai"]',
+    );
+    expect(openaiOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("Team account");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "zzz");
+      await Promise.resolve();
+    });
+
+    expect(displayNameInput?.value).toBe("Team account");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "");
+      await Promise.resolve();
+    });
+
+    const threeOhTwoOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="providers-provider-option-302ai"]',
+    );
+    expect(threeOhTwoOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("Team account");
+
+    cleanup(root, container);
+  });
+}

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
@@ -1,7 +1,9 @@
 import { registerFirstRunOnboardingFlowTests } from "./operator-ui.first-run-onboarding-flow-test-support.js";
+import { registerFirstRunOnboardingProviderPickerTests } from "./operator-ui.first-run-onboarding-provider-picker-test-support.js";
 import { registerFirstRunOnboardingStateTests } from "./operator-ui.first-run-onboarding-state-test-support.js";
 
 export function registerFirstRunOnboardingTests(): void {
   registerFirstRunOnboardingStateTests();
   registerFirstRunOnboardingFlowTests();
+  registerFirstRunOnboardingProviderPickerTests();
 }

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding.helpers.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding.helpers.ts
@@ -131,8 +131,15 @@ function getControlByLabel<T extends HTMLElement>(
   return (doc?.getElementById(htmlFor) as T | null) ?? null;
 }
 
+export function getInputByLabel(
+  container: HTMLElement | Document,
+  label: string,
+): HTMLInputElement | null {
+  return getControlByLabel<HTMLInputElement>(container, label);
+}
+
 export function setInputByLabel(container: HTMLElement, label: string, value: string): void {
-  const input = getControlByLabel<HTMLInputElement>(container, label);
+  const input = getInputByLabel(container, label);
   expect(input).not.toBeNull();
   setControlledInputValue(input!, value);
 }


### PR DESCRIPTION
## Summary
- align first-run onboarding provider setup with Configure -> Provider
- reuse a shared provider picker UI and provider-selection reconciliation helpers
- add onboarding regressions for the 302.AI -> OpenAI flow and custom display-name preservation

## Why
Onboarding could keep `302.AI` selected under the hood after filtering to another provider, which left the display name stale and could save the wrong provider account.

## Implementation
- extract the Configure-style filterable provider picker into a shared component
- share provider selection, filter reconciliation, and display-name sync logic between onboarding and Configure
- update onboarding to save the reconciled provider and method state

## Testing
- `pnpm exec vitest run packages/operator-ui/tests/pages/admin-http-providers.test.ts`
- `pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts`
- `pnpm exec oxlint packages/operator-ui/src/components/pages/admin-http-providers-dialog.tsx packages/operator-ui/src/components/pages/admin-http-providers.shared.ts packages/operator-ui/src/components/pages/provider-picker-field.tsx packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts packages/operator-ui/src/components/pages/first-run-onboarding.sections.tsx packages/operator-ui/src/components/pages/first-run-onboarding.tsx packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts packages/operator-ui/tests/operator-ui.first-run-onboarding-provider-picker-test-support.ts packages/operator-ui/tests/operator-ui.first-run-onboarding.helpers.ts packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm lint`
- `pnpm typecheck`
- repo pre-push suite: `744` test files passed, `4044` tests passed, `1` skipped

## Risk
Low. The change is isolated to operator-ui provider form behavior and reuses the same shared logic in both onboarding and Configure.

## Rollback
Revert this PR to restore the previous onboarding-specific provider picker behavior.

Closes #1406