### PR TITLE
feat(operator-ui): auto-approve embedded local nodes

### DIFF
--- a/packages/operator-ui/src/app.tsx
+++ b/packages/operator-ui/src/app.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider, useThemeOptional } from "./hooks/use-theme.js";
 import { BrowserNodeProvider } from "./browser-node/browser-node-provider.js";
 import { getDesktopApi } from "./desktop-api.js";
 import { OperatorUiHostProvider, useHostApiOptional, type HostKind } from "./host/host-api.js";
+import { LocalNodeAutoApprovalBridge } from "./local-node-auto-approval.js";
 import { CONNECT_PAGE_RENDER, getOperatorRouteDefinition } from "./operator-routes.js";
 import { RetainedUiStateProvider } from "./reconnect-ui-state.js";
 import { useOperatorAppViewModel } from "./use-operator-app-view-model.js";
@@ -157,6 +158,7 @@ function OperatorUiAppRoot({
     >
       <RetainedUiStateProvider scopeKey={reconnectUiScopeKey}>
         <AdminAccessProvider core={core} mode={mode} adminAccessController={adminAccessController}>
+          <LocalNodeAutoApprovalBridge />
           {viewModel.showConnectPage ? (
             <div className="flex min-h-0 flex-1 overflow-hidden">
               <ScrollArea className="h-full w-full">

--- a/packages/operator-ui/src/local-node-auto-approval.tsx
+++ b/packages/operator-ui/src/local-node-auto-approval.tsx
@@ -1,0 +1,391 @@
+import type { PairingGetResponse } from "@tyrum/client";
+import {
+  ElevatedModeRequiredError,
+  isElevatedModeActive,
+  type Pairing,
+} from "@tyrum/operator-core";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { useBrowserNodeOptional } from "./browser-node/browser-node-provider.js";
+import { useElevatedModeUiContext } from "./components/elevated-mode/elevated-mode-provider.js";
+import { useHostApiOptional } from "./host/host-api.js";
+import { useOperatorStore } from "./use-operator-store.js";
+
+const AUTO_APPROVE_REASON = "auto-approved local app node";
+
+type LocalNodeStatus = "disabled" | "disconnected" | "connecting" | "connected" | "error";
+
+type LocalNodeSnapshot = {
+  enabled: boolean;
+  status: LocalNodeStatus;
+  deviceId: string | null;
+};
+
+type AutoApprovalAttemptState = "in_flight" | "approved" | "blocked" | "failed";
+
+type AutoApprovalAttempt = {
+  state: AutoApprovalAttemptState;
+  summaryVersion: string;
+};
+
+const NO_LOCAL_NODE: LocalNodeSnapshot = {
+  enabled: false,
+  status: "disabled",
+  deviceId: null,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isAutoApprovablePairingStatus(status: Pairing["status"]): boolean {
+  return status === "queued" || status === "awaiting_human";
+}
+
+function buildPairingKey(input: Pick<Pairing, "pairing_id" | "requested_at">): string {
+  return `${String(input.pairing_id)}:${input.requested_at}`;
+}
+
+function isLocalNodeEligible(snapshot: LocalNodeSnapshot): boolean {
+  return (
+    snapshot.enabled &&
+    snapshot.deviceId !== null &&
+    (snapshot.status === "connected" || snapshot.status === "connecting")
+  );
+}
+
+function isLocalPairingCandidate(pairing: Pairing, localNode: LocalNodeSnapshot): boolean {
+  return (
+    isLocalNodeEligible(localNode) &&
+    pairing.node.node_id === localNode.deviceId &&
+    isAutoApprovablePairingStatus(pairing.status)
+  );
+}
+
+function buildPairingSummaryVersion(input: Pick<Pairing, "status" | "latest_review">): string {
+  const latestReview = input.latest_review;
+  return [
+    input.status,
+    latestReview?.review_id ?? "",
+    latestReview?.state ?? "",
+    latestReview?.created_at ?? "",
+    latestReview?.started_at ?? "",
+    latestReview?.completed_at ?? "",
+  ].join("|");
+}
+
+function parseDesktopNodeSnapshot(value: unknown): LocalNodeSnapshot | null {
+  if (!isRecord(value)) return null;
+  const node = isRecord(value["node"]) ? value["node"] : null;
+  if (!node) return null;
+
+  const rawStatus = readTrimmedString(value["nodeStatus"]);
+  const connected = node["connected"] === true;
+  const status: LocalNodeStatus = connected
+    ? "connected"
+    : rawStatus === "connecting"
+      ? "connecting"
+      : rawStatus === "error"
+        ? "error"
+        : "disconnected";
+
+  return {
+    enabled: true,
+    status,
+    deviceId: readTrimmedString(node["deviceId"]),
+  };
+}
+
+export function extractLatestTerminalReviewState(
+  pairing: PairingGetResponse["pairing"],
+): "approved" | "denied" | "revoked" | null {
+  const reviews = pairing.reviews ?? (pairing.latest_review ? [pairing.latest_review] : []);
+  let latest:
+    | {
+        index: number;
+        state: "approved" | "denied" | "revoked";
+        sortValue: number;
+      }
+    | undefined;
+
+  for (const [index, review] of reviews.entries()) {
+    if (review.state !== "approved" && review.state !== "denied" && review.state !== "revoked") {
+      continue;
+    }
+
+    const sortValueRaw = Date.parse(review.completed_at ?? review.started_at ?? review.created_at);
+    const sortValue = Number.isFinite(sortValueRaw) ? sortValueRaw : -1;
+    if (
+      latest === undefined ||
+      sortValue > latest.sortValue ||
+      (sortValue === latest.sortValue && index > latest.index)
+    ) {
+      latest = { index, state: review.state, sortValue };
+    }
+  }
+
+  return latest?.state ?? null;
+}
+
+export function isBenignAutoApprovalRace(
+  core: { pairingStore: { getSnapshot(): { byId: Record<number, Pairing> } } },
+  pairingId: number,
+  pairingKey: string,
+): boolean {
+  const current = core.pairingStore.getSnapshot().byId[pairingId];
+  if (!current) return true;
+  if (buildPairingKey(current) !== pairingKey) return true;
+  return !isAutoApprovablePairingStatus(current.status);
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function useDesktopLocalNodeSnapshot(): LocalNodeSnapshot {
+  const host = useHostApiOptional();
+  const desktopApi = host?.kind === "desktop" ? host.api : null;
+  const [snapshot, setSnapshot] = useState<LocalNodeSnapshot>(NO_LOCAL_NODE);
+
+  useEffect(() => {
+    if (!desktopApi?.node.getStatus) {
+      setSnapshot(NO_LOCAL_NODE);
+      return;
+    }
+
+    let disposed = false;
+
+    void desktopApi.node
+      .getStatus()
+      .then((status) => {
+        if (disposed) return;
+        setSnapshot({
+          enabled: true,
+          status: status.connected ? "connected" : "disconnected",
+          deviceId: readTrimmedString(status.deviceId),
+        });
+      })
+      .catch(() => {
+        if (!disposed) {
+          setSnapshot(NO_LOCAL_NODE);
+        }
+      });
+
+    const unsubscribe = desktopApi.onStatusChange((event) => {
+      if (disposed) return;
+      const next = parseDesktopNodeSnapshot(event);
+      if (next) {
+        setSnapshot(next);
+      }
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, [desktopApi]);
+
+  return snapshot;
+}
+
+function useMobileLocalNodeSnapshot(): LocalNodeSnapshot {
+  const host = useHostApiOptional();
+  const mobileApi = host?.kind === "mobile" ? host.api : null;
+  const [snapshot, setSnapshot] = useState<LocalNodeSnapshot>(NO_LOCAL_NODE);
+
+  useEffect(() => {
+    if (!mobileApi) {
+      setSnapshot(NO_LOCAL_NODE);
+      return;
+    }
+
+    let disposed = false;
+
+    void mobileApi.node
+      .getState()
+      .then((state) => {
+        if (disposed) return;
+        setSnapshot({
+          enabled: state.enabled,
+          status: state.status,
+          deviceId: readTrimmedString(state.deviceId),
+        });
+      })
+      .catch(() => {
+        if (!disposed) {
+          setSnapshot(NO_LOCAL_NODE);
+        }
+      });
+
+    const unsubscribe = mobileApi.onStateChange?.((state) => {
+      if (disposed) return;
+      setSnapshot({
+        enabled: state.enabled,
+        status: state.status,
+        deviceId: readTrimmedString(state.deviceId),
+      });
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, [mobileApi]);
+
+  return snapshot;
+}
+
+function useBrowserLocalNodeSnapshot(): LocalNodeSnapshot {
+  const browserNode = useBrowserNodeOptional();
+
+  return useMemo(() => {
+    if (!browserNode) return NO_LOCAL_NODE;
+    return {
+      enabled: browserNode.enabled,
+      status: browserNode.status,
+      deviceId: readTrimmedString(browserNode.deviceId),
+    };
+  }, [browserNode]);
+}
+
+function useLocalNodeSnapshot(): LocalNodeSnapshot {
+  const host = useHostApiOptional();
+  const desktopSnapshot = useDesktopLocalNodeSnapshot();
+  const mobileSnapshot = useMobileLocalNodeSnapshot();
+  const browserSnapshot = useBrowserLocalNodeSnapshot();
+
+  switch (host?.kind) {
+    case "desktop":
+      return desktopSnapshot;
+    case "mobile":
+      return mobileSnapshot;
+    case "web":
+      return browserSnapshot;
+    default:
+      return NO_LOCAL_NODE;
+  }
+}
+
+export function LocalNodeAutoApprovalBridge(): null {
+  const { core, enterElevatedMode } = useElevatedModeUiContext();
+  const localNode = useLocalNodeSnapshot();
+  const pairing = useOperatorStore(core.pairingStore);
+  const elevatedMode = useOperatorStore(core.elevatedModeStore);
+  const elevatedModeRef = useRef(elevatedMode);
+  const localNodeRef = useRef(localNode);
+  const attemptsRef = useRef(new Map<string, AutoApprovalAttempt>());
+
+  elevatedModeRef.current = elevatedMode;
+  localNodeRef.current = localNode;
+
+  const candidates = useMemo(
+    () =>
+      Object.values(pairing.byId).filter((entry) => {
+        return isLocalPairingCandidate(entry, localNode);
+      }),
+    [localNode, pairing.byId],
+  );
+
+  useEffect(() => {
+    for (const candidate of candidates) {
+      const pairingKey = buildPairingKey(candidate);
+      const summaryVersion = buildPairingSummaryVersion(candidate);
+      const previousAttempt = attemptsRef.current.get(pairingKey);
+      if (
+        previousAttempt?.state === "blocked" &&
+        previousAttempt.summaryVersion !== summaryVersion
+      ) {
+        attemptsRef.current.delete(pairingKey);
+      }
+    }
+  }, [candidates]);
+
+  useEffect(() => {
+    if (!isLocalNodeEligible(localNode)) return;
+
+    for (const candidate of candidates) {
+      const pairingKey = buildPairingKey(candidate);
+      const summaryVersion = buildPairingSummaryVersion(candidate);
+      if (attemptsRef.current.has(pairingKey)) {
+        continue;
+      }
+      attemptsRef.current.set(pairingKey, { state: "in_flight", summaryVersion });
+
+      void (async () => {
+        try {
+          const detailed = await core.http.pairings.get(candidate.pairing_id);
+          const current = detailed.pairing;
+          if (buildPairingKey(current) !== pairingKey) {
+            attemptsRef.current.delete(pairingKey);
+            return;
+          }
+          if (!isAutoApprovablePairingStatus(current.status)) {
+            attemptsRef.current.delete(pairingKey);
+            return;
+          }
+
+          const activeLocalNode = localNodeRef.current;
+          if (
+            !isLocalNodeEligible(activeLocalNode) ||
+            current.node.node_id !== activeLocalNode.deviceId
+          ) {
+            attemptsRef.current.delete(pairingKey);
+            return;
+          }
+
+          const latestTerminalReviewState = extractLatestTerminalReviewState(current);
+          if (latestTerminalReviewState === "denied" || latestTerminalReviewState === "revoked") {
+            attemptsRef.current.set(pairingKey, {
+              state: "blocked",
+              summaryVersion: buildPairingSummaryVersion(current),
+            });
+            return;
+          }
+
+          if (!isElevatedModeActive(elevatedModeRef.current)) {
+            await enterElevatedMode();
+          }
+
+          const approveInput = {
+            trust_level: "local" as const,
+            capability_allowlist: current.node.capabilities,
+            reason: AUTO_APPROVE_REASON,
+          };
+
+          try {
+            await core.pairingStore.approve(current.pairing_id, approveInput);
+          } catch (error) {
+            if (!(error instanceof ElevatedModeRequiredError)) {
+              throw error;
+            }
+            await enterElevatedMode();
+            await core.pairingStore.approve(current.pairing_id, approveInput);
+          }
+
+          attemptsRef.current.set(pairingKey, {
+            state: "approved",
+            summaryVersion: buildPairingSummaryVersion(current),
+          });
+        } catch (error) {
+          if (isBenignAutoApprovalRace(core, candidate.pairing_id, pairingKey)) {
+            attemptsRef.current.delete(pairingKey);
+            return;
+          }
+          attemptsRef.current.set(pairingKey, {
+            state: "failed",
+            summaryVersion,
+          });
+          toast.warning(`Local node auto-approval failed: ${formatErrorMessage(error)}`);
+        }
+      })();
+    }
+  }, [candidates, core, enterElevatedMode, localNode]);
+
+  return null;
+}

--- a/packages/operator-ui/tests/operator-ui.local-node-auto-approval.helpers.test.ts
+++ b/packages/operator-ui/tests/operator-ui.local-node-auto-approval.helpers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { PairingGetResponse } from "@tyrum/client/browser";
+import {
+  extractLatestTerminalReviewState,
+  isBenignAutoApprovalRace,
+} from "../src/local-node-auto-approval.js";
+import { samplePairingRequestPending } from "./operator-ui.test-fixtures.js";
+
+type PairingReview = NonNullable<PairingGetResponse["pairing"]["reviews"]>[number];
+
+function createReview(
+  state: PairingReview["state"],
+  createdAt: string,
+  reviewId = `${state}-${createdAt}`,
+): PairingReview {
+  return {
+    review_id: reviewId,
+    target_type: "pairing",
+    target_id: "1",
+    reviewer_kind: state === "requested_human" ? "system" : "human",
+    reviewer_id: null,
+    state,
+    reason: state,
+    risk_level: null,
+    risk_score: null,
+    evidence: null,
+    decision_payload: null,
+    created_at: createdAt,
+    started_at: createdAt,
+    completed_at: state === "requested_human" ? null : createdAt,
+  };
+}
+
+function createPairing(input?: {
+  pairingId?: number;
+  nodeId?: string;
+  requestedAt?: string;
+  status?: PairingGetResponse["pairing"]["status"];
+  latestReview?: PairingGetResponse["pairing"]["latest_review"];
+  reviews?: PairingReview[];
+}): PairingGetResponse["pairing"] {
+  const pairing = samplePairingRequestPending();
+  return {
+    ...pairing,
+    pairing_id: input?.pairingId ?? pairing.pairing_id,
+    requested_at: input?.requestedAt ?? pairing.requested_at,
+    status: input?.status ?? pairing.status,
+    node: {
+      ...pairing.node,
+      node_id: input?.nodeId ?? pairing.node.node_id,
+    },
+    latest_review: input?.latestReview ?? pairing.latest_review,
+    ...(input?.reviews ? { reviews: input.reviews } : {}),
+  };
+}
+
+describe("local node auto approval helpers", () => {
+  it("treats a later terminal approval as the active review state", () => {
+    const pendingReview = createReview("requested_human", "2026-01-01T00:00:03.000Z", "pending-1");
+    const pairing = createPairing({
+      latestReview: pendingReview,
+      reviews: [
+        createReview("denied", "2026-01-01T00:00:01.000Z", "denied-1"),
+        createReview("approved", "2026-01-01T00:00:02.000Z", "approved-1"),
+        pendingReview,
+      ],
+    });
+
+    expect(extractLatestTerminalReviewState(pairing)).toBe("approved");
+  });
+
+  it("marks reviewing responses as benign races", () => {
+    const pairing = createPairing({
+      pairingId: 8,
+      requestedAt: "2026-01-01T00:00:00.000Z",
+      status: "reviewing",
+    });
+
+    expect(
+      isBenignAutoApprovalRace(
+        { pairingStore: { getSnapshot: () => ({ byId: { 8: pairing } }) } },
+        8,
+        "8:2026-01-01T00:00:00.000Z",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not mark matching actionable pairings as benign races", () => {
+    const pairing = createPairing({
+      pairingId: 9,
+      requestedAt: "2026-01-01T00:00:00.000Z",
+      status: "awaiting_human",
+    });
+
+    expect(
+      isBenignAutoApprovalRace(
+        { pairingStore: { getSnapshot: () => ({ byId: { 9: pairing } }) } },
+        9,
+        "9:2026-01-01T00:00:00.000Z",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/operator-ui/tests/operator-ui.local-node-auto-approval.test.ts
+++ b/packages/operator-ui/tests/operator-ui.local-node-auto-approval.test.ts
@@ -1,0 +1,501 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import type { PairingGetResponse } from "@tyrum/client/browser";
+import {
+  createBearerTokenAuth,
+  createElevatedModeStore,
+  createOperatorCore,
+  isElevatedModeActive,
+  type ElevatedModeStore,
+  type OperatorCore,
+} from "../../operator-core/src/index.js";
+import {
+  AdminAccessProvider,
+  OperatorUiHostProvider,
+  type AdminAccessController,
+  type MobileHostApi,
+  type MobileHostState,
+  type OperatorUiHostApi,
+} from "../src/index.js";
+import { LocalNodeAutoApprovalBridge } from "../src/local-node-auto-approval.js";
+import { FakeWsClient, createFakeHttpClient } from "./operator-ui.test-fixtures.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const { browserNodeStateRef, toastErrorMock, toastWarningMock } = vi.hoisted(() => ({
+  browserNodeStateRef: { value: null as Record<string, unknown> | null },
+  toastErrorMock: vi.fn(),
+  toastWarningMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+    warning: toastWarningMock,
+  },
+}));
+
+vi.mock("../src/browser-node/browser-node-provider.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/browser-node/browser-node-provider.js")
+  >("../src/browser-node/browser-node-provider.js");
+  return {
+    ...actual,
+    useBrowserNodeOptional: () => browserNodeStateRef.value,
+  };
+});
+
+type PairingReview = NonNullable<PairingGetResponse["pairing"]["reviews"]>[number];
+
+const CAPABILITIES = [{ id: "tyrum.http", version: "1.0.0" }] as const;
+const ACTIVE_ENTERED_AT = "2026-01-01T00:00:00.000Z",
+  ACTIVE_EXPIRES_AT = "2026-01-01T00:10:00.000Z";
+
+function createReview(
+  state: PairingReview["state"],
+  createdAt: string,
+  reviewId = `${state}-${createdAt}`,
+): PairingReview {
+  return {
+    review_id: reviewId,
+    target_type: "pairing",
+    target_id: "1",
+    reviewer_kind: state === "requested_human" ? "system" : "human",
+    reviewer_id: null,
+    state,
+    reason: state,
+    risk_level: null,
+    risk_score: null,
+    evidence: null,
+    decision_payload: null,
+    created_at: createdAt,
+    started_at: createdAt,
+    completed_at: state === "requested_human" ? null : createdAt,
+  };
+}
+
+function createPairing(input?: {
+  pairingId?: number;
+  nodeId?: string;
+  requestedAt?: string;
+  status?: PairingGetResponse["pairing"]["status"];
+  capabilities?: PairingGetResponse["pairing"]["node"]["capabilities"];
+  latestReview?: PairingGetResponse["pairing"]["latest_review"];
+  reviews?: PairingReview[];
+}): PairingGetResponse["pairing"] {
+  const pairingId = input?.pairingId ?? 1;
+  const requestedAt = input?.requestedAt ?? "2026-01-01T00:00:00.000Z";
+  return {
+    pairing_id: pairingId,
+    status: input?.status ?? "awaiting_human",
+    motivation: "Local node requested pairing.",
+    trust_level: undefined,
+    requested_at: requestedAt,
+    node: {
+      node_id: input?.nodeId ?? "local-node-1",
+      label: "Local node",
+      last_seen_at: requestedAt,
+      capabilities: [...(input?.capabilities ?? CAPABILITIES)],
+      metadata: { mode: "local-node" },
+    },
+    capability_allowlist: [],
+    latest_review: input?.latestReview ?? null,
+    ...(input?.reviews ? { reviews: input.reviews } : {}),
+  };
+}
+
+function createDesktopHostApi(deviceId: string): OperatorUiHostApi {
+  return {
+    kind: "desktop",
+    api: {
+      getConfig: async () => ({}),
+      setConfig: async () => ({}),
+      gateway: {
+        getStatus: async () => ({ status: "ok", port: 8788 }),
+        start: async () => ({ status: "ok", port: 8788 }),
+        stop: async () => ({ status: "ok" }),
+      },
+      node: {
+        connect: async () => ({ status: "connecting" }),
+        disconnect: async () => ({ status: "disconnected" }),
+        getStatus: async () => ({ status: "connected", connected: true, deviceId }),
+      },
+      onStatusChange: () => () => {},
+    },
+  };
+}
+
+function createMobileHostApi(state: MobileHostState): OperatorUiHostApi {
+  const api: MobileHostApi = {
+    node: {
+      getState: vi.fn(async () => state),
+      setEnabled: vi.fn(async () => state),
+      setActionEnabled: vi.fn(async () => state),
+    },
+    onStateChange: vi.fn((_cb: (nextState: MobileHostState) => void) => () => {}),
+  };
+  return { kind: "mobile", api };
+}
+
+function createWebHost(): OperatorUiHostApi {
+  return { kind: "web" };
+}
+
+function createBrowserNodeState(deviceId: string): Record<string, unknown> {
+  return {
+    enabled: true,
+    status: "connected",
+    deviceId,
+    clientId: "browser-client-1",
+    error: null,
+    capabilityStates: {},
+    setEnabled: vi.fn(),
+    setCapabilityEnabled: vi.fn(),
+    executeLocal: vi.fn(async () => ({ success: true })),
+  };
+}
+
+function createMobileState(input: {
+  deviceId: string;
+  platform?: MobileHostState["platform"];
+  enabled?: boolean;
+  status?: MobileHostState["status"];
+}): MobileHostState {
+  return {
+    platform: input.platform ?? "ios",
+    enabled: input.enabled ?? true,
+    status: input.status ?? "connected",
+    deviceId: input.deviceId,
+    error: null,
+    actions: {
+      "location.get_current": {
+        enabled: true,
+        availabilityStatus: "ready",
+        unavailableReason: null,
+      },
+      "camera.capture_photo": {
+        enabled: true,
+        availabilityStatus: "ready",
+        unavailableReason: null,
+      },
+      "audio.record_clip": {
+        enabled: true,
+        availabilityStatus: "ready",
+        unavailableReason: null,
+      },
+    },
+  };
+}
+
+function createCoreForAutoApproval(input: {
+  http: ReturnType<typeof createFakeHttpClient>["http"];
+  elevatedModeStore: ElevatedModeStore;
+}): OperatorCore {
+  const ws = new FakeWsClient(true);
+  return createOperatorCore({
+    wsUrl: "ws://example.test/ws",
+    httpBaseUrl: "http://example.test",
+    auth: createBearerTokenAuth("test"),
+    elevatedModeStore: input.elevatedModeStore,
+    deps: {
+      ws,
+      http: input.http,
+      createPrivilegedWs: () => ws,
+      createPrivilegedHttp: () =>
+        isElevatedModeActive(input.elevatedModeStore.getSnapshot()) ? input.http : null,
+    },
+  });
+}
+
+function createActiveElevatedModeStore(): ElevatedModeStore {
+  const elevatedModeStore = createElevatedModeStore({
+    tickIntervalMs: 0,
+    now: () => Date.parse(ACTIVE_ENTERED_AT),
+  });
+  elevatedModeStore.enter({
+    elevatedToken: "test-elevated-token",
+    expiresAt: ACTIVE_EXPIRES_AT,
+  });
+  return elevatedModeStore;
+}
+
+function createInactiveElevatedModeStore(): ElevatedModeStore {
+  return createElevatedModeStore({
+    tickIntervalMs: 0,
+    now: () => Date.parse(ACTIVE_ENTERED_AT),
+  });
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 12; index += 1) {
+      await Promise.resolve();
+    }
+    await new Promise((resolve) => {
+      globalThis.setTimeout(resolve, 0);
+    });
+  });
+}
+
+async function waitForMockCallCount(
+  mock: ReturnType<typeof vi.fn>,
+  expectedCalls: number,
+): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    if (mock.mock.calls.length >= expectedCalls) {
+      return;
+    }
+    await flushAsyncWork();
+  }
+}
+
+async function renderBridge(input: {
+  core: OperatorCore;
+  host: OperatorUiHostApi;
+  controller?: AdminAccessController;
+  strictMode?: boolean;
+}): Promise<{ root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const renderTree = async (): Promise<void> => {
+    const tree = React.createElement(
+      OperatorUiHostProvider,
+      { value: input.host },
+      React.createElement(
+        AdminAccessProvider,
+        {
+          core: input.core,
+          mode: input.host.kind === "desktop" ? "desktop" : "web",
+          adminAccessController: input.controller,
+        },
+        React.createElement(LocalNodeAutoApprovalBridge),
+      ),
+    );
+    await act(async () => {
+      root.render(input.strictMode ? React.createElement(React.StrictMode, null, tree) : tree);
+    });
+    await flushAsyncWork();
+  };
+
+  await renderTree();
+  return { root };
+}
+
+function disposeRenderedBridge(root: Root, elevatedModeStore: ElevatedModeStore): void {
+  act(() => root.unmount());
+  elevatedModeStore.dispose();
+}
+
+async function seedPairings(core: OperatorCore): Promise<void> {
+  await act(async () => await core.pairingStore.refresh());
+}
+
+describe("local node auto approval", () => {
+  afterEach(() => {
+    browserNodeStateRef.value = null;
+    toastErrorMock.mockReset();
+    toastWarningMock.mockReset();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("auto-approves the matching desktop node once under StrictMode", async () => {
+    const detailedPairing = createPairing({ nodeId: "desktop-node-1" });
+    const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+    pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+    pairingsGet.mockResolvedValue({ status: "ok", pairing: detailedPairing });
+    pairingsApprove.mockResolvedValue({
+      status: "ok",
+      pairing: { ...detailedPairing, status: "approved", trust_level: "local" },
+    });
+
+    const elevatedModeStore = createActiveElevatedModeStore();
+    const core = createCoreForAutoApproval({ http, elevatedModeStore });
+    await seedPairings(core);
+
+    const { root } = await renderBridge({
+      core,
+      host: createDesktopHostApi("desktop-node-1"),
+      strictMode: true,
+    });
+
+    try {
+      await waitForMockCallCount(pairingsGet, 1);
+      await waitForMockCallCount(pairingsApprove, 1);
+      expect(pairingsGet).toHaveBeenCalledTimes(1);
+      expect(pairingsApprove).toHaveBeenCalledTimes(1);
+      expect(pairingsApprove).toHaveBeenCalledWith(1, {
+        trust_level: "local",
+        capability_allowlist: detailedPairing.node.capabilities,
+        reason: "auto-approved local app node",
+      });
+    } finally {
+      disposeRenderedBridge(root, elevatedModeStore);
+    }
+  });
+
+  it("does not auto-approve a non-matching node id", async () => {
+    const detailedPairing = createPairing({ nodeId: "remote-node-1" });
+    const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+    pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+
+    const elevatedModeStore = createActiveElevatedModeStore();
+    const core = createCoreForAutoApproval({ http, elevatedModeStore });
+    await seedPairings(core);
+
+    const { root } = await renderBridge({
+      core,
+      host: createDesktopHostApi("desktop-node-3"),
+    });
+
+    try {
+      expect(pairingsGet).not.toHaveBeenCalled();
+      expect(pairingsApprove).not.toHaveBeenCalled();
+    } finally {
+      disposeRenderedBridge(root, elevatedModeStore);
+    }
+  });
+
+  it("auto-approves the matching mobile node", async () => {
+    const detailedPairing = createPairing({ nodeId: "mobile-node-1" });
+    const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+    pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+    pairingsGet.mockResolvedValue({ status: "ok", pairing: detailedPairing });
+    pairingsApprove.mockResolvedValue({
+      status: "ok",
+      pairing: { ...detailedPairing, status: "approved", trust_level: "local" },
+    });
+
+    const elevatedModeStore = createActiveElevatedModeStore();
+    const core = createCoreForAutoApproval({ http, elevatedModeStore });
+    await seedPairings(core);
+
+    const { root } = await renderBridge({
+      core,
+      host: createMobileHostApi(createMobileState({ deviceId: "mobile-node-1" })),
+    });
+
+    try {
+      await waitForMockCallCount(pairingsGet, 1);
+      await waitForMockCallCount(pairingsApprove, 1);
+      expect(pairingsGet).toHaveBeenCalledTimes(1);
+      expect(pairingsApprove).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeRenderedBridge(root, elevatedModeStore);
+    }
+  });
+
+  it("auto-approves the matching browser node", async () => {
+    const detailedPairing = createPairing({ nodeId: "browser-node-1" });
+    const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+    pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+    pairingsGet.mockResolvedValue({ status: "ok", pairing: detailedPairing });
+    pairingsApprove.mockResolvedValue({
+      status: "ok",
+      pairing: { ...detailedPairing, status: "approved", trust_level: "local" },
+    });
+
+    browserNodeStateRef.value = createBrowserNodeState("browser-node-1");
+
+    const elevatedModeStore = createActiveElevatedModeStore();
+    const core = createCoreForAutoApproval({ http, elevatedModeStore });
+    await seedPairings(core);
+
+    const { root } = await renderBridge({
+      core,
+      host: createWebHost(),
+    });
+
+    try {
+      await waitForMockCallCount(pairingsGet, 1);
+      await waitForMockCallCount(pairingsApprove, 1);
+      expect(pairingsGet).toHaveBeenCalledTimes(1);
+      expect(pairingsApprove).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeRenderedBridge(root, elevatedModeStore);
+    }
+  });
+
+  it("enters elevated mode automatically before approving the local node", async () => {
+    const detailedPairing = createPairing({ nodeId: "desktop-node-2" });
+    const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+    pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+    pairingsGet.mockResolvedValue({ status: "ok", pairing: detailedPairing });
+    pairingsApprove.mockResolvedValue({
+      status: "ok",
+      pairing: { ...detailedPairing, status: "approved", trust_level: "local" },
+    });
+
+    const elevatedModeStore = createInactiveElevatedModeStore();
+    const core = createCoreForAutoApproval({ http, elevatedModeStore });
+    await seedPairings(core);
+
+    const controller: AdminAccessController = {
+      enter: vi.fn(async () => {
+        elevatedModeStore.enter({
+          elevatedToken: "fresh-elevated-token",
+          expiresAt: ACTIVE_EXPIRES_AT,
+        });
+      }),
+      exit: vi.fn(async () => {
+        elevatedModeStore.exit();
+      }),
+    };
+
+    const { root } = await renderBridge({
+      core,
+      host: createDesktopHostApi("desktop-node-2"),
+      controller,
+    });
+
+    try {
+      await waitForMockCallCount(pairingsApprove, 1);
+      expect(controller.enter).toHaveBeenCalledTimes(1);
+      expect(pairingsApprove).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeRenderedBridge(root, elevatedModeStore);
+    }
+  });
+
+  it.each(["denied", "revoked"] as const)(
+    "does not auto-approve when the latest terminal review is %s",
+    async (terminalState) => {
+      const reviews = [
+        createReview(terminalState, "2026-01-01T00:00:01.000Z"),
+        createReview("requested_human", "2026-01-01T00:00:02.000Z", `pending-${terminalState}`),
+      ];
+      const detailedPairing = createPairing({
+        nodeId: "mobile-node-2",
+        latestReview: reviews[1] ?? null,
+        reviews,
+      });
+      const { http, pairingsList, pairingsGet, pairingsApprove } = createFakeHttpClient();
+      pairingsList.mockResolvedValue({ status: "ok", pairings: [detailedPairing] });
+      pairingsGet.mockResolvedValue({ status: "ok", pairing: detailedPairing });
+
+      const elevatedModeStore = createActiveElevatedModeStore();
+      const core = createCoreForAutoApproval({ http, elevatedModeStore });
+      await seedPairings(core);
+
+      const { root } = await renderBridge({
+        core,
+        host: createMobileHostApi(
+          createMobileState({ deviceId: "mobile-node-2", platform: "android" }),
+        ),
+      });
+
+      try {
+        await waitForMockCallCount(pairingsGet, 1);
+        expect(pairingsGet).toHaveBeenCalledTimes(1);
+        expect(pairingsApprove).not.toHaveBeenCalled();
+      } finally {
+        disposeRenderedBridge(root, elevatedModeStore);
+      }
+    },
+  );
+});

--- a/packages/operator-ui/tests/operator-ui.test-fixtures.ts
+++ b/packages/operator-ui/tests/operator-ui.test-fixtures.ts
@@ -134,6 +134,7 @@ export function createFakeHttpClient(): {
   presenceList: ReturnType<typeof vi.fn>;
   nodesList: ReturnType<typeof vi.fn>;
   pairingsList: ReturnType<typeof vi.fn>;
+  pairingsGet: ReturnType<typeof vi.fn>;
   pairingsApprove: ReturnType<typeof vi.fn>;
   pairingsDeny: ReturnType<typeof vi.fn>;
   pairingsRevoke: ReturnType<typeof vi.fn>;
@@ -155,6 +156,9 @@ export function createFakeHttpClient(): {
   const nodesList = vi.fn(async () => sampleNodeInventoryResponse());
   const pairingsList = vi.fn(
     async () => ({ status: "ok", pairings: [samplePairingRequestPending()] }) as const,
+  );
+  const pairingsGet = vi.fn(
+    async () => ({ status: "ok", pairing: samplePairingRequestPending() }) as const,
   );
   const pairingsApprove = vi.fn(
     async () => ({ status: "ok", pairing: samplePairingRequestPending() }) as const,
@@ -424,6 +428,7 @@ export function createFakeHttpClient(): {
     },
     pairings: {
       list: pairingsList,
+      get: pairingsGet,
       approve: pairingsApprove,
       deny: pairingsDeny,
       revoke: pairingsRevoke,
@@ -474,6 +479,7 @@ export function createFakeHttpClient(): {
     presenceList,
     nodesList,
     pairingsList,
+    pairingsGet,
     pairingsApprove,
     pairingsDeny,
     pairingsRevoke,


### PR DESCRIPTION
## Summary
- auto-approve embedded desktop, mobile, and browser nodes when the pairing matches the local node device ID
- suppress automatic approval after denied/revoked terminal reviews and re-allow it when later terminal approval exists
- add regression coverage for host flows and local auto-approval helper logic

## Testing
- pnpm exec vitest run packages/operator-ui/tests/operator-ui.local-node-auto-approval.test.ts packages/operator-ui/tests/operator-ui.local-node-auto-approval.helpers.test.ts apps/web/tests/main.test.ts apps/desktop/tests/renderer-main-operator-ui-bootstrap.test.ts apps/mobile/tests/use-mobile-operator-core.test.ts
- pnpm exec vitest run packages/operator-ui/tests/operator-ui.mobile-host.test.ts packages/operator-ui/tests/operator-ui.test.ts packages/operator-ui/tests/pages/pairing-page.cards.test.ts
- pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json
- pnpm exec oxlint packages/operator-ui/src/local-node-auto-approval.tsx packages/operator-ui/src/app.tsx packages/operator-ui/tests/operator-ui.local-node-auto-approval.test.ts packages/operator-ui/tests/operator-ui.local-node-auto-approval.helpers.test.ts packages/operator-ui/tests/operator-ui.test-fixtures.ts
- pnpm exec prettier --check packages/operator-ui/src/local-node-auto-approval.tsx packages/operator-ui/src/app.tsx packages/operator-ui/tests/operator-ui.local-node-auto-approval.test.ts packages/operator-ui/tests/operator-ui.local-node-auto-approval.helpers.test.ts packages/operator-ui/tests/operator-ui.test-fixtures.ts

Closes #1415
