### PR TITLE
Fix heartbeat runtime selection for default agent

### DIFF
--- a/packages/gateway/src/bootstrap/runtime-builders.ts
+++ b/packages/gateway/src/bootstrap/runtime-builders.ts
@@ -6,7 +6,7 @@ import { NodeDispatchService } from "../modules/agent/node-dispatch-service.js";
 import { AgentRegistry } from "../modules/agent/registry.js";
 import { AuthAudit } from "../modules/auth/audit.js";
 import { SlidingWindowRateLimiter } from "../modules/auth/rate-limiter.js";
-import { deriveAgentIdFromKey } from "../modules/execution/gateway-step-executor-types.js";
+import { deriveAgentKeyFromKey } from "../modules/execution/gateway-step-executor-types.js";
 import { ApprovalEngineActionProcessor } from "../modules/approval/engine-action-processor.js";
 import { ConnectionDirectoryDal } from "../modules/backplane/connection-directory.js";
 import { OutboxDal } from "../modules/backplane/outbox-dal.js";
@@ -484,8 +484,7 @@ export function createWorkerLoop(
       ? async ({ request, planId, stepIndex, timeoutMs, context: executionContext }) => {
           const runtime = await agents.getRuntime({
             tenantId: executionContext.tenantId,
-            agentKey:
-              executionContext.agentId?.trim() || deriveAgentIdFromKey(executionContext.key),
+            agentKey: deriveAgentKeyFromKey(executionContext.key),
           });
           const response = await runtime.executeDecideAction(request, {
             timeoutMs,

--- a/packages/gateway/src/modules/execution/gateway-step-executor-types.ts
+++ b/packages/gateway/src/modules/execution/gateway-step-executor-types.ts
@@ -50,13 +50,15 @@ export function maybeTruncateText(
   return { text: decoder.decode(sliced), truncated: true };
 }
 
-export function deriveAgentIdFromKey(key: string): string {
+export function deriveAgentKeyFromKey(key: string): string {
   if (!key.startsWith("agent:")) return "default";
   const parts = key.split(":");
-  const agentId = parts.length > 1 ? parts[1] : undefined;
-  const trimmed = agentId?.trim() ?? "";
+  const agentKey = parts.length > 1 ? parts[1] : undefined;
+  const trimmed = agentKey?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : "default";
 }
+
+export const deriveAgentIdFromKey = deriveAgentKeyFromKey;
 
 export function extractToolErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;

--- a/packages/gateway/tests/unit/heartbeat-default-agent-runtime.test.ts
+++ b/packages/gateway/tests/unit/heartbeat-default-agent-runtime.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { MockLanguageModelV3 } from "ai/test";
+import { createContainer, type GatewayContainer } from "../../src/container.js";
+import { AgentRegistry } from "../../src/modules/agent/registry.js";
+import { createProtocolRuntime, createWorkerLoop } from "../../src/bootstrap/runtime-builders.js";
+import { createExecutionEngine } from "../../src/bootstrap/runtime-builders-engine.js";
+import type { GatewayBootContext } from "../../src/bootstrap/runtime-shared.js";
+import { ScheduleService } from "../../src/modules/automation/schedule-service.js";
+import { WatcherScheduler } from "../../src/modules/watcher/scheduler.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+  migrationsDir,
+  seedAgentConfig,
+  teardownTestEnv,
+} from "./agent-runtime.test-helpers.js";
+
+describe("default heartbeat runtime selection", () => {
+  let homeDir: string | undefined;
+  let container: GatewayContainer | undefined;
+
+  afterEach(async () => {
+    await teardownTestEnv({ homeDir, container });
+    container = undefined;
+    homeDir = undefined;
+  });
+
+  it("fires the seeded default heartbeat without creating a UUID-scoped agent runtime", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-heartbeat-default-"));
+    container = await createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+      tyrumHome: homeDir,
+    });
+
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { enabled: [] },
+        mcp: {
+          enabled: [],
+          server_settings: { memory: { enabled: false } },
+        },
+        tools: { allow: [] },
+        sessions: { ttl_days: 30, max_turns: 20 },
+      },
+    });
+
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        content: [{ type: "text" as const, text: "done" }],
+        finishReason: { unified: "stop" as const, raw: undefined },
+        usage: {
+          inputTokens: { total: 1, noCache: 1, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 1, text: 1, reasoning: undefined },
+        },
+        warnings: [],
+      }),
+    });
+
+    const logger = container.logger.child({ test: "heartbeat-default-agent-runtime" });
+    const secretProviderForTenant = (() => ({
+      list: async () => [],
+      resolve: async () => null,
+      store: async () => {
+        throw new Error("not implemented");
+      },
+      revoke: async () => false,
+    })) as GatewayBootContext["secretProviderForTenant"];
+    const context: GatewayBootContext = {
+      instanceId: "test-instance",
+      role: "all",
+      tyrumHome: homeDir,
+      host: "127.0.0.1",
+      port: 8788,
+      dbPath: ":memory:",
+      migrationsDir,
+      isLocalOnly: true,
+      shouldRunEdge: false,
+      shouldRunWorker: true,
+      deploymentConfig: container.deploymentConfig,
+      container,
+      logger,
+      authTokens: {} as GatewayBootContext["authTokens"],
+      secretProviderForTenant,
+      lifecycleHooks: [],
+    };
+
+    const protocol = await createProtocolRuntime(context, {
+      enabled: false,
+      shutdown: async () => undefined,
+    });
+    const agents = new AgentRegistry({
+      container,
+      baseHome: homeDir,
+      secretProviderForTenant,
+      defaultPolicyService: container.policyService,
+      defaultLanguageModel: model,
+      protocolDeps: protocol.protocolDeps,
+      logger,
+    });
+    protocol.protocolDeps.agents = agents;
+
+    const workerLoop = createWorkerLoop(context, protocol);
+    expect(workerLoop).toBeDefined();
+
+    try {
+      const scheduleService = new ScheduleService(container.db, container.identityScopeDal);
+      await scheduleService.ensureDefaultHeartbeatScheduleForMembership({
+        tenantId: DEFAULT_TENANT_ID,
+        agentId: DEFAULT_AGENT_ID,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+        nowMs: Date.now(),
+      });
+
+      const [defaultHeartbeat] = await scheduleService.listSchedules({
+        tenantId: DEFAULT_TENANT_ID,
+        includeDeleted: true,
+      });
+      if (!defaultHeartbeat) {
+        throw new Error("expected seeded default heartbeat schedule");
+      }
+
+      await scheduleService.updateSchedule({
+        tenantId: DEFAULT_TENANT_ID,
+        scheduleId: defaultHeartbeat.schedule_id,
+        patch: { cadence: { type: "interval", interval_ms: 1_000 } },
+      });
+      await container.db.run(
+        `UPDATE watchers
+         SET last_fired_at_ms = 0
+         WHERE tenant_id = ? AND watcher_id = ?`,
+        [DEFAULT_TENANT_ID, defaultHeartbeat.schedule_id],
+      );
+
+      const scheduler = new WatcherScheduler({
+        db: container.db,
+        memoryDal: container.memoryDal,
+        eventBus: container.eventBus,
+        owner: "scheduler-1",
+        logger,
+        engine: createExecutionEngine(context),
+        policyService: container.policyService,
+        automationEnabled: true,
+      });
+
+      await scheduler.tick();
+
+      const deadlineMs = Date.now() + 5_000;
+      while (Date.now() < deadlineMs) {
+        const run = await container.db.get<{ status: string }>(
+          `SELECT status
+           FROM execution_runs
+           WHERE tenant_id = ?
+           ORDER BY created_at DESC
+           LIMIT 1`,
+          [DEFAULT_TENANT_ID],
+        );
+        if (run && !["queued", "running", "paused"].includes(run.status)) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      const latestRun = await container.db.get<{ status: string }>(
+        `SELECT status
+         FROM execution_runs
+         WHERE tenant_id = ?
+         ORDER BY created_at DESC
+         LIMIT 1`,
+        [DEFAULT_TENANT_ID],
+      );
+      expect(latestRun?.status).toBe("succeeded");
+
+      const agentDirs = await readdir(join(homeDir, "agents"));
+      expect(agentDirs).toContain("default");
+      expect(agentDirs).not.toContain(DEFAULT_AGENT_ID);
+
+      const agentRows = await container.db.all<{ agent_key: string }>(
+        `SELECT agent_key
+         FROM agents
+         WHERE tenant_id = ?
+         ORDER BY agent_key ASC`,
+        [DEFAULT_TENANT_ID],
+      );
+      expect(agentRows.map((row) => row.agent_key)).toEqual(["default"]);
+    } finally {
+      workerLoop?.stop();
+      await workerLoop?.done;
+      protocol.approvalEngineActionProcessor?.stop();
+      await agents.shutdown();
+    }
+  }, 15_000);
+});

