### PR TITLE
Fix archived chat state and title updates in the operator UI

### DIFF
--- a/packages/operator-core/src/stores/chat-store.actions.ts
+++ b/packages/operator-core/src/stores/chat-store.actions.ts
@@ -8,7 +8,7 @@ import {
   supportsTyrumAiSdkChatSocket,
 } from "@tyrum/client/browser";
 import { toOperatorCoreError } from "../operator-error.js";
-import type { ChatStoreContext } from "./chat-store.types.js";
+import type { ChatState, ChatStoreContext } from "./chat-store.types.js";
 
 function normalizeAgentId(agentId: string): string {
   const trimmed = agentId.trim();
@@ -123,6 +123,48 @@ export function patchSessionList(
     ...sessions.filter((entry) => entry.session_id !== nextSummary.session_id),
     nextSummary,
   ].toSorted(compareSessionActivity);
+}
+
+function routeSessionSummary(
+  prev: ChatState,
+  session: TyrumAiSdkChatSession | TyrumAiSdkChatSessionSummary,
+): Pick<ChatState, "archivedSessions" | "sessions"> {
+  const nextSummary = toSessionSummary(session);
+  const filteredActiveSessions = prev.sessions.sessions.filter(
+    (entry) => entry.session_id !== nextSummary.session_id,
+  );
+  const filteredArchivedSessions = prev.archivedSessions.sessions.filter(
+    (entry) => entry.session_id !== nextSummary.session_id,
+  );
+
+  if (nextSummary.archived) {
+    const shouldPatchArchived =
+      prev.archivedSessions.loaded ||
+      prev.archivedSessions.sessions.some((entry) => entry.session_id === nextSummary.session_id);
+    return {
+      sessions: {
+        ...prev.sessions,
+        sessions: filteredActiveSessions,
+      },
+      archivedSessions: {
+        ...prev.archivedSessions,
+        sessions: shouldPatchArchived
+          ? patchSessionList(prev.archivedSessions.sessions, nextSummary)
+          : filteredArchivedSessions,
+      },
+    };
+  }
+
+  return {
+    sessions: {
+      ...prev.sessions,
+      sessions: patchSessionList(prev.sessions.sessions, nextSummary),
+    },
+    archivedSessions: {
+      ...prev.archivedSessions,
+      sessions: filteredArchivedSessions,
+    },
+  };
 }
 
 function applySessionMessages(
@@ -350,13 +392,7 @@ export function hydrateActiveSession(
 ): void {
   ctx.setState((prev) => ({
     ...prev,
-    sessions:
-      session === null
-        ? prev.sessions
-        : {
-            ...prev.sessions,
-            sessions: patchSessionList(prev.sessions.sessions, session),
-          },
+    ...(session === null ? {} : routeSessionSummary(prev, session)),
     active:
       session === null
         ? {
@@ -383,10 +419,7 @@ export function updateActiveMessages(ctx: ChatStoreContext, messages: UIMessage[
     const nextSession = applySessionMessages(session, messages);
     return {
       ...prev,
-      sessions: {
-        ...prev.sessions,
-        sessions: patchSessionList(prev.sessions.sessions, nextSession),
-      },
+      ...routeSessionSummary(prev, nextSession),
       active: {
         ...prev.active,
         session: nextSession,

--- a/packages/operator-core/tests/chat-store.test.ts
+++ b/packages/operator-core/tests/chat-store.test.ts
@@ -119,6 +119,56 @@ describe("chatStore", () => {
     expect(chat.getSnapshot().active.session).toEqual(sampleGetSession("session-9"));
   });
 
+  it("keeps opened archived sessions in the archived list and updates them there", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-10T00:00:00.000Z"));
+
+    try {
+      const ws = createFakeWs();
+      const archivedItem = { ...sampleListItem("session-1"), archived: true };
+      const archivedSession = { ...sampleGetSession("session-1"), archived: true };
+      ws.sessionList
+        .mockResolvedValueOnce({ sessions: [], next_cursor: null })
+        .mockResolvedValueOnce({ sessions: [archivedItem], next_cursor: null });
+      ws.sessionGet.mockResolvedValueOnce({ session: archivedSession });
+      const chat = createChatStore(ws as never, createFakeHttp() as never);
+
+      await chat.refreshSessions();
+      await chat.loadArchivedSessions();
+      await chat.openSession("session-1");
+
+      expect(chat.getSnapshot().sessions.sessions).toEqual([]);
+      expect(chat.getSnapshot().archivedSessions.sessions[0]).toEqual(archivedItem);
+
+      chat.updateActiveMessages([
+        ...archivedSession.messages,
+        {
+          id: "session-1-assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Archived update" }],
+        },
+      ]);
+
+      const snapshot = chat.getSnapshot();
+      expect(snapshot.active.session?.archived).toBe(true);
+      expect(snapshot.sessions.sessions).toEqual([]);
+      expect(snapshot.archivedSessions.sessions[0]).toEqual(
+        expect.objectContaining({
+          session_id: "session-1",
+          archived: true,
+          message_count: 2,
+          last_message: {
+            role: "assistant",
+            text: "Archived update",
+          },
+          updated_at: "2026-01-10T00:00:00.000Z",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps existing thread order when opening an older session", async () => {
     const ws = createFakeWs();
     ws.sessionList.mockResolvedValueOnce({

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -18,6 +18,7 @@ import type {
   TyrumAiSdkChatSession,
 } from "@tyrum/client";
 import { AiSdkChatMessageList } from "./chat-page-ai-sdk-messages.js";
+import { getSessionDisplayTitle } from "./chat-page-ai-sdk-shared.js";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
 
@@ -143,7 +144,7 @@ export function AiSdkConversation({
           return;
         }
         chat.setMessages(reloaded.messages);
-        onSessionMessages(reloaded.messages);
+        core.chatStore.hydrateActiveSession(reloaded);
       })
       .catch((error) => {
         if (!cancelled) {
@@ -154,7 +155,7 @@ export function AiSdkConversation({
     return () => {
       cancelled = true;
     };
-  }, [chat.setMessages, chat.status, onSessionMessages, session.session_id, sessionClient]);
+  }, [chat.setMessages, chat.status, core.chatStore, session.session_id, sessionClient]);
 
   useLayoutEffect(() => {
     const textarea = draftRef.current;
@@ -228,7 +229,9 @@ export function AiSdkConversation({
             </Button>
           ) : null}
           <div className="min-w-0">
-            <div className="truncate text-sm font-medium text-fg">{session.thread_id}</div>
+            <div className="truncate text-sm font-medium text-fg">
+              {getSessionDisplayTitle(session.title)}
+            </div>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-shared.ts
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-shared.ts
@@ -2,8 +2,14 @@ import { isTextUIPart, type UIMessage } from "ai";
 import type { TyrumAiSdkChatSession, TyrumAiSdkChatSessionSummary } from "@tyrum/client";
 import type { ChatThreadSummary } from "./chat-page-threads.js";
 
-function firstLine(text: string): string {
-  return text.split(/\r?\n/)[0]?.trim() ?? "";
+export const DEFAULT_CHAT_TITLE = "New chat";
+
+function firstLine(text: string | null | undefined): string {
+  return typeof text === "string" ? (text.split(/\r?\n/)[0]?.trim() ?? "") : "";
+}
+
+export function getSessionDisplayTitle(title: string | null | undefined): string {
+  return firstLine(title) || DEFAULT_CHAT_TITLE;
 }
 
 function deriveSessionPreview(session: TyrumAiSdkChatSessionSummary): string {
@@ -11,7 +17,7 @@ function deriveSessionPreview(session: TyrumAiSdkChatSessionSummary): string {
 }
 
 function deriveSessionTitle(session: TyrumAiSdkChatSessionSummary): string {
-  return firstLine(session.title) || session.thread_id;
+  return getSessionDisplayTitle(session.title);
 }
 
 export function toThreadSummary(session: TyrumAiSdkChatSessionSummary): ChatThreadSummary {

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
@@ -291,13 +291,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
             }}
             canLoadMore={Boolean(chat.sessions.nextCursor)}
             onOpenThread={(sessionId) => {
-              const isArchived = chat.archivedSessions.sessions.some(
-                (s) => s.session_id === sessionId,
-              );
               const open = async () => {
-                if (isArchived) {
-                  await core.chatStore.unarchiveSession(sessionId);
-                }
                 await core.chatStore.openSession(sessionId);
                 if (!lgUp && core.chatStore.getSnapshot().active.sessionId === sessionId) {
                   setMobileView("conversation");

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-conversation.test.ts
@@ -9,7 +9,13 @@ import { click, cleanupTestRoot, renderIntoDocument, setNativeValue } from "../t
 const e = React.createElement;
 const useChatMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
-const testCore = { http: {} } as unknown as OperatorCore;
+const hydrateActiveSessionMock = vi.hoisted(() => vi.fn());
+const testCore = {
+  http: {},
+  chatStore: {
+    hydrateActiveSession: hydrateActiveSessionMock,
+  },
+} as unknown as OperatorCore;
 const DRAFT_LINE_HEIGHT_PX = 20;
 const DRAFT_PADDING_PX = 8;
 const DRAFT_BORDER_PX = 1;
@@ -112,6 +118,74 @@ describe("AiSdkConversation", () => {
   beforeEach(() => {
     useChatMock.mockReset();
     toastErrorMock.mockReset();
+    hydrateActiveSessionMock.mockReset();
+  });
+
+  it("renders the session title in the header and falls back to New chat", async () => {
+    const chatState = makeUseChatState();
+    useChatMock.mockReturnValue(chatState);
+    const sessionClient = {
+      get: vi.fn(async () => ({
+        session_id: "session-1",
+        messages: [],
+      })),
+    };
+
+    const { AiSdkConversation } =
+      await import("../../src/components/pages/chat-page-ai-sdk-conversation.js");
+    const titledRoot = renderIntoDocument(
+      e(AiSdkConversation, {
+        approvalsById: {},
+        core: testCore,
+        onDelete: vi.fn(),
+        onResolveApproval: vi.fn(),
+        onRenderModeChange: vi.fn(),
+        onSessionMessages: vi.fn(),
+        renderMode: "markdown",
+        resolvingApproval: null,
+        resolveAttachedNodeId: vi.fn(async () => null),
+        session: {
+          session_id: "session-1",
+          thread_id: "thread-1",
+          title: "Visible chat title",
+          messages: [],
+        },
+        sessionClient,
+        transport: { transport: true },
+      } as never),
+    );
+
+    expect(titledRoot.container.textContent).toContain("Visible chat title");
+    expect(titledRoot.container.textContent).not.toContain("thread-1");
+
+    cleanupTestRoot(titledRoot);
+
+    const untitledRoot = renderIntoDocument(
+      e(AiSdkConversation, {
+        approvalsById: {},
+        core: testCore,
+        onDelete: vi.fn(),
+        onResolveApproval: vi.fn(),
+        onRenderModeChange: vi.fn(),
+        onSessionMessages: vi.fn(),
+        renderMode: "markdown",
+        resolvingApproval: null,
+        resolveAttachedNodeId: vi.fn(async () => null),
+        session: {
+          session_id: "session-2",
+          thread_id: "thread-2",
+          title: "",
+          messages: [],
+        },
+        sessionClient,
+        transport: { transport: true },
+      } as never),
+    );
+
+    expect(untitledRoot.container.textContent).toContain("New chat");
+    expect(untitledRoot.container.textContent).not.toContain("thread-2");
+
+    cleanupTestRoot(untitledRoot);
   });
 
   it("sends messages and updates the markdown toggle", async () => {
@@ -285,12 +359,15 @@ describe("AiSdkConversation", () => {
         parts: [{ type: "text", text: "done" }],
       },
     ] as unknown as UIMessage[];
+    const reloadedSession = {
+      session_id: "session-1",
+      thread_id: "thread-1",
+      title: "Generated title",
+      messages: reloadedMessages,
+    };
     const onSessionMessages = vi.fn();
     const sessionClient = {
-      get: vi.fn(async () => ({
-        session_id: "session-1",
-        messages: reloadedMessages,
-      })),
+      get: vi.fn(async () => reloadedSession),
     };
 
     const { AiSdkConversation } =
@@ -324,7 +401,7 @@ describe("AiSdkConversation", () => {
 
     expect(sessionClient.get).toHaveBeenCalledWith({ session_id: "session-1" });
     expect(chatState.setMessages).toHaveBeenCalledWith(reloadedMessages);
-    expect(onSessionMessages).toHaveBeenCalledWith(reloadedMessages);
+    expect(hydrateActiveSessionMock).toHaveBeenCalledWith(reloadedSession);
 
     cleanupTestRoot(testRoot);
   });

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-shared.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-shared.test.ts
@@ -123,4 +123,20 @@ describe("chat-page-ai-sdk-shared", () => {
       archived: false,
     });
   });
+
+  it("falls back to New chat when a session title is blank", () => {
+    const summary = toThreadSummary({
+      session_id: "session-1",
+      agent_id: "default",
+      channel: "ui",
+      thread_id: "thread-1",
+      title: "   ",
+      created_at: "2026-03-13T00:00:00.000Z",
+      updated_at: "2026-03-14T00:00:00.000Z",
+      message_count: 0,
+      last_message: null,
+    });
+
+    expect(summary.title).toBe("New chat");
+  });
 });

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk.integration.test.ts
@@ -45,10 +45,12 @@ vi.mock("../../src/host/host-api.js", () => ({
 
 vi.mock("../../src/components/pages/chat-page-threads.js", () => ({
   ChatThreadsPanel: ({
+    archivedThreads,
     onNewChat,
     onOpenThread,
     threads,
   }: {
+    archivedThreads: Array<{ preview: string; session_id: string; title: string }>;
     onNewChat: () => void;
     onOpenThread: (sessionId: string) => void;
     threads: Array<{ preview: string; session_id: string; title: string }>;
@@ -69,6 +71,20 @@ vi.mock("../../src/components/pages/chat-page-threads.js", () => ({
             type: "button",
           },
           `${thread.title}:${thread.preview}`,
+        ),
+      ),
+      ...archivedThreads.map((thread) =>
+        e(
+          "button",
+          {
+            key: `archived-${thread.session_id}`,
+            "data-testid": `mock-open-archived-${thread.session_id}`,
+            onClick: () => {
+              onOpenThread(thread.session_id);
+            },
+            type: "button",
+          },
+          `archived:${thread.title}:${thread.preview}`,
         ),
       ),
     ),
@@ -281,6 +297,108 @@ describe("AiSdkChatPage integration", () => {
 
     expect(sessionClient.delete).toHaveBeenCalledWith({ session_id: "session-2" });
     expect(testRoot.container.textContent).toContain("session-1");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("opens archived chats without unarchiving them first", async () => {
+    const sessionClient = {
+      list: vi.fn(async () => ({ sessions: [], next_cursor: null })),
+      get: vi.fn(async ({ session_id }: { session_id: string }) => createSession(session_id, "")),
+      create: vi.fn(async () => createSession("session-2", "New preview")),
+      delete: vi.fn(async () => undefined),
+    };
+    createSessionClientMock.mockReturnValue(sessionClient);
+
+    const { store: connectionStore } = createStore({
+      status: "disconnected",
+      clientId: null,
+      lastDisconnect: null,
+      transportError: null,
+    });
+    const approvalsStore = createApprovalsStoreStub();
+    const { store: chatStoreBase } = createStore({
+      agentId: "default",
+      agents: {
+        agents: [{ agent_id: "default", persona: { name: "Default" } }],
+        loading: false,
+        error: null,
+      },
+      sessions: {
+        sessions: [],
+        nextCursor: null,
+        loading: false,
+        error: null,
+      },
+      archivedSessions: {
+        sessions: [
+          {
+            ...createSessionSummary("session-archived", "Archived preview"),
+            title: "",
+            archived: true,
+          },
+        ],
+        nextCursor: null,
+        loading: false,
+        loaded: true,
+        error: null,
+      },
+      active: {
+        sessionId: null,
+        session: null,
+        loading: false,
+        error: null,
+      },
+    });
+    const chatStore = {
+      ...chatStoreBase,
+      setAgentId: vi.fn(),
+      refreshAgents: vi.fn(async () => undefined),
+      refreshSessions: vi.fn(async () => undefined),
+      loadMoreSessions: vi.fn(async () => undefined),
+      openSession: vi.fn(async () => undefined),
+      hydrateActiveSession: vi.fn(),
+      updateActiveMessages: vi.fn(),
+      newChat: vi.fn(async () => undefined),
+      deleteActive: vi.fn(async () => undefined),
+      archiveSession: vi.fn(async () => undefined),
+      unarchiveSession: vi.fn(async () => undefined),
+      loadArchivedSessions: vi.fn(async () => undefined),
+      loadMoreArchivedSessions: vi.fn(async () => undefined),
+    };
+    const ws = {
+      connected: true,
+      off: vi.fn(),
+      on: vi.fn(),
+      requestDynamic: vi.fn(),
+      onDynamicEvent: vi.fn(),
+      offDynamicEvent: vi.fn(),
+    };
+    const http = {
+      agentList: {
+        get: vi.fn(async () => ({ agents: [] })),
+      },
+    };
+    const core = {
+      approvalsStore,
+      chatStore,
+      connectionStore,
+      http,
+      ws,
+    } as unknown as OperatorCore;
+
+    const { AiSdkChatPage } = await import("../../src/components/pages/chat-page-ai-sdk.js");
+    const testRoot = renderIntoDocument(e(AiSdkChatPage, { core }));
+
+    await flushEffects();
+    await clickAndFlush(
+      testRoot.container.querySelector(
+        "[data-testid='mock-open-archived-session-archived']",
+      ) as HTMLElement,
+    );
+
+    expect(chatStore.openSession).toHaveBeenCalledWith("session-archived");
+    expect(chatStore.unarchiveSession).not.toHaveBeenCalled();
 
     cleanupTestRoot(testRoot);
   });


### PR DESCRIPTION
## Summary
Closes #1521.

This fixes the operator chat regressions where opening an archived chat immediately unarchived it, blank chat titles rendered as UUIDs, generated titles did not appear automatically after a turn, and the conversation header showed the thread id instead of the chat title.

## What changed
- removed the UI-side unarchive-on-open behavior for archived chats
- routed hydrated and live-updated archived sessions back into the archived collection in the chat store
- added a shared `New chat` title fallback for blank session titles
- updated the conversation header to use the chat title
- hydrated the full reloaded session after streaming so generated titles appear automatically
- added store and UI regressions for archived-session routing and title refresh behavior

## How to test
- open an archived chat and confirm it stays in Archived until explicitly restored
- start a new chat and confirm untitled sessions show `New chat`
- finish a turn that generates a title and confirm the thread list and open conversation update automatically
- confirm the conversation header shows the chat title instead of the UUID-like thread id

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm format:check`
- `pnpm exec vitest run packages/operator-core/tests/chat-store.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk*.test.ts packages/operator-ui/tests/pages/chat-page-threads.test.ts packages/operator-ui/tests/app-retained-ai-sdk-chat.integration.test.ts packages/operator-ui/tests/app-retained-chat-route.test.ts`
- `pnpm test`

## Risk and rollback
Low risk and isolated to chat UI/store behavior. Rollback is a straight revert of commit `3a28f496`.
