### PR TITLE
fix(deps): patch fast-xml-parser override

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "@modelcontextprotocol/sdk>express-rate-limit": "8.3.0",
       "dmg-license>ajv": "8.18.0",
       "dbus-next>xml2js": "0.5.0",
-      "fast-xml-parser": "5.3.8",
+      "fast-xml-parser": "5.5.6",
       "file-loader>schema-utils": "4.3.3",
       "dompurify": "3.3.2",
       "immutable": "4.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@modelcontextprotocol/sdk>express-rate-limit': 8.3.0
   dmg-license>ajv: 8.18.0
   dbus-next>xml2js: 0.5.0
-  fast-xml-parser: 5.3.8
+  fast-xml-parser: 5.5.6
   file-loader>schema-utils: 4.3.3
   dompurify: 3.3.2
   immutable: 4.3.8
@@ -7330,8 +7330,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.8:
-    resolution: {integrity: sha512-53jIF4N6u/pxvaL1eb/hEZts/cFLWZ92eCfLrNyCI0k38lettCG/Bs40W9pPwoPXyHQlKu2OUbQtiEIZK/J6Vw==}
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.6:
+    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
     hasBin: true
 
   fastq@1.20.1:
@@ -9493,6 +9496,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-expression-matcher@1.1.3:
+    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -12885,7 +12892,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.11':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.3.8
+      fast-xml-parser: 5.5.6
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -20792,8 +20799,14 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.8:
+  fast-xml-builder@1.1.4:
     dependencies:
+      path-expression-matcher: 1.1.3
+
+  fast-xml-parser@5.5.6:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.1.3
       strnum: 2.2.0
 
   fastq@1.20.1:
@@ -23360,6 +23373,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-expression-matcher@1.1.3: {}
 
   path-is-absolute@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- bump the workspace `fast-xml-parser` override from `5.3.8` to patched `5.5.6`
- refresh `pnpm-lock.yaml` so `@aws-sdk/xml-builder` resolves the patched parser and its new support deps
- clear the high-severity `pnpm audit` finding for GHSA-8gc5-j5rx-235r / CVE-2026-26278

## Validation
- `pnpm audit`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`
- pre-push hook (`pnpm lint`, `pnpm typecheck`, desktop TS check, `pnpm test --coverage.enabled --coverage.reporter=text-summary`)

Closes #1514