### PR TITLE
fix(desktop): unify embedded and remote token recovery

### DIFF
--- a/apps/desktop/src/main/gateway-manager.ts
+++ b/apps/desktop/src/main/gateway-manager.ts
@@ -18,6 +18,11 @@ export interface GatewayManagerOptions {
   host?: string;
 }
 
+type GatewayProcessOptions = Pick<
+  GatewayManagerOptions,
+  "gatewayBin" | "gatewayBinSource" | "dbPath" | "home"
+>;
+
 export interface GatewayLogEntry {
   level: "info" | "error";
   message: string;
@@ -162,6 +167,38 @@ function inferHomeFromDbPath(dbPath: string): string | undefined {
   }
 }
 
+function resolveGatewayMigrationsDir(gatewayBin: string): string | undefined {
+  const gatewayDir = dirname(gatewayBin);
+  const alongsideGateway = join(gatewayDir, "migrations");
+  if (existsSync(alongsideGateway)) {
+    const sqliteDir = join(alongsideGateway, "sqlite");
+    return existsSync(sqliteDir) ? sqliteDir : alongsideGateway;
+  }
+
+  // Monorepo layout: packages/gateway/dist/index.mjs -> packages/gateway/migrations
+  const monorepoMigrations = join(gatewayDir, "../migrations");
+  if (existsSync(monorepoMigrations)) {
+    const sqliteDir = join(monorepoMigrations, "sqlite");
+    return existsSync(sqliteDir) ? sqliteDir : monorepoMigrations;
+  }
+
+  return undefined;
+}
+
+function buildGatewayDbArgs(opts: GatewayProcessOptions): string[] {
+  const home = opts.home ?? inferHomeFromDbPath(opts.dbPath);
+  const args: string[] = [];
+  if (home) args.push("--home", home);
+  args.push("--db", opts.dbPath);
+
+  const migrationsDir = resolveGatewayMigrationsDir(opts.gatewayBin);
+  if (migrationsDir) {
+    args.push("--migrations-dir", migrationsDir);
+  }
+
+  return args;
+}
+
 function isElectronRuntime(versions: NodeJS.ProcessVersions = process.versions): boolean {
   return typeof versions.electron === "string" && versions.electron.length > 0;
 }
@@ -244,36 +281,95 @@ export class GatewayManager extends EventEmitter<GatewayManagerEvents> {
     this.emit("status-change", status);
   }
 
