### PR TITLE
fix(operator-ui): prevent sidebar secondary header overflow

### DIFF
--- a/apps/web/src/layout-harness-app.tsx
+++ b/apps/web/src/layout-harness-app.tsx
@@ -164,6 +164,7 @@ export function LayoutHarnessApp() {
     { id: "desktop", label: "Desktop", icon: HarnessIcon },
     { id: "onboarding", label: "Onboarding", icon: HarnessIcon },
   ];
+  const secondaryNavItems = [{ id: "node-browser", label: "Browser", icon: HarnessIcon }];
 
   return (
     <AppShell
@@ -173,6 +174,8 @@ export function LayoutHarnessApp() {
       sidebar={
         <Sidebar
           items={navItems}
+          secondaryItems={secondaryNavItems}
+          secondaryLabel="Node"
           activeItemId={route}
           onNavigate={() => undefined}
           collapsible

--- a/apps/web/tests/sidebar-layout-regression.test.ts
+++ b/apps/web/tests/sidebar-layout-regression.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium, type Browser, type Page } from "playwright";
+import { createServer, type ViteDevServer } from "vite";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = resolve(__dirname, "..");
+const VITE_CONFIG = resolve(APP_ROOT, "vite.config.ts");
+
+let browser: Browser;
+let server: ViteDevServer;
+let baseUrl: string;
+const originalCwd = process.cwd();
+
+async function assertNoInternalHorizontalClipping(page: Page, selectors: string[]): Promise<void> {
+  const result = await page.evaluate((candidateSelectors) => {
+    return candidateSelectors.map((selector) => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) {
+        return { selector, found: false, clippedBy: null };
+      }
+      return {
+        selector,
+        found: true,
+        clippedBy: Math.max(0, element.scrollWidth - element.clientWidth),
+      };
+    });
+  }, selectors);
+
+  for (const measurement of result) {
+    expect(measurement.found, `${measurement.selector} should exist`).toBe(true);
+    expect(
+      measurement.clippedBy,
+      `${measurement.selector} clipped ${measurement.clippedBy}px of horizontal content`,
+    ).toBeLessThanOrEqual(1);
+  }
+}
+
+describe("sidebar layout regression harness", () => {
+  beforeAll(async () => {
+    process.chdir(APP_ROOT);
+    server = await createServer({
+      configFile: VITE_CONFIG,
+      logLevel: "error",
+      server: {
+        host: "127.0.0.1",
+        port: 0,
+      },
+    });
+    await server.listen();
+    browser = await chromium.launch({ headless: true });
+    const devOrigin = server.resolvedUrls?.local[0]?.replace(/\/$/, "");
+    if (!devOrigin) {
+      throw new Error("Dev server did not expose a local URL.");
+    }
+    baseUrl = `${devOrigin}/layout-harness.html`;
+  }, 120_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+    process.chdir(originalCwd);
+  });
+
+  it("does not clip the sidebar when the secondary node section is visible", async () => {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 820 } });
+    try {
+      await page.goto(`${baseUrl}?route=dashboard`, { waitUntil: "load" });
+      await page.waitForSelector('[data-testid="sidebar-secondary-label"]');
+
+      await assertNoInternalHorizontalClipping(page, [
+        '[data-testid="sidebar-nav"]',
+        '[data-testid="sidebar-secondary-label"]',
+      ]);
+
+      const overflowBy = await page
+        .locator('[data-testid="sidebar-secondary-label"]')
+        .evaluate((label) => {
+          const nav = label.closest<HTMLElement>('[data-testid="sidebar-nav"]');
+          if (!nav) {
+            return Number.NaN;
+          }
+          return Math.max(
+            0,
+            label.getBoundingClientRect().right - nav.getBoundingClientRect().right,
+          );
+        });
+
+      expect(overflowBy).toBeLessThanOrEqual(1);
+    } finally {
+      await page.close();
+    }
+  });
+});

--- a/packages/operator-ui/src/components/layout/sidebar.tsx
+++ b/packages/operator-ui/src/components/layout/sidebar.tsx
@@ -37,7 +37,7 @@ export interface SidebarProps extends React.HTMLAttributes<HTMLElement> {
 const STORAGE_KEY_SECONDARY = "tyrum-sidebar-secondary-collapsed";
 const STORAGE_KEY_SIDEBAR = "tyrum-sidebar-collapsed";
 const SIDEBAR_EXPANDED_ROW_LAYOUT =
-  "grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-x-2";
+  "box-border grid w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-x-2";
 
 function readStoredBool(key: string, defaultValue: boolean): boolean {
   try {
@@ -165,6 +165,7 @@ function SidebarNav({
   return (
     <TooltipProvider>
       <nav
+        data-testid="sidebar-nav"
         className={cn(
           "flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto py-2",
           collapsed ? "px-1" : "px-2",
@@ -195,6 +196,7 @@ function SidebarNav({
               </button>
             ) : !collapsed ? (
               <div
+                data-testid="sidebar-secondary-label"
                 className={cn(
                   "mt-2 py-1 text-xs font-medium text-fg-muted",
                   SIDEBAR_EXPANDED_ROW_LAYOUT,


### PR DESCRIPTION
## Summary
- prevent the shared sidebar secondary header row from overflowing horizontally
- extend the web layout harness to render the secondary `Node` section
- add a focused Playwright regression for sidebar clipping

## Testing
- pnpm exec vitest run apps/web/tests/layout-regression.test.ts apps/web/tests/sidebar-layout-regression.test.ts
- pnpm exec vitest run packages/operator-ui/tests/layout/sidebar.test.ts
- pre-push hook: pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test

Closes #1444
