### PR TITLE
Clarify memory-search guidance for incomplete pre-turn recall

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/prompts.ts
+++ b/packages/gateway/src/modules/agent/runtime/prompts.ts
@@ -258,7 +258,16 @@ export function formatMemoryGuidancePrompt(tools: readonly ToolDescriptor[]): st
 
   if (hasSearch) {
     lines.push(
-      "Search memory when pre-turn recall may have missed relevant items — for example when the user references prior context, the task scope differs from the seed query, or recall returned few results.",
+      "Search memory when pre-turn recall may have missed relevant items — for example when the user references prior context, asks a broad question, the task scope differs from the seed query, or recall returned few results.",
+    );
+    lines.push(
+      "Do not assume pre-turn recall is complete or that missing details are unavailable in memory. Pre-turn recall is seed-based and may omit relevant memory that uses different terms.",
+    );
+    lines.push(
+      "If the requested information is not in pre-turn recall, run mcp.memory.search before answering. Do this for broad questions and for follow-up probes about specific topics.",
+    );
+    lines.push(
+      "When pre-turn recall is insufficient, search with alternative terms, paraphrases, broader or narrower queries, and related entities or topics.",
     );
   }
 

--- a/packages/gateway/tests/unit/runtime-prompts.test.ts
+++ b/packages/gateway/tests/unit/runtime-prompts.test.ts
@@ -122,6 +122,12 @@ describe("formatMemoryGuidancePrompt", () => {
     expect(result).toContain("Proactively persist durable memory");
     expect(result).toContain("Never write: secrets");
     expect(result).toContain("Search memory when pre-turn recall");
+    expect(result).toContain("asks a broad question");
+    expect(result).toContain("Do not assume pre-turn recall is complete");
+    expect(result).toContain("Pre-turn recall is seed-based");
+    expect(result).toContain("If the requested information is not in pre-turn recall");
+    expect(result).toContain("run mcp.memory.search before answering");
+    expect(result).toContain("search with alternative terms, paraphrases");
   });
 
   it("returns only search guidance for read-only profiles without mcp.memory.write", () => {
@@ -131,6 +137,9 @@ describe("formatMemoryGuidancePrompt", () => {
     expect(result).not.toContain("Proactively persist");
     expect(result).not.toContain("Never write");
     expect(result).toContain("Search memory when pre-turn recall");
+    expect(result).toContain("Pre-turn recall is seed-based");
+    expect(result).toContain("run mcp.memory.search before answering");
+    expect(result).toContain("search with alternative terms, paraphrases");
   });
 
   it("returns undefined when only seed is present", () => {


### PR DESCRIPTION
## Summary
- broaden durable memory prompt guidance so pre-turn recall is treated as seed-based and potentially incomplete
- instruct the model to run `mcp.memory.search` when requested information is missing from pre-turn recall, including broad questions and topic follow-ups
- tell the model to try alternative terms, paraphrases, and broader or narrower topic queries when searching memory

## Testing
- `pnpm exec vitest run packages/gateway/tests/unit/runtime-prompts.test.ts`
- `git push -u origin 1519-clarify-memory-search-guidance` (ran repo pre-push checks: lint, typecheck, desktop typecheck, full test suite with coverage)

Closes #1519
