### PR TITLE
Auto-focus chat input when opening a thread

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -163,6 +163,10 @@ export function AiSdkConversation({
     syncDraftHeight(textarea);
   }, [draft]);
 
+  useEffect(() => {
+    draftRef.current?.focus();
+  }, []);
+
   const send = async (): Promise<void> => {
     const text = draft.trim();
     if (!text) {


### PR DESCRIPTION
## Summary
- Auto-focus the chat compose textarea when a new thread is created or an existing thread is opened
- Adds a mount-time `useEffect` that calls `focus()` on the existing textarea ref

Closes #1496

## Test plan
- [x] Existing chat tests pass (6/6)
- [ ] Open chat page, click "Start new chat" — textarea is focused immediately
- [ ] Switch to a different thread — textarea is focused
- [ ] Verify textarea auto-resize still works correctly