### PR TITLE
fix(operator-ui): clean up agents page display

### DIFF
--- a/packages/operator-ui/src/components/pages/agents-page-agent-display.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-agent-display.tsx
@@ -1,0 +1,234 @@
+import { ChevronDown } from "lucide-react";
+import { cn } from "../../lib/cn.js";
+import { Button } from "../ui/button.js";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu.js";
+import { StatusDot } from "../ui/status-dot.js";
+
+export type AgentOption = {
+  agentKey: string;
+  agentId: string;
+  canDelete: boolean;
+  displayName: string;
+};
+
+function hashAgentKey(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+const AVATAR_VARIANT_CLASSES = [
+  "border-primary/25 bg-primary-dim text-primary",
+  "border-success/25 bg-success/10 text-success",
+  "border-warning/25 bg-warning/10 text-warning",
+  "border-error/25 bg-error/10 text-error",
+  "border-border bg-bg-subtle text-fg-muted",
+] as const;
+
+function getAvatarInitial(displayName: string): string {
+  const initial = displayName.trim().match(/[A-Za-z0-9]/)?.[0];
+  return initial ? initial.toUpperCase() : "?";
+}
+
+function getAvatarVariant(agentKey: string): number {
+  return hashAgentKey(agentKey) % AVATAR_VARIANT_CLASSES.length;
+}
+
+function getAvatarPattern(agentKey: string): string {
+  return hashAgentKey(`${agentKey}:pattern`).toString(16).padStart(8, "0");
+}
+
+export function AgentAvatar({
+  agentKey,
+  displayName,
+  className,
+  testId,
+}: {
+  agentKey: string;
+  displayName: string;
+  className?: string;
+  testId?: string;
+}) {
+  const variant = getAvatarVariant(agentKey);
+  const pattern = getAvatarPattern(agentKey);
+  const patternBits = Array.from(
+    { length: 6 },
+    (_value, index) => ((Number.parseInt(pattern, 16) >> index) & 1) === 1,
+  );
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={testId}
+      data-avatar-variant={String(variant)}
+      data-avatar-pattern={pattern}
+      className={cn(
+        "relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border text-xs font-semibold uppercase",
+        AVATAR_VARIANT_CLASSES[variant],
+        className,
+      )}
+    >
+      <svg
+        viewBox="0 0 12 12"
+        className="absolute inset-0 h-full w-full opacity-25"
+        aria-hidden="true"
+      >
+        {patternBits.map((enabled, index) => {
+          if (!enabled) return null;
+          const column = index % 3;
+          const row = Math.floor(index / 3);
+          return (
+            <rect
+              key={`${pattern}-${index}`}
+              x={1.5 + column * 3}
+              y={1.5 + row * 4}
+              width="2"
+              height="2.5"
+              rx="0.5"
+              fill="currentColor"
+            />
+          );
+        })}
+      </svg>
+      <span className="relative">{getAvatarInitial(displayName)}</span>
+    </span>
+  );
+}
+
+export function AgentListRow({
+  agent,
+  active,
+  selected,
+  onSelect,
+}: {
+  agent: AgentOption;
+  active: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={`agents-select-${agent.agentKey}`}
+      data-active={selected ? "true" : undefined}
+      className={cn(
+        "rounded-md px-2.5 py-2 text-left transition-colors duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
+        selected
+          ? "bg-bg-subtle text-fg"
+          : "bg-transparent text-fg-muted hover:bg-bg-subtle hover:text-fg",
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <AgentAvatar
+          agentKey={agent.agentKey}
+          displayName={agent.displayName}
+          className="mt-0.5 h-8 w-8 text-sm"
+          testId={`agents-avatar-${agent.agentKey}`}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-fg" title={agent.displayName}>
+            {agent.displayName}
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-xs opacity-80">
+            <StatusDot variant={active ? "success" : "neutral"} pulse={active} />
+            {active ? "Active" : "Idle"}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function AgentMobilePicker({
+  agentOptions,
+  selectedAgentOption,
+  selectedAgentKey,
+  disabled,
+  onSelect,
+}: {
+  agentOptions: AgentOption[];
+  selectedAgentOption: AgentOption | null;
+  selectedAgentKey: string;
+  disabled: boolean;
+  onSelect: (agentKey: string) => void;
+}) {
+  const selectedLabel = selectedAgentOption?.displayName ?? "No agent selected";
+
+  if (agentOptions.length === 0) {
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        data-testid="agents-select"
+        className="h-8 min-w-[11rem] justify-between px-2 text-sm lg:hidden"
+        disabled
+      >
+        <span className="truncate">{selectedLabel}</span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-fg-muted" />
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          data-testid="agents-select"
+          aria-label="Selected agent"
+          className="h-8 min-w-[11rem] justify-between gap-2 px-2 text-sm lg:hidden"
+          disabled={disabled}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            {selectedAgentOption ? (
+              <AgentAvatar
+                agentKey={selectedAgentOption.agentKey}
+                displayName={selectedAgentOption.displayName}
+                className="h-6 w-6 text-[11px]"
+                testId="agents-mobile-selected-avatar"
+              />
+            ) : null}
+            <span className="truncate">{selectedLabel}</span>
+          </span>
+          <ChevronDown className="h-4 w-4 shrink-0 text-fg-muted" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[min(18rem,calc(100vw-2rem))] p-1 lg:hidden">
+        {agentOptions.map((agent) => (
+          <DropdownMenuItem
+            key={agent.agentKey}
+            data-testid={`agents-mobile-select-${agent.agentKey}`}
+            className={cn(
+              "gap-3 px-2 py-2",
+              agent.agentKey === selectedAgentKey ? "bg-bg-subtle text-fg" : null,
+            )}
+            onSelect={() => {
+              onSelect(agent.agentKey);
+            }}
+          >
+            <AgentAvatar
+              agentKey={agent.agentKey}
+              displayName={agent.displayName}
+              className="h-7 w-7 text-xs"
+              testId={`agents-mobile-avatar-${agent.agentKey}`}
+            />
+            <span className="min-w-0 flex-1 truncate font-medium">{agent.displayName}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/operator-ui/src/components/pages/agents-page-identity.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-identity.tsx
@@ -257,14 +257,7 @@ export function AgentIdentityPanel({
 
   return (
     <div className="grid min-w-0 gap-4" data-testid="agents-identity-panel">
-      <div
-        className="flex min-w-0 flex-wrap items-center justify-between gap-3"
-        data-testid="agents-identity-header"
-      >
-        <div className="min-w-0 flex-1 text-sm text-fg-muted [overflow-wrap:anywhere]">
-          Identity, runtime model, tool access, memory support, and session policy for the selected
-          agent.
-        </div>
+      <div className="flex min-w-0 items-center justify-end" data-testid="agents-identity-header">
         <Button
           type="button"
           size="sm"

--- a/packages/operator-ui/src/components/pages/agents-page.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page.tsx
@@ -3,7 +3,6 @@ import type { AgentStatusResponse } from "@tyrum/schemas";
 import { Bot, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useApiAction } from "../../hooks/use-api-action.js";
-import { cn } from "../../lib/cn.js";
 import {
   getActiveAgentIdsFromSessionLanes,
   resolveAgentIdForRun,
@@ -18,28 +17,21 @@ import { EmptyState } from "../ui/empty-state.js";
 import { ScrollArea } from "../ui/scroll-area.js";
 import { StatusDot } from "../ui/status-dot.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs.js";
+import {
+  AgentAvatar,
+  AgentListRow,
+  AgentMobilePicker,
+  type AgentOption,
+} from "./agents-page-agent-display.js";
 import { AgentIdentityPanel } from "./agents-page-identity.js";
 import { AgentsPageEditor } from "./agents-page-editor.js";
 import { RunsPage } from "./runs-page.js";
 import { useReconnectScrollArea, useReconnectTabState } from "../../reconnect-ui-state.js";
-
-type AgentOption = {
-  agentKey: string;
-  agentId: string;
-  canDelete: boolean;
-  displayName: string;
-};
 type AgentsPageTab = "identity" | "editor" | "runs";
 
 function trimAgentKey(value: string): string {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : "default";
-}
-
-function formatAgentOptionLabel(agent: AgentOption): string {
-  return agent.displayName === agent.agentKey
-    ? agent.agentKey
-    : `${agent.displayName} (${agent.agentKey})`;
 }
 
 function normalizeAgentOptions(
@@ -175,28 +167,17 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
   const renderEditor = createMode || selectedAgentOption !== null;
   const mobileToolbarActions = (
     <div className="flex flex-wrap items-center gap-2 lg:hidden">
-      <select
-        data-testid="agents-select"
-        aria-label="Selected agent"
-        value={selectedAgentKey}
+      <AgentMobilePicker
+        agentOptions={agentOptions}
+        selectedAgentOption={selectedAgentOption}
+        selectedAgentKey={selectedAgentKey}
         disabled={agentOptions.length === 0}
-        onChange={(event) => {
+        onSelect={(agentKey) => {
           setCreateMode(false);
           setSelectionReady(true);
-          setSelectedAgentKey(event.currentTarget.value);
+          setSelectedAgentKey(agentKey);
         }}
-        className="flex h-8 w-[11rem] rounded-md border border-border bg-bg px-2 py-1 text-sm text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0 lg:hidden"
-      >
-        {agentOptions.length === 0 ? (
-          <option value={selectedAgentKey}>{selectedAgentKey}</option>
-        ) : (
-          agentOptions.map((agent) => (
-            <option key={agent.agentKey} value={agent.agentKey}>
-              {formatAgentOptionLabel(agent)}
-            </option>
-          ))
-        )}
-      </select>
+      />
       <Button
         type="button"
         size="sm"
@@ -234,12 +215,16 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
       className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-bg"
       data-testid="agents-page"
     >
-      <AppPageToolbar actions={mobileToolbarActions} />
+      <AppPageToolbar
+        actions={mobileToolbarActions}
+        className="lg:hidden"
+        data-testid="agents-mobile-toolbar"
+      />
 
       <ConfirmDangerDialog
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
-        title={`Delete agent ${selectedAgentKey}`}
+        title={selectedAgentOption ? `Delete ${selectedAgentOption.displayName}` : "Delete agent"}
         description="This permanently removes the managed agent configuration and identity history."
         confirmLabel="Delete agent"
         isLoading={deleteAction.isLoading}
@@ -314,43 +299,17 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
                       activeAgentIds.has(agent.agentId) || activeAgentIds.has(agent.agentKey);
                     const selected = agent.agentKey === selectedAgentKey;
                     return (
-                      <button
+                      <AgentListRow
                         key={agent.agentKey}
-                        type="button"
-                        data-testid={`agents-select-${agent.agentKey}`}
-                        data-active={selected ? "true" : undefined}
-                        className={cn(
-                          "grid gap-1.5 rounded-md px-2.5 py-2 text-left transition-colors duration-150",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0",
-                          selected
-                            ? "bg-bg-subtle text-fg"
-                            : "bg-transparent text-fg-muted hover:bg-bg-subtle hover:text-fg",
-                        )}
-                        onClick={() => {
+                        agent={agent}
+                        active={active}
+                        selected={selected}
+                        onSelect={() => {
                           setCreateMode(false);
                           setSelectionReady(true);
                           setSelectedAgentKey(agent.agentKey);
                         }}
-                      >
-                        <div
-                          className="truncate text-sm font-medium text-fg"
-                          title={agent.displayName}
-                        >
-                          {agent.displayName}
-                        </div>
-                        {agent.displayName !== agent.agentKey ? (
-                          <div
-                            className="truncate font-mono text-xs text-fg-muted"
-                            title={agent.agentKey}
-                          >
-                            Key {agent.agentKey}
-                          </div>
-                        ) : null}
-                        <div className="flex items-center gap-2 text-xs opacity-80">
-                          <StatusDot variant={active ? "success" : "neutral"} pulse={active} />
-                          {active ? "Active" : "Idle"}
-                        </div>
-                      </button>
+                      />
                     );
                   })}
                 </div>
@@ -360,21 +319,38 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
         </div>
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid="agents-detail-pane">
-          <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border px-4">
+          <div
+            className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border px-4"
+            data-testid="agents-detail-header"
+          >
             <div className="min-w-0 flex flex-wrap items-center gap-3">
-              <div
-                data-testid="agents-selected-key"
-                className="max-w-full rounded-md border border-border bg-bg-subtle px-2 py-1 font-mono text-xs text-fg break-all"
-              >
-                {selectedAgentOption?.agentKey ?? "No agent selected"}
-              </div>
-              <div className="flex items-center gap-2 text-sm text-fg-muted">
-                <StatusDot
-                  variant={selectedAgentActive ? "success" : "neutral"}
-                  pulse={selectedAgentActive}
-                />
-                {selectedAgentActive ? "Currently active" : "Currently idle"}
-              </div>
+              {selectedAgentOption ? (
+                <>
+                  <AgentAvatar
+                    agentKey={selectedAgentOption.agentKey}
+                    displayName={selectedAgentOption.displayName}
+                    className="h-8 w-8 text-sm"
+                    testId="agents-selected-avatar"
+                  />
+                  <div
+                    data-testid="agents-selected-name"
+                    className="min-w-0 truncate text-sm font-medium text-fg"
+                  >
+                    {selectedAgentOption.displayName}
+                  </div>
+                  <div className="flex items-center gap-2 text-sm text-fg-muted">
+                    <StatusDot
+                      variant={selectedAgentActive ? "success" : "neutral"}
+                      pulse={selectedAgentActive}
+                    />
+                    {selectedAgentActive ? "Currently active" : "Currently idle"}
+                  </div>
+                </>
+              ) : (
+                <div data-testid="agents-selected-name" className="text-sm text-fg-muted">
+                  No agent selected
+                </div>
+              )}
             </div>
             <div className="flex items-center gap-2">
               <Button

--- a/packages/operator-ui/tests/pages/agents-page-layout.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-layout.test.ts
@@ -199,6 +199,11 @@ describe("AgentsPage layout", () => {
     const testRoot = renderIntoDocument(React.createElement(AgentsPage, { core }));
     await flush();
 
+    const mobileToolbar = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-mobile-toolbar"]',
+    );
+    expect(mobileToolbar?.className).toContain("lg:hidden");
+
     const detailPane = testRoot.container.querySelector<HTMLDivElement>(
       '[data-testid="agents-detail-pane"]',
     );
@@ -222,6 +227,7 @@ describe("AgentsPage layout", () => {
       '[data-testid="agents-identity-header"]',
     );
     expect(identityHeader?.className).toContain("min-w-0");
+    expect(identityHeader?.className).toContain("justify-end");
 
     const identitySections = testRoot.container.querySelector<HTMLDivElement>(
       '[data-testid="agents-identity-sections"]',

--- a/packages/operator-ui/tests/pages/agents-page.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page.test.ts
@@ -215,7 +215,7 @@ function createCore(options?: {
 }
 
 describe("AgentsPage", () => {
-  it("loads managed agents, auto-selects a valid agent, and refreshes on selection changes", async () => {
+  it("loads managed agents, shows names in display surfaces, and refreshes when mobile selection changes", async () => {
     const list = vi.fn(async () => ({
       agents: [
         {
@@ -257,16 +257,32 @@ describe("AgentsPage", () => {
     );
     expect(agentButton).not.toBeNull();
     expect(agentButton?.textContent).toContain("Ada");
-    expect(agentButton?.textContent).toContain("agent-1");
-    const mobileSelect = testRoot.container.querySelector<HTMLSelectElement>(
+    expect(agentButton?.textContent).not.toContain("agent-1");
+
+    const selectedName = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-selected-name"]',
+    );
+    expect(selectedName?.textContent).toContain("Feynman");
+
+    const mobileSelect = testRoot.container.querySelector<HTMLButtonElement>(
       '[data-testid="agents-select"]',
     );
-    expect(mobileSelect?.querySelector('option[value="agent-1"]')?.textContent).toBe(
-      "Ada (agent-1)",
-    );
+    expect(mobileSelect?.textContent).toContain("Feynman");
+    expect(mobileSelect?.textContent).not.toContain("default");
 
     await act(async () => {
-      agentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      if (mobileSelect) click(mobileSelect);
+      await Promise.resolve();
+    });
+
+    const mobileOption = document.querySelector<HTMLElement>(
+      '[data-testid="agents-mobile-select-agent-1"]',
+    );
+    expect(mobileOption?.textContent).toContain("Ada");
+    expect(mobileOption?.textContent).not.toContain("agent-1");
+
+    await act(async () => {
+      if (mobileOption) click(mobileOption);
       await Promise.resolve();
     });
 
@@ -276,14 +292,20 @@ describe("AgentsPage", () => {
     cleanupTestRoot(testRoot);
   });
 
-  it("uses a wider desktop rail and avoids duplicating raw keys when no friendly name exists", async () => {
+  it("uses avatars to distinguish duplicate names without rendering raw keys", async () => {
     const list = vi.fn(async () => ({
       agents: [
         {
-          agent_key: "00000000-0000-4000-8000-000000000002",
+          agent_key: "default",
           agent_id: "11111111-1111-4111-8111-111111111111",
+          can_delete: false,
+          persona: { name: "Ada" },
+        },
+        {
+          agent_key: "agent-1",
+          agent_id: "22222222-2222-4222-8222-222222222222",
           can_delete: true,
-          persona: { name: "00000000-0000-4000-8000-000000000002" },
+          persona: { name: "Ada" },
         },
       ],
     }));
@@ -295,14 +317,41 @@ describe("AgentsPage", () => {
     const listPanel = testRoot.container.querySelector<HTMLElement>(
       '[data-testid="agents-list-panel"]',
     );
-    const agentButton = testRoot.container.querySelector<HTMLButtonElement>(
-      '[data-testid="agents-select-00000000-0000-4000-8000-000000000002"]',
+    const firstAgentButton = testRoot.container.querySelector<HTMLButtonElement>(
+      '[data-testid="agents-select-default"]',
+    );
+    const secondAgentButton = testRoot.container.querySelector<HTMLButtonElement>(
+      '[data-testid="agents-select-agent-1"]',
+    );
+    const firstAvatar = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-avatar-default"]',
+    );
+    const secondAvatar = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-avatar-agent-1"]',
     );
 
     expect(listPanel?.className).toContain("w-[clamp(220px,24vw,300px)]");
-    expect(agentButton?.textContent?.match(/00000000-0000-4000-8000-000000000002/g)?.length).toBe(
-      1,
+    expect(firstAgentButton?.textContent).toContain("Ada");
+    expect(firstAgentButton?.textContent).not.toContain("default");
+    expect(secondAgentButton?.textContent).toContain("Ada");
+    expect(secondAgentButton?.textContent).not.toContain("agent-1");
+    expect(firstAvatar?.getAttribute("data-avatar-variant")).toBe(
+      secondAvatar?.getAttribute("data-avatar-variant"),
     );
+    expect(firstAvatar?.getAttribute("data-avatar-pattern")).not.toBe(
+      secondAvatar?.getAttribute("data-avatar-pattern"),
+    );
+
+    await act(async () => {
+      secondAgentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const selectedName = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-selected-name"]',
+    );
+    expect(selectedName?.textContent).toBe("Ada");
+    expect(testRoot.container.querySelector('[data-testid="agents-selected-key"]')).toBeNull();
 
     cleanupTestRoot(testRoot);
   });
@@ -439,6 +488,12 @@ describe("AgentsPage", () => {
       deleteButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await Promise.resolve();
     });
+
+    const confirmDialog = document.querySelector<HTMLElement>(
+      '[data-testid="confirm-danger-dialog"]',
+    );
+    expect(confirmDialog?.textContent).toContain("Delete Ada");
+    expect(confirmDialog?.textContent).not.toContain("agent-1");
 
     const confirmCheckbox = document.querySelector<HTMLElement>(
       '[data-testid="confirm-danger-checkbox"]',


### PR DESCRIPTION
## Summary

Closes #1471.

This cleans up the Agents page display surfaces so they show agent names instead of raw keys, removes the empty desktop toolbar strip, and adds deterministic avatars to keep same-name agents distinguishable without re-exposing the key.

## What Changed

- hid raw agent keys from the desktop rail, mobile picker, selected-agent header, and delete confirmation title
- replaced the mobile native select with a dropdown picker that supports the same avatar + name row treatment as desktop
- extracted the new display helpers into a page-local `agents-page-agent-display.tsx` helper to keep the main page component below the file-size ratchet
- simplified the Identity tab header copy down to the refresh action
- updated page tests to cover name-only display, duplicate-name avatar disambiguation, and the mobile picker flow

## Verification

- `pnpm exec vitest run packages/operator-ui/tests/pages/agents-page.test.ts packages/operator-ui/tests/pages/agents-page-layout.test.ts packages/operator-ui/tests/pages/agents-page-editor.test.ts`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm exec oxlint packages/operator-ui/src/components/pages/agents-page.tsx packages/operator-ui/src/components/pages/agents-page-agent-display.tsx packages/operator-ui/src/components/pages/agents-page-identity.tsx packages/operator-ui/tests/pages/agents-page.test.ts packages/operator-ui/tests/pages/agents-page-layout.test.ts`
- repo pre-push gate passed: `pnpm lint`, `pnpm typecheck`, desktop TS check, and full `pnpm test`
