### PR TITLE
Add shared model picker for model setup flows

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-models-preset-dialog.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-models-preset-dialog.tsx
@@ -14,16 +14,20 @@ import { Input } from "../ui/input.js";
 import { Select } from "../ui/select.js";
 import {
   emptyDialogState,
+  filterAvailableModels,
   modelRefFor,
   normalizeDialogState,
+  reconcileModelDialogState,
   REASONING_OPTIONS,
   REASONING_VISIBILITY_OPTIONS,
+  selectModelDialogState,
   splitModelRef,
   type AvailableModel,
   type ModelConfigHttpClient,
   type ModelDialogState,
   type ModelPreset,
 } from "./admin-http-models.shared.js";
+import { ModelPickerField } from "./model-picker-field.js";
 
 export function ModelPresetDialog({
   open,
@@ -43,16 +47,46 @@ export function ModelPresetDialog({
   api: ModelConfigHttpClient["modelConfig"];
 }): React.ReactElement {
   const [state, setState] = React.useState<ModelDialogState>(emptyDialogState());
+  const [modelFilter, setModelFilter] = React.useState("");
   const [saving, setSaving] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const selectedModel = availableModels.find((model) => modelRefFor(model) === state.modelRef);
+  const filteredAvailableModels = React.useMemo(
+    () => filterAvailableModels(availableModels, modelFilter),
+    [availableModels, modelFilter],
+  );
 
   React.useEffect(() => {
     if (!open) return;
     setState(normalizeDialogState({ preset, availableModels }));
+    setModelFilter("");
     setSaving(false);
     setErrorMessage(null);
   }, [availableModels, open, preset]);
+
+  React.useEffect(() => {
+    if (!open || preset) return;
+    setState((current) =>
+      reconcileModelDialogState({
+        currentState: current,
+        filteredModels: filteredAvailableModels,
+        availableModels,
+      }),
+    );
+  }, [availableModels, filteredAvailableModels, open, preset]);
+
+  const applyModelSelection = React.useCallback(
+    (modelRef: string) => {
+      setState((current) =>
+        selectModelDialogState({
+          currentState: current,
+          modelRef,
+          availableModels,
+        }),
+      );
+    },
+    [availableModels],
+  );
 
   const submit = async (): Promise<void> => {
     if (!canMutate) {
@@ -135,28 +169,13 @@ export function ModelPresetDialog({
               helperText="The underlying model is fixed after creation."
             />
           ) : (
-            <Select
-              label="Model"
-              value={state.modelRef}
-              onChange={(event) => {
-                setState((current) => ({
-                  ...current,
-                  modelRef: event.currentTarget.value,
-                  displayName:
-                    current.displayName.trim().length > 0
-                      ? current.displayName
-                      : (availableModels.find(
-                          (model) => modelRefFor(model) === event.currentTarget.value,
-                        )?.model_name ?? current.displayName),
-                }));
-              }}
-            >
-              {availableModels.map((model) => (
-                <option key={modelRefFor(model)} value={modelRefFor(model)}>
-                  {model.provider_name} / {model.model_name}
-                </option>
-              ))}
-            </Select>
+            <ModelPickerField
+              filteredModels={filteredAvailableModels}
+              modelFilter={modelFilter}
+              onModelFilterChange={setModelFilter}
+              onSelectModel={applyModelSelection}
+              selectedModelRef={state.modelRef}
+            />
           )}
 
           <Select
@@ -193,13 +212,6 @@ export function ModelPresetDialog({
               </option>
             ))}
           </Select>
-
-          {selectedModel && !preset ? (
-            <div className="text-sm text-fg-muted">
-              Selected: {selectedModel.provider_name} / {selectedModel.model_name}
-            </div>
-          ) : null}
-
           {errorMessage ? (
             <Alert variant="error" title="Unable to save" description={errorMessage} />
           ) : null}

--- a/packages/operator-ui/src/components/pages/admin-http-models.shared.ts
+++ b/packages/operator-ui/src/components/pages/admin-http-models.shared.ts
@@ -57,6 +57,19 @@ type ModelRefSource = {
   model_id: string;
 };
 
+function modelPickerSearchText(model: AvailableModel): string {
+  return [
+    model.model_name,
+    model.provider_name,
+    model.provider_key,
+    model.model_id,
+    model.family ?? "",
+    modelRefFor(model),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
 export type DeletePresetDialogState = {
   preset: ModelPreset;
   requiredExecutionProfileIds: string[];
@@ -104,6 +117,101 @@ export function modelRefFor(model: ModelRefSource): string {
   return `${model.provider_key}/${model.model_id}`;
 }
 
+export function filterAvailableModels(
+  availableModels: readonly AvailableModel[],
+  query: string,
+): AvailableModel[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return [...availableModels];
+  }
+  return availableModels.filter((model) => modelPickerSearchText(model).includes(normalizedQuery));
+}
+
+export function syncDisplayNameOnModelChange(input: {
+  currentDisplayName: string;
+  currentModelName?: string;
+  nextModelName?: string;
+}): string {
+  if (!input.currentDisplayName.trim()) {
+    return input.nextModelName ?? "";
+  }
+  if (input.currentDisplayName === (input.currentModelName ?? "")) {
+    return input.nextModelName ?? "";
+  }
+  return input.currentDisplayName;
+}
+
+export function selectModelDialogState(input: {
+  currentState: ModelDialogState;
+  modelRef: string;
+  availableModels: readonly AvailableModel[];
+}): ModelDialogState {
+  const nextModel = input.availableModels.find((model) => modelRefFor(model) === input.modelRef);
+  const currentModelName = input.availableModels.find(
+    (model) => modelRefFor(model) === input.currentState.modelRef,
+  )?.model_name;
+
+  return {
+    ...input.currentState,
+    modelRef: nextModel ? modelRefFor(nextModel) : "",
+    displayName: syncDisplayNameOnModelChange({
+      currentDisplayName: input.currentState.displayName,
+      currentModelName,
+      nextModelName: nextModel?.model_name,
+    }),
+  };
+}
+
+function clearModelDialogState(input: {
+  currentState: ModelDialogState;
+  availableModels: readonly AvailableModel[];
+}): ModelDialogState {
+  if (!input.currentState.modelRef) {
+    return input.currentState;
+  }
+
+  const currentModelName = input.availableModels.find(
+    (model) => modelRefFor(model) === input.currentState.modelRef,
+  )?.model_name;
+  const shouldClearDisplayName =
+    !input.currentState.displayName.trim() ||
+    input.currentState.displayName === (currentModelName ?? "");
+
+  return {
+    ...input.currentState,
+    modelRef: "",
+    displayName: shouldClearDisplayName ? "" : input.currentState.displayName,
+  };
+}
+
+export function reconcileModelDialogState(input: {
+  currentState: ModelDialogState;
+  filteredModels: readonly AvailableModel[];
+  availableModels: readonly AvailableModel[];
+}): ModelDialogState {
+  if (
+    input.currentState.modelRef &&
+    input.filteredModels.some((model) => modelRefFor(model) === input.currentState.modelRef)
+  ) {
+    return input.currentState;
+  }
+
+  const firstVisibleModel = input.filteredModels[0];
+  if (firstVisibleModel) {
+    return selectModelDialogState({
+      currentState: input.currentState,
+      modelRef: modelRefFor(firstVisibleModel),
+      availableModels: input.availableModels,
+    });
+  }
+
+  return clearModelDialogState({
+    currentState: input.currentState,
+    availableModels: input.availableModels,
+  });
+}
+
 export function splitModelRef(modelRef: string): { providerKey: string; modelId: string } | null {
   const slashIndex = modelRef.indexOf("/");
   if (slashIndex <= 0 || slashIndex === modelRef.length - 1) return null;
@@ -131,7 +239,7 @@ export function normalizeDialogState(input: {
   }
 
   return {
-    displayName: "",
+    displayName: input.availableModels[0]?.model_name ?? "",
     modelRef: input.availableModels[0] ? modelRefFor(input.availableModels[0]) : "",
     reasoningEffort: "",
     reasoningVisibility: "",

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.logic.ts
@@ -14,9 +14,10 @@ import {
 import {
   EXECUTION_PROFILE_IDS,
   emptyDialogState,
-  modelRefFor,
+  filterAvailableModels,
   normalizeAssignments,
   normalizeDialogState,
+  reconcileModelDialogState,
   splitModelRef,
   type Assignment,
   type AvailableModel,
@@ -263,6 +264,7 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
   const [providerState, setProviderState] = React.useState<ProviderFormState>(emptyFormState());
   const [providerFilter, setProviderFilter] = React.useState("");
   const [modelState, setModelState] = React.useState<ModelDialogState>(emptyDialogState());
+  const [modelFilter, setModelFilter] = React.useState("");
   const [selectedPresetKey, setSelectedPresetKey] = React.useState("");
   const [assignmentDraft, setAssignmentDraft] = React.useState<Record<string, string | null>>({});
   const [assignmentTouched, setAssignmentTouched] = React.useState(false);
@@ -281,6 +283,10 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
       );
     });
   }, [providerFilter, supportedProviders]);
+  const filteredAvailableModels = React.useMemo(
+    () => filterAvailableModels(data.availableModels, modelFilter),
+    [data.availableModels, modelFilter],
+  );
   const selectedProvider = supportedProviders.find(
     (provider) => provider.provider_key === providerState.providerKey,
   );
@@ -303,16 +309,23 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
   }, [data.registry]);
 
   React.useEffect(() => {
-    setModelState((current) => {
-      if (
-        current.modelRef &&
-        data.availableModels.some((model) => modelRefFor(model) === current.modelRef)
-      ) {
-        return current;
-      }
-      return normalizeDialogState({ availableModels: data.availableModels });
-    });
+    setModelFilter("");
   }, [data.availableModels]);
+
+  React.useEffect(() => {
+    setModelState((current) => {
+      const nextState =
+        current.modelRef || current.displayName.trim() || modelFilter.trim()
+          ? current
+          : normalizeDialogState({ availableModels: data.availableModels });
+
+      return reconcileModelDialogState({
+        currentState: nextState,
+        filteredModels: filteredAvailableModels,
+        availableModels: data.availableModels,
+      });
+    });
+  }, [data.availableModels, filteredAvailableModels, modelFilter]);
 
   React.useEffect(() => {
     setSelectedPresetKey((current) =>
@@ -338,7 +351,9 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
 
   return {
     assignmentDraft,
+    filteredAvailableModels,
     filteredProviders,
+    modelFilter,
     modelState,
     providerFilter,
     providerState,
@@ -347,6 +362,7 @@ export function useOnboardingDrafts(data: OnboardingDataState) {
     selectedProvider,
     setAssignmentDraft,
     setAssignmentTouched,
+    setModelFilter,
     setModelState,
     setProviderFilter,
     setProviderState,

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.sections.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.sections.tsx
@@ -18,9 +18,11 @@ import {
   EXECUTION_PROFILE_LABELS,
   REASONING_OPTIONS,
   REASONING_VISIBILITY_OPTIONS,
+  type AvailableModel,
   type ModelDialogState,
   type ModelPreset,
 } from "./admin-http-models.shared.js";
+import { ModelPickerField } from "./model-picker-field.js";
 import { OnboardingStepFrame } from "./first-run-onboarding.parts.js";
 import { ProviderPickerField } from "./provider-picker-field.js";
 
@@ -260,59 +262,47 @@ export function OnboardingProviderStep({
 }
 
 export function OnboardingPresetStep({
-  availableModels,
+  filteredAvailableModels,
   busy,
   canSave,
+  modelFilter,
   modelState,
+  onModelFilterChange,
   onModelSave,
+  onModelSelectionChange,
   onModelStateChange,
 }: {
-  availableModels: Array<{
-    modelRef: string;
-    label: string;
-    modelName: string;
-  }>;
+  filteredAvailableModels: AvailableModel[];
   busy: boolean;
   canSave: boolean;
+  modelFilter: string;
   modelState: ModelDialogState;
+  onModelFilterChange: (value: string) => void;
   onModelSave: () => void;
+  onModelSelectionChange: (modelRef: string) => void;
   onModelStateChange: (updater: (current: ModelDialogState) => ModelDialogState) => void;
 }): React.ReactElement {
   return (
     <OnboardingStepFrame stepId="preset">
       <div className="grid gap-4" data-testid="first-run-onboarding-step-preset">
+        <Input
+          label="Display name"
+          value={modelState.displayName}
+          onChange={(event) => {
+            onModelStateChange((current) => ({
+              ...current,
+              displayName: event.currentTarget.value,
+            }));
+          }}
+        />
+        <ModelPickerField
+          filteredModels={filteredAvailableModels}
+          modelFilter={modelFilter}
+          onModelFilterChange={onModelFilterChange}
+          onSelectModel={onModelSelectionChange}
+          selectedModelRef={modelState.modelRef}
+        />
         <div className="grid gap-4 md:grid-cols-2">
-          <Input
-            label="Display name"
-            value={modelState.displayName}
-            onChange={(event) => {
-              onModelStateChange((current) => ({
-                ...current,
-                displayName: event.currentTarget.value,
-              }));
-            }}
-          />
-          <Select
-            label="Model"
-            value={modelState.modelRef}
-            onChange={(event) => {
-              onModelStateChange((current) => ({
-                ...current,
-                modelRef: event.currentTarget.value,
-                displayName:
-                  current.displayName.trim().length > 0
-                    ? current.displayName
-                    : (availableModels.find((model) => model.modelRef === event.currentTarget.value)
-                        ?.modelName ?? current.displayName),
-              }));
-            }}
-          >
-            {availableModels.map((model) => (
-              <option key={model.modelRef} value={model.modelRef}>
-                {model.label}
-              </option>
-            ))}
-          </Select>
           <Select
             label="Reasoning effort"
             value={modelState.reasoningEffort}

--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from "../ui/card.js";
 import { useElevatedModeUiContext } from "../elevated-mode/elevated-mode-provider.js";
 import { useAdminMutationAccess, useAdminMutationHttpClient } from "./admin-http-shared.js";
 import { selectProviderFormState, validateProviderForm } from "./admin-http-providers.shared.js";
-import { modelRefFor } from "./admin-http-models.shared.js";
+import { selectModelDialogState } from "./admin-http-models.shared.js";
 import {
   buildDefaultAgentConfigUpdate,
   buildDefaultAssignments,
@@ -71,11 +71,6 @@ export function FirstRunOnboardingPage({
     drafts.selectedMethod,
     "create",
   );
-  const availableModelChoices = data.availableModels.map((model) => ({
-    modelRef: modelRefFor(model),
-    label: `${model.provider_name} / ${model.model_name}`,
-    modelName: model.model_name,
-  }));
 
   React.useEffect(() => {
     if (issues.length === 0) {
@@ -106,6 +101,19 @@ export function FirstRunOnboardingPage({
       });
     },
     [drafts],
+  );
+
+  const applyModelSelection = React.useCallback(
+    (modelRef: string) => {
+      drafts.setModelState((current) =>
+        selectModelDialogState({
+          currentState: current,
+          modelRef,
+          availableModels: data.availableModels,
+        }),
+      );
+    },
+    [data.availableModels, drafts],
   );
 
   const runMutation = React.useCallback(
@@ -186,10 +194,12 @@ export function FirstRunOnboardingPage({
     if (step === "preset") {
       return (
         <OnboardingPresetStep
-          availableModels={availableModelChoices}
           busy={submitBusy}
           canSave={Boolean(mutationHttp)}
+          filteredAvailableModels={drafts.filteredAvailableModels}
+          modelFilter={drafts.modelFilter}
           modelState={drafts.modelState}
+          onModelFilterChange={drafts.setModelFilter}
           onModelSave={() => {
             void runMutation(async () => {
               if (!mutationHttp) {
@@ -202,6 +212,7 @@ export function FirstRunOnboardingPage({
               drafts.setSelectedPresetKey(presetKey);
             });
           }}
+          onModelSelectionChange={applyModelSelection}
           onModelStateChange={drafts.setModelState}
         />
       );

--- a/packages/operator-ui/src/components/pages/model-picker-field.tsx
+++ b/packages/operator-ui/src/components/pages/model-picker-field.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import { cn } from "../../lib/cn.js";
+import { Badge } from "../ui/badge.js";
+import { Label } from "../ui/label.js";
+import { ScrollArea } from "../ui/scroll-area.js";
+import { modelRefFor, type AvailableModel } from "./admin-http-models.shared.js";
+
+const MODEL_PICKER_VISIBLE_COUNT = 5;
+const MODEL_PICKER_ROW_REM = 4.25;
+
+function modelOptionTestId(model: AvailableModel): string {
+  return `models-model-option-${modelRefFor(model)}`;
+}
+
+export function ModelPickerField({
+  filteredModels,
+  modelFilter,
+  onModelFilterChange,
+  onSelectModel,
+  selectedModelRef,
+}: {
+  filteredModels: readonly AvailableModel[];
+  modelFilter: string;
+  onModelFilterChange: (value: string) => void;
+  onSelectModel: (modelRef: string) => void;
+  selectedModelRef: string;
+}): React.ReactElement {
+  const modelFilterId = React.useId();
+  const pickerHeightRem =
+    Math.min(Math.max(filteredModels.length, 1), MODEL_PICKER_VISIBLE_COUNT) * MODEL_PICKER_ROW_REM;
+
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={modelFilterId} required>
+        Model
+      </Label>
+      <div className="overflow-hidden rounded-lg border border-border bg-bg-card/40">
+        <div className="border-b border-border/70 p-2">
+          <input
+            id={modelFilterId}
+            type="text"
+            value={modelFilter}
+            data-testid="models-filter-input"
+            aria-label="Filter models"
+            placeholder="Filter models by provider, model, or family"
+            onChange={(event) => {
+              onModelFilterChange(event.currentTarget.value);
+            }}
+            className={cn(
+              "box-border flex h-8 w-full rounded-md border border-border bg-bg px-2.5 py-1 text-sm text-fg transition-[border-color,box-shadow] duration-150",
+              "placeholder:text-fg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
+            )}
+          />
+        </div>
+        <ScrollArea
+          className="w-full"
+          data-testid="models-model-picker"
+          style={{ height: `${pickerHeightRem}rem` }}
+        >
+          <div className="grid gap-1 p-2" role="radiogroup" aria-label="Model">
+            {filteredModels.length > 0 ? (
+              filteredModels.map((model) => {
+                const modelRef = modelRefFor(model);
+                const active = modelRef === selectedModelRef;
+
+                return (
+                  <button
+                    key={modelRef}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    data-testid={modelOptionTestId(model)}
+                    className={cn(
+                      "flex w-full items-start justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
+                      active
+                        ? "border-primary bg-bg text-fg"
+                        : "border-border bg-bg hover:bg-bg-subtle",
+                    )}
+                    onClick={() => {
+                      onSelectModel(modelRef);
+                    }}
+                  >
+                    <div className="grid min-w-0 gap-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-fg">{model.model_name}</span>
+                        {model.family ? <Badge variant="outline">{model.family}</Badge> : null}
+                      </div>
+                      <span className="text-xs text-fg-muted">{model.provider_name}</span>
+                      <span className="text-xs text-fg-muted [overflow-wrap:anywhere]">
+                        {modelRef}
+                      </span>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                      {model.reasoning === true ? <Badge variant="outline">Reasoning</Badge> : null}
+                      {model.tool_call === true ? <Badge variant="outline">Tools</Badge> : null}
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="rounded-md border border-dashed border-border px-3 py-4 text-sm text-fg-muted">
+                No models match this filter.
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+      <p className="text-sm text-fg-muted">
+        Type to narrow the list. Up to five models stay visible before scrolling.
+      </p>
+    </div>
+  );
+}

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-model-picker-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-model-picker-test-support.ts
@@ -1,0 +1,345 @@
+import { expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createBearerTokenAuth, createOperatorCore } from "../../operator-core/src/index.js";
+import { OperatorUiApp } from "../src/index.js";
+import { stubAdminHttpFetch } from "./admin-http-fetch-test-support.js";
+import {
+  TEST_DEVICE_IDENTITY,
+  requestInfoToUrl,
+  setControlledInputValue,
+  stubPersistentStorage,
+  waitForSelector,
+} from "./operator-ui.test-support.js";
+import { FakeWsClient, createFakeHttpClient } from "./operator-ui.test-fixtures.js";
+import {
+  buildIssueStatusResponse,
+  cleanup,
+  createConfiguredProviderGroup,
+  findButtonByText,
+  getInputByLabel,
+} from "./operator-ui.first-run-onboarding.helpers.js";
+
+function createRegistryProvider(providerKey: string, name: string) {
+  return {
+    provider_key: providerKey,
+    name,
+    doc: null,
+    supported: true,
+    methods: [
+      {
+        method_key: "api_key",
+        label: "API key",
+        type: "api_key",
+        fields: [
+          {
+            key: "api_key",
+            label: "API key",
+            description: null,
+            kind: "secret",
+            input: "password",
+            required: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function registerFirstRunOnboardingModelPickerTests(): void {
+  it("filters models, auto-selects Claude, and saves the visible model selection", async () => {
+    stubPersistentStorage();
+    const ws = new FakeWsClient();
+    const { http, statusGet } = createFakeHttpClient();
+    const providers = [createConfiguredProviderGroup()];
+    let presets: Array<{
+      preset_id: string;
+      preset_key: string;
+      display_name: string;
+      provider_key: string;
+      model_id: string;
+      options: Record<string, unknown>;
+      created_at: string;
+      updated_at: string;
+    }> = [];
+    let savedBody: {
+      display_name: string;
+      provider_key: string;
+      model_id: string;
+      options: Record<string, string>;
+    } | null = null;
+
+    http.providerConfig.listRegistry = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [
+        createRegistryProvider("openai", "OpenAI"),
+        createRegistryProvider("anthropic", "Anthropic"),
+      ],
+    }));
+    http.providerConfig.listProviders = vi.fn(async () => ({
+      status: "ok" as const,
+      providers,
+    }));
+    http.modelConfig.listPresets = vi.fn(async () => ({
+      status: "ok" as const,
+      presets,
+    }));
+    http.modelConfig.listAvailable = vi.fn(async () => ({
+      status: "ok" as const,
+      models: [
+        {
+          provider_key: "openai",
+          provider_name: "OpenAI",
+          model_id: "gpt-4.1",
+          model_name: "GPT-4.1",
+          family: null,
+          reasoning: true,
+          tool_call: true,
+          modalities: { output: ["text"] },
+        },
+        {
+          provider_key: "anthropic",
+          provider_name: "Anthropic",
+          model_id: "claude-3.7-sonnet",
+          model_name: "Claude 3.7 Sonnet",
+          family: "Claude",
+          reasoning: true,
+          tool_call: true,
+          modalities: { output: ["text"] },
+        },
+      ],
+    }));
+
+    statusGet.mockImplementation(async () => {
+      if (presets.length === 0) {
+        return buildIssueStatusResponse([
+          {
+            code: "no_model_presets",
+            severity: "error",
+            message: "No model presets are configured.",
+            target: { kind: "deployment", id: null },
+          },
+        ]);
+      }
+
+      return buildIssueStatusResponse([
+        {
+          code: "execution_profile_unassigned",
+          severity: "error",
+          message: "Execution profiles still need assignments.",
+          target: { kind: "execution_profile", id: "interaction" },
+        },
+      ]);
+    });
+
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deviceIdentity: TEST_DEVICE_IDENTITY,
+      deps: { ws, http },
+    });
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    stubAdminHttpFetch(core, async (input, init) => {
+      const url = requestInfoToUrl(input);
+      if (!url.endsWith("/config/models/presets")) {
+        throw new Error(`Unexpected fetch call: ${url}`);
+      }
+
+      savedBody = JSON.parse(String(init?.body)) as typeof savedBody;
+      presets = [
+        {
+          preset_id: "00000000-0000-4000-8000-000000000301",
+          preset_key: "preset-claude-3-7-sonnet",
+          display_name: savedBody!.display_name,
+          provider_key: savedBody!.provider_key,
+          model_id: savedBody!.model_id,
+          options: savedBody!.options,
+          created_at: "2026-03-01T00:00:00.000Z",
+          updated_at: "2026-03-01T00:00:00.000Z",
+        },
+      ];
+
+      return new Response(JSON.stringify({ status: "ok", preset: presets[0] }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await waitForSelector(container, '[data-testid="first-run-onboarding-step-preset"]');
+    const filterInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="models-filter-input"]',
+    );
+    const displayNameInput = getInputByLabel(container, "Display name");
+
+    expect(filterInput).not.toBeNull();
+    expect(displayNameInput).not.toBeNull();
+    expect(displayNameInput?.value).toBe("GPT-4.1");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "claude");
+      await Promise.resolve();
+    });
+
+    const claudeOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="models-model-option-anthropic/claude-3.7-sonnet"]',
+    );
+    expect(
+      container.querySelector('[data-testid="models-model-option-openai/gpt-4.1"]'),
+    ).toBeNull();
+    expect(claudeOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("Claude 3.7 Sonnet");
+
+    await act(async () => {
+      findButtonByText(container, "Save model preset")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(savedBody).toEqual({
+      display_name: "Claude 3.7 Sonnet",
+      provider_key: "anthropic",
+      model_id: "claude-3.7-sonnet",
+      options: {},
+    });
+    expect(
+      await waitForSelector(container, '[data-testid="first-run-onboarding-step-assignments"]'),
+    ).not.toBeNull();
+
+    cleanup(root, container);
+  });
+
+  it("preserves a custom display name across onboarding model filter changes", async () => {
+    stubPersistentStorage();
+    const ws = new FakeWsClient();
+    const { http, statusGet } = createFakeHttpClient();
+
+    http.providerConfig.listRegistry = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [createRegistryProvider("openai", "OpenAI")],
+    }));
+    http.providerConfig.listProviders = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [createConfiguredProviderGroup()],
+    }));
+    http.modelConfig.listPresets = vi.fn(async () => ({ status: "ok" as const, presets: [] }));
+    http.modelConfig.listAvailable = vi.fn(async () => ({
+      status: "ok" as const,
+      models: [
+        {
+          provider_key: "openai",
+          provider_name: "OpenAI",
+          model_id: "gpt-4.1",
+          model_name: "GPT-4.1",
+          family: null,
+          reasoning: true,
+          tool_call: true,
+          modalities: { output: ["text"] },
+        },
+        {
+          provider_key: "openai",
+          provider_name: "OpenAI",
+          model_id: "gpt-4.1-mini",
+          model_name: "GPT-4.1 Mini",
+          family: null,
+          reasoning: true,
+          tool_call: true,
+          modalities: { output: ["text"] },
+        },
+      ],
+    }));
+    statusGet.mockResolvedValue(
+      buildIssueStatusResponse([
+        {
+          code: "no_model_presets",
+          severity: "error",
+          message: "No model presets are configured.",
+          target: { kind: "deployment", id: null },
+        },
+      ]),
+    );
+
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deviceIdentity: TEST_DEVICE_IDENTITY,
+      deps: { ws, http },
+    });
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    stubAdminHttpFetch(core);
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await waitForSelector(container, '[data-testid="first-run-onboarding-step-preset"]');
+    const filterInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="models-filter-input"]',
+    );
+    const displayNameInput = getInputByLabel(container, "Display name");
+
+    expect(filterInput).not.toBeNull();
+    expect(displayNameInput).not.toBeNull();
+
+    await act(async () => {
+      setControlledInputValue(displayNameInput!, "Team preset");
+      setControlledInputValue(filterInput!, "mini");
+      await Promise.resolve();
+    });
+
+    const miniOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="models-model-option-openai/gpt-4.1-mini"]',
+    );
+    expect(miniOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("Team preset");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "zzz");
+      await Promise.resolve();
+    });
+
+    expect(displayNameInput?.value).toBe("Team preset");
+
+    await act(async () => {
+      setControlledInputValue(filterInput!, "");
+      await Promise.resolve();
+    });
+
+    const defaultOption = await waitForSelector<HTMLButtonElement>(
+      container,
+      '[data-testid="models-model-option-openai/gpt-4.1"]',
+    );
+    expect(defaultOption.getAttribute("aria-checked")).toBe("true");
+    expect(displayNameInput?.value).toBe("Team preset");
+
+    cleanup(root, container);
+  });
+}

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
@@ -1,9 +1,11 @@
 import { registerFirstRunOnboardingFlowTests } from "./operator-ui.first-run-onboarding-flow-test-support.js";
+import { registerFirstRunOnboardingModelPickerTests } from "./operator-ui.first-run-onboarding-model-picker-test-support.js";
 import { registerFirstRunOnboardingProviderPickerTests } from "./operator-ui.first-run-onboarding-provider-picker-test-support.js";
 import { registerFirstRunOnboardingStateTests } from "./operator-ui.first-run-onboarding-state-test-support.js";
 
 export function registerFirstRunOnboardingTests(): void {
   registerFirstRunOnboardingStateTests();
   registerFirstRunOnboardingFlowTests();
+  registerFirstRunOnboardingModelPickerTests();
   registerFirstRunOnboardingProviderPickerTests();
 }

--- a/packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts
@@ -6,6 +6,7 @@ import { stubAdminHttpFetch } from "../admin-http-fetch-test-support.js";
 import { setNativeValue } from "../test-utils.js";
 import {
   ADMIN_HTTP_EXECUTION_PROFILE_IDS,
+  createAvailableModel,
   setModelConfigResponses,
 } from "./admin-page.http.models.shared.js";
 import {
@@ -63,6 +64,14 @@ function getDialogSelect(dialog: HTMLElement, labelText: string): HTMLSelectElem
     throw new Error(`Expected label "${labelText}" to target a select.`);
   }
   return control;
+}
+
+function getModelFilterInput(dialog: HTMLElement): HTMLInputElement {
+  return getByTestId<HTMLInputElement>(dialog, "models-filter-input");
+}
+
+function getModelPickerOption(dialog: HTMLElement, modelRef: string): HTMLButtonElement {
+  return getByTestId<HTMLButtonElement>(dialog, `models-model-option-${modelRef}`);
 }
 
 describe("ConfigurePage (HTTP) models", () => {
@@ -126,23 +135,11 @@ describe("ConfigurePage (HTTP) models", () => {
 
     click(getByTestId<HTMLButtonElement>(page.container, "models-add-open"));
     const dialog = getByTestId<HTMLElement>(document.body, "models-preset-dialog");
-    expectPresent(
-      Array.from(dialog.querySelectorAll<HTMLInputElement>("input")).find(
-        (input) => input.type !== "hidden" && !input.readOnly,
-      ),
-    );
-
-    const modelSelect = getDialogSelect(dialog, "Model");
+    const displayNameInput = getDialogInput(dialog, "Display name");
     const reasoningEffortSelect = getDialogSelect(dialog, "Reasoning effort");
     expect(getDialogSelect(dialog, "Reasoning display").value).toBe("");
-    setSelectValue(modelSelect, "openai/gpt-4.1-mini");
-    expect(
-      expectPresent(
-        Array.from(dialog.querySelectorAll<HTMLInputElement>("input")).find(
-          (input) => input.type !== "hidden" && !input.readOnly,
-        ),
-      ).value,
-    ).toBe("GPT-4.1 Mini");
+    click(getModelPickerOption(dialog, "openai/gpt-4.1-mini"));
+    expect(displayNameInput.value).toBe("GPT-4.1 Mini");
     setSelectValue(reasoningEffortSelect, "high");
 
     await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "models-save"));
@@ -162,7 +159,7 @@ describe("ConfigurePage (HTTP) models", () => {
 
     click(getByTestId<HTMLButtonElement>(page.container, "models-add-open"));
     const dialog = getByTestId<HTMLElement>(document.body, "models-preset-dialog");
-    setSelectValue(getDialogSelect(dialog, "Model"), "openai/gpt-4.1-mini");
+    click(getModelPickerOption(dialog, "openai/gpt-4.1-mini"));
 
     await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "models-save"));
     await flush();
@@ -200,6 +197,114 @@ describe("ConfigurePage (HTTP) models", () => {
 
     expect(countMutationCalls(fetchMock)).toBe(1);
     expect(page.container.textContent).toContain("Renamed preset");
+    cleanupAdminHttpPage(page);
+  });
+
+  it("filters the model list, auto-selects the first match, and caps the visible list to five rows", async () => {
+    const { core } = createAdminHttpTestCore();
+    setModelConfigResponses(core, {
+      presets: [],
+      models: [
+        createAvailableModel(),
+        createAvailableModel({ model_id: "gpt-4.1-mini", model_name: "GPT-4.1 Mini" }),
+        createAvailableModel({
+          provider_key: "anthropic",
+          provider_name: "Anthropic",
+          model_id: "claude-3.7-sonnet",
+          model_name: "Claude 3.7 Sonnet",
+          family: "Claude",
+        }),
+        createAvailableModel({
+          provider_key: "meta",
+          provider_name: "Meta",
+          model_id: "llama-3.3-70b",
+          model_name: "Llama 3.3 70B",
+        }),
+        createAvailableModel({
+          provider_key: "google",
+          provider_name: "Google",
+          model_id: "gemma-3-27b",
+          model_name: "Gemma 3 27B",
+        }),
+        createAvailableModel({
+          provider_key: "mistral",
+          provider_name: "Mistral",
+          model_id: "mistral-large",
+          model_name: "Mistral Large",
+        }),
+      ],
+      assignments: [],
+    });
+    stubAdminHttpFetch(core);
+
+    const page = renderAdminHttpConfigurePage(core);
+    await openModelsTab(page.container);
+
+    click(getByTestId<HTMLButtonElement>(page.container, "models-add-open"));
+    const dialog = getByTestId<HTMLElement>(document.body, "models-preset-dialog");
+    const filterInput = getModelFilterInput(dialog);
+    const modelPicker = getByTestId<HTMLElement>(dialog, "models-model-picker");
+    const displayNameInput = getDialogInput(dialog, "Display name");
+
+    expect(modelPicker.style.height).toBe("21.25rem");
+    expect(displayNameInput.value).toBe("GPT-4.1");
+
+    act(() => {
+      setNativeValue(filterInput, "claude");
+    });
+
+    expect(dialog.querySelector("[data-testid='models-model-option-openai/gpt-4.1']")).toBeNull();
+    expect(
+      getModelPickerOption(dialog, "anthropic/claude-3.7-sonnet").getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(displayNameInput.value).toBe("Claude 3.7 Sonnet");
+    cleanupAdminHttpPage(page);
+  });
+
+  it("preserves a custom display name across model filter changes", async () => {
+    const { core } = createAdminHttpTestCore();
+    setModelConfigResponses(core, {
+      presets: [],
+      models: [
+        createAvailableModel(),
+        createAvailableModel({ model_id: "gpt-4.1-mini", model_name: "GPT-4.1 Mini" }),
+      ],
+      assignments: [],
+    });
+    stubAdminHttpFetch(core);
+
+    const page = renderAdminHttpConfigurePage(core);
+    await openModelsTab(page.container);
+
+    click(getByTestId<HTMLButtonElement>(page.container, "models-add-open"));
+    const dialog = getByTestId<HTMLElement>(document.body, "models-preset-dialog");
+    const filterInput = getModelFilterInput(dialog);
+    const displayNameInput = getDialogInput(dialog, "Display name");
+
+    act(() => {
+      setNativeValue(displayNameInput, "Team preset");
+      setNativeValue(filterInput, "mini");
+    });
+
+    expect(getModelPickerOption(dialog, "openai/gpt-4.1-mini").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(displayNameInput.value).toBe("Team preset");
+
+    act(() => {
+      setNativeValue(filterInput, "zzz");
+    });
+
+    expect(displayNameInput.value).toBe("Team preset");
+
+    act(() => {
+      setNativeValue(filterInput, "");
+    });
+
+    expect(getModelPickerOption(dialog, "openai/gpt-4.1").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(displayNameInput.value).toBe("Team preset");
     cleanupAdminHttpPage(page);
   });
 


### PR DESCRIPTION
Closes #1436

## What changed
- add a shared `ModelPickerField` with provider-style filtering, auto-selection, and metadata rows
- use the shared picker in `Configure -> Models` create flow while keeping edit mode read-only
- reuse the same picker and shared reconciliation logic in first-run onboarding
- add regression coverage for configure-models and onboarding model-picker behavior

## Verification
- `pnpm exec vitest run packages/operator-ui/tests/operator-ui.test.ts`
- `pnpm exec vitest run packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- pre-push hook passed `pnpm lint`, `pnpm typecheck`, and `pnpm test` during `git push`

## Risk
UI-only change in operator model-setup flows.

## Rollback
Revert commit `e9e9dc75`.
