### PR TITLE
feat(operator-ui): relax extensions page access

### DIFF
--- a/packages/gateway/src/modules/authz/http-scope-middleware.ts
+++ b/packages/gateway/src/modules/authz/http-scope-middleware.ts
@@ -61,12 +61,25 @@ function isReadOnlyMethod(method: string): boolean {
   return method === "GET" || method === "HEAD" || method === "OPTIONS";
 }
 
+function isExtensionsInventoryRoute(routePath: string): boolean {
+  const segments = routePath.split("/").filter((segment) => segment.length > 0);
+  if (segments[0] !== "config" || segments[1] !== "extensions") {
+    return false;
+  }
+
+  return segments.length === 3 || segments.length === 4;
+}
+
 export function resolveHttpRouteRequiredScopes(input: {
   method: string;
   routePath: string;
 }): string[] | null {
   const method = input.method.toUpperCase();
   const routePath = input.routePath;
+
+  if (isReadOnlyMethod(method) && isExtensionsInventoryRoute(routePath)) {
+    return ["operator.read"];
+  }
 
   // Tenant administration surfaces.
   if (

--- a/packages/gateway/tests/unit/http-scope-middleware-routepath-fallback.test.ts
+++ b/packages/gateway/tests/unit/http-scope-middleware-routepath-fallback.test.ts
@@ -53,4 +53,71 @@ describe("HTTP scope middleware request-path fallback", () => {
       message: "insufficient scope",
     });
   });
+
+  it("allows operator.read on extension inventory reads but keeps mutations admin-only", async () => {
+    const { createAuthMiddleware } = await import("../../src/modules/auth/middleware.js");
+    const { createHttpScopeAuthorizationMiddleware } =
+      await import("../../src/modules/authz/http-scope-middleware.js");
+
+    const tokenStore = {
+      authenticate: (token: string) => {
+        if (token === "scoped-admin-token") {
+          return {
+            token_kind: "device",
+            role: "client",
+            scopes: ["operator.admin"],
+          };
+        }
+        if (token === "scoped-read-token") {
+          return {
+            token_kind: "device",
+            role: "client",
+            scopes: ["operator.read"],
+          };
+        }
+        return null;
+      },
+    } as unknown as TokenStore;
+
+    const app = new Hono();
+    app.use("*", createAuthMiddleware(tokenStore));
+    app.use("*", createHttpScopeAuthorizationMiddleware());
+    app.get("/config/extensions/:kind", (c) => c.json({ kind: c.req.param("kind"), items: [] }));
+    app.get("/config/extensions/:kind/:key", (c) =>
+      c.json({ kind: c.req.param("kind"), key: c.req.param("key") }),
+    );
+    app.post("/config/extensions/:kind/:key/toggle", (c) =>
+      c.json({
+        kind: c.req.param("kind"),
+        key: c.req.param("key"),
+        toggled: true,
+      }),
+    );
+
+    const listRes = await app.request("/config/extensions/skill", {
+      headers: { Authorization: "Bearer scoped-read-token" },
+    });
+    expect(listRes.status).toBe(200);
+
+    const detailRes = await app.request("/config/extensions/skill/example-skill", {
+      headers: { Authorization: "Bearer scoped-read-token" },
+    });
+    expect(detailRes.status).toBe(200);
+
+    const toggleRes = await app.request("/config/extensions/skill/example-skill/toggle", {
+      method: "POST",
+      headers: { Authorization: "Bearer scoped-read-token" },
+    });
+    expect(toggleRes.status).toBe(403);
+    await expect(toggleRes.json()).resolves.toMatchObject({
+      error: "forbidden",
+      message: "insufficient scope",
+    });
+
+    const adminToggleRes = await app.request("/config/extensions/skill/example-skill/toggle", {
+      method: "POST",
+      headers: { Authorization: "Bearer scoped-admin-token" },
+    });
+    expect(adminToggleRes.status).toBe(200);
+  });
 });

--- a/packages/gateway/tests/unit/http-scope-middleware.test.ts
+++ b/packages/gateway/tests/unit/http-scope-middleware.test.ts
@@ -47,6 +47,30 @@ describe("HTTP scope middleware route mapping", () => {
     ).toEqual(["operator.pairing"]);
   });
 
