### PR TITLE
fix(operator-ui): resume chat follow-scroll after send

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -74,6 +74,7 @@ export function AiSdkConversation({
   transport: ReturnType<typeof createTyrumAiSdkChatTransport>;
 }) {
   const [draft, setDraft] = useState("");
+  const [followRequestId, setFollowRequestId] = useState(0);
   const previousStatusRef = useRef<ReturnType<typeof useChat<UIMessage>>["status"]>("ready");
   const chat = useChat<UIMessage>({
     id: session.session_id,
@@ -126,6 +127,7 @@ export function AiSdkConversation({
     }
     const attachedNodeId = await resolveAttachedNodeId();
     setDraft("");
+    setFollowRequestId((value) => value + 1);
     await chat.sendMessage(
       {
         text,
@@ -194,6 +196,7 @@ export function AiSdkConversation({
       <AiSdkChatMessageList
         approvalsById={approvalsById}
         core={core}
+        followRequestId={followRequestId}
         messages={chat.messages}
         onResolveApproval={onResolveApproval}
         renderMode={renderMode}

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
@@ -13,9 +13,14 @@ function isBottomLocked(element: HTMLElement): boolean {
   );
 }
 
+function scrollToBottom(element: HTMLElement): void {
+  element.scrollTop = element.scrollHeight;
+}
+
 export function AiSdkChatMessageList({
   approvalsById,
   core,
+  followRequestId,
   messages,
   onResolveApproval,
   renderMode,
@@ -24,6 +29,7 @@ export function AiSdkChatMessageList({
 }: {
   approvalsById: Record<string, Approval>;
   core: OperatorCore;
+  followRequestId: number;
   messages: UIMessage[];
   onResolveApproval: (input: ResolveApprovalInput) => void;
   renderMode: "markdown" | "text";
@@ -32,6 +38,7 @@ export function AiSdkChatMessageList({
 }) {
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const wasBottomLockedRef = useRef(true);
+  const lastFollowRequestIdRef = useRef(followRequestId);
 
   useEffect(() => {
     const element = transcriptRef.current;
@@ -50,10 +57,20 @@ export function AiSdkChatMessageList({
 
   useLayoutEffect(() => {
     const element = transcriptRef.current;
+    if (!element || followRequestId === lastFollowRequestIdRef.current) {
+      return;
+    }
+    lastFollowRequestIdRef.current = followRequestId;
+    wasBottomLockedRef.current = true;
+    scrollToBottom(element);
+  }, [followRequestId]);
+
+  useLayoutEffect(() => {
+    const element = transcriptRef.current;
     if (!element || !wasBottomLockedRef.current) {
       return;
     }
-    element.scrollTop = element.scrollHeight;
+    scrollToBottom(element);
   }, [messages, working]);
 
   return (

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
@@ -22,8 +22,21 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("../../src/components/pages/chat-page-ai-sdk-messages.js", () => ({
-  AiSdkChatMessageList: ({ messages }: { messages: UIMessage[] }) =>
-    e("div", { "data-testid": "mock-message-list" }, String(messages.length)),
+  AiSdkChatMessageList: ({
+    followRequestId,
+    messages,
+  }: {
+    followRequestId: number;
+    messages: UIMessage[];
+  }) =>
+    e(
+      "div",
+      {
+        "data-follow-request-id": String(followRequestId),
+        "data-testid": "mock-message-list",
+      },
+      String(messages.length),
+    ),
 }));
 
 function makeUseChatState(overrides?: Partial<ReturnType<typeof useChatMock>>) {
@@ -99,6 +112,11 @@ describe("AiSdkConversation", () => {
 
     await flushEffects();
     expect(onSessionMessages).toHaveBeenCalledWith([]);
+    expect(
+      testRoot.container
+        .querySelector("[data-testid='mock-message-list']")
+        ?.getAttribute("data-follow-request-id"),
+    ).toBe("0");
 
     const conversationPanel = testRoot.container.querySelector(
       "[data-testid='chat-conversation-panel']",
@@ -117,6 +135,11 @@ describe("AiSdkConversation", () => {
       { text: "hello world" },
       { body: { attached_node_id: "node-1" } },
     );
+    expect(
+      testRoot.container
+        .querySelector("[data-testid='mock-message-list']")
+        ?.getAttribute("data-follow-request-id"),
+    ).toBe("1");
     expect(draft.value).toBe("");
 
     const textToggle = Array.from(testRoot.container.querySelectorAll("button")).find(

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-messages.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-messages.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import React from "react";
+import React, { act } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
 import type { OperatorCore } from "../../../operator-core/src/index.js";
@@ -14,21 +14,78 @@ vi.mock("../../src/components/pages/chat-page-ai-sdk-message-card.js", () => ({
     e("div", { "data-testid": `mock-message-${message.id}` }, message.id),
 }));
 
+function createMessage(id: string): UIMessage {
+  return {
+    id,
+    parts: [{ type: "text", text: id }],
+    role: "assistant",
+  } as unknown as UIMessage;
+}
+
+function createProps(
+  overrides?: Partial<
+    React.ComponentProps<
+      typeof import("../../src/components/pages/chat-page-ai-sdk-messages.js").AiSdkChatMessageList
+    >
+  >,
+) {
+  return {
+    approvalsById: {},
+    core: testCore,
+    followRequestId: 0,
+    messages: [] as UIMessage[],
+    onResolveApproval: vi.fn(),
+    renderMode: "markdown" as const,
+    resolvingApproval: null,
+    working: false,
+    ...overrides,
+  };
+}
+
+function installScrollMetrics(
+  element: HTMLElement,
+  initial: { clientHeight: number; scrollHeight: number; scrollTop: number },
+): {
+  getScrollTop: () => number;
+  setScrollHeight: (value: number) => void;
+  setScrollTop: (value: number) => void;
+} {
+  let scrollTop = initial.scrollTop;
+  let scrollHeight = initial.scrollHeight;
+  const clientHeight = initial.clientHeight;
+
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    get: () => clientHeight,
+  });
+
+  return {
+    getScrollTop: () => scrollTop,
+    setScrollHeight(value: number) {
+      scrollHeight = value;
+    },
+    setScrollTop(value: number) {
+      scrollTop = value;
+    },
+  };
+}
+
 describe("AiSdkChatMessageList", () => {
   it("renders an empty state when there are no messages", async () => {
     const { AiSdkChatMessageList } =
       await import("../../src/components/pages/chat-page-ai-sdk-messages.js");
-    const testRoot = renderIntoDocument(
-      e(AiSdkChatMessageList, {
-        approvalsById: {},
-        core: testCore,
-        messages: [],
-        onResolveApproval: vi.fn(),
-        renderMode: "markdown",
-        resolvingApproval: null,
-        working: false,
-      }),
-    );
+    const testRoot = renderIntoDocument(e(AiSdkChatMessageList, createProps()));
 
     expect(testRoot.container.textContent).toContain("No messages yet.");
 
@@ -38,23 +95,15 @@ describe("AiSdkChatMessageList", () => {
   it("renders message cards inside the transcript container", async () => {
     const { AiSdkChatMessageList } =
       await import("../../src/components/pages/chat-page-ai-sdk-messages.js");
-    const messages = [
-      {
-        id: "assistant-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "reply" }],
-      },
-    ] as unknown as UIMessage[];
+    const messages = [createMessage("assistant-1")];
     const testRoot = renderIntoDocument(
-      e(AiSdkChatMessageList, {
-        approvalsById: {},
-        core: testCore,
-        messages,
-        onResolveApproval: vi.fn(),
-        renderMode: "markdown",
-        resolvingApproval: null,
-        working: true,
-      }),
+      e(
+        AiSdkChatMessageList,
+        createProps({
+          messages,
+          working: true,
+        }),
+      ),
     );
 
     const transcript = testRoot.container.querySelector("[data-testid='ai-sdk-chat-transcript']");
@@ -62,6 +111,180 @@ describe("AiSdkChatMessageList", () => {
     expect(
       testRoot.container.querySelector("[data-testid='mock-message-assistant-1']"),
     ).not.toBeNull();
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("forces the transcript back to the bottom when a new follow request arrives", async () => {
+    const { AiSdkChatMessageList } =
+      await import("../../src/components/pages/chat-page-ai-sdk-messages.js");
+    const messages = [createMessage("assistant-1")];
+    const testRoot = renderIntoDocument(
+      e(
+        AiSdkChatMessageList,
+        createProps({
+          messages,
+        }),
+      ),
+    );
+
+    const transcript = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-transcript']",
+    ) as HTMLElement | null;
+    expect(transcript).not.toBeNull();
+    const scroll = installScrollMetrics(transcript as HTMLElement, {
+      clientHeight: 100,
+      scrollHeight: 400,
+      scrollTop: 400,
+    });
+
+    act(() => {
+      scroll.setScrollTop(120);
+      transcript?.dispatchEvent(new Event("scroll"));
+    });
+
+    act(() => {
+      testRoot.root.render(
+        e(
+          AiSdkChatMessageList,
+          createProps({
+            followRequestId: 1,
+            messages,
+          }),
+        ),
+      );
+    });
+
+    expect(scroll.getScrollTop()).toBe(400);
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("keeps following streamed updates after a follow request re-enables bottom lock", async () => {
+    const { AiSdkChatMessageList } =
+      await import("../../src/components/pages/chat-page-ai-sdk-messages.js");
+    const initialMessages = [createMessage("assistant-1")];
+    const testRoot = renderIntoDocument(
+      e(
+        AiSdkChatMessageList,
+        createProps({
+          messages: initialMessages,
+        }),
+      ),
+    );
+
+    const transcript = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-transcript']",
+    ) as HTMLElement | null;
+    expect(transcript).not.toBeNull();
+    const scroll = installScrollMetrics(transcript as HTMLElement, {
+      clientHeight: 100,
+      scrollHeight: 400,
+      scrollTop: 400,
+    });
+
+    act(() => {
+      scroll.setScrollTop(120);
+      transcript?.dispatchEvent(new Event("scroll"));
+    });
+
+    act(() => {
+      testRoot.root.render(
+        e(
+          AiSdkChatMessageList,
+          createProps({
+            followRequestId: 1,
+            messages: initialMessages,
+          }),
+        ),
+      );
+    });
+    expect(scroll.getScrollTop()).toBe(400);
+
+    scroll.setScrollHeight(520);
+    act(() => {
+      testRoot.root.render(
+        e(
+          AiSdkChatMessageList,
+          createProps({
+            followRequestId: 1,
+            messages: [...initialMessages, createMessage("assistant-2")],
+            working: true,
+          }),
+        ),
+      );
+    });
+
+    expect(scroll.getScrollTop()).toBe(520);
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("stops following once the user scrolls away from the bottom again", async () => {
+    const { AiSdkChatMessageList } =
+      await import("../../src/components/pages/chat-page-ai-sdk-messages.js");
+    const initialMessages = [createMessage("assistant-1")];
+    const testRoot = renderIntoDocument(
+      e(
+        AiSdkChatMessageList,
+        createProps({
+          messages: initialMessages,
+        }),
+      ),
+    );
+
+    const transcript = testRoot.container.querySelector(
+      "[data-testid='ai-sdk-chat-transcript']",
+    ) as HTMLElement | null;
+    expect(transcript).not.toBeNull();
+    const scroll = installScrollMetrics(transcript as HTMLElement, {
+      clientHeight: 100,
+      scrollHeight: 400,
+      scrollTop: 400,
+    });
+
+    act(() => {
+      scroll.setScrollTop(120);
+      transcript?.dispatchEvent(new Event("scroll"));
+    });
+
+    act(() => {
+      testRoot.root.render(
+        e(
+          AiSdkChatMessageList,
+          createProps({
+            followRequestId: 1,
+            messages: initialMessages,
+          }),
+        ),
+      );
+    });
+    expect(scroll.getScrollTop()).toBe(400);
+
+    act(() => {
+      scroll.setScrollTop(180);
+      transcript?.dispatchEvent(new Event("scroll"));
+    });
+
+    scroll.setScrollHeight(620);
+    act(() => {
+      testRoot.root.render(
+        e(
+          AiSdkChatMessageList,
+          createProps({
+            followRequestId: 1,
+            messages: [
+              ...initialMessages,
+              createMessage("assistant-2"),
+              createMessage("assistant-3"),
+            ],
+            working: true,
+          }),
+        ),
+      );
+    });
+
+    expect(scroll.getScrollTop()).toBe(180);
 
     cleanupTestRoot(testRoot);
   });


### PR DESCRIPTION
## Summary
- re-enable transcript follow mode whenever the user sends a chat message
- force the transcript to jump back to the latest message on that follow request while preserving manual scroll opt-out
- add regression coverage for send-triggered follow mode, streamed updates, and manual upward scrolling

Closes #1465.

## Testing
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm format:check
- pnpm test

## Risk
This only changes the shared operator chat transcript scroll behavior. The main risk is over-eager auto-scroll while reading older messages; the implementation keeps the existing scroll listener so any manual upward scroll disables follow mode again.

## Rollback
Revert commit af5d29d7.