### PR TITLE
Enable Preflight and fix chat markdown typography

### DIFF
--- a/apps/web/src/layout-harness-chat-fixtures.ts
+++ b/apps/web/src/layout-harness-chat-fixtures.ts
@@ -71,6 +71,19 @@ function parseDynamicResult<T>(
 }
 
 function createActiveSession(): HarnessChatSession {
+  const assistantMarkdown = [
+    "# Markdown Rendering",
+    "",
+    "Preflight should keep real markdown semantics inside the chat bubble:",
+    "",
+    "- first bullet",
+    "- second bullet with `inline code` and a [docs link](https://example.com/docs)",
+    "",
+    "```ts",
+    "const viewportWidth = 1280;",
+    "```",
+  ].join("\n");
+
   return {
     session_id: "session-1",
     agent_id: "default",
@@ -80,7 +93,7 @@ function createActiveSession(): HarnessChatSession {
     message_count: 2,
     last_message: {
       role: "assistant",
-      text: "Yes. We can add browser geometry checks.",
+      text: "Rendered markdown with heading, list, link, and code block.",
     },
     messages: [
       {
@@ -91,7 +104,7 @@ function createActiveSession(): HarnessChatSession {
       {
         id: "turn-2",
         role: "assistant",
-        parts: [{ type: "text", text: "Yes. We can add browser geometry checks." }],
+        parts: [{ type: "text", text: assistantMarkdown }],
       },
     ],
     updated_at: "2026-03-08T00:00:00.000Z",

--- a/apps/web/src/layout-harness-chat-store-fixtures.ts
+++ b/apps/web/src/layout-harness-chat-store-fixtures.ts
@@ -1,6 +1,19 @@
 import { createStore } from "../../../packages/operator-core/src/store.js";
 
 export function createChatStore() {
+  const assistantMarkdown = [
+    "# Markdown Rendering",
+    "",
+    "Preflight should keep real markdown semantics inside the chat bubble:",
+    "",
+    "- first bullet",
+    "- second bullet with `inline code` and a [docs link](https://example.com/docs)",
+    "",
+    "```ts",
+    "const viewportWidth = 1280;",
+    "```",
+  ].join("\n");
+
   const activeSession = {
     session_id: "session-1",
     agent_id: "default",
@@ -10,7 +23,7 @@ export function createChatStore() {
     message_count: 2,
     last_message: {
       role: "assistant" as const,
-      text: "Yes. We can add browser geometry checks.",
+      text: "Rendered markdown with heading, list, link, and code block.",
     },
     messages: [
       {
@@ -21,7 +34,7 @@ export function createChatStore() {
       {
         id: "turn-2",
         role: "assistant" as const,
-        parts: [{ type: "text" as const, text: "Yes. We can add browser geometry checks." }],
+        parts: [{ type: "text" as const, text: assistantMarkdown }],
       },
     ],
     updated_at: "2026-03-08T00:00:00.000Z",

--- a/apps/web/tests/layout-regression-test-support.ts
+++ b/apps/web/tests/layout-regression-test-support.ts
@@ -1,0 +1,84 @@
+import { expect } from "vitest";
+import type { Page } from "playwright";
+
+export async function assertSingleRowTabs(page: Page, selector: string): Promise<void> {
+  const result = await page.evaluate((targetSelector) => {
+    const list = document.querySelector<HTMLElement>(targetSelector);
+    if (!list) {
+      return { found: false, uniqueTopCount: 0, scrollable: false };
+    }
+    const triggerTops = Array.from(list.querySelectorAll<HTMLElement>('[role="tab"]')).map((tab) =>
+      Math.round(tab.getBoundingClientRect().top),
+    );
+    return {
+      found: true,
+      uniqueTopCount: new Set(triggerTops).size,
+      scrollable: list.scrollWidth > list.clientWidth,
+    };
+  }, selector);
+
+  expect(result.found, `${selector} should exist`).toBe(true);
+  expect(result.uniqueTopCount).toBe(1);
+  expect(typeof result.scrollable).toBe("boolean");
+}
+
+export async function assertChatMarkdownTypography(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const transcript = document.querySelector<HTMLElement>(
+      '[data-testid="ai-sdk-chat-transcript"]',
+    );
+    return Boolean(
+      transcript?.querySelector("h1") &&
+      transcript.querySelector("p") &&
+      transcript.querySelector("ul") &&
+      transcript.querySelector("a") &&
+      transcript.querySelector("pre"),
+    );
+  });
+
+  const result = await page.evaluate(() => {
+    const transcript = document.querySelector<HTMLElement>(
+      '[data-testid="ai-sdk-chat-transcript"]',
+    );
+    const heading = transcript?.querySelector<HTMLElement>("h1");
+    const paragraph = transcript?.querySelector<HTMLElement>("p");
+    const list = transcript?.querySelector<HTMLElement>("ul");
+    const link = transcript?.querySelector<HTMLElement>("a");
+    const codeBlock = transcript?.querySelector<HTMLElement>("pre");
+    if (!transcript || !heading || !paragraph || !list || !link || !codeBlock) {
+      return {
+        found: false,
+        headingFontSize: 0,
+        paragraphFontSize: 0,
+        listStyleType: "",
+        listPaddingLeft: 0,
+        linkTextDecorationLine: "",
+        codeWithinTranscript: false,
+      };
+    }
+
+    const headingStyle = getComputedStyle(heading);
+    const paragraphStyle = getComputedStyle(paragraph);
+    const listStyle = getComputedStyle(list);
+    const linkStyle = getComputedStyle(link);
+    const transcriptRect = transcript.getBoundingClientRect();
+    const codeRect = codeBlock.getBoundingClientRect();
+
+    return {
+      found: true,
+      headingFontSize: Number.parseFloat(headingStyle.fontSize),
+      paragraphFontSize: Number.parseFloat(paragraphStyle.fontSize),
+      listStyleType: listStyle.listStyleType,
+      listPaddingLeft: Number.parseFloat(listStyle.paddingLeft),
+      linkTextDecorationLine: linkStyle.textDecorationLine,
+      codeWithinTranscript: codeRect.right <= transcriptRect.right + 1,
+    };
+  });
+
+  expect(result.found).toBe(true);
+  expect(result.headingFontSize).toBeGreaterThan(result.paragraphFontSize);
+  expect(result.listStyleType).toBe("disc");
+  expect(result.listPaddingLeft).toBeGreaterThan(0);
+  expect(result.linkTextDecorationLine).toContain("underline");
+  expect(result.codeWithinTranscript).toBe(true);
+}

--- a/apps/web/tests/layout-regression.test.ts
+++ b/apps/web/tests/layout-regression.test.ts
@@ -3,6 +3,10 @@ import { chromium, type Browser, type Page } from "playwright";
 import { createServer, type ViteDevServer } from "vite";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  assertChatMarkdownTypography,
+  assertSingleRowTabs,
+} from "./layout-regression-test-support.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = resolve(__dirname, "..");
@@ -289,27 +293,6 @@ async function assertDashboardLayout(
   }, expected);
 }
 
-async function assertSingleRowTabs(page: Page, selector: string): Promise<void> {
-  const result = await page.evaluate((targetSelector) => {
-    const list = document.querySelector<HTMLElement>(targetSelector);
-    if (!list) {
-      return { found: false, uniqueTopCount: 0, scrollable: false };
-    }
-    const triggerTops = Array.from(list.querySelectorAll<HTMLElement>('[role="tab"]')).map((tab) =>
-      Math.round(tab.getBoundingClientRect().top),
-    );
-    return {
-      found: true,
-      uniqueTopCount: new Set(triggerTops).size,
-      scrollable: list.scrollWidth > list.clientWidth,
-    };
-  }, selector);
-
-  expect(result.found, `${selector} should exist`).toBe(true);
-  expect(result.uniqueTopCount).toBe(1);
-  expect(typeof result.scrollable).toBe("boolean");
-}
-
 describe("layout regression harness", () => {
   beforeAll(async () => {
     process.chdir(APP_ROOT);
@@ -416,6 +399,23 @@ describe("layout regression harness", () => {
         '[data-testid="chat-threads-panel"]',
         '[data-testid="chat-conversation-panel"]',
       ]);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("renders chat markdown with typography styles", { timeout: 30_000 }, async () => {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 820 } });
+    try {
+      await page.goto(`${baseUrl}?route=chat`, { waitUntil: "load" });
+      await page.waitForSelector('[data-testid="chat-conversation-panel"]');
+
+      await assertNoHorizontalOverflow(page, [
+        '[data-testid="chat-page"]',
+        '[data-testid="chat-panels"]',
+        '[data-testid="chat-conversation-panel"]',
+      ]);
+      await assertChatMarkdownTypography(page);
     } finally {
       await page.close();
     }

--- a/apps/web/tests/web-build.test.ts
+++ b/apps/web/tests/web-build.test.ts
@@ -25,6 +25,18 @@ function getReferencedResourcePaths(indexHtml: string): string[] {
   return [...indexHtml.matchAll(HTML_RESOURCE_PATH)].map((match) => match[1]);
 }
 
+function readBuiltCssAsset(indexHtml: string): string {
+  const cssResourcePath = getReferencedResourcePaths(indexHtml).find((resourcePath) =>
+    resourcePath.endsWith(".css"),
+  );
+
+  if (!cssResourcePath?.startsWith("/ui/")) {
+    throw new Error(`Expected a built CSS asset reference in ${DIST_INDEX}.`);
+  }
+
+  return readFileSync(resolve(DIST_ROOT, cssResourcePath.slice("/ui/".length)), "utf8");
+}
+
 function shouldRefreshBuildOutput(): boolean {
   return !process.argv.includes("run") && !process.argv.includes("--run");
 }
@@ -62,5 +74,13 @@ describe("apps/web", () => {
       expect(resourcePath.startsWith("/ui/")).toBe(true);
       expect(existsSync(resolve(DIST_ROOT, resourcePath.slice("/ui/".length)))).toBe(true);
     }
+  });
+
+  it("includes Tailwind typography styles for markdown content", { timeout: 180_000 }, async () => {
+    const indexHtml = await ensureBuiltIndexHtml();
+    const css = readBuiltCssAsset(indexHtml);
+
+    expect(css).toContain(".prose");
+    expect(css).toContain("--tw-prose-body");
   });
 });

--- a/packages/operator-ui/package.json
+++ b/packages/operator-ui/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@tailwindcss/typography": "^0.5.16",
     "@tyrum/client": "workspace:*",
     "@tyrum/operator-core": "workspace:*",
     "@tyrum/schemas": "workspace:*",

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
@@ -150,10 +150,25 @@ function readToolApprovalId(
   return approval?.id?.trim() ? approval.id : null;
 }
 
+const MARKDOWN_PROSE_CLASS_NAME = [
+  "prose prose-sm min-w-0 max-w-none break-words text-fg [overflow-wrap:anywhere]",
+  "prose-headings:mb-2 prose-headings:mt-3 prose-headings:text-fg",
+  "prose-p:my-2 prose-p:break-words prose-p:text-fg",
+  "prose-a:text-primary prose-a:underline prose-a:underline-offset-2",
+  "prose-ul:my-2 prose-ul:list-disc prose-ul:pl-5",
+  "prose-ol:my-2 prose-ol:list-decimal prose-ol:pl-5",
+  "prose-li:my-1 prose-li:text-fg",
+  "prose-bullets:text-fg-muted prose-counters:text-fg-muted",
+  "prose-strong:text-fg prose-code:break-words prose-code:text-fg prose-code:[overflow-wrap:anywhere]",
+  "prose-blockquote:border-border prose-blockquote:text-fg",
+  "prose-hr:border-border prose-th:text-fg prose-td:text-fg",
+  "prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:bg-bg-subtle prose-pre:text-fg prose-pre:[overflow-wrap:anywhere]",
+].join(" ");
+
 function TextBlock({ value, renderMode }: { value: string; renderMode: "markdown" | "text" }) {
   if (renderMode === "markdown") {
     return (
-      <div className="prose prose-sm min-w-0 max-w-none break-words text-fg [overflow-wrap:anywhere] prose-headings:mb-2 prose-headings:mt-3 prose-headings:text-fg prose-p:my-2 prose-p:break-words prose-p:text-fg prose-ul:my-2 prose-ol:my-2 prose-strong:text-fg prose-code:break-words prose-code:text-fg prose-code:[overflow-wrap:anywhere] prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:bg-bg-subtle prose-pre:[overflow-wrap:anywhere]">
+      <div className={MARKDOWN_PROSE_CLASS_NAME}>
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{value}</ReactMarkdown>
       </div>
     );

--- a/packages/operator-ui/src/globals.css
+++ b/packages/operator-ui/src/globals.css
@@ -12,6 +12,7 @@
 
 /* Ensure Tailwind scans operator-ui component sources for class names. */
 @source ".";
+@plugin "@tailwindcss/typography";
 
 @layer base {
   /*

--- a/packages/operator-ui/tests/globals-css.test.ts
+++ b/packages/operator-ui/tests/globals-css.test.ts
@@ -9,6 +9,12 @@ describe("globals.css", () => {
     expect(css).toContain('@import "tailwindcss/preflight.css" layer(base);');
   });
 
+  it("registers the Tailwind typography plugin", () => {
+    const css = readFileSync(join(process.cwd(), "packages/operator-ui/src/globals.css"), "utf8");
+
+    expect(css).toContain('@plugin "@tailwindcss/typography";');
+  });
+
   it("resets native chrome for plain text-entry controls", () => {
     const css = readFileSync(join(process.cwd(), "packages/operator-ui/src/globals.css"), "utf8");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.2.4
         version: 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.19(tailwindcss@4.2.1)
       '@tyrum/client':
         specifier: workspace:*
         version: link:../client
@@ -5093,6 +5096,11 @@ packages:
   '@tailwindcss/oxide@4.2.1':
     resolution: {integrity: sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==}
     engines: {node: '>= 20'}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
@@ -10049,6 +10057,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -18100,6 +18112,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.1
+
   '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
@@ -23925,6 +23942,11 @@ snapshots:
     dependencies:
       postcss: 8.5.8
       postcss-selector-parser: 7.1.1
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:


### PR DESCRIPTION
Closes #1461

## Summary
- enable Tailwind Preflight in `@tyrum/operator-ui`
- restore chat markdown styling by wiring in `@tailwindcss/typography`
- keep markdown bubble behavior scoped with explicit prose overrides for headings, lists, links, and code blocks
- add browser/build regression coverage for rendered chat markdown

## Testing
- `pnpm exec vitest run packages/operator-ui/tests/globals-css.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts apps/web/tests/web-build.test.ts apps/web/tests/layout-regression.test.ts`
- `pnpm --filter @tyrum/web build`
- `pnpm --filter tyrum-desktop build`
- full pre-push suite via `git push`
