### PR TITLE
docs: simplify platform positioning language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tyrum
 
-Tyrum is a self-hosted autonomous worker agent platform built around a single gateway runtime. It is local-first by default, serves an operator UI at `/ui`, and uses authenticated HTTP and WebSocket access for automation, approvals, and auditability.
+Tyrum is an autonomous worker platform built around a gateway, an agent runtime, and safety boundaries for execution, approvals, and audit evidence. It is self-hosted, serves an operator UI at `/ui`, and exposes authenticated HTTP and WebSocket access.
 
 The repository contains the gateway runtime, the client SDK, shared schemas, the desktop app, and the public docs site. Detailed architecture, deployment, and feature documentation lives under [`docs/`](docs/index.md).
 

--- a/docs/architecture/client/index.md
+++ b/docs/architecture/client/index.md
@@ -42,7 +42,7 @@ Clients exist so operators can interact with Tyrum's control plane without coupl
 
 ## Invariants and constraints
 
-- Clients are WebSocket-first for interactive state and event delivery.
+- Clients use WebSocket for interactive state and event delivery.
 - When a client host also runs a local node, the client and node remain separate peers with separate device identities, pairing state, and presence.
 - Administrative actions must remain scoped, auditable, and compatible with elevated-mode controls.
 

--- a/docs/architecture/gateway/index.md
+++ b/docs/architecture/gateway/index.md
@@ -29,7 +29,7 @@ The gateway exists so Tyrum has one authoritative runtime boundary for interacti
 
 ## Internal building blocks
 
-- **Protocol and transport handling:** WebSocket-first connectivity, HTTP resource surfaces, and message validation.
+- **Protocol and transport handling:** WebSocket connectivity, HTTP resource surfaces, and message validation.
 - **Execution and safety controls:** execution engine, approvals, reviews, policy, automation, and audit/event emission.
 - **Managed runtime surfaces:** node pairing/orchestration, gateway-managed desktop environments, and location-aware automation control APIs.
 - **Extension surface:** tools, plugins, skills, MCP, and provider integrations.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Tyrum is a WebSocket-first autonomous worker platform built around a long-lived gateway, a durable agent runtime, and explicit safety boundaries for execution, approvals, and audit evidence.
+Tyrum is an autonomous worker platform built around a gateway, an agent runtime, and safety boundaries for execution, approvals, and audit evidence.
 
 ## Purpose
 
@@ -62,7 +62,7 @@ flowchart LR
 
 ## Key decisions and tradeoffs
 
-- **WebSocket-first control plane:** Tyrum optimizes for long-lived interactive control and event delivery rather than a request-only HTTP model.
+- **Interactive control plane over WebSocket:** Tyrum optimizes for long-lived interactive control and event delivery rather than a request-only HTTP model.
 - **Durable runtime over prompt memory:** Work state, approvals, and evidence are externalized so correctness does not depend on transcript recall.
 - **Device capabilities outside the gateway:** Desktop, mobile, and other device-specific actions live behind nodes so the gateway stays policy-centric and deployable.
 - **Capability boundaries survive co-location:** browser and mobile operator hosts may embed a node runtime, but capability execution still stays on the node side of the trust boundary.

--- a/docs/architecture/protocol/api-surfaces.md
+++ b/docs/architecture/protocol/api-surfaces.md
@@ -4,7 +4,7 @@ slug: /architecture/api-surfaces
 
 # API surfaces (WebSocket vs HTTP)
 
-Tyrum is **WebSocket-first**, but not WebSocket-only. The Gateway exposes two operator-facing API surfaces:
+The gateway uses WebSocket for interactive control, but it is not WebSocket-only. It exposes two operator-facing API surfaces:
 
 - **WebSocket protocol (control plane):** typed requests/responses plus server-push events.
 - **HTTP API (resource plane):** bootstrap/auth flows, resource/blob transfer, and callback/webhook endpoints.
@@ -31,7 +31,7 @@ Use WebSocket for **interactive, eventful, low-latency control plane** work:
 - any UX that benefits from immediate server-push updates
 - any operation where you want a single connection to carry: requests + events + heartbeats
 
-In practice: most operator interactions should be WS-first, even if some backing data is fetched over HTTP.
+In practice: most operator interactions should use WebSocket, even if some backing data is fetched over HTTP.
 
 ## When to use HTTP
 

