### PR TITLE
fix: update default desktop sandbox image ref

### DIFF
--- a/packages/gateway/tests/unit/desktop-environment-dal.test.ts
+++ b/packages/gateway/tests/unit/desktop-environment-dal.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF } from "@tyrum/schemas";
 import {
   DesktopEnvironmentDal,
   DesktopEnvironmentHostDal,
@@ -36,7 +37,7 @@ describe("DesktopEnvironmentDal", () => {
       tenantId: DEFAULT_TENANT_ID,
       hostId: "host-1",
       label: "Research desktop",
-      imageRef: "ghcr.io/rhernaus/tyrum-desktop-sandbox:latest",
+      imageRef: DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF,
       desiredRunning: true,
     });
 

--- a/packages/schemas/src/desktop-environment.ts
+++ b/packages/schemas/src/desktop-environment.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 import { DateTimeSchema } from "./common.js";
 import { NodeId } from "./keys.js";
 
-export const DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF =
-  "ghcr.io/rhernaus/tyrum-desktop-sandbox:latest";
+export const DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF = "ghcr.io/rhernaus/tyrum-desktop-sandbox:main";
 
 export const DesktopEnvironmentId = z.string().trim().min(1);
 export const DesktopEnvironmentHostId = z.string().trim().min(1);


### PR DESCRIPTION
Closes #1432

## Summary
- change the built-in desktop environment default image ref to `ghcr.io/rhernaus/tyrum-desktop-sandbox:main`
- update the gateway DAL unit test to use the shared default constant instead of hardcoding the old tag

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

## Risk
Low. This only changes the default desktop sandbox image used when no explicit image ref is configured.

## Rollback
Revert commit `3b963f01`.
