### PR TITLE
fix(chat): preserve thread order when opening sessions

### DIFF
--- a/packages/operator-core/src/stores/chat-store.actions.ts
+++ b/packages/operator-core/src/stores/chat-store.actions.ts
@@ -59,12 +59,69 @@ function buildPreview(messages: UIMessage[]): TyrumAiSdkChatSessionSummary["last
   return null;
 }
 
+function compareSessionActivity(
+  left: TyrumAiSdkChatSessionSummary,
+  right: TyrumAiSdkChatSessionSummary,
+): number {
+  if (left.updated_at !== right.updated_at) {
+    return right.updated_at.localeCompare(left.updated_at);
+  }
+  return right.session_id.localeCompare(left.session_id);
+}
+
+function isComparableRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toComparableEntries(record: Record<string, unknown>): Array<[string, unknown]> {
+  return Object.entries(record)
+    .filter(([, value]) => value !== undefined)
+    .toSorted(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
+}
+
+function areComparableValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false;
+    }
+    return left.every((value, index) => areComparableValuesEqual(value, right[index]));
+  }
+  if (!isComparableRecord(left) || !isComparableRecord(right)) {
+    return false;
+  }
+
+  const leftEntries = toComparableEntries(left);
+  const rightEntries = toComparableEntries(right);
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+
+  return leftEntries.every(([leftKey, leftValue], index) => {
+    const rightEntry = rightEntries[index];
+    return (
+      rightEntry !== undefined &&
+      leftKey === rightEntry[0] &&
+      areComparableValuesEqual(leftValue, rightEntry[1])
+    );
+  });
+}
+
+function areMessagesEqual(left: UIMessage[], right: UIMessage[]): boolean {
+  return areComparableValuesEqual(left, right);
+}
+
 function patchSessionList(
   sessions: TyrumAiSdkChatSessionSummary[],
   session: TyrumAiSdkChatSession | TyrumAiSdkChatSessionSummary,
 ): TyrumAiSdkChatSessionSummary[] {
   const nextSummary = toSessionSummary(session);
-  return [nextSummary, ...sessions.filter((entry) => entry.session_id !== nextSummary.session_id)];
+  return [
+    ...sessions.filter((entry) => entry.session_id !== nextSummary.session_id),
+    nextSummary,
+  ].toSorted(compareSessionActivity);
 }
 
 function applySessionMessages(
@@ -311,7 +368,7 @@ export function hydrateActiveSession(
 export function updateActiveMessages(ctx: ChatStoreContext, messages: UIMessage[]): void {
   ctx.setState((prev) => {
     const session = prev.active.session;
-    if (!session) {
+    if (!session || areMessagesEqual(session.messages, messages)) {
       return prev;
     }
     const nextSession = applySessionMessages(session, messages);

--- a/packages/operator-core/tests/chat-store.test.ts
+++ b/packages/operator-core/tests/chat-store.test.ts
@@ -15,9 +15,9 @@ function sampleListItem(sessionId: string, updatedAt = "2026-01-01T00:00:00.000Z
   };
 }
 
-function sampleGetSession(sessionId: string) {
+function sampleGetSession(sessionId: string, updatedAt = "2026-01-01T00:00:00.000Z") {
   return {
-    ...sampleListItem(sessionId),
+    ...sampleListItem(sessionId, updatedAt),
     messages: [
       {
         id: `${sessionId}-user-1`,
@@ -111,41 +111,121 @@ describe("chatStore", () => {
     expect(chat.getSnapshot().active.session).toEqual(sampleGetSession("session-9"));
   });
 
-  it("updates the active session and thread preview when live messages change", async () => {
+  it("keeps existing thread order when opening an older session", async () => {
     const ws = createFakeWs();
-    ws.sessionGet.mockResolvedValueOnce({ session: sampleGetSession("session-3") });
+    ws.sessionList.mockResolvedValueOnce({
+      sessions: [
+        sampleListItem("session-1", "2026-01-02T00:00:00.000Z"),
+        sampleListItem("session-2", "2026-01-01T00:00:00.000Z"),
+      ],
+      next_cursor: null,
+    });
+    ws.sessionGet.mockResolvedValueOnce({
+      session: sampleGetSession("session-2", "2026-01-01T00:00:00.000Z"),
+    });
     const chat = createChatStore(ws as never, createFakeHttp() as never);
 
-    await chat.openSession("session-3");
-    chat.updateActiveMessages([
-      {
-        id: "session-3-user-1",
-        role: "user",
-        parts: [{ type: "text", text: "hello" }],
-      },
-      {
-        id: "session-3-assistant-1",
-        role: "assistant",
-        parts: [{ type: "text", text: "Fresh assistant reply" }],
-      },
-    ]);
+    await chat.refreshSessions();
+    await chat.openSession("session-2");
 
-    const snapshot = chat.getSnapshot();
-    expect(snapshot.active.session?.messages).toHaveLength(2);
-    expect(snapshot.active.session?.last_message).toEqual({
-      role: "assistant",
-      text: "Fresh assistant reply",
-    });
-    expect(snapshot.sessions.sessions[0]).toEqual(
-      expect.objectContaining({
-        session_id: "session-3",
-        message_count: 2,
-        last_message: {
-          role: "assistant",
-          text: "Fresh assistant reply",
+    expect(chat.getSnapshot().sessions.sessions.map((session) => session.session_id)).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+    expect(chat.getSnapshot().active.sessionId).toBe("session-2");
+  });
+
+  it("ignores unchanged message arrays so activity order does not reset on open", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+
+    try {
+      const ws = createFakeWs();
+      ws.sessionList.mockResolvedValueOnce({
+        sessions: [
+          sampleListItem("session-1", "2026-01-02T00:00:00.000Z"),
+          sampleListItem("session-2", "2026-01-01T00:00:00.000Z"),
+        ],
+        next_cursor: null,
+      });
+      ws.sessionGet.mockResolvedValueOnce({
+        session: sampleGetSession("session-2", "2026-01-01T00:00:00.000Z"),
+      });
+      const chat = createChatStore(ws as never, createFakeHttp() as never);
+
+      await chat.refreshSessions();
+      await chat.openSession("session-2");
+      chat.updateActiveMessages(sampleGetSession("session-2", "2026-01-01T00:00:00.000Z").messages);
+
+      const snapshot = chat.getSnapshot();
+      expect(snapshot.active.session?.updated_at).toBe("2026-01-01T00:00:00.000Z");
+      expect(snapshot.sessions.sessions.map((session) => session.session_id)).toEqual([
+        "session-1",
+        "session-2",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("promotes the active session when live messages actually change", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+
+    try {
+      const ws = createFakeWs();
+      ws.sessionList.mockResolvedValueOnce({
+        sessions: [
+          sampleListItem("session-1", "2026-01-02T00:00:00.000Z"),
+          sampleListItem("session-3", "2026-01-01T00:00:00.000Z"),
+        ],
+        next_cursor: null,
+      });
+      ws.sessionGet.mockResolvedValueOnce({
+        session: sampleGetSession("session-3", "2026-01-01T00:00:00.000Z"),
+      });
+      const chat = createChatStore(ws as never, createFakeHttp() as never);
+
+      await chat.refreshSessions();
+      await chat.openSession("session-3");
+      chat.updateActiveMessages([
+        {
+          id: "session-3-user-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
         },
-      }),
-    );
+        {
+          id: "session-3-assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Fresh assistant reply" }],
+        },
+      ]);
+
+      const snapshot = chat.getSnapshot();
+      expect(snapshot.active.session?.messages).toHaveLength(2);
+      expect(snapshot.active.session?.last_message).toEqual({
+        role: "assistant",
+        text: "Fresh assistant reply",
+      });
+      expect(snapshot.active.session?.updated_at).toBe("2026-01-10T00:00:00.000Z");
+      expect(snapshot.sessions.sessions.map((session) => session.session_id)).toEqual([
+        "session-3",
+        "session-1",
+      ]);
+      expect(snapshot.sessions.sessions[0]).toEqual(
+        expect.objectContaining({
+          session_id: "session-3",
+          message_count: 2,
+          last_message: {
+            role: "assistant",
+            text: "Fresh assistant reply",
+          },
+          updated_at: "2026-01-10T00:00:00.000Z",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates and deletes sessions while retaining live message state", async () => {

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React, { act } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
 import type { OperatorCore } from "../../../operator-core/src/index.js";
 import { createChatStore } from "../../../operator-core/src/stores/chat-store.js";
@@ -178,7 +178,20 @@ async function clickAndFlush(element: HTMLElement): Promise<void> {
   });
 }
 
+function listThreadOrder(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLElement>("[data-testid^='mock-open-']")).map(
+    (button) => button.getAttribute("data-testid")?.replace("mock-open-", "") ?? "",
+  );
+}
+
 describe("AiSdkChatPage integration", () => {
+  beforeEach(() => {
+    createSessionClientMock.mockReset();
+    createTransportMock.mockClear();
+    toastErrorMock.mockReset();
+    supportsSocketMock.mockReturnValue(true);
+  });
+
   it("loads sessions, starts chats, applies message updates, and deletes sessions", async () => {
     const sessionClient = {
       list: vi.fn(async () => ({
@@ -268,6 +281,93 @@ describe("AiSdkChatPage integration", () => {
 
     expect(sessionClient.delete).toHaveBeenCalledWith({ session_id: "session-2" });
     expect(testRoot.container.textContent).toContain("session-1");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("keeps thread order stable when opening an older thread and promotes on real updates", async () => {
+    const sessionClient = {
+      list: vi.fn(async () => ({
+        sessions: [
+          createSessionSummary("session-1", "Newest preview"),
+          {
+            ...createSessionSummary("session-2", "Older preview"),
+            created_at: "2026-03-12T00:00:00.000Z",
+            updated_at: "2026-03-12T00:00:00.000Z",
+          },
+        ],
+        next_cursor: null,
+      })),
+      get: vi.fn(async ({ session_id }: { session_id: string }) =>
+        session_id === "session-2"
+          ? {
+              ...createSession("session-2", "Older preview"),
+              created_at: "2026-03-12T00:00:00.000Z",
+              updated_at: "2026-03-12T00:00:00.000Z",
+            }
+          : createSession("session-1", "Newest preview"),
+      ),
+      create: vi.fn(async () => createSession("session-3", "New preview")),
+      delete: vi.fn(async () => undefined),
+    };
+    createSessionClientMock.mockReturnValue(sessionClient);
+
+    const agentList = vi.fn(async () => ({
+      agents: [{ agent_key: "default", persona: { name: "Default" } }],
+    }));
+    const { store: connectionStore } = createStore({
+      status: "connected",
+      clientId: null,
+      lastDisconnect: null,
+      transportError: null,
+    });
+    const approvalsStore = createApprovalsStoreStub();
+    const ws = {
+      connected: true,
+      off: vi.fn(),
+      on: vi.fn(),
+      requestDynamic: vi.fn(),
+      onDynamicEvent: vi.fn(),
+      offDynamicEvent: vi.fn(),
+    };
+    const http = {
+      agentList: {
+        get: agentList,
+      },
+    };
+    const chatStore = createChatStore(ws as never, http as never);
+    const core = {
+      approvalsStore,
+      chatStore,
+      connectionStore,
+      http,
+      ws,
+    } as unknown as OperatorCore;
+
+    const { AiSdkChatPage } = await import("../../src/components/pages/chat-page-ai-sdk.js");
+    const testRoot = renderIntoDocument(e(AiSdkChatPage, { core }));
+
+    await flushEffects();
+    await flushEffects();
+
+    expect(agentList).toHaveBeenCalledOnce();
+    expect(sessionClient.get).toHaveBeenCalledWith({ session_id: "session-1" });
+    expect(listThreadOrder(testRoot.container)).toEqual(["session-1", "session-2"]);
+
+    await clickAndFlush(
+      testRoot.container.querySelector("[data-testid='mock-open-session-2']") as HTMLElement,
+    );
+
+    expect(sessionClient.get).toHaveBeenLastCalledWith({ session_id: "session-2" });
+    expect(listThreadOrder(testRoot.container)).toEqual(["session-1", "session-2"]);
+    expect(testRoot.container.textContent).toContain("session-2");
+
+    await clickAndFlush(
+      testRoot.container.querySelector("[data-testid='mock-conversation-messages']") as HTMLElement,
+    );
+
+    expect(listThreadOrder(testRoot.container)).toEqual(["session-2", "session-1"]);
+    expect(testRoot.container.textContent).toContain("Title session-2:Fresh assistant reply");
 
     cleanupTestRoot(testRoot);
   });


### PR DESCRIPTION
## Summary
- preserve chat thread ordering when opening an existing session by merging hydrated sessions back into the list using activity sort order instead of always prepending them
- ignore unchanged message arrays during active session hydration so opening a thread does not refresh `updated_at`
- add store and chat page integration regressions covering open-without-reorder and real-message promotion

## Why
Opening a thread in the chat UI could reorder the thread list even though no actual chat activity occurred. The client-side hydration path treated the open action like fresh activity.

Closes #1469

## How to test
- `pnpm exec vitest run packages/operator-core/tests/chat-store.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts`
- `pnpm exec tsc --noEmit --project packages/operator-core/tsconfig.json`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm exec oxlint packages/operator-core/src/stores/chat-store.actions.ts packages/operator-core/tests/chat-store.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts`
- `git push -u origin 1469-fix-chat-thread-order-on-open` (passed repo pre-push gate: 4168 tests, 773 files)

## Risk
Low. The change is isolated to chat-store ordering and no-op detection for identical message payloads.

## Rollback
Revert commit `e85c48f8` to restore the prior chat-store merge behavior.
