### PR TITLE
fix(gateway): prevent spurious agent row creation during heartbeat

### DIFF
--- a/packages/gateway/src/modules/agent/context-store.ts
+++ b/packages/gateway/src/modules/agent/context-store.ts
@@ -63,6 +63,13 @@ class LocalAgentContextStore implements AgentContextStore {
        LIMIT 1`,
       [scope.tenantId, scope.agentId],
     );
+    const agentId =
+      resolvedAgentRow?.agent_id ??
+      (await this.identityScopeDal.resolveAgentId(scope.tenantId, scope.agentId));
+    if (!agentId) {
+      throw new Error(`agent not found for tenant_id=${scope.tenantId}, agent_id=${scope.agentId}`);
+    }
+
     const resolvedWorkspaceRow = await this.db.get<{ workspace_id: string }>(
       `SELECT workspace_id
        FROM workspaces
@@ -70,49 +77,20 @@ class LocalAgentContextStore implements AgentContextStore {
        LIMIT 1`,
       [scope.tenantId, scope.workspaceId],
     );
+    const workspaceId =
+      resolvedWorkspaceRow?.workspace_id ??
+      (await this.identityScopeDal.resolveWorkspaceId(scope.tenantId, scope.workspaceId));
+    if (!workspaceId) {
+      throw new Error(
+        `workspace not found for tenant_id=${scope.tenantId}, workspace_id=${scope.workspaceId}`,
+      );
+    }
 
-    return {
-      tenantId: scope.tenantId,
-      agentId:
-        resolvedAgentRow?.agent_id ??
-        (await this.identityScopeDal.ensureAgentId(scope.tenantId, scope.agentId)),
-      workspaceId:
-        resolvedWorkspaceRow?.workspace_id ??
-        (await this.identityScopeDal.ensureWorkspaceId(scope.tenantId, scope.workspaceId)),
-    };
-  }
-
-  private async ensureScopeRows(scope: AgentContextScope): Promise<AgentContextScope> {
-    await this.db.run(
-      `INSERT INTO tenants (tenant_id, tenant_key)
-       VALUES (?, ?)
-       ON CONFLICT (tenant_id) DO NOTHING`,
-      [scope.tenantId, scope.tenantId],
-    );
-    const resolved = await this.resolveScopeIds(scope);
-    await this.db.run(
-      `INSERT INTO agents (tenant_id, agent_id, agent_key)
-       VALUES (?, ?, ?)
-       ON CONFLICT (tenant_id, agent_id) DO NOTHING`,
-      [resolved.tenantId, resolved.agentId, resolved.agentId],
-    );
-    await this.db.run(
-      `INSERT INTO workspaces (tenant_id, workspace_id, workspace_key)
-       VALUES (?, ?, ?)
-       ON CONFLICT (tenant_id, workspace_id) DO NOTHING`,
-      [resolved.tenantId, resolved.workspaceId, resolved.workspaceId],
-    );
-    await this.db.run(
-      `INSERT INTO agent_workspaces (tenant_id, agent_id, workspace_id)
-       VALUES (?, ?, ?)
-       ON CONFLICT (tenant_id, agent_id, workspace_id) DO NOTHING`,
-      [resolved.tenantId, resolved.agentId, resolved.workspaceId],
-    );
-    return resolved;
+    return { tenantId: scope.tenantId, agentId, workspaceId };
   }
 
   private async ensureIdentity(scope: AgentContextScope): Promise<IdentityPackT> {
-    const resolved = await this.ensureScopeRows(scope);
+    const resolved = await this.resolveScopeIds(scope);
     const revision = await this.identityDal.ensureSeeded({
       tenantId: resolved.tenantId,
       agentId: resolved.agentId,

--- a/packages/gateway/tests/unit/agent-context-store.test.ts
+++ b/packages/gateway/tests/unit/agent-context-store.test.ts
@@ -32,6 +32,22 @@ describe("LocalAgentContextStore", () => {
     await container.db.close();
   });
 
+  async function setupLocalScope() {
+    const store = createLocalAgentContextStore({
+      db: container.db,
+      home: homeDir,
+      identityScopeDal: container.identityScopeDal,
+    });
+    const tenantId = await container.identityScopeDal.ensureTenantId("tenant-local");
+    const agentId = await container.identityScopeDal.ensureAgentId(tenantId, "default");
+    const workspaceId = await container.identityScopeDal.ensureWorkspaceId(
+      tenantId,
+      DEFAULT_WORKSPACE_KEY,
+    );
+    await container.identityScopeDal.ensureMembership(tenantId, agentId, workspaceId);
+    return { store, tenantId, agentId, workspaceId };
+  }
+
   it("loads identity from DB and skills/mcp from the local workspace", async () => {
     await mkdir(join(homeDir, "skills/file-reader"), { recursive: true });
     await mkdir(join(homeDir, "mcp/calendar"), { recursive: true });
@@ -61,19 +77,7 @@ args:
       "utf-8",
     );
 
-    const store = createLocalAgentContextStore({
-      db: container.db,
-      home: homeDir,
-      identityScopeDal: container.identityScopeDal,
-    });
-    const tenantId = await container.identityScopeDal.ensureTenantId("tenant-local");
-    const agentId = await container.identityScopeDal.ensureAgentId(tenantId, "default");
-    const workspaceId = await container.identityScopeDal.ensureWorkspaceId(
-      tenantId,
-      DEFAULT_WORKSPACE_KEY,
-    );
-    await container.identityScopeDal.ensureMembership(tenantId, agentId, workspaceId);
-    const scope = { tenantId, agentId, workspaceId };
+    const { store, ...scope } = await setupLocalScope();
     const config = AgentConfig.parse({
       model: { model: "openai/gpt-4.1" },
       skills: { enabled: ["file-reader"], workspace_trusted: true },
@@ -366,18 +370,7 @@ cwd: .
   });
 
   it("resolves runtime scope keys to durable ids before seeding local identity", async () => {
-    const store = createLocalAgentContextStore({
-      db: container.db,
-      home: homeDir,
-      identityScopeDal: container.identityScopeDal,
-    });
-    const tenantId = await container.identityScopeDal.ensureTenantId("tenant-local");
-    const agentId = await container.identityScopeDal.ensureAgentId(tenantId, "default");
-    const workspaceId = await container.identityScopeDal.ensureWorkspaceId(
-      tenantId,
-      DEFAULT_WORKSPACE_KEY,
-    );
-    await container.identityScopeDal.ensureMembership(tenantId, agentId, workspaceId);
+    const { store, tenantId, agentId } = await setupLocalScope();
 
     await store.ensureAgentContext({
       tenantId,
@@ -396,6 +389,27 @@ cwd: .
 
     const identity = await new AgentIdentityDal(container.db).getLatest({ tenantId, agentId });
     expect(identity?.identity.meta.name).toBe("Tyrum");
+  });
+
+  it("does not create a spurious agent row when a UUID is passed as agentId", async () => {
+    const { store, tenantId, agentId, workspaceId } = await setupLocalScope();
+    await store.ensureAgentContext({ tenantId, agentId, workspaceId });
+    const agents = await container.db.all<{ agent_key: string }>(
+      `SELECT agent_key FROM agents WHERE tenant_id = ? ORDER BY agent_key ASC`,
+      [tenantId],
+    );
+    expect(agents.map((r) => r.agent_key)).toEqual(["default"]);
+  });
+
+  it("throws when scope references a non-existent agent", async () => {
+    const { store, tenantId, workspaceId } = await setupLocalScope();
+    await expect(
+      store.ensureAgentContext({
+        tenantId,
+        agentId: "00000000-0000-4000-8000-999999999999",
+        workspaceId,
+      }),
+    ).rejects.toThrow(/agent not found/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace write-path `ensureAgentId`/`ensureWorkspaceId` with read-only `resolveAgentId`/`resolveWorkspaceId` in `LocalAgentContextStore.resolveScopeIds`, so a UUID passed as `scope.agentId` is never treated as an `agent_key`
- Remove `ensureScopeRows` entirely — it inserted agent/workspace rows with UUID-as-key, which is semantically wrong and the root cause of spurious agent creation
- Add regression tests guarding against the reported bug

## Test plan

- [x] `agent-context-store.test.ts` — all 8 tests pass (6 existing + 2 new)
- [x] `heartbeat-default-agent-runtime.test.ts` — heartbeat integration test passes
- [x] Full gateway test suite — 453 files, 2251 tests, 0 failures

Closes #1439