### PR TITLE
fix: bound desktop error output on the Desktops page

### DIFF
--- a/packages/operator-ui/src/components/pages/desktop-environments-page.sections.tsx
+++ b/packages/operator-ui/src/components/pages/desktop-environments-page.sections.tsx
@@ -27,6 +27,17 @@ export interface DesktopEnvironmentLogsState {
   lastSyncedAt: string | null;
 }
 
+function DesktopErrorOutput({ message, testId }: { message: string; testId?: string }) {
+  return (
+    <pre
+      className="mt-2 max-h-40 overflow-auto whitespace-pre rounded-md border border-error/30 bg-error/10 px-3 py-2 font-mono text-xs text-error"
+      data-testid={testId}
+    >
+      {message}
+    </pre>
+  );
+}
+
 export function DesktopEnvironmentsSummaryCard({
   hostsError,
   environmentsError,
@@ -102,7 +113,10 @@ export function DesktopEnvironmentHostsCard({
               </span>
             </div>
             {host.last_error ? (
-              <div className="mt-2 text-xs text-error">{host.last_error}</div>
+              <DesktopErrorOutput
+                message={host.last_error}
+                testId={`desktop-host-error-${host.host_id}`}
+              />
             ) : null}
           </div>
         ))}
@@ -246,7 +260,10 @@ export function DesktopEnvironmentListCard({
                 </span>
               </div>
               {environment.last_error ? (
-                <div className="mt-2 text-xs text-error">{environment.last_error}</div>
+                <DesktopErrorOutput
+                  message={environment.last_error}
+                  testId={`desktop-environment-error-${environment.environment_id}`}
+                />
               ) : null}
             </button>
           );

--- a/packages/operator-ui/tests/pages/desktop-environments-page.sections.test.ts
+++ b/packages/operator-ui/tests/pages/desktop-environments-page.sections.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  DesktopEnvironmentHostsCard,
+  DesktopEnvironmentListCard,
+  type DesktopEnvironment,
+  type DesktopEnvironmentHost,
+} from "../../src/components/pages/desktop-environments-page.sections.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+describe("Desktop environment sections", () => {
+  it("renders host and environment errors in bounded raw-output blocks", () => {
+    const host: DesktopEnvironmentHost = {
+      host_id: "host-1",
+      label: "Primary runtime",
+      version: "0.1.0",
+      docker_available: false,
+      healthy: false,
+      last_seen_at: null,
+      last_error:
+        "Command failed: docker info\nCannot connect to the Docker daemon at unix:///tmp/docker.sock.",
+    };
+    const environment: DesktopEnvironment = {
+      environment_id: "env-1",
+      host_id: host.host_id,
+      label: "Research desktop",
+      image_ref: "registry.example.test/desktop@sha256:1234",
+      managed_kind: "docker",
+      status: "error",
+      desired_running: true,
+      node_id: null,
+      takeover_url: null,
+      last_seen_at: null,
+      last_error: "Container startup failed\nstderr: port bind rejected by runtime policy.",
+      created_at: "2026-03-10T12:00:00.000Z",
+      updated_at: "2026-03-10T12:00:00.000Z",
+    };
+    const testRoot = renderIntoDocument(
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(DesktopEnvironmentHostsCard, { hosts: [host] }),
+        React.createElement(DesktopEnvironmentListCard, {
+          environments: [environment],
+          hostById: { [host.host_id]: host },
+          selectedEnvironmentId: null,
+          onSelect: () => {},
+        }),
+      ),
+    );
+
+    const hostErrorBlock = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="desktop-host-error-host-1"]',
+    );
+    expect(hostErrorBlock?.tagName).toBe("PRE");
+    expect(hostErrorBlock?.textContent).toBe(host.last_error);
+    expect(hostErrorBlock?.className).toContain("max-h-40");
+    expect(hostErrorBlock?.className).toContain("overflow-auto");
+    expect(hostErrorBlock?.className).toContain("whitespace-pre");
+    expect(hostErrorBlock?.className).toContain("font-mono");
+
+    const environmentErrorBlock = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="desktop-environment-error-env-1"]',
+    );
+    expect(environmentErrorBlock?.tagName).toBe("PRE");
+    expect(environmentErrorBlock?.textContent).toBe(environment.last_error);
+    expect(environmentErrorBlock?.className).toContain("max-h-40");
+    expect(environmentErrorBlock?.className).toContain("overflow-auto");
+    expect(environmentErrorBlock?.className).toContain("whitespace-pre");
+    expect(environmentErrorBlock?.className).toContain("font-mono");
+
+    cleanupTestRoot(testRoot);
+  });
+});


### PR DESCRIPTION
## Summary
- bound raw desktop host and environment error output in the Desktops page UI
- preserve raw formatting in a scrollable `pre` block instead of letting long errors expand the cards
- add focused operator-ui regression coverage in a dedicated sections test

Closes #1414

## How to test
- `pnpm exec vitest run packages/operator-ui/tests/pages/desktop-environments-page.test.ts packages/operator-ui/tests/pages/desktop-environments-page.sections.test.ts`
- `pnpm exec oxlint packages/operator-ui/src/components/pages/desktop-environments-page.sections.tsx packages/operator-ui/tests/pages/desktop-environments-page.test.ts packages/operator-ui/tests/pages/desktop-environments-page.sections.test.ts`
- `git push -u origin 1414-bound-raw-desktop-error-output` (pre-push hook passed: lint, typecheck, builds, and full test suite)

## Risk
- low; UI-only rendering change in operator-ui with dedicated regression coverage

## Rollback
- revert commit `6b1cebce` if the new presentation needs to be backed out