### PR TITLE
feat(operator-ui): refresh design tokens

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -15,16 +15,16 @@
     }
     body {
       overflow: hidden;
-      background: var(--tyrum-color-bg, #000);
-      color: var(--tyrum-color-fg, #ededed);
+      background: var(--tyrum-color-bg, #141614);
+      color: var(--tyrum-color-fg, #ede9df);
       font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
         "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
     }
     ::selection {
-      background: var(--tyrum-color-selection, rgba(99, 102, 241, 0.3));
+      background: var(--tyrum-color-selection, oklch(60% 0.155 46 / 0.20));
     }
     :focus-visible {
-      outline: 2px solid var(--tyrum-color-focus-ring, #6366f1);
+      outline: 2px solid var(--tyrum-color-focus-ring, oklch(60% 0.155 46 / 0.35));
       outline-offset: 2px;
     }
     input, textarea, select, button {

--- a/packages/operator-ui/package.json
+++ b/packages/operator-ui/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.118",
+    "@fontsource-variable/dm-sans": "^5.2.5",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/operator-ui/src/globals.css
+++ b/packages/operator-ui/src/globals.css
@@ -1,3 +1,5 @@
+@import "@fontsource-variable/dm-sans";
+
 @layer theme, base, components, utilities;
 
 /* Tailwind 4 (CSS-first). Keep preflight disabled for now to avoid global visual changes. */

--- a/packages/operator-ui/src/themes.css
+++ b/packages/operator-ui/src/themes.css
@@ -2,45 +2,45 @@
   /* Dark is the default operator theme. */
   color-scheme: dark;
 
-  --tyrum-color-bg: #161716;
+  --tyrum-color-bg: #141614;
   --tyrum-app-bg-image: none;
-  --tyrum-color-bg-subtle: #1d1f1d;
-  --tyrum-color-bg-card: #202321;
-  --tyrum-color-fg: #f2f0ea;
-  --tyrum-color-fg-muted: #aaa59a;
-  --tyrum-color-border: #343833;
+  --tyrum-color-bg-subtle: #1b1d1b;
+  --tyrum-color-bg-card: #1f211f;
+  --tyrum-color-fg: #ede9df;
+  --tyrum-color-fg-muted: #9e9889;
+  --tyrum-color-border: #2e322d;
 
-  --tyrum-color-primary: #7b6b52;
-  --tyrum-color-primary-dim: rgb(123 107 82 / 0.16);
+  --tyrum-color-primary: oklch(60% 0.155 46);
+  --tyrum-color-primary-dim: oklch(60% 0.155 46 / 0.14);
 
-  --tyrum-color-success: #4d8a61;
-  --tyrum-color-warning: #b3823c;
-  --tyrum-color-error: #c56a5f;
-  --tyrum-color-neutral: #8a887f;
-  --tyrum-color-focus-ring: rgb(123 107 82 / 0.35);
-  --tyrum-color-selection: rgb(123 107 82 / 0.22);
+  --tyrum-color-success: #3d8a56;
+  --tyrum-color-warning: #c4882e;
+  --tyrum-color-error: #c45549;
+  --tyrum-color-neutral: #7d7b72;
+  --tyrum-color-focus-ring: oklch(60% 0.155 46 / 0.35);
+  --tyrum-color-selection: oklch(60% 0.155 46 / 0.20);
 }
 
 html[data-theme="light"] {
   color-scheme: light;
 
-  --tyrum-color-bg: #f4f1ea;
+  --tyrum-color-bg: #f2efe6;
   --tyrum-app-bg-image: none;
-  --tyrum-color-bg-subtle: #ece6dc;
-  --tyrum-color-bg-card: #fcfaf5;
-  --tyrum-color-fg: #201f1b;
-  --tyrum-color-fg-muted: #615b50;
-  --tyrum-color-border: #d6cfc2;
+  --tyrum-color-bg-subtle: #e8e3d8;
+  --tyrum-color-bg-card: #faf8f2;
+  --tyrum-color-fg: #1c1b17;
+  --tyrum-color-fg-muted: #5c574c;
+  --tyrum-color-border: #d1c9b8;
 
-  --tyrum-color-primary: #8a5b2c;
-  --tyrum-color-primary-dim: rgb(138 91 44 / 0.12);
+  --tyrum-color-primary: oklch(47% 0.128 40);
+  --tyrum-color-primary-dim: oklch(47% 0.128 40 / 0.10);
 
-  --tyrum-color-success: #2f7d55;
-  --tyrum-color-warning: #a56d1f;
-  --tyrum-color-error: #b44c3f;
-  --tyrum-color-neutral: #6b665d;
-  --tyrum-color-focus-ring: rgb(138 91 44 / 0.28);
-  --tyrum-color-selection: rgb(138 91 44 / 0.16);
+  --tyrum-color-success: #267a4a;
+  --tyrum-color-warning: #9a6518;
+  --tyrum-color-error: #b03d32;
+  --tyrum-color-neutral: #65625a;
+  --tyrum-color-focus-ring: oklch(47% 0.128 40 / 0.30);
+  --tyrum-color-selection: oklch(47% 0.128 40 / 0.14);
 }
 
 /* System mode: rely on prefers-color-scheme when data-theme-mode=system. */
@@ -52,22 +52,22 @@ html[data-theme-mode="system"] {
   html[data-theme-mode="system"] {
     color-scheme: light;
 
-    --tyrum-color-bg: #f4f1ea;
+    --tyrum-color-bg: #f2efe6;
     --tyrum-app-bg-image: none;
-    --tyrum-color-bg-subtle: #ece6dc;
-    --tyrum-color-bg-card: #fcfaf5;
-    --tyrum-color-fg: #201f1b;
-    --tyrum-color-fg-muted: #615b50;
-    --tyrum-color-border: #d6cfc2;
+    --tyrum-color-bg-subtle: #e8e3d8;
+    --tyrum-color-bg-card: #faf8f2;
+    --tyrum-color-fg: #1c1b17;
+    --tyrum-color-fg-muted: #5c574c;
+    --tyrum-color-border: #d1c9b8;
 
-    --tyrum-color-primary: #8a5b2c;
-    --tyrum-color-primary-dim: rgb(138 91 44 / 0.12);
+    --tyrum-color-primary: oklch(47% 0.128 40);
+    --tyrum-color-primary-dim: oklch(47% 0.128 40 / 0.10);
 
-    --tyrum-color-success: #2f7d55;
-    --tyrum-color-warning: #a56d1f;
-    --tyrum-color-error: #b44c3f;
-    --tyrum-color-neutral: #6b665d;
-    --tyrum-color-focus-ring: rgb(138 91 44 / 0.28);
-    --tyrum-color-selection: rgb(138 91 44 / 0.16);
+    --tyrum-color-success: #267a4a;
+    --tyrum-color-warning: #9a6518;
+    --tyrum-color-error: #b03d32;
+    --tyrum-color-neutral: #65625a;
+    --tyrum-color-focus-ring: oklch(47% 0.128 40 / 0.30);
+    --tyrum-color-selection: oklch(47% 0.128 40 / 0.14);
   }
 }

--- a/packages/operator-ui/src/tokens.css
+++ b/packages/operator-ui/src/tokens.css
@@ -1,17 +1,17 @@
 @theme {
-  --font-sans: "IBM Plex Sans", "Avenir Next", "Helvetica Neue", sans-serif;
+  --font-sans: "DM Sans Variable", "DM Sans", "Avenir Next", "Helvetica Neue", sans-serif;
 
-  --color-indigo-50: oklch(96.2% 0.018 272.314);
-  --color-indigo-100: oklch(93% 0.034 272.788);
-  --color-indigo-200: oklch(87% 0.065 274.039);
-  --color-indigo-300: oklch(78.5% 0.115 274.713);
-  --color-indigo-400: oklch(67.3% 0.182 276.935);
-  --color-indigo-500: oklch(58.5% 0.233 277.117);
-  --color-indigo-600: oklch(51.1% 0.262 276.966);
-  --color-indigo-700: oklch(45.7% 0.24 277.023);
-  --color-indigo-800: oklch(39.8% 0.195 277.366);
-  --color-indigo-900: oklch(35.9% 0.144 278.697);
-  --color-indigo-950: oklch(25.7% 0.09 281.288);
+  --color-copper-50: oklch(97% 0.012 70);
+  --color-copper-100: oklch(93% 0.028 68);
+  --color-copper-200: oklch(86% 0.058 65);
+  --color-copper-300: oklch(77% 0.098 58);
+  --color-copper-400: oklch(68% 0.135 52);
+  --color-copper-500: oklch(60% 0.155 46);
+  --color-copper-600: oklch(53% 0.148 42);
+  --color-copper-700: oklch(47% 0.128 40);
+  --color-copper-800: oklch(40% 0.100 38);
+  --color-copper-900: oklch(34% 0.072 36);
+  --color-copper-950: oklch(24% 0.040 34);
 
   /* Semantic app colors (theme-specific values live in themes.css). */
   --color-bg: var(--tyrum-color-bg);
@@ -64,13 +64,13 @@
   --radius-3xl: 0.875rem;
 
   /* Shadows. */
-  --shadow-2xs: 0 1px rgb(0 0 0 / 0.05);
-  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.05);
-  --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.08);
-  --shadow-md: 0 2px 8px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 4px 10px rgb(0 0 0 / 0.12);
-  --shadow-xl: 0 6px 12px rgb(0 0 0 / 0.14);
-  --shadow-2xl: 0 8px 16px rgb(0 0 0 / 0.16);
+  --shadow-2xs: 0 1px rgb(0 0 0 / 0.12);
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.15);
+  --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.20);
+  --shadow-md: 0 2px 8px rgb(0 0 0 / 0.25);
+  --shadow-lg: 0 4px 12px rgb(0 0 0 / 0.30);
+  --shadow-xl: 0 8px 20px rgb(0 0 0 / 0.35);
+  --shadow-2xl: 0 12px 28px rgb(0 0 0 / 0.40);
 
   /* Z-index scale (for use in app CSS/components). */
   --z-0: 0;
@@ -80,4 +80,11 @@
   --z-40: 40;
   --z-50: 50;
   --z-60: 60;
+
+  /* Motion. */
+  --duration-fast: 100ms;
+  --duration-normal: 200ms;
+  --duration-slow: 350ms;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
 }

--- a/packages/operator-ui/tests/tokens-css.test.ts
+++ b/packages/operator-ui/tests/tokens-css.test.ts
@@ -11,6 +11,8 @@ describe("tokens.css", () => {
 
     expect(fontSansLine).toBeDefined();
     expect(fontSansLine).not.toContain('"Outfit"');
+    expect(fontSansLine).not.toContain('"IBM Plex Sans"');
+    expect(fontSansLine).not.toContain('"Inter"');
   });
 
   it("avoids the banned fallback-heavy font stack", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.118
         version: 3.0.118(react@19.2.4)(zod@4.3.6)
+      '@fontsource-variable/dm-sans':
+        specifier: ^5.2.5
+        version: 5.2.8
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2639,6 +2642,9 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource-variable/dm-sans@5.2.8':
+    resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
 
   '@gitlab/gitlab-ai-provider@4.1.0':
     resolution: {integrity: sha512-wYW0bB4qI4IA46vcs7zRTox6jkRjxJd357p6Nal84/kjAplOCskn8QhQTUXa8LpNutlYepJfOSZtKArGISCHdQ==}
@@ -14819,6 +14825,8 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource-variable/dm-sans@5.2.8': {}
 
   '@gitlab/gitlab-ai-provider@4.1.0(@ai-sdk/provider-utils@4.0.19(zod@4.3.6))(@ai-sdk/provider@3.0.8)(encoding@0.1.13)(graphql@16.13.1)(ws@8.19.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- Bundle **DM Sans Variable** font via `@fontsource-variable/dm-sans` (build-time woff2, no CDN fetch)
- Replace unused indigo color scale with 11-shade **copper scale** in oklch
- Update dark and light theme colors to richer burnished copper primary
- Strengthen shadow opacity (0.12–0.40) for dark-theme visibility
- Add centralized motion tokens (`duration-fast/normal/slow`, `ease-out`, `ease-in-out`)
- Align desktop `index.html` fallback colors to new dark theme
- Update font ban tests to cover IBM Plex Sans and Inter

Closes #1427

## Test plan
- [x] All 750 test files pass (4066 tests green, 0 failures)
- [x] `tokens-css.test.ts` — font bans pass with new DM Sans declaration
- [x] `themes-css.test.ts` — opaque bg + no gradients constraints hold
- [x] `globals-css.test.ts` — input resets unaffected
- [x] `renderer-shell.test.ts` — no Google Fonts CDN URLs introduced
- [ ] Visual: run desktop app, confirm DM Sans renders in DevTools > Fonts
- [ ] Visual: verify copper primary is visible and distinct on both dark and light themes
- [ ] Visual: verify shadows are perceptible on dark backgrounds