+  async issueDefaultTenantAdminToken(opts: GatewayProcessOptions): Promise<string> {
+    const startupLogLines: string[] = [];
+    const tokens = new Map<string, string>();
+    const launch = resolveGatewayLaunchCommand({
+      gatewayBin: opts.gatewayBin,
+      gatewayBinSource: opts.gatewayBinSource,
+    });
+    const args = [
+      opts.gatewayBin,
+      "tokens",
+      "issue-default-tenant-admin",
+      ...buildGatewayDbArgs(opts),
+    ];
+    const proc = spawn(launch.command, args, {
+      env: {
+        ...process.env,
+        ...launch.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const stdoutProcessor = createBootstrapTokenChunkProcessor(tokens);
+    const stderrProcessor = createBootstrapTokenChunkProcessor(tokens);
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      const redacted = stdoutProcessor.processChunk(data.toString());
+      if (redacted) {
+        appendStartupLogLines(startupLogLines, redacted);
+      }
+    });
+    proc.stderr?.on("data", (data: Buffer) => {
+      const redacted = stderrProcessor.processChunk(data.toString());
+      if (redacted) {
+        appendStartupLogLines(startupLogLines, redacted);
+      }
+    });
+
+    const exit = await new Promise<{ code: number | null; signal: string | null }>(
+      (resolve, reject) => {
+        proc.once("error", reject);
+        proc.once("exit", (code, signal) => {
+          const stdoutFlush = stdoutProcessor.flushRemainder();
+          if (stdoutFlush) {
+            appendStartupLogLines(startupLogLines, stdoutFlush);
+          }
+          const stderrFlush = stderrProcessor.flushRemainder();
+          if (stderrFlush) {
+            appendStartupLogLines(startupLogLines, stderrFlush);
+          }
+          resolve({ code, signal });
+        });
+      },
+    ).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Gateway token recovery command failed to launch: ${message}`);
+    });
+
+    if (exit.code !== 0 || exit.signal !== null) {
+      const reason =
+        summarizeGatewayStartupFailure(startupLogLines) ??
+        `process exited (code ${String(exit.code)}, signal ${String(exit.signal)})`;
+      throw new Error(`Gateway token recovery command failed: ${reason}`);
+    }
+
+    const token = tokens.get("default-tenant-admin")?.trim();
+    if (!token) {
+      throw new Error(
+        "Gateway token recovery command completed without returning a default-tenant-admin token.",
+      );
+    }
+    return token;
+  }
+
   async start(opts: GatewayManagerOptions): Promise<void> {
     if (this.process) throw new Error("Gateway already running");
     this.setStatus("starting");
     this.bootstrapTokens.clear();
 
     const host = opts.host ?? "127.0.0.1";
-    const home = opts.home ?? inferHomeFromDbPath(opts.dbPath);
-    const gatewayDir = dirname(opts.gatewayBin);
-    const migrationsDir = (() => {
-      const alongsideGateway = join(gatewayDir, "migrations");
-      if (existsSync(alongsideGateway)) {
-        const sqliteDir = join(alongsideGateway, "sqlite");
-        return existsSync(sqliteDir) ? sqliteDir : alongsideGateway;
-      }
-
-      // Monorepo layout: packages/gateway/dist/index.mjs -> packages/gateway/migrations
-      const monorepoMigrations = join(gatewayDir, "../migrations");
-      if (existsSync(monorepoMigrations)) {
-        const sqliteDir = join(monorepoMigrations, "sqlite");
-        return existsSync(sqliteDir) ? sqliteDir : monorepoMigrations;
-      }
-
-      return undefined;
-    })();
     const startupLogLines: string[] = [];
-
-    const args: string[] = [opts.gatewayBin, "start", "--host", host, "--port", String(opts.port)];
-    if (home) args.push("--home", home);
-    args.push("--db", opts.dbPath);
-    if (migrationsDir) args.push("--migrations-dir", migrationsDir);
+    const args: string[] = [
+      opts.gatewayBin,
+      "start",
+      "--host",
+      host,
+      "--port",
+      String(opts.port),
+      ...buildGatewayDbArgs(opts),
+    ];
 
     const launch = resolveGatewayLaunchCommand({
       gatewayBin: opts.gatewayBin,

--- a/apps/desktop/src/main/ipc/gateway-ipc-embedded-token.ts
+++ b/apps/desktop/src/main/ipc/gateway-ipc-embedded-token.ts
@@ -1,0 +1,234 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { resolveGatewayBin } from "../gateway-bin-path.js";
+import type { DesktopNodeConfig } from "../config/schema.js";
+import { saveConfig } from "../config/store.js";
+import { decryptToken, encryptToken } from "../config/token-store.js";
+import type { GatewayManager } from "../gateway-manager.js";
+
+export type EmbeddedGatewayTokenState = {
+  current: string | null;
+};
+
+export type EmbeddedGatewayTokenRecoveryContext = "running" | "started";
+type EmbeddedGatewayTokenFailure = "missing" | "decrypt" | "empty";
+type EmbeddedGatewayTokenMessages = {
+  missingTokenRefError: string;
+  decryptWarn: string;
+  decryptFailError: string;
+  emptyTokenWarn: string;
+  emptyTokenFailError: string;
+};
+
+export const EMBEDDED_GATEWAY_TOKEN_RECOVERY_MESSAGES: Record<
+  EmbeddedGatewayTokenRecoveryContext,
+  EmbeddedGatewayTokenMessages
+> = {
+  running: {
+    missingTokenRefError:
+      "Embedded gateway is running but no saved token is available. Restarting the embedded gateway will recover access automatically.",
+    decryptWarn: "Failed to decrypt the saved embedded gateway token while the gateway is running.",
+    decryptFailError:
+      "Embedded gateway token could not be decrypted while the gateway is running. Restarting the embedded gateway will recover access automatically.",
+    emptyTokenWarn: "Saved embedded gateway token was empty while the gateway is running.",
+    emptyTokenFailError:
+      "Embedded gateway token is empty while the gateway is running. Restarting the embedded gateway will recover access automatically.",
+  },
+  started: {
+    missingTokenRefError:
+      "Embedded gateway started but no saved token is available. Automatic recovery should recreate one.",
+    decryptWarn: "Failed to decrypt the saved embedded gateway token after startup.",
+    decryptFailError:
+      "Embedded gateway token could not be decrypted after startup. Automatic recovery should recreate one.",
+    emptyTokenWarn: "Saved embedded gateway token was empty after startup.",
+    emptyTokenFailError:
+      "Embedded gateway token is empty after startup. Automatic recovery should recreate one.",
+  },
+};
+
+type EmbeddedGatewayRuntimeContext = {
+  tyrumHome: string;
+  dbPath: string;
+  gatewayBin: ReturnType<typeof resolveGatewayBin>;
+};
+
+export function normalizeGatewayToken(token: string | undefined | null): string | null {
+  const trimmed = token?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function ensureEmbeddedGatewayToken(
+  config: DesktopNodeConfig,
+  tokenState: EmbeddedGatewayTokenState,
+): string {
+  return resolveEmbeddedGatewayAccessTokenOrThrow(config, tokenState, {
+    missingTokenRefError:
+      "Embedded gateway token is missing. Start the embedded gateway from the Desktop app to recover it automatically.",
+    decryptWarn: "Failed to decrypt the saved embedded gateway token.",
+    decryptFailError:
+      "Embedded gateway token could not be decrypted. Start the embedded gateway from the Desktop app to recover it automatically.",
+    emptyTokenWarn: "Saved embedded gateway token was empty.",
+    emptyTokenFailError:
+      "Embedded gateway token is empty. Start the embedded gateway from the Desktop app to recover it automatically.",
+  });
+}
+
+export function ensureEmbeddedGatewayTokenForRecoveryContext(
+  config: DesktopNodeConfig,
+  tokenState: EmbeddedGatewayTokenState,
+  context: EmbeddedGatewayTokenRecoveryContext,
+): string {
+  return resolveEmbeddedGatewayAccessTokenOrThrow(
+    config,
+    tokenState,
+    EMBEDDED_GATEWAY_TOKEN_RECOVERY_MESSAGES[context],
+  );
+}
+
+export function captureEmbeddedBootstrapToken(
+  mgr: GatewayManager,
+  config: DesktopNodeConfig,
+  tokenState: EmbeddedGatewayTokenState,
+): string | undefined {
+  const bootstrap = normalizeGatewayToken(mgr.getBootstrapToken("default-tenant-admin"));
+  if (!bootstrap) return undefined;
+  persistEmbeddedGatewayToken(config, bootstrap, tokenState);
+  return bootstrap;
+}
+
+export function resolveEmbeddedGatewayRuntimeContext(
+  config: DesktopNodeConfig,
+): EmbeddedGatewayRuntimeContext {
+  const tyrumHome = process.env["TYRUM_HOME"] ?? join(homedir(), ".tyrum");
+  return {
+    tyrumHome,
+    dbPath: resolveEmbeddedGatewayDbPath(config, tyrumHome),
+    gatewayBin: resolveGatewayBin(),
+  };
+}
+
+export async function recoverEmbeddedGatewayAccessToken(
+  config: DesktopNodeConfig,
+  mgr: GatewayManager,
+  runtimeContext: EmbeddedGatewayRuntimeContext,
+  tokenState: EmbeddedGatewayTokenState,
+): Promise<string> {
+  const provisionedToken = resolveProvisionedGatewayToken();
+  if (provisionedToken) {
+    persistEmbeddedGatewayToken(config, provisionedToken, tokenState);
+    return provisionedToken;
+  }
+
+  try {
+    const issuedToken = await mgr.issueDefaultTenantAdminToken({
+      gatewayBin: runtimeContext.gatewayBin.path,
+      gatewayBinSource: runtimeContext.gatewayBin.source,
+      dbPath: runtimeContext.dbPath,
+      home: runtimeContext.tyrumHome,
+    });
+    persistEmbeddedGatewayToken(config, issuedToken, tokenState);
+    return issuedToken;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Automatic embedded token recovery failed: ${message}`);
+  }
+}
+
+function resolveProvisionedGatewayToken(): string | null {
+  return normalizeGatewayToken(
+    process.env["TYRUM_GATEWAY_TOKEN"] ?? process.env["GATEWAY_TOKEN"] ?? "",
+  );
+}
+
+function persistEmbeddedGatewayToken(
+  config: DesktopNodeConfig,
+  token: string,
+  tokenState: EmbeddedGatewayTokenState,
+): void {
+  const normalized = normalizeGatewayToken(token);
+  if (!normalized) {
+    throw new Error("Embedded gateway token must be non-empty.");
+  }
+  config.embedded.tokenRef = encryptToken(normalized);
+  saveConfig(config);
+  tokenState.current = normalized;
+}
+
+function resolveEmbeddedGatewayDbPath(config: DesktopNodeConfig, tyrumHome: string): string {
+  const configured = config.embedded.dbPath.trim();
+  if (configured) return configured;
+
+  const currentPath = join(tyrumHome, "gateway.db");
+  const legacyPath = join(tyrumHome, "gateway", "gateway.db");
+
+  try {
+    if (existsSync(currentPath)) return currentPath;
+  } catch {
+    // ignore
+  }
+
+  try {
+    if (existsSync(legacyPath)) return legacyPath;
+  } catch {
+    // ignore
+  }
+
+  return currentPath;
+}
+
+function readStoredEmbeddedGatewayAccessToken(
+  config: DesktopNodeConfig,
+  tokenState: EmbeddedGatewayTokenState,
+  messages: EmbeddedGatewayTokenMessages,
+): { token: string | null; failure: EmbeddedGatewayTokenFailure | null } {
+  if (tokenState.current) {
+    return { token: tokenState.current, failure: null };
+  }
+
+  const tokenRef = config.embedded.tokenRef;
+  if (!tokenRef) {
+    return { token: null, failure: "missing" };
+  }
+
+  let decrypted: string;
+  try {
+    decrypted = decryptToken(tokenRef);
+  } catch (error) {
+    console.warn(messages.decryptWarn, error);
+    return { token: null, failure: "decrypt" };
+  }
+
+  const normalized = normalizeGatewayToken(decrypted);
+  if (!normalized) {
+    console.warn(messages.emptyTokenWarn);
+    return { token: null, failure: "empty" };
+  }
+
+  tokenState.current = normalized;
+  return { token: normalized, failure: null };
+}
+
+function resolveEmbeddedGatewayAccessTokenOrThrow(
+  config: DesktopNodeConfig,
+  tokenState: EmbeddedGatewayTokenState,
+  messages: EmbeddedGatewayTokenMessages,
+): string {
+  const stored = readStoredEmbeddedGatewayAccessToken(config, tokenState, messages);
+  if (stored.token) return stored.token;
+
+  const provisionedToken = resolveProvisionedGatewayToken();
+  if (provisionedToken) {
+    persistEmbeddedGatewayToken(config, provisionedToken, tokenState);
+    return provisionedToken;
+  }
+
+  switch (stored.failure) {
+    case "decrypt":
+      throw new Error(messages.decryptFailError);
+    case "empty":
+      throw new Error(messages.emptyTokenFailError);
+    default:
+      throw new Error(messages.missingTokenRefError);
+  }
+}

