### PR TITLE
fix: emit pinned-transport bridge file for bundled dynamic import

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts src/browser.ts src/node.ts --format esm --dts"
+    "build": "tsdown src/index.ts src/browser.ts src/node.ts --format esm --dts && node scripts/post-build.mjs"
   },
   "dependencies": {
     "ai": "^6.0.116",

--- a/packages/client/scripts/post-build.mjs
+++ b/packages/client/scripts/post-build.mjs
@@ -1,0 +1,13 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+
+mkdirSync("dist/node", { recursive: true });
+writeFileSync(
+  "dist/node/pinned-transport.js",
+  [
+    "// Bridge file: re-exports pinned-transport functions from the node entrypoint",
+    "// where tsdown inlines them. Needed because the dynamic import in the shared",
+    "// chunk resolves to this path at runtime (see load-node-pinned-transport.ts).",
+    'export { createPinnedNodeTransportState, createPinnedNodeWebSocket, destroyPinnedNodeDispatcher } from "../node.mjs";',
+    "",
+  ].join("\n"),
+);


### PR DESCRIPTION
## Summary
- Fixes the desktop sandbox node failing to start with TLS pinning enabled (`Cannot find module 'dist/node/pinned-transport.js'`)
- Adds a post-build step that creates `dist/node/pinned-transport.js` as a bridge file re-exporting pinned-transport functions from `node.mjs`, where tsdown inlines them

## Root Cause
`tsdown` inlines the static import of `node/pinned-transport.ts` into `dist/node.mjs`, but preserves the computed dynamic import in the shared chunk verbatim. At runtime, the import resolves to `dist/node/pinned-transport.js` — which doesn't exist as a separate file.

## Test plan
- [x] `pnpm build` in `packages/client` produces `dist/node/pinned-transport.js` with correct re-exports
- [x] Dynamic import resolves and exposes the three expected functions
- [x] All 4276 existing tests pass (796/797 files; sole failure is pre-existing Docker e2e infra)

Closes #1511