+  it("maps extension inventory reads to operator.read while keeping mutations on operator.admin", () => {
+    expect(
+      resolveHttpRouteRequiredScopes({ method: "GET", routePath: "/config/extensions/skill" }),
+    ).toEqual(["operator.read"]);
+    expect(
+      resolveHttpRouteRequiredScopes({
+        method: "HEAD",
+        routePath: "/config/extensions/mcp/filesystem",
+      }),
+    ).toEqual(["operator.read"]);
+    expect(
+      resolveHttpRouteRequiredScopes({
+        method: "POST",
+        routePath: "/config/extensions/skill/import",
+      }),
+    ).toEqual(["operator.admin"]);
+    expect(
+      resolveHttpRouteRequiredScopes({
+        method: "PUT",
+        routePath: "/config/extensions/mcp/filesystem/defaults",
+      }),
+    ).toEqual(["operator.admin"]);
+  });
+
   it("maps tenant admin surfaces to operator.admin", () => {
     expect(resolveHttpRouteRequiredScopes({ method: "GET", routePath: "/agents" })).toEqual([
       "operator.admin",

--- a/packages/operator-ui/src/components/pages/extensions-page-import-panels.tsx
+++ b/packages/operator-ui/src/components/pages/extensions-page-import-panels.tsx
@@ -1,20 +1,51 @@
-import { Upload } from "lucide-react";
+import { ChevronDown, ChevronRight, Upload } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
 import { Card, CardContent, CardHeader } from "../ui/card.js";
 import { Input } from "../ui/input.js";
 
-export function ImportGuard({
+export function ImportDisclosure({
+  title,
+  open,
+  onToggle,
+  children,
+}: {
+  title: string;
+  open: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-3 text-left"
+          aria-expanded={open}
+          onClick={onToggle}
+        >
+          <span className="text-base font-semibold text-fg">{title}</span>
+          {open ? (
+            <ChevronDown className="h-4 w-4 shrink-0 text-fg-muted" />
+          ) : (
+            <ChevronRight className="h-4 w-4 shrink-0 text-fg-muted" />
+          )}
+        </button>
+      </CardHeader>
+      {open ? <CardContent className="grid gap-4">{children}</CardContent> : null}
+    </Card>
+  );
+}
+
+export function ImportAdminNotice({
   canMutate,
   requestEnter,
-  children,
 }: {
   canMutate: boolean;
   requestEnter: () => void;
-  children: ReactNode;
 }) {
-  if (canMutate) return <>{children}</>;
+  if (canMutate) return null;
   return (
     <Alert
       variant="warning"
@@ -45,52 +76,47 @@ export function SkillImportPanel({
   const [url, setUrl] = useState("");
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="text-base font-semibold text-fg">Import Skill</div>
-      </CardHeader>
-      <CardContent className="grid gap-4">
-        <Input
-          label="Archive or SKILL.md URL"
-          value={url}
-          onChange={(event) => setUrl(event.currentTarget.value)}
-          placeholder="https://example.com/skill.zip"
-          helperText="Use ClawHub-style download links or direct SKILL.md URLs."
-        />
-        <div className="flex flex-wrap gap-2">
-          <Button
-            disabled={disabled || url.trim().length === 0}
-            isLoading={isLoading}
-            onClick={() => {
-              onImportUrl(url.trim());
-              setUrl("");
+    <div className="grid gap-4">
+      <Input
+        label="Archive or SKILL.md URL"
+        value={url}
+        onChange={(event) => setUrl(event.currentTarget.value)}
+        placeholder="https://example.com/skill.zip"
+        helperText="Use ClawHub-style download links or direct SKILL.md URLs."
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          disabled={disabled || url.trim().length === 0}
+          isLoading={isLoading}
+          onClick={() => {
+            onImportUrl(url.trim());
+            setUrl("");
+          }}
+        >
+          Import URL
+        </Button>
+        <label className="inline-flex">
+          <input
+            type="file"
+            accept=".zip,.md,.markdown,text/markdown,application/zip"
+            className="hidden"
+            disabled={disabled || isLoading}
+            onChange={(event) => {
+              const file = event.currentTarget.files?.[0];
+              if (!file) return;
+              onUpload(file);
+              event.currentTarget.value = "";
             }}
-          >
-            Import URL
+          />
+          <Button asChild variant="outline" disabled={disabled || isLoading}>
+            <span>
+              <Upload className="h-4 w-4" />
+              Upload
+            </span>
           </Button>
-          <label className="inline-flex">
-            <input
-              type="file"
-              accept=".zip,.md,.markdown,text/markdown,application/zip"
-              className="hidden"
-              disabled={disabled || isLoading}
-              onChange={(event) => {
-                const file = event.currentTarget.files?.[0];
-                if (!file) return;
-                onUpload(file);
-                event.currentTarget.value = "";
-              }}
-            />
-            <Button asChild variant="outline" disabled={disabled || isLoading}>
-              <span>
-                <Upload className="h-4 w-4" />
-                Upload
-              </span>
-            </Button>
-          </label>
-        </div>
-      </CardContent>
-    </Card>
+        </label>
+      </div>
+    </div>
   );
 }
 
@@ -111,67 +137,62 @@ export function McpImportPanel({
   const [npmSpec, setNpmSpec] = useState("");
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="text-base font-semibold text-fg">Import MCP Server</div>
-      </CardHeader>
-      <CardContent className="grid gap-4">
-        <Input
-          label="Remote endpoint URL"
-          value={url}
-          onChange={(event) => setUrl(event.currentTarget.value)}
-          placeholder="https://mcp.example.com"
-        />
+    <div className="grid gap-4">
+      <Input
+        label="Remote endpoint URL"
+        value={url}
+        onChange={(event) => setUrl(event.currentTarget.value)}
+        placeholder="https://mcp.example.com"
+      />
+      <Button
+        disabled={disabled || url.trim().length === 0}
+        isLoading={isLoading}
+        onClick={() => {
+          onImportRemote(url.trim());
+          setUrl("");
+        }}
+      >
+        Import Remote URL
+      </Button>
+      <Input
+        label="npm spec"
+        value={npmSpec}
+        onChange={(event) => setNpmSpec(event.currentTarget.value)}
+        placeholder="@modelcontextprotocol/server-filesystem"
+        helperText="Stored as an `npx -y <spec>` stdio MCP server."
+      />
+      <div className="flex flex-wrap gap-2">
         <Button
-          disabled={disabled || url.trim().length === 0}
+          disabled={disabled || npmSpec.trim().length === 0}
           isLoading={isLoading}
           onClick={() => {
-            onImportRemote(url.trim());
-            setUrl("");
+            onImportNpm(npmSpec.trim());
+            setNpmSpec("");
           }}
         >
-          Import Remote URL
+          Import npm
         </Button>
-        <Input
-          label="npm spec"
-          value={npmSpec}
-          onChange={(event) => setNpmSpec(event.currentTarget.value)}
-          placeholder="@modelcontextprotocol/server-filesystem"
-          helperText="Stored as an `npx -y <spec>` stdio MCP server."
-        />
-        <div className="flex flex-wrap gap-2">
-          <Button
-            disabled={disabled || npmSpec.trim().length === 0}
-            isLoading={isLoading}
-            onClick={() => {
-              onImportNpm(npmSpec.trim());
-              setNpmSpec("");
+        <label className="inline-flex">
+          <input
+            type="file"
+            accept=".zip,.yml,.yaml,application/zip,text/yaml,application/yaml"
+            className="hidden"
+            disabled={disabled || isLoading}
+            onChange={(event) => {
+              const file = event.currentTarget.files?.[0];
+              if (!file) return;
+              onUpload(file);
+              event.currentTarget.value = "";
             }}
-          >
-            Import npm
+          />
+          <Button asChild variant="outline" disabled={disabled || isLoading}>
+            <span>
+              <Upload className="h-4 w-4" />
+              Upload
+            </span>
           </Button>
-          <label className="inline-flex">
-            <input
-              type="file"
-              accept=".zip,.yml,.yaml,application/zip,text/yaml,application/yaml"
-              className="hidden"
-              disabled={disabled || isLoading}
-              onChange={(event) => {
-                const file = event.currentTarget.files?.[0];
-                if (!file) return;
-                onUpload(file);
-                event.currentTarget.value = "";
-              }}
-            />
-            <Button asChild variant="outline" disabled={disabled || isLoading}>
-              <span>
-                <Upload className="h-4 w-4" />
-                Upload
-              </span>
-            </Button>
-          </label>
-        </div>
-      </CardContent>
-    </Card>
+        </label>
+      </div>
+    </div>
   );
 }

--- a/packages/operator-ui/src/components/pages/extensions-page.sections.tsx
+++ b/packages/operator-ui/src/components/pages/extensions-page.sections.tsx
@@ -1,5 +1,5 @@
 import type { ManagedExtensionDetail, ManagedExtensionSummary } from "@tyrum/schemas";
-import { History, RefreshCw } from "lucide-react";
+import { ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
   applyMemorySettingsToForm,
@@ -52,6 +52,7 @@ function describeSource(source: ManagedExtensionSummary["source"]): string | nul
 export function ExtensionCard({
   item,
   detail,
+  isExpanded,
   inspectLoading,
   mutateLoading,
   canMutate,
@@ -64,6 +65,7 @@ export function ExtensionCard({
 }: {
   item: ManagedExtensionSummary;
   detail: ManagedExtensionDetail | undefined;
+  isExpanded: boolean;
   inspectLoading: boolean;
   mutateLoading: boolean;
   canMutate: boolean;
@@ -191,9 +193,19 @@ export function ExtensionCard({
           </div>
 
           <div className="flex flex-wrap gap-2">
-            <Button variant="outline" size="sm" isLoading={inspectLoading} onClick={onInspect}>
-              <History className="h-4 w-4" />
-              Inspect
+            <Button
+              variant="outline"
+              size="sm"
+              aria-expanded={isExpanded}
+              isLoading={inspectLoading}
+              onClick={onInspect}
+            >
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              {isExpanded ? "Collapse" : "Inspect"}
             </Button>
             {item.can_toggle_source_enabled ? (
               <Button variant="outline" size="sm" isLoading={mutateLoading} onClick={onToggle}>

--- a/packages/operator-ui/src/components/pages/extensions-page.tsx
+++ b/packages/operator-ui/src/components/pages/extensions-page.tsx
@@ -3,46 +3,80 @@ import type { ManagedExtensionDetail } from "@tyrum/schemas";
 import { Blocks, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useApiAction } from "../../hooks/use-api-action.js";
+import { useReconnectScrollArea, useReconnectTabState } from "../../reconnect-ui-state.js";
 import { AppPage } from "../layout/app-page.js";
-import {
-  AdminMutationGate,
-  useAdminHttpClient,
-  useAdminMutationAccess,
-} from "./admin-http-shared.js";
-import { ExtensionCard } from "./extensions-page.sections.js";
-import { ImportGuard, McpImportPanel, SkillImportPanel } from "./extensions-page-import-panels.js";
-import {
-  EMPTY_EXTENSIONS_BY_TAB,
-  encodeFileToBase64,
-  kindToTab,
-  sortExtensions,
-  tabToKind,
-  toErrorMessage,
-  type ExtensionKind,
-  type ExtensionsTab,
-} from "./extensions-page.lib.js";
 import { Alert } from "../ui/alert.js";
 import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
 import { Card, CardContent, CardHeader } from "../ui/card.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs.js";
-import { useReconnectScrollArea, useReconnectTabState } from "../../reconnect-ui-state.js";
+import {
+  useAdminHttpClient,
+  useAdminMutationAccess,
+  useAdminMutationHttpClient,
+} from "./admin-http-shared.js";
+import {
+  ImportAdminNotice,
+  ImportDisclosure,
+  McpImportPanel,
+  SkillImportPanel,
+} from "./extensions-page-import-panels.js";
+import {
+  EMPTY_EXTENSIONS_BY_TAB,
+  encodeFileToBase64,
+  kindToTab,
+  sortExtensions,
+  toErrorMessage,
+  type ExtensionKind,
+  type ExtensionsTab,
+} from "./extensions-page.lib.js";
+import { ExtensionCard } from "./extensions-page.sections.js";
+
+type DetailByKind = Record<ExtensionKind, Record<string, ManagedExtensionDetail>>;
+type ExpandedKeysByTab = Record<ExtensionsTab, string | null>;
+type ImportDisclosures = Record<ExtensionKind, boolean>;
+type ActiveItem = { kind: ExtensionKind; key: string } | null;
+
+const EMPTY_DETAIL_BY_KIND: DetailByKind = {
+  skill: {},
+  mcp: {},
+};
+
+const EMPTY_EXPANDED_KEYS: ExpandedKeysByTab = {
+  skills: null,
+  mcp: null,
+};
+
+const DEFAULT_IMPORT_DISCLOSURES: ImportDisclosures = {
+  skill: false,
+  mcp: false,
+};
 
 export function ExtensionsPage({ core }: { core: OperatorCore }) {
   const [tab, setTab] = useReconnectTabState<ExtensionsTab>("extensions.tab", "skills");
   const [items, setItems] = useState(EMPTY_EXTENSIONS_BY_TAB);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const [detailByKey, setDetailByKey] = useState<Record<string, ManagedExtensionDetail>>({});
+  const [detailByKind, setDetailByKind] = useState<DetailByKind>(EMPTY_DETAIL_BY_KIND);
+  const [expandedKeys, setExpandedKeys] = useState<ExpandedKeysByTab>(EMPTY_EXPANDED_KEYS);
+  const [importDisclosures, setImportDisclosures] = useState<ImportDisclosures>(
+    DEFAULT_IMPORT_DISCLOSURES,
+  );
+  const [activeItem, setActiveItem] = useState<ActiveItem>(null);
   const [loading, setLoading] = useState(true);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const adminHttp = useAdminHttpClient({ access: "strict" });
-  const mutationHttp = adminHttp;
-  const extensionsApi = adminHttp?.extensions;
+  const readExtensionsApi = useAdminHttpClient().extensions;
+  const mutationHttp = useAdminMutationHttpClient();
   const { canMutate, requestEnter } = useAdminMutationAccess(core);
   const mutation = useApiAction<ManagedExtensionDetail>();
   const scrollAreaRef = useReconnectScrollArea(`extensions:${tab}:page`);
+  const sortedItems = useMemo(
+    () => ({
+      skills: sortExtensions(items.skills),
+      mcp: sortExtensions(items.mcp),
+    }),
+    [items],
+  );
 
   function requireExtensionsMutationApi() {
     if (!mutationHttp?.extensions) {
@@ -51,16 +85,60 @@ export function ExtensionsPage({ core }: { core: OperatorCore }) {
     return mutationHttp.extensions;
   }
 
+  function cacheDetail(kind: ExtensionKind, key: string, item: ManagedExtensionDetail): void {
+    setDetailByKind((current) => ({
+      ...current,
+      [kind]: {
+        ...current[kind],
+        [key]: item,
+      },
+    }));
+  }
+
+  function setExpandedKey(kind: ExtensionKind, key: string | null): void {
+    setExpandedKeys((current) => ({
+      ...current,
+      [kindToTab(kind)]: key,
+    }));
+  }
+
+  function setImportDisclosure(kind: ExtensionKind, open: boolean): void {
+    setImportDisclosures((current) => ({
+      ...current,
+      [kind]: open,
+    }));
+  }
+
+  async function refreshListAndDetail(
+    kind: ExtensionKind,
+    key: string,
+    options?: { activateTab?: boolean },
+  ): Promise<void> {
+    const [list, detail] = await Promise.all([
+      readExtensionsApi.list(kind),
+      readExtensionsApi.get(kind, key),
+    ]);
+    setItems((current) => ({
+      ...current,
+      [kindToTab(kind)]: list.items,
+    }));
+    cacheDetail(kind, key, detail.item);
+    setExpandedKey(kind, key);
+    if (options?.activateTab) {
+      setTab(kindToTab(kind));
+    }
+  }
+
   useEffect(() => {
-    if (!extensionsApi) return;
     let cancelled = false;
+
     const load = async (): Promise<void> => {
       setLoading(true);
       setError(null);
       try {
         const [skills, mcp] = await Promise.all([
-          extensionsApi.list("skill"),
-          extensionsApi.list("mcp"),
+          readExtensionsApi.list("skill"),
+          readExtensionsApi.list("mcp"),
         ]);
         if (cancelled) return;
         setItems({
@@ -77,42 +155,29 @@ export function ExtensionsPage({ core }: { core: OperatorCore }) {
         }
       }
     };
+
     void load();
     return () => {
       cancelled = true;
     };
-  }, [extensionsApi, refreshNonce]);
+  }, [readExtensionsApi, refreshNonce]);
 
-  const selectedDetail = selectedKey ? detailByKey[selectedKey] : undefined;
-  const loadingKey = mutation.state.status === "loading" ? selectedKey : null;
-  const sortedItems = useMemo(() => sortExtensions(items[tab]), [items, tab]);
-
-  async function refreshListsAndSelect(nextKind: ExtensionKind, key?: string): Promise<void> {
-    if (!extensionsApi || !mutationHttp?.extensions) {
-      throw new Error("Admin access is required to manage extensions.");
+  function toggleInspect(kind: ExtensionKind, key: string): void {
+    const tabKey = kindToTab(kind);
+    if (expandedKeys[tabKey] === key) {
+      setExpandedKey(kind, null);
+      return;
     }
-    const [list, detail] = await Promise.all([
-      extensionsApi.list(nextKind),
-      key ? mutationHttp.extensions.get(nextKind, key) : Promise.resolve(undefined),
-    ]);
-    setItems((current) => ({
-      ...current,
-      [kindToTab(nextKind)]: list.items,
-    }));
-    if (detail && key) {
-      setDetailByKey((current) => ({ ...current, [key]: detail.item }));
-      setSelectedKey(key);
-    }
-  }
 
-  function inspect(kind: ExtensionKind, key: string): void {
-    setSelectedKey(key);
+    setExpandedKey(kind, key);
+    if (detailByKind[kind][key]) {
+      return;
+    }
+
+    setActiveItem({ kind, key });
     void mutation.run(async () => {
-      if (!mutationHttp?.extensions) {
-        throw new Error("Admin access is required to inspect extensions.");
-      }
-      const response = await mutationHttp.extensions.get(kind, key);
-      setDetailByKey((current) => ({ ...current, [key]: response.item }));
+      const response = await readExtensionsApi.get(kind, key);
+      cacheDetail(kind, key, response.item);
       return response.item;
     });
   }
@@ -122,71 +187,85 @@ export function ExtensionsPage({ core }: { core: OperatorCore }) {
     itemKey: string,
     action: () => Promise<{ item: ManagedExtensionDetail }>,
   ): void {
-    setSelectedKey(itemKey);
+    setActiveItem({ kind, key: itemKey });
+    setExpandedKey(kind, itemKey);
     void mutation.run(async () => {
       const response = await action();
-      await refreshListsAndSelect(kind, itemKey);
+      await refreshListAndDetail(kind, itemKey);
       return response.item;
     });
   }
 
   function renderExtensionList(kind: ExtensionKind, emptyMessage: string) {
+    const listTab = kindToTab(kind);
+    const expandedKey = expandedKeys[listTab];
+    const entries = sortedItems[listTab];
+
     return (
       <>
-        {sortedItems.length === 0 && !loading ? (
+        {entries.length === 0 && !loading ? (
           <Card>
             <CardContent className="pt-6 text-sm text-fg-muted">{emptyMessage}</CardContent>
           </Card>
         ) : null}
-        {sortedItems.map((item) => (
-          <ExtensionCard
-            key={item.key}
-            item={item}
-            detail={item.key === selectedKey ? selectedDetail : undefined}
-            inspectLoading={loadingKey === item.key}
-            mutateLoading={loadingKey === item.key}
-            canMutate={canMutate}
-            requestEnter={requestEnter}
-            onInspect={() => {
-              inspect(kind, item.key);
-            }}
-            onToggle={() => {
-              if (!canMutate) return requestEnter();
-              mutateItem(
-                kind,
-                item.key,
-                async () =>
-                  await mutationHttp!.extensions!.toggle(kind, item.key, {
-                    enabled: !item.enabled,
-                  }),
-              );
-            }}
-            onRefresh={() => {
-              if (!canMutate) return requestEnter();
-              mutateItem(
-                kind,
-                item.key,
-                async () => await mutationHttp!.extensions!.refresh(kind, item.key),
-              );
-            }}
-            onRevert={(revision) => {
-              if (!canMutate) return requestEnter();
-              mutateItem(
-                kind,
-                item.key,
-                async () => await mutationHttp!.extensions!.revert(kind, item.key, { revision }),
-              );
-            }}
-            onUpdateDefaults={(input) => {
-              mutateItem(
-                kind,
-                item.key,
-                async () =>
-                  await requireExtensionsMutationApi().updateDefaults(kind, item.key, input),
-              );
-            }}
-          />
-        ))}
+        {entries.map((item) => {
+          const itemIsLoading =
+            mutation.state.status === "loading" &&
+            activeItem?.kind === kind &&
+            activeItem.key === item.key;
+
+          return (
+            <ExtensionCard
+              key={item.key}
+              item={item}
+              detail={item.key === expandedKey ? detailByKind[kind][item.key] : undefined}
+              isExpanded={item.key === expandedKey}
+              inspectLoading={itemIsLoading}
+              mutateLoading={itemIsLoading}
+              canMutate={canMutate}
+              requestEnter={requestEnter}
+              onInspect={() => {
+                toggleInspect(kind, item.key);
+              }}
+              onToggle={() => {
+                if (!canMutate) return requestEnter();
+                mutateItem(
+                  kind,
+                  item.key,
+                  async () =>
+                    await requireExtensionsMutationApi().toggle(kind, item.key, {
+                      enabled: !item.enabled,
+                    }),
+                );
+              }}
+              onRefresh={() => {
+                if (!canMutate) return requestEnter();
+                mutateItem(
+                  kind,
+                  item.key,
+                  async () => await requireExtensionsMutationApi().refresh(kind, item.key),
+                );
+              }}
+              onRevert={(revision) => {
+                if (!canMutate) return requestEnter();
+                mutateItem(
+                  kind,
+                  item.key,
+                  async () =>
+                    await requireExtensionsMutationApi().revert(kind, item.key, { revision }),
+                );
+              }}
+              onUpdateDefaults={(input) => {
+                mutateItem(
+                  kind,
+                  item.key,
+                  async () =>
+                    await requireExtensionsMutationApi().updateDefaults(kind, item.key, input),
+                );
+              }}
+            />
+          );
+        })}
       </>
     );
   }
@@ -231,106 +310,121 @@ export function ExtensionsPage({ core }: { core: OperatorCore }) {
         </CardContent>
       </Card>
 
-      {adminHttp ? (
-        <ImportGuard canMutate={canMutate} requestEnter={requestEnter}>
-          {tabToKind(tab) === "skill" ? (
-            <SkillImportPanel
-              disabled={!canMutate}
-              isLoading={mutation.isLoading}
-              onImportUrl={(url) => {
-                void mutation.run(async () => {
-                  const response = await requireExtensionsMutationApi().importSkill({ url });
-                  await refreshListsAndSelect("skill", response.item.key);
-                  return response.item;
-                });
-              }}
-              onUpload={(file) => {
-                void mutation.run(async () => {
-                  const response = await requireExtensionsMutationApi().uploadSkill({
-                    filename: file.name,
-                    content_type: file.type || undefined,
-                    content_base64: await encodeFileToBase64(file),
-                  });
-                  await refreshListsAndSelect("skill", response.item.key);
-                  return response.item;
-                });
-              }}
-            />
-          ) : (
-            <McpImportPanel
-              disabled={!canMutate}
-              isLoading={mutation.isLoading}
-              onImportRemote={(url) => {
-                void mutation.run(async () => {
-                  const response = await requireExtensionsMutationApi().importMcp({
-                    source: "direct-url",
-                    url,
-                  });
-                  await refreshListsAndSelect("mcp", response.item.key);
-                  return response.item;
-                });
-              }}
-              onImportNpm={(npmSpec) => {
-                void mutation.run(async () => {
-                  const response = await requireExtensionsMutationApi().importMcp({
-                    source: "npm",
-                    npm_spec: npmSpec,
-                  });
-                  await refreshListsAndSelect("mcp", response.item.key);
-                  return response.item;
-                });
-              }}
-              onUpload={(file) => {
-                void mutation.run(async () => {
-                  const response = await requireExtensionsMutationApi().uploadMcp({
-                    filename: file.name,
-                    content_type: file.type || undefined,
-                    content_base64: await encodeFileToBase64(file),
-                  });
-                  await refreshListsAndSelect("mcp", response.item.key);
-                  return response.item;
-                });
-              }}
-            />
-          )}
-        </ImportGuard>
-      ) : (
-        <AdminMutationGate
-          core={core}
-          description="Authorizing admin access loads extension inventories and enables import, toggle, refresh, and revert actions."
+      <div className="grid gap-3">
+        <ImportDisclosure
+          title="Import Skill"
+          open={importDisclosures.skill}
+          onToggle={() => {
+            setImportDisclosure("skill", !importDisclosures.skill);
+          }}
         >
-          {null}
-        </AdminMutationGate>
-      )}
+          <ImportAdminNotice canMutate={canMutate} requestEnter={requestEnter} />
+          <SkillImportPanel
+            disabled={!canMutate}
+            isLoading={mutation.isLoading}
+            onImportUrl={(url) => {
+              setActiveItem(null);
+              void mutation.run(async () => {
+                const response = await requireExtensionsMutationApi().importSkill({ url });
+                await refreshListAndDetail("skill", response.item.key, { activateTab: true });
+                setImportDisclosure("skill", false);
+                return response.item;
+              });
+            }}
+            onUpload={(file) => {
+              setActiveItem(null);
+              void mutation.run(async () => {
+                const response = await requireExtensionsMutationApi().uploadSkill({
+                  filename: file.name,
+                  content_type: file.type || undefined,
+                  content_base64: await encodeFileToBase64(file),
+                });
+                await refreshListAndDetail("skill", response.item.key, { activateTab: true });
+                setImportDisclosure("skill", false);
+                return response.item;
+              });
+            }}
+          />
+        </ImportDisclosure>
+
+        <ImportDisclosure
+          title="Import MCP Server"
+          open={importDisclosures.mcp}
+          onToggle={() => {
+            setImportDisclosure("mcp", !importDisclosures.mcp);
+          }}
+        >
+          <ImportAdminNotice canMutate={canMutate} requestEnter={requestEnter} />
+          <McpImportPanel
+            disabled={!canMutate}
+            isLoading={mutation.isLoading}
+            onImportRemote={(url) => {
+              setActiveItem(null);
+              void mutation.run(async () => {
+                const response = await requireExtensionsMutationApi().importMcp({
+                  source: "direct-url",
+                  url,
+                });
+                await refreshListAndDetail("mcp", response.item.key, { activateTab: true });
+                setImportDisclosure("mcp", false);
+                return response.item;
+              });
+            }}
+            onImportNpm={(npmSpec) => {
+              setActiveItem(null);
+              void mutation.run(async () => {
+                const response = await requireExtensionsMutationApi().importMcp({
+                  source: "npm",
+                  npm_spec: npmSpec,
+                });
+                await refreshListAndDetail("mcp", response.item.key, { activateTab: true });
+                setImportDisclosure("mcp", false);
+                return response.item;
+              });
+            }}
+            onUpload={(file) => {
+              setActiveItem(null);
+              void mutation.run(async () => {
+                const response = await requireExtensionsMutationApi().uploadMcp({
+                  filename: file.name,
+                  content_type: file.type || undefined,
+                  content_base64: await encodeFileToBase64(file),
+                });
+                await refreshListAndDetail("mcp", response.item.key, { activateTab: true });
+                setImportDisclosure("mcp", false);
+                return response.item;
+              });
+            }}
+          />
+        </ImportDisclosure>
+      </div>
 
       {mutation.state.status === "error" ? (
         <Alert
           variant="error"
-          title="Extension change failed"
+          title="Extension action failed"
           description={toErrorMessage(mutation.state.error)}
         />
       ) : null}
 
-      {adminHttp ? (
-        <Tabs
-          value={tab}
-          onValueChange={(value) => setTab(value as ExtensionsTab)}
-          className="grid gap-3"
-        >
-          <TabsList className="flex-wrap">
-            <TabsTrigger value="skills">Skills</TabsTrigger>
-            <TabsTrigger value="mcp">MCP Servers</TabsTrigger>
-          </TabsList>
+      <Tabs
+        value={tab}
+        onValueChange={(value) => setTab(value as ExtensionsTab)}
+        className="grid gap-3"
+      >
+        <TabsList className="flex-wrap">
+          <TabsTrigger value="skills">Skills</TabsTrigger>
+          <TabsTrigger value="mcp">MCP Servers</TabsTrigger>
+        </TabsList>
 
-          <TabsContent value="skills" className="grid gap-3">
-            {renderExtensionList("skill", "No discoverable skills yet.")}
-          </TabsContent>
+        <TabsContent value="skills" className="grid gap-3">
+          {renderExtensionList("skill", "No discoverable skills yet.")}
+        </TabsContent>
 
-          <TabsContent value="mcp" className="grid gap-3">
-            {renderExtensionList("mcp", "No discoverable MCP servers yet.")}
-          </TabsContent>
-        </Tabs>
-      ) : null}
+        <TabsContent value="mcp" className="grid gap-3">
+          {renderExtensionList("mcp", "No discoverable MCP servers yet.")}
+        </TabsContent>
+      </Tabs>
     </AppPage>
   );
 }

--- a/packages/operator-ui/tests/pages/extensions-page.test-helpers.tsx
+++ b/packages/operator-ui/tests/pages/extensions-page.test-helpers.tsx
@@ -3,7 +3,7 @@ import React, { act } from "react";
 import { expect } from "vitest";
 import { setNativeValue } from "../test-utils.js";
 
-type ExtensionKind = "skill" | "mcp";
+export type ExtensionKind = "skill" | "mcp";
 
 export type ExtensionApiMock = {
   list: ReturnType<typeof import("vitest").vi.fn>;
@@ -310,13 +310,7 @@ export async function setInput(
 }
 
 export async function clickButton(container: HTMLElement, label: string): Promise<void> {
-  const activePanel = container.querySelector<HTMLElement>(
-    '[role="tabpanel"][data-state="active"]',
-  );
-  const searchRoots = activePanel ? [activePanel, container] : [container];
-  const button = searchRoots
-    .flatMap((root) => Array.from(root.querySelectorAll<HTMLButtonElement>("button")))
-    .find((candidate) => candidate.textContent?.trim() === label);
+  const button = findButtonByText(container, label);
   expect(button).toBeDefined();
   await act(async () => {
     button!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
@@ -326,6 +320,19 @@ export async function clickButton(container: HTMLElement, label: string): Promis
     button!.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
     await Promise.resolve();
   });
+}
+
+export function findButtonByText(
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement | undefined {
+  const activePanel = container.querySelector<HTMLElement>(
+    '[role="tabpanel"][data-state="active"]',
+  );
+  const searchRoots = activePanel ? [activePanel, container] : [container];
+  return searchRoots
+    .flatMap((root) => Array.from(root.querySelectorAll<HTMLButtonElement>("button")))
+    .find((candidate) => candidate.textContent?.trim() === label);
 }
 
 export async function setSelect(

--- a/packages/operator-ui/tests/pages/extensions-page.test.ts
+++ b/packages/operator-ui/tests/pages/extensions-page.test.ts
@@ -2,7 +2,7 @@
 
 import { createElevatedModeStore, type OperatorCore } from "@tyrum/operator-core";
 import type { ManagedExtensionDetail } from "@tyrum/schemas";
-import React from "react";
+import React, { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExtensionsPage } from "../../src/components/pages/extensions-page.js";
 import {
@@ -12,6 +12,7 @@ import {
   createBuiltinMemoryDetail,
   createMcpDetail,
   createSkillDetail,
+  findButtonByText,
   flush,
   setInput,
   setLabeledInput,
@@ -30,6 +31,8 @@ const mutationAccess = {
 
 vi.mock("../../src/components/pages/admin-http-shared.js", () => ({
   useAdminHttpClient: () => ({ extensions: extensionsApi }),
+  useAdminMutationHttpClient: () =>
+    mutationAccess.canMutate ? { extensions: extensionsApi } : null,
   useAdminMutationAccess: () => mutationAccess,
 }));
 
@@ -214,7 +217,7 @@ beforeEach(() => {
 });
 
 describe("ExtensionsPage", () => {
-  it("loads, inspects, mutates, and imports managed extensions", async () => {
+  it("loads inventories, toggles inspect, preserves per-tab expansion, mutates, and switches tabs after imports", async () => {
     const testRoot = renderIntoDocument(
       React.createElement(ExtensionsPage, { core: createCore() }),
     );
@@ -225,12 +228,40 @@ describe("ExtensionsPage", () => {
       expect(testRoot.container.textContent).toContain("Agent Review");
       expect(testRoot.container.textContent).toContain("1 skills");
       expect(testRoot.container.textContent).toContain("1 MCP servers");
+      expect(testRoot.container.textContent).not.toContain("Archive or SKILL.md URL");
+      expect(testRoot.container.textContent).not.toContain("Remote endpoint URL");
+
+      const inspectButton = findButtonByText(testRoot.container, "Inspect");
+      expect(inspectButton?.getAttribute("aria-expanded")).toBe("false");
 
       await clickButton(testRoot.container, "Inspect");
       await flush();
       expect(extensionsApi.get).toHaveBeenCalledWith("skill", "agent-review");
       expect(testRoot.container.textContent).toContain("Revision history");
-      expect(testRoot.container.textContent).toContain("Revision 2");
+      expect(findButtonByText(testRoot.container, "Collapse")?.getAttribute("aria-expanded")).toBe(
+        "true",
+      );
+
+      await clickButton(testRoot.container, "Collapse");
+      await flush();
+      expect(testRoot.container.textContent).not.toContain("Revision history");
+
+      await clickButton(testRoot.container, "Inspect");
+      await flush();
+      expect(testRoot.container.textContent).toContain("Revision history");
+
+      await clickTab(testRoot.container, "MCP Servers");
+      await flush();
+      await clickButton(testRoot.container, "Inspect");
+      await flush();
+      expect(extensionsApi.get).toHaveBeenCalledWith("mcp", "filesystem");
+      expect(testRoot.container.textContent).toContain("Filesystem MCP");
+      expect(testRoot.container.textContent).toContain("Revision history");
+
+      await clickTab(testRoot.container, "Skills");
+      await flush();
+      expect(testRoot.container.textContent).toContain("Agent Review");
+      expect(testRoot.container.textContent).toContain("Revision history");
 
       await clickButton(testRoot.container, "Disable");
       await flush();
@@ -239,6 +270,10 @@ describe("ExtensionsPage", () => {
       });
       expect(testRoot.container.textContent).toContain("disabled");
 
+      await clickTab(testRoot.container, "MCP Servers");
+      await flush();
+      await clickButton(testRoot.container, "Import Skill");
+      await flush();
       await setInput(
         testRoot.container,
         "https://example.com/skill.zip",
@@ -250,12 +285,10 @@ describe("ExtensionsPage", () => {
         url: "https://example.com/imported-skill.zip",
       });
       expect(testRoot.container.textContent).toContain("Imported Skill");
+      expect(testRoot.container.textContent).not.toContain("Archive or SKILL.md URL");
 
-      await clickTab(testRoot.container, "MCP Servers");
+      await clickButton(testRoot.container, "Import MCP Server");
       await flush();
-      expect(testRoot.container.textContent).toContain("Filesystem MCP");
-      expect(testRoot.container.textContent).toContain("managed");
-
       await setInput(
         testRoot.container,
         "@modelcontextprotocol/server-filesystem",
@@ -268,12 +301,93 @@ describe("ExtensionsPage", () => {
         npm_spec: "@modelcontextprotocol/server-memory",
       });
       expect(testRoot.container.textContent).toContain("Imported MCP");
+      expect(testRoot.container.textContent).not.toContain("npm spec");
     } finally {
       cleanupTestRoot(testRoot);
     }
   });
 
-  it("shows the elevated-mode guard when mutations are locked", async () => {
+  it("keeps only one extension expanded per list", async () => {
+    const primarySkill = createSkillDetail({
+      revisions: [
+        {
+          revision: 2,
+          enabled: true,
+          created_at: "2026-03-09T10:00:00.000Z",
+          reason: "review-detail",
+          reverted_from_revision: null,
+        },
+      ],
+    });
+    const secondarySkill = createSkillDetail({
+      key: "triage-skill",
+      name: "Triage Skill",
+      description: "Sorts incoming work",
+      manifest: {
+        meta: {
+          id: "triage-skill",
+          name: "Triage Skill",
+          version: "1.0.0",
+          description: "Sorts incoming work",
+        },
+        body: "Triage requests before escalation.",
+      },
+      revisions: [
+        {
+          revision: 1,
+          enabled: true,
+          created_at: "2026-03-09T09:00:00.000Z",
+          reason: "triage-detail",
+          reverted_from_revision: null,
+        },
+      ],
+    });
+
+    extensionsApi.list.mockImplementation(async (kind: ExtensionKind) => ({
+      items:
+        kind === "skill"
+          ? [cloneDetail(primarySkill), cloneDetail(secondarySkill)]
+          : [cloneDetail(mcpDetail)],
+    }));
+    extensionsApi.get.mockImplementation(async (kind: ExtensionKind, key: string) => ({
+      item: cloneDetail(
+        kind === "skill" && key === secondarySkill.key
+          ? secondarySkill
+          : kind === "skill"
+            ? primarySkill
+            : mcpDetail,
+      ),
+    }));
+
+    const testRoot = renderIntoDocument(
+      React.createElement(ExtensionsPage, { core: createCore() }),
+    );
+    try {
+      await flush();
+
+      await clickButton(testRoot.container, "Inspect");
+      await flush();
+      expect(testRoot.container.textContent).toContain("review-detail");
+
+      const inspectButtons = Array.from(
+        testRoot.container.querySelectorAll<HTMLButtonElement>("button"),
+      ).filter((button) => button.textContent?.trim() === "Inspect");
+      expect(inspectButtons).toHaveLength(1);
+      await act(async () => {
+        inspectButtons[0]?.click();
+        await Promise.resolve();
+      });
+      await flush();
+
+      expect(testRoot.container.textContent).not.toContain("review-detail");
+      expect(testRoot.container.textContent).toContain("triage-detail");
+      expect(testRoot.container.querySelectorAll('button[aria-expanded="true"]')).toHaveLength(1);
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("loads inventories without admin access and keeps import disclosures collapsed by default", async () => {
     mutationAccess.canMutate = false;
     const testRoot = renderIntoDocument(
       React.createElement(ExtensionsPage, { core: createCore() }),
@@ -281,7 +395,23 @@ describe("ExtensionsPage", () => {
     try {
       await flush();
 
+      expect(testRoot.container.textContent).toContain("Agent Review");
+      expect(testRoot.container.textContent).toContain("Import Skill");
+      expect(testRoot.container.textContent).toContain("Import MCP Server");
+      expect(testRoot.container.textContent).not.toContain("Archive or SKILL.md URL");
+      expect(testRoot.container.textContent).not.toContain("Remote endpoint URL");
+
+      await clickTab(testRoot.container, "MCP Servers");
+      await flush();
+      expect(testRoot.container.textContent).toContain("Filesystem MCP");
+      await clickTab(testRoot.container, "Skills");
+      await flush();
+
+      await clickButton(testRoot.container, "Import Skill");
+      await flush();
       expect(testRoot.container.textContent).toContain("Admin access required");
+      expect(testRoot.container.textContent).toContain("Archive or SKILL.md URL");
+
       await clickButton(testRoot.container, "Authorize admin access");
       expect(mutationAccess.requestEnter).toHaveBeenCalledTimes(1);
     } finally {


### PR DESCRIPTION
## Summary
- allow the Extensions page to load inventories for `operator.read` sessions while keeping mutations admin-only
- always show Skill and MCP import sections as collapsed disclosures regardless of the active list tab
- turn extension inspect into a real expand/collapse toggle with per-list expanded state and regression coverage

## Testing
- `pnpm exec vitest run packages/operator-ui/tests/pages/extensions-page.test.ts packages/gateway/tests/unit/http-scope-middleware.test.ts packages/gateway/tests/unit/http-scope-middleware-routepath-fallback.test.ts packages/gateway/tests/unit/extensions-routes.test.ts`
- `pnpm exec oxlint packages/gateway/src/modules/authz/http-scope-middleware.ts packages/gateway/tests/unit/http-scope-middleware.test.ts packages/gateway/tests/unit/http-scope-middleware-routepath-fallback.test.ts packages/gateway/tests/unit/extensions-routes.test.ts packages/operator-ui/src/components/pages/extensions-page-import-panels.tsx packages/operator-ui/src/components/pages/extensions-page.sections.tsx packages/operator-ui/src/components/pages/extensions-page.tsx packages/operator-ui/tests/pages/extensions-page.test-helpers.tsx packages/operator-ui/tests/pages/extensions-page.test.ts`
- `git push -u origin 1474-extensions-read-without-admin` (pre-push hook: lint, typecheck, desktop typecheck, test)

## Risk
- low; behavior is limited to Extensions auth scope resolution and the Extensions operator UI flow

## Rollback
- revert commit `a637bb43`

Closes #1474
