### PR TITLE
feat(gateway): add memory guidance to system prompt and enrich pre-turn recall metadata

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/preturn-hydration.ts
+++ b/packages/gateway/src/modules/agent/runtime/preturn-hydration.ts
@@ -193,19 +193,42 @@ export async function runPreTurnHydration(params: {
         continue;
       }
 
-      const text = `Pre-turn recall (${tool.id}):\n${result.output}`;
-      sections.push({ toolId: tool.id, text });
-      reports.push({
-        tool_id: tool.id,
-        status: "succeeded",
-        injected_chars: text.length,
-      });
-
       if (result.meta?.kind === "memory.seed") {
-        memory.keyword_hits += result.meta.keyword_hit_count;
-        memory.semantic_hits += result.meta.semantic_hit_count;
-        memory.structured_hits += result.meta.structured_item_count;
-        memory.included_items += result.meta.included_item_ids.length;
+        const meta = result.meta;
+        const metaParts: string[] = [];
+        if (meta.query) {
+          metaParts.push(`seed_query="${meta.query}"`);
+        }
+        const hitParts: string[] = [];
+        if (meta.structured_item_count > 0)
+          hitParts.push(`structured=${meta.structured_item_count}`);
+        if (meta.keyword_hit_count > 0) hitParts.push(`keyword=${meta.keyword_hit_count}`);
+        if (meta.semantic_hit_count > 0) hitParts.push(`semantic=${meta.semantic_hit_count}`);
+        const included = meta.included_item_ids.length;
+        if (hitParts.length > 0) {
+          hitParts.push(`included=${included}`);
+          metaParts.push(hitParts.join(" "));
+        }
+        const header = metaParts.length > 0 ? `[${metaParts.join(" | ")}]\n` : "";
+        const text = `Pre-turn recall (${tool.id}):\n${header}${result.output}`;
+        sections.push({ toolId: tool.id, text });
+        reports.push({
+          tool_id: tool.id,
+          status: "succeeded",
+          injected_chars: text.length,
+        });
+        memory.keyword_hits += meta.keyword_hit_count;
+        memory.semantic_hits += meta.semantic_hit_count;
+        memory.structured_hits += meta.structured_item_count;
+        memory.included_items += included;
+      } else {
+        const text = `Pre-turn recall (${tool.id}):\n${result.output}`;
+        sections.push({ toolId: tool.id, text });
+        reports.push({
+          tool_id: tool.id,
+          status: "succeeded",
+          injected_chars: text.length,
+        });
       }
     } catch (error) {
       reports.push({

--- a/packages/gateway/src/modules/agent/runtime/prompts.ts
+++ b/packages/gateway/src/modules/agent/runtime/prompts.ts
@@ -231,3 +231,36 @@ export function formatWorkOrchestrationPrompt(
     ...lines.map((line) => `- ${line}`),
   ].join("\n");
 }
+
+export function formatMemoryGuidancePrompt(tools: readonly ToolDescriptor[]): string | undefined {
+  const toolIds = new Set(tools.map((tool) => tool.id));
+  const hasWrite = toolIds.has("mcp.memory.write");
+  const hasSearch = toolIds.has("mcp.memory.search");
+
+  if (!hasWrite && !hasSearch) return undefined;
+
+  const lines: string[] = [];
+
+  if (hasWrite) {
+    lines.push(
+      "Proactively persist durable memory when the turn yields reusable knowledge — do not wait for an explicit request to remember.",
+    );
+    lines.push(
+      "Write: user preferences and corrections, project context and constraints, successful procedures, important decisions and outcomes.",
+    );
+    lines.push(
+      "Kinds: fact (stable key-value, requires key+value), note (contextual info, requires body_md), procedure (learned workflow, requires body_md), episode (significant outcome, requires summary_md).",
+    );
+    lines.push(
+      "Never write: secrets or credentials, transient chatter, information derivable from tools or code, raw conversation transcripts.",
+    );
+  }
+
+  if (hasSearch) {
+    lines.push(
+      "Search memory when pre-turn recall may have missed relevant items — for example when the user references prior context, the task scope differs from the seed query, or recall returned few results.",
+    );
+  }
+
+  return lines.map((line) => `- ${line}`).join("\n");
+}

--- a/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
@@ -21,6 +21,7 @@ export interface ContextReportInput {
   skillsText: string;
   toolsText: string;
   workOrchestrationText: string | undefined;
+  memoryGuidanceText: string | undefined;
   sessionText: string;
   workFocusText: string;
   preTurnTexts: string[];
@@ -59,6 +60,7 @@ export function buildContextReport(input: ContextReportInput): AgentContextRepor
     skillsText,
     toolsText,
     workOrchestrationText,
+    memoryGuidanceText,
     sessionText,
     workFocusText,
     preTurnTexts,
@@ -104,6 +106,7 @@ export function buildContextReport(input: ContextReportInput): AgentContextRepor
         { id: "skill_guidance", chars: skillsText.length },
         { id: "tool_contracts", chars: toolsText.length },
         { id: "work_orchestration", chars: workOrchestrationText?.length ?? 0 },
+        { id: "memory_guidance", chars: memoryGuidanceText?.length ?? 0 },
       ],
     },
     user_parts: [

--- a/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-helpers.ts
@@ -210,16 +210,6 @@ export function resolveMainLaneSessionKey(input: {
   });
 }
 
-export function shouldPromoteToCoreMemory(message: string): boolean {
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes("i prefer") ||
-    normalized.includes("remember that") ||
-    normalized.includes("always ") ||
-    normalized.includes("never ")
-  );
-}
-
 export function isStatusQuery(message: string): boolean {
   const normalized = message.trim().toLowerCase();
   return normalized === "status?" || normalized === "status";

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
@@ -11,6 +11,7 @@ import {
   formatSessionContext,
   formatSkillsPrompt,
   formatToolPrompt,
+  formatMemoryGuidancePrompt,
   formatWorkOrchestrationPrompt,
 } from "./prompts.js";
 import {
@@ -166,6 +167,7 @@ export function assemblePrompts(
   const promptContractPrompt = PROMPT_CONTRACT_PROMPT;
   const skillsText = `Skill guidance:\n${formatSkillsPrompt(ctx.skills)}`;
   const workOrchestrationText = formatWorkOrchestrationPrompt(filteredTools);
+  const memoryGuidanceText = formatMemoryGuidancePrompt(filteredTools);
   const toolsText = `Tool contracts:\n${formatToolPrompt(filteredTools)}`;
   const sessionText = `Session state:\n${sessionCtx.trim() || "No stored session state."}`;
   const automationDirectiveText =
@@ -191,6 +193,9 @@ export function assemblePrompts(
     toolsText,
     workOrchestrationText: workOrchestrationText
       ? `Work orchestration guidance:\n${workOrchestrationText}`
+      : undefined,
+    memoryGuidanceText: memoryGuidanceText
+      ? `Durable memory guidance:\n${memoryGuidanceText}`
       : undefined,
     sessionText,
     preTurnTexts: [...preTurnTexts],

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation.ts
@@ -326,6 +326,7 @@ export async function prepareTurn(
         skillsText: "Skill guidance:\nGuardian review mode disables normal skill guidance.",
         toolsText: "Tool contracts:\nguardian_review_decision",
         workOrchestrationText: undefined as string | undefined,
+        memoryGuidanceText: undefined as string | undefined,
         sessionText:
           "Session state:\nGuardian review mode relies on the supplied review request evidence.",
         preTurnTexts: [] as string[],
@@ -349,6 +350,7 @@ export async function prepareTurn(
           skillsText: assembled.skillsText,
           toolsText: assembled.toolsText,
           workOrchestrationText: assembled.workOrchestrationText,
+          memoryGuidanceText: assembled.memoryGuidanceText,
           sessionText: assembled.sessionText,
           preTurnTexts: assembled.preTurnTexts,
           automationDirectiveText: assembled.automationDirectiveText,
@@ -367,6 +369,7 @@ export async function prepareTurn(
         promptParts.skillsText,
         promptParts.toolsText,
         promptParts.workOrchestrationText,
+        promptParts.memoryGuidanceText,
       ]
         .filter((value): value is string => typeof value === "string" && value.length > 0)
         .join("\n\n");
@@ -402,6 +405,7 @@ export async function prepareTurn(
     skillsText: promptParts.skillsText,
     toolsText: promptParts.toolsText,
     workOrchestrationText: promptParts.workOrchestrationText,
+    memoryGuidanceText: promptParts.memoryGuidanceText,
     sessionText: promptParts.sessionText,
     workFocusText,
     preTurnTexts: [...promptParts.preTurnTexts],

--- a/packages/gateway/src/modules/agent/tool-executor-shared.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-shared.ts
@@ -37,6 +37,7 @@ export type ToolResultMeta =
     }
   | {
       kind: "memory.seed";
+      query?: string;
       keyword_hit_count: number;
       semantic_hit_count: number;
       structured_item_count: number;

--- a/packages/gateway/src/modules/memory/builtin-mcp.ts
+++ b/packages/gateway/src/modules/memory/builtin-mcp.ts
@@ -202,6 +202,7 @@ export async function executeBuiltinMemoryMcpTool(params: {
       ...makeToolResult(params.toolCallId, result.digest as string, "tool"),
       meta: {
         kind: "memory.seed",
+        query: typeof result.query === "string" ? result.query : undefined,
         keyword_hit_count: Number(result.keyword_hit_count ?? 0),
         semantic_hit_count: Number(result.semantic_hit_count ?? 0),
         structured_item_count: Number(result.structured_item_count ?? 0),

--- a/packages/gateway/tests/unit/agent-behavior-policy-approvals.test.ts
+++ b/packages/gateway/tests/unit/agent-behavior-policy-approvals.test.ts
@@ -348,7 +348,8 @@ describe("Agent behavior - policy and approvals", () => {
     );
     expect(approvalSpy).toHaveBeenCalledTimes(1);
     expect(capturedMemoryDigest).toContain("always send messages to ops");
-    expect(capturedMemoryDigest).not.toContain("send a message to ops now");
+    const dataContent = capturedMemoryDigest.match(/<data[^>]*>([\s\S]*?)<\/data>/)?.[1] ?? "";
+    expect(dataContent).not.toContain("send a message to ops now");
   });
 
   it("executes the approved tool exactly once through runtime.turn()", async () => {
@@ -420,7 +421,8 @@ describe("Agent behavior - policy and approvals", () => {
     expect(await readMarkerFile(markerPath)).toBe("approved");
     expect(policyService.evaluateToolCall).toHaveBeenCalled();
     expect(capturedMemoryDigest).toContain("always send messages to ops");
-    expect(capturedMemoryDigest).not.toContain("send a message to ops now");
+    const dataContent = capturedMemoryDigest.match(/<data[^>]*>([\s\S]*?)<\/data>/)?.[1] ?? "";
+    expect(dataContent).not.toContain("send a message to ops now");
 
     const session = await container.sessionDal.getById({
       tenantId: DEFAULT_TENANT_ID,

--- a/packages/gateway/tests/unit/agent-runtime-guardian-review-mode.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-guardian-review-mode.test.ts
@@ -141,6 +141,7 @@ describe("AgentRuntime guardian review mode", () => {
           { id: "skill_guidance", chars: expect.any(Number) },
           { id: "tool_contracts", chars: expect.any(Number) },
           { id: "work_orchestration", chars: 0 },
+          { id: "memory_guidance", chars: 0 },
         ],
       },
     });

--- a/packages/gateway/tests/unit/preturn-hydration.test.ts
+++ b/packages/gateway/tests/unit/preturn-hydration.test.ts
@@ -209,6 +209,46 @@ describe("runPreTurnHydration", () => {
     ]);
   });
 
+  it("enriches memory.seed section text with retrieval metadata header", async () => {
+    const execute = vi.fn(async () => ({
+      output: "- [fact] abc (public) key=user value=Ron",
+      error: undefined,
+      meta: {
+        kind: "memory.seed" as const,
+        query: "recall prior context",
+        keyword_hit_count: 3,
+        semantic_hit_count: 1,
+        structured_item_count: 2,
+        included_item_ids: ["abc", "def", "ghi"],
+      },
+    }));
+
+    const result = await runPreTurnHydration({
+      toolIds: [memorySeedTool.id],
+      availableTools: [memorySeedTool],
+      toolExecutor: { execute } as unknown as ToolExecutor,
+      toolSetBuilderDeps: createToolSetBuilderDeps({}),
+      toolExecutionContext,
+      session,
+      resolved,
+    });
+
+    expect(result.sections).toHaveLength(1);
+    const text = result.sections[0]!.text;
+    expect(text).toContain('seed_query="recall prior context"');
+    expect(text).toContain("structured=2");
+    expect(text).toContain("keyword=3");
+    expect(text).toContain("semantic=1");
+    expect(text).toContain("included=3");
+    expect(text).toContain("- [fact] abc (public) key=user value=Ron");
+    expect(result.memory).toEqual({
+      keyword_hits: 3,
+      semantic_hits: 1,
+      structured_hits: 2,
+      included_items: 3,
+    });
+  });
+
   it("treats unexpected executor throws as best-effort skips", async () => {
     const execute = vi.fn(async () => {
       throw new Error("executor crashed");

--- a/packages/gateway/tests/unit/runtime-prompts.test.ts
+++ b/packages/gateway/tests/unit/runtime-prompts.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatSkillsPrompt, formatToolPrompt } from "../../src/modules/agent/runtime/prompts.js";
+import {
+  formatMemoryGuidancePrompt,
+  formatSkillsPrompt,
+  formatToolPrompt,
+} from "../../src/modules/agent/runtime/prompts.js";
+import type { ToolDescriptor } from "../../src/modules/agent/tools.js";
 
 describe("formatSkillsPrompt", () => {
   it("includes inline skill instructions with provenance metadata", () => {
@@ -66,7 +71,7 @@ describe("formatSkillsPrompt", () => {
     expect(prompt).not.toContain("confirmation=");
   });
 
-  it("renders prompt guidance and examples for risky tools", () => {
+  it("renders prompt guidance and examples for tools", () => {
     const prompt = formatToolPrompt([
       {
         id: "bash",
@@ -93,5 +98,43 @@ describe("formatSkillsPrompt", () => {
     expect(prompt).toContain("Guidance: Put action-specific arguments inside the input object.");
     expect(prompt).toContain('Example: {"node_id":"node_123"');
     expect(prompt).toContain('"input":{"display":"all"}');
+  });
+});
+
+function makeTool(id: string): ToolDescriptor {
+  return { id, description: `Tool ${id}`, effect: "read_only", keywords: [] };
+}
+
+describe("formatMemoryGuidancePrompt", () => {
+  it("returns undefined when no memory tools are present", () => {
+    const result = formatMemoryGuidancePrompt([makeTool("bash"), makeTool("fs.read")]);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns write and search guidance when all memory tools are present", () => {
+    const tools = [
+      makeTool("mcp.memory.seed"),
+      makeTool("mcp.memory.search"),
+      makeTool("mcp.memory.write"),
+    ];
+    const result = formatMemoryGuidancePrompt(tools);
+    expect(result).toBeDefined();
+    expect(result).toContain("Proactively persist durable memory");
+    expect(result).toContain("Never write: secrets");
+    expect(result).toContain("Search memory when pre-turn recall");
+  });
+
+  it("returns only search guidance for read-only profiles without mcp.memory.write", () => {
+    const tools = [makeTool("mcp.memory.seed"), makeTool("mcp.memory.search")];
+    const result = formatMemoryGuidancePrompt(tools);
+    expect(result).toBeDefined();
+    expect(result).not.toContain("Proactively persist");
+    expect(result).not.toContain("Never write");
+    expect(result).toContain("Search memory when pre-turn recall");
+  });
+
+  it("returns undefined when only seed is present", () => {
+    const result = formatMemoryGuidancePrompt([makeTool("mcp.memory.seed")]);
+    expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1489

- Add a **Durable memory guidance** section to the agent system prompt that instructs the agent when/how to proactively use `mcp.memory.write` and `mcp.memory.search` (conditional on tool availability per execution profile)
- Enrich the **pre-turn recall** text with a metadata header showing the seed query and hit counts per retrieval method, so the agent can decide whether to search with different terms
- Propagate the seed query through `ToolResultMeta` so it's available downstream in the hydration pipeline
- Remove dead `shouldPromoteToCoreMemory` function (zero consumers)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 776 files, 4191 tests pass
- [x] New unit tests for `formatMemoryGuidancePrompt` (4 cases) and pre-turn hydration metadata enrichment (1 case)
- [ ] Manual: start gateway, send a message, verify system prompt includes "Durable memory guidance" section and pre-turn recall shows metadata header