### PR TITLE
Fix WorkBoard scope toolbar and local connection chrome

### DIFF
--- a/packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx
+++ b/packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx
@@ -1,18 +1,12 @@
 import type { OperatorCore, WorkboardScopeKeys } from "@tyrum/operator-core";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "../ui/button.js";
-import { Input } from "../ui/input.js";
 import { Select } from "../ui/select.js";
-import { StatusDot, type StatusDotVariant } from "../ui/status-dot.js";
 
 type WorkboardScopeControlsProps = {
   core: OperatorCore;
   isConnected: boolean;
   scopeKeys: WorkboardScopeKeys;
-};
-
-type WorkboardToolbarActionsProps = WorkboardScopeControlsProps & {
-  connectionStatus: string;
 };
 
 type AgentOption = {
@@ -25,11 +19,8 @@ const DEFAULT_SCOPE_KEYS: WorkboardScopeKeys = {
   workspace_key: "default",
 } as const;
 
-function normalizeScopeKeys(scopeKeys: Partial<WorkboardScopeKeys>): WorkboardScopeKeys {
-  return {
-    agent_key: scopeKeys.agent_key?.trim() || DEFAULT_SCOPE_KEYS.agent_key,
-    workspace_key: scopeKeys.workspace_key?.trim() || DEFAULT_SCOPE_KEYS.workspace_key,
-  };
+function normalizeAgentKey(agentKey?: string): string {
+  return agentKey?.trim() || DEFAULT_SCOPE_KEYS.agent_key;
 }
 
 function normalizeAgentOptions(agents: unknown): AgentOption[] {
@@ -58,10 +49,7 @@ function normalizeAgentOptions(agents: unknown): AgentOption[] {
         : "";
     options.push({
       agentKey,
-      label:
-        personaName && personaName.toLowerCase() !== agentKey.toLowerCase()
-          ? `${agentKey} · ${personaName}`
-          : agentKey,
+      label: personaName || agentKey,
     });
   }
   options.sort((left, right) => left.agentKey.localeCompare(right.agentKey));
@@ -73,12 +61,12 @@ export function WorkboardScopeControls({
   isConnected,
   scopeKeys,
 }: WorkboardScopeControlsProps) {
-  const [scopeDraft, setScopeDraft] = useState<WorkboardScopeKeys>(scopeKeys);
+  const [agentKeyDraft, setAgentKeyDraft] = useState(() => normalizeAgentKey(scopeKeys.agent_key));
   const [agentOptions, setAgentOptions] = useState<AgentOption[]>([]);
 
   useEffect(() => {
-    setScopeDraft(scopeKeys);
-  }, [scopeKeys]);
+    setAgentKeyDraft(normalizeAgentKey(scopeKeys.agent_key));
+  }, [scopeKeys.agent_key]);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,18 +91,21 @@ export function WorkboardScopeControls({
   }, [core.http]);
 
   const visibleAgentOptions = useMemo(() => {
-    if (agentOptions.some((option) => option.agentKey === scopeDraft.agent_key)) {
+    if (agentOptions.some((option) => option.agentKey === agentKeyDraft)) {
       return agentOptions;
     }
-    return [{ agentKey: scopeDraft.agent_key, label: scopeDraft.agent_key }, ...agentOptions];
-  }, [agentOptions, scopeDraft.agent_key]);
+    return [{ agentKey: agentKeyDraft, label: agentKeyDraft }, ...agentOptions];
+  }, [agentKeyDraft, agentOptions]);
 
   const applyScope = useCallback(async (): Promise<void> => {
-    const nextScopeKeys = normalizeScopeKeys(scopeDraft);
+    const nextScopeKeys = {
+      agent_key: normalizeAgentKey(agentKeyDraft),
+      workspace_key: DEFAULT_SCOPE_KEYS.workspace_key,
+    } satisfies WorkboardScopeKeys;
     core.workboardStore.setScopeKeys(nextScopeKeys);
     if (!isConnected) return;
     await core.workboardStore.refreshList();
-  }, [core.workboardStore, isConnected, scopeDraft]);
+  }, [agentKeyDraft, core.workboardStore, isConnected]);
 
   return (
     <div className="flex flex-wrap items-center gap-3">
@@ -122,10 +113,10 @@ export function WorkboardScopeControls({
         data-testid="workboard-scope-agent"
         aria-label="Workboard agent scope"
         className="min-w-44"
-        value={scopeDraft.agent_key}
-        onChange={(event) =>
-          setScopeDraft((prev) => ({ ...prev, agent_key: event.currentTarget.value }))
-        }
+        value={agentKeyDraft}
+        onChange={(event) => {
+          setAgentKeyDraft(event.currentTarget.value);
+        }}
       >
         {visibleAgentOptions.map((option) => (
           <option key={option.agentKey} value={option.agentKey}>
@@ -133,15 +124,6 @@ export function WorkboardScopeControls({
           </option>
         ))}
       </Select>
-      <Input
-        data-testid="workboard-scope-workspace"
-        aria-label="Workboard workspace scope"
-        className="w-36"
-        value={scopeDraft.workspace_key}
-        onChange={(event) =>
-          setScopeDraft((prev) => ({ ...prev, workspace_key: event.currentTarget.value }))
-        }
-      />
       <Button
         data-testid="workboard-scope-apply"
         variant="secondary"
@@ -156,36 +138,6 @@ export function WorkboardScopeControls({
   );
 }
 
-export function WorkboardToolbarActions({
-  connectionStatus,
-  core,
-  isConnected,
-  scopeKeys,
-}: WorkboardToolbarActionsProps) {
-  const connectionDotVariant: StatusDotVariant =
-    connectionStatus === "connected"
-      ? "success"
-      : connectionStatus === "connecting"
-        ? "warning"
-        : "neutral";
-
-  return (
-    <>
-      <WorkboardScopeControls core={core} isConnected={isConnected} scopeKeys={scopeKeys} />
-      <div className="flex items-center gap-2 text-sm text-fg-muted">
-        <StatusDot variant={connectionDotVariant} pulse={connectionStatus === "connecting"} />
-        {connectionStatus}
-      </div>
-      <Button
-        variant="secondary"
-        size="sm"
-        onClick={() => {
-          core.disconnect();
-          core.connect();
-        }}
-      >
-        Reconnect
-      </Button>
-    </>
-  );
+export function WorkboardToolbarActions(props: WorkboardScopeControlsProps) {
+  return <WorkboardScopeControls {...props} />;
 }

--- a/packages/operator-ui/src/components/pages/workboard-page.tsx
+++ b/packages/operator-ui/src/components/pages/workboard-page.tsx
@@ -54,6 +54,13 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
   const isConnected = connection.status === "connected";
   const workboard = useOperatorStore(core.workboardStore);
   const currentScopeKeys = workboard.scopeKeys;
+  const effectiveScopeKeys = useMemo(
+    () => ({
+      agent_key: currentScopeKeys.agent_key,
+      workspace_key: "default",
+    }),
+    [currentScopeKeys.agent_key],
+  );
   const desktopBoard = useAppShellMinWidth(WORKBOARD_DESKTOP_CONTENT_WIDTH_PX);
 
   const selectedIdRef = useRef<string | null>(null);
@@ -74,7 +81,16 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
 
   useEffect(() => {
     setSelectedWorkItemId(null);
-  }, [currentScopeKeys.agent_key, currentScopeKeys.workspace_key]);
+  }, [effectiveScopeKeys.agent_key, effectiveScopeKeys.workspace_key]);
+
+  useEffect(() => {
+    if (currentScopeKeys.workspace_key === effectiveScopeKeys.workspace_key) {
+      return;
+    }
+    core.workboardStore.setScopeKeys(effectiveScopeKeys);
+    if (!isConnected) return;
+    void core.workboardStore.refreshList();
+  }, [core.workboardStore, currentScopeKeys.workspace_key, effectiveScopeKeys, isConnected]);
 
   useEffect(() => {
     selectedIdRef.current = selectedWorkItemId;
@@ -113,7 +129,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       setDrilldownError(null);
       try {
         const res = await core.ws.workTransition({
-          ...currentScopeKeys,
+          ...effectiveScopeKeys,
           work_item_id: selectedWorkItemId,
           status,
           reason,
@@ -130,7 +146,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
         setTransitionTarget(null);
       }
     },
-    [core.ws, core.workboardStore, currentScopeKeys, isConnected, selectedWorkItemId],
+    [core.ws, core.workboardStore, effectiveScopeKeys, isConnected, selectedWorkItemId],
   );
 
   useEffect(() => {
@@ -167,7 +183,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       const selectedId = selectedIdRef.current;
       if (!selectedId) return;
       void core.ws
-        .workSignalGet({ ...currentScopeKeys, signal_id: event.payload.signal_id })
+        .workSignalGet({ ...effectiveScopeKeys, signal_id: event.payload.signal_id })
         .then((res) => {
           if (disposed) return;
           if (res.signal.work_item_id !== selectedIdRef.current) return;
@@ -213,7 +229,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       core.ws.off("work.signal.fired", onWorkSignalFired);
       core.ws.off("work.state_kv.updated", onWorkStateKvUpdated);
     };
-  }, [core.ws, currentScopeKeys, isConnected]);
+  }, [core.ws, effectiveScopeKeys, isConnected]);
 
   useEffect(() => {
     if (!isConnected || !selectedWorkItemId) {
@@ -236,25 +252,25 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       try {
         const [workItemRes, artifactsRes, decisionsRes, signalsRes, agentKvRes, workItemKvRes] =
           await Promise.all([
-            core.ws.workGet({ ...currentScopeKeys, work_item_id: selectedWorkItemId }),
+            core.ws.workGet({ ...effectiveScopeKeys, work_item_id: selectedWorkItemId }),
             core.ws.workArtifactList({
-              ...currentScopeKeys,
+              ...effectiveScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
             core.ws.workDecisionList({
-              ...currentScopeKeys,
+              ...effectiveScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
             core.ws.workSignalList({
-              ...currentScopeKeys,
+              ...effectiveScopeKeys,
               work_item_id: selectedWorkItemId,
               limit: 200,
             }),
-            core.ws.workStateKvList({ scope: makeAgentScope(currentScopeKeys) }),
+            core.ws.workStateKvList({ scope: makeAgentScope(effectiveScopeKeys) }),
             core.ws.workStateKvList({
-              scope: makeWorkItemScope(currentScopeKeys, selectedWorkItemId),
+              scope: makeWorkItemScope(effectiveScopeKeys, selectedWorkItemId),
             }),
           ]);
 
@@ -280,7 +296,7 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
     return () => {
       cancelled = true;
     };
-  }, [core.ws, currentScopeKeys, isConnected, selectedWorkItemId]);
+  }, [core.ws, effectiveScopeKeys, isConnected, selectedWorkItemId]);
 
   const tasksForSelected = selectTasksForSelectedWorkItem(
     workboard.tasksByWorkItemId,
@@ -314,10 +330,9 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
       <AppPageToolbar
         actions={
           <WorkboardToolbarActions
-            connectionStatus={connection.status}
             core={core}
             isConnected={isConnected}
-            scopeKeys={currentScopeKeys}
+            scopeKeys={effectiveScopeKeys}
           />
         }
       />
@@ -326,14 +341,6 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
         <div className="min-h-0 flex-1 overflow-hidden">
           <ScrollArea className="h-full">
             <div data-layout-content="" className="grid gap-4 px-4 py-4 md:px-5 md:py-5">
-              {!isConnected ? (
-                <Alert
-                  variant="warning"
-                  title="Not connected"
-                  description="Connect to the gateway to use WorkBoard."
-                />
-              ) : null}
-
               {workboard.error ? (
                 <Alert variant="error" title="WorkBoard error" description={workboard.error} />
               ) : null}
@@ -417,14 +424,6 @@ export function WorkBoardPage({ core }: WorkBoardPageProps) {
         <div className="min-h-0 flex-1 overflow-hidden">
           <ScrollArea className="h-full">
             <div data-layout-content="" className="grid gap-4 px-4 py-4 md:px-5 md:py-5">
-              {!isConnected ? (
-                <Alert
-                  variant="warning"
-                  title="Not connected"
-                  description="Connect to the gateway to use WorkBoard."
-                />
-              ) : null}
-
               {workboard.error ? (
                 <Alert variant="error" title="WorkBoard error" description={workboard.error} />
               ) : null}

--- a/packages/operator-ui/tests/pages/workboard-page.test.ts
+++ b/packages/operator-ui/tests/pages/workboard-page.test.ts
@@ -17,21 +17,34 @@ import {
 } from "./workboard-page.test-support.js";
 import { cleanupTestRoot, renderIntoDocument, stubMatchMedia } from "../test-utils.js";
 
+function setSelectValue(container: HTMLElement, testId: string, value: string): void {
+  const select = container.querySelector<HTMLSelectElement>(`[data-testid="${testId}"]`);
+  expect(select).not.toBeNull();
+  select!.value = value;
+  select!.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 describe("WorkBoardPage", () => {
-  it("shows disconnected state and reconnects", () => {
-    const { core } = createCore("disconnected");
+  it("uses global connection handling and keeps stale work visible while disconnected", async () => {
+    const workItem = makeWorkItem({ work_item_id: "wi-stale" });
+    const { core } = createCore("disconnected", undefined, {
+      items: [workItem],
+      supported: true,
+      lastSyncedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const matchMedia = stubMatchMedia("(min-width: 1160px)", true);
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
 
     try {
-      expect(testRoot.container.textContent).toContain("Not connected");
-
-      act(() => {
-        clickButton(testRoot.container, "Reconnect");
-      });
-
-      expect(core.disconnect).toHaveBeenCalledTimes(1);
-      expect(core.connect).toHaveBeenCalledTimes(1);
+      await flushEffects();
+      expect(testRoot.container.textContent).not.toContain("Not connected");
+      expect(testRoot.container.textContent).toContain("Ship regression tests");
+      expect(testRoot.container.textContent).not.toContain("Reconnect");
+      expect(
+        testRoot.container.querySelector('[data-testid="workboard-scope-workspace"]'),
+      ).toBeNull();
     } finally {
+      matchMedia.cleanup();
       cleanupTestRoot(testRoot);
     }
   });
@@ -333,25 +346,56 @@ describe("WorkBoardPage", () => {
       );
       expect(testRoot.container.textContent).toContain("agent.from-event");
       expect(testRoot.container.textContent).toContain("work.from-event");
-
-      act(() => {
-        clickButton(testRoot.container, "Reconnect");
-      });
-      expect(core.disconnect).toHaveBeenCalledTimes(1);
-      expect(core.connect).toHaveBeenCalledTimes(1);
+      expect(testRoot.container.textContent).not.toContain("Reconnect");
     } finally {
       matchMedia.cleanup();
       cleanupTestRoot(testRoot);
     }
   });
 
-  it("uses the current workboard scope for drilldown requests", async () => {
-    const workItem = makeWorkItem({
-      work_item_id: "wi-scope",
-      agent_id: "agent-scope",
-      workspace_id: "workspace-scope",
+  it("shows agent names without keys and applies scope with the default workspace", async () => {
+    const { core, http, workboard } = createCore("connected");
+    http.agents.list.mockResolvedValueOnce({
+      agents: [
+        { agent_key: "builder", persona: { name: "" } },
+        { agent_key: "default", persona: { name: "Default Agent" } },
+      ],
     });
-    const { core, ws } = createCore(
+
+    const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
+    try {
+      await flushEffects();
+
+      const agentSelect = testRoot.container.querySelector<HTMLSelectElement>(
+        '[data-testid="workboard-scope-agent"]',
+      );
+      expect(agentSelect).not.toBeNull();
+      expect(Array.from(agentSelect!.options).map((option) => option.text)).toEqual([
+        "builder",
+        "Default Agent",
+      ]);
+      expect(testRoot.container.textContent).not.toContain("default · Default Agent");
+
+      act(() => {
+        setSelectValue(testRoot.container, "workboard-scope-agent", "builder");
+      });
+      await act(async () => {
+        clickButton(testRoot.container, "Load scope");
+        await Promise.resolve();
+      });
+
+      expect(workboard.store.setScopeKeys).toHaveBeenLastCalledWith({
+        agent_key: "builder",
+        workspace_key: "default",
+      });
+    } finally {
+      cleanupTestRoot(testRoot);
+    }
+  });
+
+  it("normalizes hidden workspace scope back to default for workboard requests", async () => {
+    const workItem = makeWorkItem({ work_item_id: "wi-scope" });
+    const { core, ws, workboard } = createCore(
       "connected",
       {
         workGet: vi.fn(async () => ({ item: workItem })),
@@ -360,16 +404,25 @@ describe("WorkBoardPage", () => {
         workSignalList: vi.fn(async () => ({ signals: [] })),
         workStateKvList: vi.fn(async () => ({ entries: [] })),
       },
-      {
-        items: [workItem],
-        scopeKeys: { agent_key: "planner", workspace_key: "ops" },
-        supported: true,
-      },
+      { scopeKeys: { agent_key: "planner", workspace_key: "ops" }, supported: true },
     );
+    workboard.store.refreshList = vi.fn(async () => {
+      workboard.setState((prev) => ({
+        ...prev,
+        items: [workItem],
+        supported: true,
+        lastSyncedAt: "2026-01-01T00:00:00.000Z",
+      }));
+    });
 
     const testRoot = renderIntoDocument(React.createElement(WorkBoardPage, { core }));
     try {
       await flushEffects();
+      expect(workboard.store.setScopeKeys).toHaveBeenCalledWith({
+        agent_key: "planner",
+        workspace_key: "default",
+      });
+      expect(workboard.store.refreshList).toHaveBeenCalledTimes(1);
 
       const scopedCard = testRoot.container.querySelector<HTMLButtonElement>(
         '[data-testid="work-item-wi-scope"]',
@@ -383,12 +436,12 @@ describe("WorkBoardPage", () => {
 
       expect(ws.workGet).toHaveBeenCalledWith({
         agent_key: "planner",
-        workspace_key: "ops",
+        workspace_key: "default",
         work_item_id: "wi-scope",
       });
       expect(ws.workArtifactList).toHaveBeenCalledWith({
         agent_key: "planner",
-        workspace_key: "ops",
+        workspace_key: "default",
         work_item_id: "wi-scope",
         limit: 200,
       });


### PR DESCRIPTION
Closes #1479

## What
- simplify the WorkBoard toolbar so it only shows the agent selector and `Load scope`
- show agent options by persona name with `agent_key` fallback when no name exists
- remove the WorkBoard workspace textbox and force this page to use `workspace_key: "default"`
- remove the page-local connection state, reconnect button, and inline disconnected warning
- update WorkBoard tests to cover the simplified toolbar, default-workspace normalization, and disconnected rendering

## Why
- the WorkBoard page was exposing extra scope and connection controls that duplicated the broader operator UI and made the toolbar noisy
- this keeps workspace support in the underlying APIs while simplifying the operator-facing page to the intended default-workspace behavior

## How To Test
- open the WorkBoard page and confirm the toolbar only shows the agent selector and `Load scope`
- verify agent labels render by name instead of `agent_key · name`
- switch agents and confirm requests stay on `workspace_key: "default"`
- disconnect and confirm the page no longer shows its own reconnect/offline chrome while global connection UI still reflects the state

## Validation
- `pnpm exec prettier --check packages/operator-ui/src/components/pages/workboard-page.tsx packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx packages/operator-ui/tests/pages/workboard-page.test.ts`
- `pnpm exec oxlint packages/operator-ui/src/components/pages/workboard-page.tsx packages/operator-ui/src/components/pages/workboard-page-scope-controls.tsx packages/operator-ui/tests/pages/workboard-page.test.ts`
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm exec vitest run packages/operator-ui/tests/pages/workboard-page.test.ts`
- `pnpm exec vitest run apps/web/tests/layout-regression.test.ts -t workboard`
- repo pre-push hook: lint, typecheck, mobile typecheck, web/gateway/operator-ui builds, desktop tsconfig check, and full `vitest run --coverage.enabled --coverage.reporter=text-summary` (`773` files passed, `4166` tests passed)

## Risk And Rollback
- risk is limited to WorkBoard page behavior in operator UI; backend scope support is unchanged
- rollback is a straightforward revert of this PR if the simplified toolbar causes issues
