### PR TITLE
Remove stale DOMPurify audit ignore

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -67,8 +67,8 @@ jobs:
 
       - name: pnpm audit (workspace packages)
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || steps.filter.outputs.deps == 'true'
-        # CVE-2026-0540 (DOMPurify) has no released patched version yet.
-        # We apply the upstream fix via pnpm patchedDependencies and ignore it via pnpm auditConfig.
+        # CVE-2026-31808 (file-type) is fixed upstream, but @nut-tree-fork/nut-js still pulls file-type 16.5.4 via Jimp.
+        # We apply the loop-guard patch locally and keep the audit ignore until that transitive chain upgrades.
         run: pnpm audit
 
       - name: Report failure for triage

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "allowUnusedPatches": true,
     "auditConfig": {
       "ignoreCves": [
-        "CVE-2026-0540",
         "CVE-2026-31808"
       ]
     },


### PR DESCRIPTION
## Summary
- remove the stale `CVE-2026-0540` ignore from `pnpm.auditConfig`
- keep the live `CVE-2026-31808` ignore for the locally patched `file-type` dependency
- update the security baseline workflow comment so it matches the current audit state

## Verification
- `pnpm audit`
- `node scripts/check-file-type-patch.mjs`
- pre-commit hook (`pnpm format:check-staged`, `pnpm lint`)
- pre-push hook (`pnpm lint`, `pnpm typecheck`, `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`, `pnpm test`)

Fixes #1529