--- a/apps/desktop/src/main/ipc/gateway-ipc.ts
+++ b/apps/desktop/src/main/ipc/gateway-ipc.ts
@@ -5,13 +5,9 @@ import {
   normalizeFingerprint256,
 } from "@tyrum/operator-core/node";
 import { GatewayManager } from "../gateway-manager.js";
-import { configExists, loadConfig, saveConfig } from "../config/store.js";
-import { decryptToken, encryptToken } from "../config/token-store.js";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
+import { configExists, loadConfig } from "../config/store.js";
+import { decryptToken } from "../config/token-store.js";
 import { createWindowSender } from "./window-sender.js";
-import { resolveGatewayBin } from "../gateway-bin-path.js";
 import type { DesktopNodeConfig } from "../config/schema.js";
 import { getGatewayStatusSnapshot } from "./gateway-status.js";
 import {
@@ -21,6 +17,14 @@ import {
   parseGatewayHttpFetchInput,
   resolveGatewayHttpFetchUrl,
 } from "./gateway-ipc-helpers.js";
+import {
+  captureEmbeddedBootstrapToken,
+  ensureEmbeddedGatewayToken as ensureEmbeddedGatewayTokenFromState,
+  ensureEmbeddedGatewayTokenForRecoveryContext,
+  recoverEmbeddedGatewayAccessToken,
+  resolveEmbeddedGatewayRuntimeContext,
+  type EmbeddedGatewayTokenState,
+} from "./gateway-ipc-embedded-token.js";
 
 const sender = createWindowSender();
 let manager: GatewayManager | null = null,
@@ -120,132 +124,11 @@ export interface OperatorConnectionInfo {
   tlsAllowSelfSigned: boolean;
 }
 
-let startPromise: Promise<void> | null = null,
-  embeddedGatewayAccessToken: string | null = null;
-
-type EmbeddedGatewayTokenRecoveryContext = "running" | "started";
-
-const EMBEDDED_GATEWAY_TOKEN_RECOVERY_MESSAGES: Record<
-  EmbeddedGatewayTokenRecoveryContext,
-  {
-    missingTokenRefError: string;
-    decryptWarn: string;
-    decryptFailError: string;
-    invalidFormatWarn: string;
-    invalidFormatFailError: string;
-  }
-> = {
-  running: {
-    missingTokenRefError:
-      "Embedded gateway is running but the stored token is missing. Restart the embedded gateway from the Desktop app.",
-    decryptWarn:
-      "Failed to decrypt embedded gateway token while the gateway is running; refusing to rotate token.",
-    decryptFailError:
-      "Embedded gateway token could not be decrypted while the gateway is running. Restart the embedded gateway from the Desktop app.",
-    invalidFormatWarn:
-      "Invalid embedded gateway token format while the gateway is running; refusing to rotate token.",
-    invalidFormatFailError:
-      "Embedded gateway token has an invalid format while the gateway is running. Restart the embedded gateway from the Desktop app.",
-  },
-  started: {
-    missingTokenRefError:
-      "Embedded gateway started but the stored token is missing. Restart the embedded gateway from the Desktop app.",
-    decryptWarn: "Failed to decrypt embedded gateway token after start; refusing to rotate token.",
-    decryptFailError:
-      "Embedded gateway token could not be decrypted after starting. Restart the embedded gateway from the Desktop app.",
-    invalidFormatWarn:
-      "Invalid embedded gateway token format after start; refusing to rotate token.",
-    invalidFormatFailError:
-      "Embedded gateway token has an invalid format after starting. Restart the embedded gateway from the Desktop app.",
-  },
-};
-
-const TYRUM_TOKEN_PATTERN = /^tyrum-token\.v1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
-
-function isValidEmbeddedGatewayToken(token: string): boolean {
-  return TYRUM_TOKEN_PATTERN.test(token.trim());
-}
-
-function persistEmbeddedGatewayToken(config: DesktopNodeConfig, token: string): void {
-  config.embedded.tokenRef = encryptToken(token);
-  saveConfig(config);
-  embeddedGatewayAccessToken = token;
-}
-
-function resolveEmbeddedGatewayDbPath(config: DesktopNodeConfig, tyrumHome: string): string {
-  const configured = config.embedded.dbPath.trim();
-  if (configured) return configured;
-
-  const currentPath = join(tyrumHome, "gateway.db");
-  const legacyPath = join(tyrumHome, "gateway", "gateway.db");
-
-  try {
-    if (existsSync(currentPath)) return currentPath;
-  } catch {
-    // ignore
-  }
-
-  try {
-    if (existsSync(legacyPath)) return legacyPath;
-  } catch {
-    // ignore
-  }
-
-  return currentPath;
-}
-
-function loadEmbeddedGatewayAccessToken(
-  config: DesktopNodeConfig,
-  messages: {
-    missingTokenRefError: string;
-    decryptWarn: string;
-    decryptFailError: string;
-    invalidFormatWarn: string;
-    invalidFormatFailError: string;
-  },
-): string {
-  if (embeddedGatewayAccessToken) return embeddedGatewayAccessToken;
-
-  const tokenRef = config.embedded.tokenRef;
-  if (!tokenRef) {
-    throw new Error(messages.missingTokenRefError);
-  }
-
-  let decrypted: string;
-  try {
-    decrypted = decryptToken(tokenRef);
-  } catch (error) {
-    console.warn(messages.decryptWarn, error);
-    throw new Error(messages.decryptFailError);
-  }
-
-  if (!isValidEmbeddedGatewayToken(decrypted)) {
-    console.warn(messages.invalidFormatWarn, new Error("Invalid embedded gateway token format"));
-    throw new Error(messages.invalidFormatFailError);
-  }
-
-  embeddedGatewayAccessToken = decrypted;
-  return decrypted;
-}
-
-function recoverEmbeddedGatewayAccessToken(
-  config: DesktopNodeConfig,
-  context: EmbeddedGatewayTokenRecoveryContext,
-): string {
-  return loadEmbeddedGatewayAccessToken(config, EMBEDDED_GATEWAY_TOKEN_RECOVERY_MESSAGES[context]);
-}
+let startPromise: Promise<string> | null = null,
+  embeddedGatewayAccessToken: EmbeddedGatewayTokenState = { current: null };
 
 export function ensureEmbeddedGatewayToken(config: DesktopNodeConfig): string {
-  return loadEmbeddedGatewayAccessToken(config, {
-    missingTokenRefError:
-      "Embedded gateway token is missing. Start the embedded gateway from the Desktop app to bootstrap a token.",
-    decryptWarn: "Failed to decrypt embedded gateway token; restart the embedded gateway.",
-    decryptFailError:
-      "Embedded gateway token could not be decrypted. Restart the embedded gateway from the Desktop app.",
-    invalidFormatWarn: "Invalid embedded gateway token format; restart the embedded gateway.",
-    invalidFormatFailError:
-      "Embedded gateway token has an invalid format. Restart the embedded gateway from the Desktop app.",
-  });
+  return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
 }
 
 function toHttpBaseUrlFromWsUrl(rawUrl: string): string | null {
@@ -283,18 +166,38 @@ function resolveOperatorHttpBaseUrl(config: DesktopNodeConfig): string {
 export function resolveOperatorConnection(config: DesktopNodeConfig): OperatorConnectionInfo {
   if (config.mode === "embedded") {
     const token = (() => {
-      if (embeddedGatewayAccessToken) return embeddedGatewayAccessToken;
+      if (embeddedGatewayAccessToken.current) return embeddedGatewayAccessToken.current;
       const mgr = manager;
       if (mgr?.status === "running") {
-        return recoverEmbeddedGatewayAccessToken(config, "running");
+        try {
+          return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
+        } catch {
+          const bootstrap = captureEmbeddedBootstrapToken(mgr, config, embeddedGatewayAccessToken);
+          if (bootstrap) return bootstrap;
+          return ensureEmbeddedGatewayTokenForRecoveryContext(
+            config,
+            embeddedGatewayAccessToken,
+            "running",
+          );
+        }
       }
       if (startPromise) {
-        return recoverEmbeddedGatewayAccessToken(config, "started");
+        try {
+          return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
+        } catch {
+          const bootstrap = mgr
+            ? captureEmbeddedBootstrapToken(mgr, config, embeddedGatewayAccessToken)
+            : undefined;
+          if (bootstrap) return bootstrap;
+          return ensureEmbeddedGatewayTokenForRecoveryContext(
+            config,
+            embeddedGatewayAccessToken,
+            "started",
+          );
+        }
       }
 
-      const ensured = ensureEmbeddedGatewayToken(config);
-      embeddedGatewayAccessToken = ensured;
-      return ensured;
+      return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
     })();
     const port = config.embedded.port;
     return {
@@ -307,8 +210,6 @@ export function resolveOperatorConnection(config: DesktopNodeConfig): OperatorCo
     };
   }
 
-  // Remote deployments may still use opaque GATEWAY_TOKEN values, so do not
-  // apply the embedded bootstrap-token format check here.
   const token = config.remote.tokenRef ? decryptToken(config.remote.tokenRef) : "";
   const tlsCertFingerprint256 =
     typeof config.remote.tlsCertFingerprint256 === "string"
@@ -331,55 +232,75 @@ async function startEmbeddedGatewayWithConfig(
 ): Promise<string> {
   if (mgr.status === "running") {
     try {
-      return ensureEmbeddedGatewayToken(config);
+      return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
     } catch {
-      const bootstrap = mgr.getBootstrapToken("default-tenant-admin");
-      if (bootstrap && isValidEmbeddedGatewayToken(bootstrap)) {
-        persistEmbeddedGatewayToken(config, bootstrap);
+      const bootstrap = captureEmbeddedBootstrapToken(mgr, config, embeddedGatewayAccessToken);
+      if (bootstrap) {
         return bootstrap;
       }
-      return recoverEmbeddedGatewayAccessToken(config, "running");
+      await mgr.stop();
+      embeddedGatewayAccessToken.current = null;
+      return await startEmbeddedGatewayWithConfig(mgr, loadConfig());
     }
   }
   if (startPromise) {
-    await startPromise;
-    return recoverEmbeddedGatewayAccessToken(config, "started");
+    return await startPromise;
   }
 
-  const tyrumHome = process.env["TYRUM_HOME"] ?? join(homedir(), ".tyrum");
-  const dbPath = resolveEmbeddedGatewayDbPath(config, tyrumHome);
-  const gatewayBin = resolveGatewayBin();
+  const runtimeContext = resolveEmbeddedGatewayRuntimeContext(config);
+  const starter = (async () => {
+    let token: string | null = null;
+    let recoveryError: Error | null = null;
+    try {
+      token = ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
+    } catch (error) {
+      recoveryError = error instanceof Error ? error : new Error(String(error));
+      try {
+        token = await recoverEmbeddedGatewayAccessToken(
+          config,
+          mgr,
+          runtimeContext,
+          embeddedGatewayAccessToken,
+        );
+        recoveryError = null;
+      } catch (recoveryFailure) {
+        recoveryError =
+          recoveryFailure instanceof Error ? recoveryFailure : new Error(String(recoveryFailure));
+      }
+    }
 
-  const starter = mgr.start({
-    gatewayBin: gatewayBin.path,
-    gatewayBinSource: gatewayBin.source,
-    port: config.embedded.port,
-    dbPath,
-    home: tyrumHome,
-    host: "127.0.0.1",
-  });
+    await mgr.start({
+      gatewayBin: runtimeContext.gatewayBin.path,
+      gatewayBinSource: runtimeContext.gatewayBin.source,
+      port: config.embedded.port,
+      dbPath: runtimeContext.dbPath,
+      home: runtimeContext.tyrumHome,
+      host: "127.0.0.1",
+    });
+
+    if (token) return token;
+    try {
+      return ensureEmbeddedGatewayTokenFromState(config, embeddedGatewayAccessToken);
+    } catch {
+      const bootstrap = captureEmbeddedBootstrapToken(mgr, config, embeddedGatewayAccessToken);
+      if (bootstrap) return bootstrap;
+    }
+
+    if (recoveryError) {
+      throw new Error(
+        `Embedded gateway started but automatic token recovery failed: ${recoveryError.message}`,
+      );
+    }
+    throw new Error("Embedded gateway started but no usable access token could be recovered.");
+  })();
   startPromise = starter;
   try {
-    await starter;
+    return await starter;
   } finally {
     if (startPromise === starter) {
       startPromise = null;
     }
   }
-
-  try {
-    return ensureEmbeddedGatewayToken(config);
-  } catch {
-    const bootstrap = mgr.getBootstrapToken("default-tenant-admin");
-    if (bootstrap && isValidEmbeddedGatewayToken(bootstrap)) {
-      persistEmbeddedGatewayToken(config, bootstrap);
-      return bootstrap;
-    }
-  }
-
-  throw new Error(
-    "Embedded gateway started but no bootstrap token was captured. Delete the embedded gateway database or issue a new token, then restart the embedded gateway.",
-  );
 }
 
 export async function startEmbeddedGatewayFromConfig(): Promise<{
@@ -410,7 +331,7 @@ async function handleGatewayStop(): Promise<{ status: "stopped" }> {
   const mgr = manager;
   if (!mgr) return { status: "stopped" };
   await mgr.stop();
-  embeddedGatewayAccessToken = null;
+  embeddedGatewayAccessToken.current = null;
   return { status: "stopped" };
 }
 
@@ -420,7 +341,8 @@ export async function resetGatewayIpcStateForTests(): Promise<void> {
     await manager?.stop();
   } catch {}
   manager?.removeAllListeners();
-  [manager, ipcRegistered, startPromise, embeddedGatewayAccessToken] = [null, false, null, null];
+  [manager, ipcRegistered, startPromise] = [null, false, null];
+  embeddedGatewayAccessToken.current = null;
   sender.setWindow(null);
   await destroyPinnedGatewayFetchState();
 }

--- a/apps/desktop/tests/gateway-ipc-handlers.test-helpers.ts
+++ b/apps/desktop/tests/gateway-ipc-handlers.test-helpers.ts
@@ -5,23 +5,35 @@ import type { BrowserWindow } from "electron";
 export class MockGatewayManager extends EventEmitter {
   public status: "stopped" | "starting" | "running" | "error" = "stopped";
   public lastStartOptions: unknown;
+  public startCalls = 0;
+  public stopCalls = 0;
+  public bootstrapToken: string | undefined = "tyrum-token.v1.bootstrap.token";
+  public issuedDefaultTenantAdminTokenValue = "tyrum-token.v1.issued.token";
+  public issueDefaultTenantAdminTokenCalls = 0;
 
   async start(opts?: unknown): Promise<void> {
     this.lastStartOptions = opts;
+    this.startCalls += 1;
     this.status = "running";
     this.emit("status-change", "running");
   }
 
   async stop(): Promise<void> {
+    this.stopCalls += 1;
     this.status = "stopped";
     this.emit("status-change", "stopped");
   }
 
   getBootstrapToken(label: string): string | undefined {
     if (label === "default-tenant-admin") {
-      return "tyrum-token.v1.bootstrap.token";
+      return this.bootstrapToken;
     }
     return undefined;
+  }
+
+  async issueDefaultTenantAdminToken(): Promise<string> {
+    this.issueDefaultTenantAdminTokenCalls += 1;
+    return this.issuedDefaultTenantAdminTokenValue;
   }
 }
 

--- a/apps/desktop/tests/gateway-ipc-handlers.test.ts
+++ b/apps/desktop/tests/gateway-ipc-handlers.test.ts
@@ -249,75 +249,103 @@ describe("registerGatewayIpc handlers", () => {
     await expect(handler!({} as never)).rejects.toThrow("not configured");
   });
 
-  it("rotates embedded token when persisted token cannot be decrypted", async () => {
+  it("recovers embedded token by issuing a replacement when decryption fails", async () => {
     decryptTokenMock.mockImplementationOnce(() => {
       throw new Error(
         "Error while decrypting the ciphertext provided to safeStorage.decryptString.",
       );
     });
-    await registerGatewayIpcForTest();
+    const { manager } = await registerGatewayIpcForTest();
+    const mgr = manager as MockGatewayManager;
     const handler = getRegisteredHandler("gateway:operator-connection");
     const connection = await handler!({} as never);
     expectConnection(connection, {
       mode: "embedded",
       wsUrl: "ws://127.0.0.1:8788/ws",
       httpBaseUrl: "http://127.0.0.1:8788/",
-      token: "tyrum-token.v1.bootstrap.token",
+      token: "tyrum-token.v1.issued.token",
     });
     expect(generateTokenMock).not.toHaveBeenCalled();
-    expect(encryptTokenMock).toHaveBeenCalledWith("tyrum-token.v1.bootstrap.token");
+    expect(mgr.issueDefaultTenantAdminTokenCalls).toBe(1);
+    expect(encryptTokenMock).toHaveBeenCalledWith("tyrum-token.v1.issued.token");
     expect(saveConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        embedded: expect.objectContaining({ tokenRef: "enc:tyrum-token.v1.bootstrap.token" }),
+        embedded: expect.objectContaining({ tokenRef: "enc:tyrum-token.v1.issued.token" }),
       }),
     );
   });
 
-  it("bootstraps and persists the embedded token on first launch when tokenRef is missing", async () => {
+  it("issues and persists the embedded token on first launch when tokenRef is missing", async () => {
     testState.embeddedTokenRef = "";
-    await registerGatewayIpcForTest();
+    const { manager } = await registerGatewayIpcForTest();
+    const mgr = manager as MockGatewayManager;
     const handler = getRegisteredHandler("gateway:operator-connection");
     const connection = await handler!({} as never);
     expectConnection(connection, {
       mode: "embedded",
       wsUrl: "ws://127.0.0.1:8788/ws",
       httpBaseUrl: "http://127.0.0.1:8788/",
-      token: "tyrum-token.v1.bootstrap.token",
+      token: "tyrum-token.v1.issued.token",
     });
-    expect(encryptTokenMock).toHaveBeenCalledWith("tyrum-token.v1.bootstrap.token");
+    expect(mgr.issueDefaultTenantAdminTokenCalls).toBe(1);
+    expect(encryptTokenMock).toHaveBeenCalledWith("tyrum-token.v1.issued.token");
     expect(saveConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        embedded: expect.objectContaining({ tokenRef: "enc:tyrum-token.v1.bootstrap.token" }),
+        embedded: expect.objectContaining({ tokenRef: "enc:tyrum-token.v1.issued.token" }),
       }),
     );
   });
 
-  it("reports invalid embedded token format distinctly from decryption failures (ensure)", async () => {
-    decryptTokenMock.mockImplementationOnce(() => "not-a-token");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("accepts opaque embedded gateway tokens", async () => {
+    decryptTokenMock.mockImplementationOnce(() => "opaque-embedded-token");
     const { ensureEmbeddedGatewayToken } = await import("../src/main/ipc/gateway-ipc.js");
     const { loadConfig } = await import("../src/main/config/store.js");
-    expect(() => ensureEmbeddedGatewayToken(loadConfig())).toThrow();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/invalid embedded gateway token format/i),
-      expect.any(Error),
-    );
-    warnSpy.mockRestore();
+    expect(ensureEmbeddedGatewayToken(loadConfig())).toBe("opaque-embedded-token");
   });
 
-  it("reports invalid embedded token format distinctly from decryption failures (recover)", async () => {
-    decryptTokenMock.mockImplementationOnce(() => "not-a-token");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const { resolveOperatorConnection, manager } = await registerGatewayIpcForTest();
-    const { loadConfig } = await import("../src/main/config/store.js");
-    const mgr = manager as { status: string };
+  it("uses the provisioned embedded token when the saved token is missing", async () => {
+    const previousGatewayToken = process.env["GATEWAY_TOKEN"];
+    process.env["GATEWAY_TOKEN"] = "opaque-provisioned-token";
+    testState.embeddedTokenRef = "";
+
+    try {
+      const { manager } = await registerGatewayIpcForTest();
+      const mgr = manager as MockGatewayManager;
+      mgr.bootstrapToken = undefined;
+      const handler = getRegisteredHandler("gateway:operator-connection");
+      const connection = await handler!({} as never);
+      expectConnection(connection, {
+        mode: "embedded",
+        wsUrl: "ws://127.0.0.1:8788/ws",
+        httpBaseUrl: "http://127.0.0.1:8788/",
+        token: "opaque-provisioned-token",
+      });
+      expect(mgr.issueDefaultTenantAdminTokenCalls).toBe(0);
+      expect(encryptTokenMock).toHaveBeenCalledWith("opaque-provisioned-token");
+    } finally {
+      if (previousGatewayToken === undefined) delete process.env["GATEWAY_TOKEN"];
+      else process.env["GATEWAY_TOKEN"] = previousGatewayToken;
+    }
+  });
+
+  it("restarts the embedded gateway and reissues a token when a running session has lost it", async () => {
+    testState.embeddedTokenRef = "";
+    const { manager } = await registerGatewayIpcForTest();
+    const mgr = manager as MockGatewayManager;
     mgr.status = "running";
-    expect(() => resolveOperatorConnection(loadConfig())).toThrow();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringMatching(/invalid embedded gateway token format/i),
-      expect.any(Error),
-    );
-    warnSpy.mockRestore();
+    mgr.bootstrapToken = undefined;
+
+    const handler = getRegisteredHandler("gateway:operator-connection");
+    const connection = await handler!({} as never);
+    expectConnection(connection, {
+      mode: "embedded",
+      wsUrl: "ws://127.0.0.1:8788/ws",
+      httpBaseUrl: "http://127.0.0.1:8788/",
+      token: "tyrum-token.v1.issued.token",
+    });
+    expect(mgr.stopCalls).toBe(1);
+    expect(mgr.startCalls).toBe(1);
+    expect(mgr.issueDefaultTenantAdminTokenCalls).toBe(1);
   });
 
   it("does not rotate embedded token when the gateway is already running", async () => {

--- a/apps/desktop/tests/gateway-manager.test.ts
+++ b/apps/desktop/tests/gateway-manager.test.ts
@@ -207,6 +207,62 @@ describe("GatewayManager", () => {
     await gm.stop();
   });
 
+  it("issues a default tenant admin token via the embedded gateway bundle", async () => {
+    const gm = new GatewayManager();
+    const { proc, stdout } = mockStreamingProc();
+    spawnMock.mockReturnValue(proc as never);
+
+    queueMicrotask(() => {
+      stdout.emit("data", Buffer.from("tokens.issue-default-tenant-admin: ok\n"));
+      stdout.emit("data", Buffer.from("default-tenant-admin: tyrum-token.v1.issued.token\n"));
+      proc.exitCode = 0;
+      proc.emit("exit", 0, null);
+    });
+
+    const token = await gm.issueDefaultTenantAdminToken({
+      gatewayBin: "/nonexistent",
+      dbPath: "/tmp/test.db",
+    });
+
+    expect(token).toBe("tyrum-token.v1.issued.token");
+
+    const [, args, options] = spawnMock.mock.calls[0] ?? [];
+    expect(args).toEqual([
+      "/nonexistent",
+      "tokens",
+      "issue-default-tenant-admin",
+      "--home",
+      "/tmp",
+      "--db",
+      "/tmp/test.db",
+    ]);
+    const env = (options as { env?: Record<string, string> }).env;
+    expect(env?.["ELECTRON_RUN_AS_NODE"]).toBeUndefined();
+  });
+
+  it("redacts recovered tokens from token-issue failures", async () => {
+    const gm = new GatewayManager();
+    const { proc, stdout } = mockStreamingProc();
+    spawnMock.mockReturnValue(proc as never);
+
+    queueMicrotask(() => {
+      stdout.emit("data", Buffer.from("default-tenant-admin: tyrum-token.v1.secret.token\n"));
+      proc.exitCode = 1;
+      proc.emit("exit", 1, null);
+    });
+
+    const issue = gm.issueDefaultTenantAdminToken({
+      gatewayBin: "/nonexistent",
+      dbPath: "/tmp/test.db",
+    });
+
+    await expect(issue).rejects.toThrow("default-tenant-admin: [REDACTED]");
+    await issue.catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toContain("tyrum-token.v1.secret.token");
+    });
+  });
+
   it.each([
     {
       name: "uses Electron-as-Node for staged gateway bundles inside Electron",

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -24,6 +24,11 @@ Start an embedded gateway managed by the desktop app.
 1. Keep the default port (`8788`) or pick a free port.
 2. Click **Start Gateway**.
 
+Embedded mode stores its saved gateway token in the desktop config and recovers it automatically if
+that saved value is missing or can no longer be decrypted. If the gateway is provisioned with
+`GATEWAY_TOKEN` or `TYRUM_GATEWAY_TOKEN`, the desktop app reuses and persists that token for later
+embedded reconnects.
+
 When the desktop app is connected, it maintains two gateway connections on this machine:
 
 - an operator client connection for the UI
@@ -72,7 +77,9 @@ the dashboard if you want to use it.
 
 - Confirm the gateway is reachable from your machine (host/port/firewalls).
 - Confirm the WebSocket URL includes `/ws`.
-- If you changed `GATEWAY_TOKEN`, update the token used by the desktop app.
+- Remote mode: if you changed `GATEWAY_TOKEN`, update the token used by the desktop app.
+- Embedded mode: restarting the embedded gateway recovers a missing saved token automatically; you
+  should not need to delete the embedded gateway database just to regain access.
 
 ### macOS permissions
 


### PR DESCRIPTION
## Summary
- unify desktop token handling so embedded mode accepts the same bearer token shapes as remote mode
- auto-recover embedded access by reusing provisioned env tokens or issuing a fresh default-tenant admin token through the embedded gateway bundle
- remove the old delete-the-database recovery guidance and cover the new flow with desktop tests

## Testing
- pnpm exec prettier --check apps/desktop/src/main/ipc/gateway-ipc.ts apps/desktop/src/main/ipc/gateway-ipc-embedded-token.ts
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm -w vitest run apps/desktop/tests/gateway-manager.test.ts apps/desktop/tests/gateway-ipc-handlers.test.ts
- pnpm lint
- pnpm --filter tyrum-desktop test
- git push -u origin 1410-unify-desktop-embedded-and-remote-token-handling

## Risk
- embedded token recovery now depends on the new helper module and one-shot CLI issuance path; the main remaining gap is no packaged Electron smoke test in this environment

## Rollback
- revert commit ee04a8c4

Closes #1410