### PR TITLE
fix: default allow mcp.memory.write in policy engine

### DIFF
--- a/packages/gateway/src/modules/policy/tool-evaluation.ts
+++ b/packages/gateway/src/modules/policy/tool-evaluation.ts
@@ -53,19 +53,18 @@ export async function evaluateToolCallAgainstBundle(params: {
       detail: `tool_id=${params.toolId};source=role_ceiling`,
     });
   } else {
-    toolDecision =
-      explicitToolDecision ??
-      (params.toolEffect === "read_only"
-        ? "allow"
-        : params.toolEffect === "state_changing"
-          ? "require_approval"
-          : evaluateDomain(toolsDomain, params.toolId));
+    const implicitToolDecision = resolveImplicitToolDecision({
+      toolId: params.toolId,
+      toolEffect: params.toolEffect,
+      toolsDomain,
+    });
+    toolDecision = explicitToolDecision ?? implicitToolDecision.decision;
     rules.push({
       rule: "tool_policy",
       outcome: toolDecision,
       detail:
         explicitToolDecision === undefined
-          ? `tool_id=${params.toolId};default=${params.toolEffect ?? "bundle"}`
+          ? `tool_id=${params.toolId};default=${implicitToolDecision.source}`
           : `tool_id=${params.toolId};source=explicit_rule`,
     });
   }
@@ -177,4 +176,30 @@ function evaluateToolDecisionOverride(
   }
 
   return undefined;
+}
+
+function resolveImplicitToolDecision(input: {
+  toolId: string;
+  toolEffect?: ToolEffect;
+  toolsDomain: ReturnType<typeof normalizeDomain>;
+}): { decision: Decision; source: string } {
+  if (input.toolEffect === "read_only") {
+    return { decision: "allow", source: "read_only" };
+  }
+
+  if (input.toolEffect === "state_changing") {
+    if (isDefaultAllowedStateChangingTool(input.toolId)) {
+      return { decision: "allow", source: "mcp_memory_write" };
+    }
+    return { decision: "require_approval", source: "state_changing" };
+  }
+
+  return {
+    decision: evaluateDomain(input.toolsDomain, input.toolId),
+    source: "bundle",
+  };
+}
+
+function isDefaultAllowedStateChangingTool(toolId: string): boolean {
+  return toolId.trim() === "mcp.memory.write";
 }

--- a/packages/gateway/tests/unit/policy-service-effect-defaults.test.ts
+++ b/packages/gateway/tests/unit/policy-service-effect-defaults.test.ts
@@ -61,6 +61,91 @@ describe("PolicyService effect defaults", () => {
     }
   });
 
+  it("allows mcp.memory.write by default even though it is state-changing", async () => {
+    const db = openTestSqliteDb();
+    try {
+      const policy = new PolicyService({
+        home: "/tmp/unused",
+        snapshotDal: new PolicySnapshotDal(db),
+        overrideDal: new PolicyOverrideDal(db),
+      });
+
+      const res = await policy.evaluateToolCall({
+        tenantId: DEFAULT_TENANT_ID,
+        agentId: DEFAULT_AGENT_ID,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+        toolId: "mcp.memory.write",
+        toolMatchTarget: "mcp.memory.write",
+        toolEffect: "state_changing",
+        roleAllowed: true,
+      });
+
+      expect(res.decision).toBe("allow");
+      expect(res.decision_record?.rules).toContainEqual(
+        expect.objectContaining({
+          rule: "tool_policy",
+          outcome: "allow",
+          detail: expect.stringContaining("default=mcp_memory_write"),
+        }),
+      );
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("still honors explicit policy rules for mcp.memory.write", async () => {
+    const db = openTestSqliteDb();
+    try {
+      await db.run(
+        `INSERT INTO policy_bundle_config_revisions (
+           tenant_id, scope_kind, agent_id, bundle_json, created_at, created_by_json, reason
+         ) VALUES (?, 'deployment', NULL, ?, ?, ?, ?)`,
+        [
+          DEFAULT_TENANT_ID,
+          JSON.stringify({
+            v: 1,
+            tools: { default: "deny", allow: [], require_approval: ["mcp.memory.write"], deny: [] },
+          }),
+          new Date().toISOString(),
+          JSON.stringify({ kind: "test" }),
+          "deployment-memory-write-requires-approval",
+        ],
+      );
+
+      const policy = new PolicyService({
+        home: "/tmp/unused",
+        snapshotDal: new PolicySnapshotDal(db),
+        overrideDal: new PolicyOverrideDal(db),
+        configStore: createGatewayConfigStore({
+          db,
+          home: "/tmp/unused",
+          deploymentConfig: { state: { mode: "shared" } },
+        }),
+      });
+
+      const res = await policy.evaluateToolCall({
+        tenantId: DEFAULT_TENANT_ID,
+        agentId: DEFAULT_AGENT_ID,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+        toolId: "mcp.memory.write",
+        toolMatchTarget: "mcp.memory.write",
+        toolEffect: "state_changing",
+        roleAllowed: true,
+      });
+
+      expect(res.decision).toBe("require_approval");
+      expect(res.decision_record?.rules).toContainEqual(
+        expect.objectContaining({
+          rule: "tool_policy",
+          outcome: "require_approval",
+          detail: expect.stringContaining("source=explicit_rule"),
+        }),
+      );
+    } finally {
+      await db.close();
+    }
+  });
+
   it("denies tools outside the role ceiling before approval logic", async () => {
     const db = openTestSqliteDb();
     try {


### PR DESCRIPTION
Closes #1517

## What
- special-case `mcp.memory.write` in policy evaluation so it defaults to `allow` when no explicit tool rule matches
- keep explicit tool rules and role-ceiling denies authoritative
- add regression coverage for the new default-allow path and explicit-rule precedence

## Why
`mcp.memory.write` is part of the normal durable-memory workflow, but the policy engine was treating it like a generic state-changing tool and forcing approval by default. This change makes its default policy behavior match the intended low-friction memory flow.

## How to test
- `pnpm exec vitest run packages/gateway/tests/unit/policy-service-effect-defaults.test.ts`
- `pnpm exec vitest run packages/gateway/tests/unit/agent-behavior-policy-approvals.test.ts`
- `pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json`
- `pnpm exec oxlint packages/gateway/src/modules/policy/tool-evaluation.ts packages/gateway/tests/unit/policy-service-effect-defaults.test.ts`
- repo pre-push hook: full lint, typecheck, desktop typecheck, and `vitest run --coverage.enabled --coverage.reporter=text-summary`

## Risk and rollback
Risk is limited to the default policy fallback for one tool id. Rollback is a single revert of the `mcp.memory.write` implicit-allow exception if that policy surface turns out to be too broad.