--- a/packages/gateway/tests/unit/runtime-builders-worker-agent-key.test.ts
+++ b/packages/gateway/tests/unit/runtime-builders-worker-agent-key.test.ts
@@ -1,0 +1,134 @@
+import { DeploymentConfig } from "@tyrum/schemas";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StepExecutionContext } from "../../src/modules/execution/engine.js";
+
+type DecideExecutorInput = {
+  request: {
+    channel: string;
+    thread_id: string;
+    message: string;
+  };
+  planId: string;
+  stepIndex: number;
+  timeoutMs: number;
+  context: StepExecutionContext;
+};
+
+type DecideExecutor = (
+  input: DecideExecutorInput,
+) => Promise<{ success: boolean; result: unknown }>;
+
+describe("createWorkerLoop runtime selection", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("resolves decide runtimes from the execution key instead of run.agent_id", async () => {
+    vi.resetModules();
+
+    let decideExecutor: DecideExecutor | undefined;
+    const executeDecideAction = vi.fn(async () => ({ reply: "", session_id: "session-1" }));
+    const getRuntime = vi.fn(async () => ({ executeDecideAction }));
+
+    vi.doMock("../../src/bootstrap/runtime-builders-engine.js", () => ({
+      createExecutionEngine: vi.fn(() => ({ kind: "execution-engine" })),
+    }));
+
+    vi.doMock("../../src/modules/execution/toolrunner-step-executor.js", () => ({
+      createToolRunnerStepExecutor: vi.fn(() => ({ kind: "toolrunner" })),
+    }));
+
+    vi.doMock("../../src/modules/execution/kubernetes-toolrunner-step-executor.js", () => ({
+      createKubernetesToolRunnerStepExecutor: vi.fn(() => ({ kind: "kubernetes-toolrunner" })),
+    }));
+
+    vi.doMock("../../src/modules/execution/node-dispatch-step-executor.js", () => ({
+      createNodeDispatchStepExecutor: vi.fn(({ fallback }: { fallback: unknown }) => fallback),
+    }));
+
+    vi.doMock("../../src/modules/agent/node-dispatch-service.js", () => ({
+      NodeDispatchService: function NodeDispatchService() {},
+    }));
+
+    vi.doMock("../../src/modules/execution/gateway-step-executor.js", () => ({
+      createGatewayStepExecutor: vi.fn((opts: { decideExecutor?: DecideExecutor }) => {
+        decideExecutor = opts.decideExecutor;
+        return { kind: "gateway-step-executor" };
+      }),
+    }));
+
+    vi.doMock("../../src/modules/execution/worker-loop.js", () => ({
+      startExecutionWorkerLoop: vi.fn(() => ({
+        stop: vi.fn(),
+        done: Promise.resolve(),
+      })),
+    }));
+
+    vi.doMock("../../src/bootstrap/entrypoint-path.js", () => ({
+      resolveGatewayEntrypointPath: vi.fn(() => "/tmp/tyrum-entrypoint"),
+    }));
+
+    const { createWorkerLoop } = await import("../../src/bootstrap/runtime-builders.js");
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const context = {
+      shouldRunWorker: true,
+      deploymentConfig: DeploymentConfig.parse({}),
+      dbPath: ":memory:",
+      tyrumHome: "/tmp/tyrum-home",
+      migrationsDir: "/tmp/tyrum-migrations",
+      container: {
+        db: {},
+        artifactStore: {},
+      },
+      logger,
+      instanceId: "worker-1",
+    } as const;
+    const protocol = {
+      protocolDeps: {
+        agents: { getRuntime },
+      },
+    } as const;
+
+    expect(createWorkerLoop(context as never, protocol as never)).toBeDefined();
+    expect(decideExecutor).toBeDefined();
+    if (!decideExecutor) {
+      throw new Error("expected createWorkerLoop to wire a decide executor");
+    }
+
+    await decideExecutor({
+      request: {
+        channel: "automation:default",
+        thread_id: "schedule-1",
+        message: "Run the heartbeat.",
+      },
+      planId: "plan-1",
+      stepIndex: 0,
+      timeoutMs: 5_000,
+      context: {
+        tenantId: "tenant-1",
+        runId: "run-1",
+        stepId: "step-1",
+        attemptId: "attempt-1",
+        approvalId: null,
+        agentId: "00000000-0000-4000-8000-000000000002",
+        key: "agent:default:main",
+        lane: "heartbeat",
+        workspaceId: "workspace-1",
+        policySnapshotId: null,
+      },
+    });
+
+    expect(getRuntime).toHaveBeenCalledOnce();
+    expect(getRuntime).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      agentKey: "default",
+    });
+    expect(executeDecideAction).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- resolve heartbeat `Decide` runtimes from the execution key instead of `run.agent_id`
- rename the key parser to `deriveAgentKeyFromKey` while keeping the old export as a compatibility alias
- add worker and end-to-end regressions proving the default heartbeat stays on the `default` agent runtime

## Why
The first heartbeat for the seeded default agent could create a UUID-scoped runtime/home because the worker passed the execution run's agent UUID into `agents.getRuntime()`, which expects an agent key.

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

## Risk
Low. The change is isolated to heartbeat runtime selection and is covered by both a narrow worker regression and an end-to-end scheduler/worker regression.

## Rollback
Revert commit `b394a822` to restore the previous worker runtime selection behavior.

Closes #1412