--- a/docs/architecture/protocol/index.md
+++ b/docs/architecture/protocol/index.md
@@ -90,7 +90,7 @@ The protocol uses run-scoped identifiers such as `run_id`, `step_id`, and `attem
 
 ## Key decisions and tradeoffs
 
-- **WebSocket-first control plane:** Tyrum optimizes for long-lived interactive state and event streaming rather than a request-only API model.
+- **Interactive control plane over WebSocket:** Tyrum optimizes for long-lived interactive state and event streaming rather than a request-only API model.
 - **Typed protocol over implicit conventions:** compatibility, retries, and reconnect behavior are explicit so the runtime stays understandable under failure.
 - **HTTP as a complementary surface:** HTTP handles bootstrap, resources, and callbacks, but does not replace the typed control model.
 

--- a/docs/architecture/scaling-ha/backplane.md
+++ b/docs/architecture/scaling-ha/backplane.md
@@ -4,7 +4,7 @@ slug: /architecture/backplane
 
 # Backplane (Outbox Contract)
 
-Tyrum is WebSocket-first: most operator UX is powered by server-push events delivered over long-lived WebSocket connections.
+Most operator UX is powered by server-push events delivered over WebSocket connections.
 When the gateway is replicated, only the edge instance that owns a connection can write to that socket. The **backplane** is the cross-instance mechanism that makes “cluster with N replicas” behave like “cluster with 1 replica” for event delivery.
 
 This page defines the required _behavior_ of the backplane and its durable outbox, independent of any specific implementation (polling, Postgres `LISTEN/NOTIFY`, external pub/sub, etc.).

--- a/docs/architecture/scaling-ha/data-lifecycle.md
+++ b/docs/architecture/scaling-ha/data-lifecycle.md
@@ -4,7 +4,7 @@ slug: /architecture/data-lifecycle
 
 # Data lifecycle and retention
 
-Tyrum is durable by design: the StateStore is the source of truth for sessions, execution, approvals, and audit evidence.
+The StateStore is the source of truth for sessions, execution, approvals, and audit evidence.
 That durability must be paired with explicit **retention** and **deletion** rules so deployments remain operable (bounded cost), safe (privacy), and explainable (audit).
 
 This page summarizes lifecycle expectations across the major data surfaces. Most sections stay implementation-agnostic, but the session/channel transcript surfaces below document the current retention contract and deployment knobs because they are high-volume by default.
@@ -134,7 +134,7 @@ Lifecycle expectations:
 
 ## Memory budgets (special case)
 
-Agent memory is durable by design, but must remain bounded for cost and operability. The default lifecycle model is **budget-based**, not time-based:
+Agent memory persists across restarts, but must remain bounded for cost and operability. The default lifecycle model is **budget-based**, not time-based:
 
 - Inactivity must not cause forgetting.
 - When budgets are exceeded, the system performs consolidation and eviction until back under budget.
@@ -143,7 +143,7 @@ Agent memory is durable by design, but must remain bounded for cost and operabil
 
 ## WorkBoard budgets (special case)
 
-The WorkBoard is durable by design (work state must survive restarts and multi-channel use), but its drilldown surfaces must remain bounded for cost and operator usability.
+The WorkBoard must persist across restarts and multi-channel use, but its drilldown surfaces must remain bounded for cost and operator usability.
 
 Lifecycle expectations:
 

--- a/docs/architecture/scaling-ha/index.md
+++ b/docs/architecture/scaling-ha/index.md
@@ -140,9 +140,9 @@ The gateway supports snapshot export/import for the durable tables required to r
 - imports preserve stable identifiers (`session_key`, `run_id`, `step_id`, `attempt_id`, `approval_id`, `artifact_id`) and hashes
 - snapshot bundles declare whether they include artifact bytes (and for which sensitivity classes), and include artifact retention lifecycle metadata needed to interpret "missing bytes" states
 
-## WebSocket-first event delivery (the "WS reality")
+## Event delivery over WebSocket
 
-Tyrum is **WebSocket-first**: typed requests/responses plus server-push events are the primary operator interface transport (see [Protocol](/architecture/protocol)).
+Typed requests/responses plus server-push events over WebSocket are the primary operator interface transport (see [Protocol](/architecture/protocol)).
 
 A WebSocket connection is a single long-lived TCP connection. Practically that means:
 


### PR DESCRIPTION
## Summary
- simplify the main platform description in README and architecture docs
- replace similar "WebSocket-first" and "durable by design" positioning copy with plainer technical wording
- keep the existing technical meaning while limiting changes to documentation text

Closes #1430

## Testing
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm format:check
- pnpm test (failed in this environment: apps/desktop/tests/integration/embedded-gateway-startup.test.ts timed out after 180s; apps/desktop/tests/integration/electron-process-smoke.test.ts timed out after 180s)

## Notes
- low-risk docs-only change
- branch was pushed with --no-verify after explicit user approval because the local pre-push hook was blocked by the desktop integration test timeouts