### PR TITLE
fix(gateway): default execution steps to one attempt

### DIFF
--- a/packages/gateway/migrations/postgres/100_rebuild_v2.sql
+++ b/packages/gateway/migrations/postgres/100_rebuild_v2.sql
@@ -561,7 +561,7 @@ CREATE TABLE execution_steps (
   idempotency_key  TEXT,
   postcondition_json TEXT,
   approval_id      UUID,
-  max_attempts     INTEGER NOT NULL DEFAULT 3,
+  max_attempts     INTEGER NOT NULL DEFAULT 1,
   timeout_ms       INTEGER NOT NULL DEFAULT 60000,
   PRIMARY KEY (tenant_id, step_id),
   UNIQUE (tenant_id, run_id, step_index),

--- a/packages/gateway/migrations/sqlite/100_rebuild_v2.sql
+++ b/packages/gateway/migrations/sqlite/100_rebuild_v2.sql
@@ -539,7 +539,7 @@ CREATE TABLE execution_steps (
   idempotency_key   TEXT,
   postcondition_json TEXT,
   approval_id       TEXT,
-  max_attempts      INTEGER NOT NULL DEFAULT 3,
+  max_attempts      INTEGER NOT NULL DEFAULT 1,
   timeout_ms        INTEGER NOT NULL DEFAULT 60000,
   PRIMARY KEY (tenant_id, step_id),
   UNIQUE (tenant_id, run_id, step_index),

--- a/packages/gateway/src/modules/agent/tool-executor-node-dispatch-internals.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-node-dispatch-internals.ts
@@ -149,8 +149,16 @@ export async function ensureSyntheticExecutionScope(
     );
 
     await tx.run(
-      `INSERT INTO execution_steps (tenant_id, step_id, run_id, step_index, status, action_json)
-       VALUES (?, ?, ?, 0, 'running', ?)`,
+      `INSERT INTO execution_steps (
+         tenant_id,
+         step_id,
+         run_id,
+         step_index,
+         status,
+         action_json,
+         max_attempts
+       )
+       VALUES (?, ?, ?, 0, 'running', ?, 1)`,
       [
         lease.tenantId,
         input.stepId,

--- a/packages/gateway/src/modules/execution/engine/queueing.ts
+++ b/packages/gateway/src/modules/execution/engine/queueing.ts
@@ -156,15 +156,17 @@ export async function enqueuePlanInTx(
          step_index,
          status,
          action_json,
+         max_attempts,
          idempotency_key,
          postcondition_json
-       ) VALUES (?, ?, ?, ?, 'queued', ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, 'queued', ?, ?, ?, ?)`,
       [
         tenantId,
         stepId,
         runId,
         idx,
         JSON.stringify(action),
+        1,
         action.idempotency_key ?? null,
         action.postcondition ? JSON.stringify(action.postcondition) : null,
       ],

--- a/packages/gateway/tests/integration/workflow.test.ts
+++ b/packages/gateway/tests/integration/workflow.test.ts
@@ -42,11 +42,12 @@ describe("workflow routes", () => {
     );
     expect(run?.status).toBe("queued");
 
-    const stepAgg = await container.db.get<{ n: number }>(
-      "SELECT COUNT(*) AS n FROM execution_steps WHERE tenant_id = ? AND run_id = ?",
+    const stepAgg = await container.db.get<{ n: number; max_attempts: number }>(
+      "SELECT COUNT(*) AS n, MIN(max_attempts) AS max_attempts FROM execution_steps WHERE tenant_id = ? AND run_id = ?",
       [DEFAULT_TENANT_ID, payload.run_id],
     );
     expect(stepAgg?.n).toBe(1);
+    expect(stepAgg?.max_attempts).toBe(1);
 
     const outboxRows = await container.db.all<{ topic: string; payload_json: string }>(
       "SELECT topic, payload_json FROM outbox ORDER BY id ASC",


### PR DESCRIPTION
## Summary
- default newly enqueued execution steps to `max_attempts = 1` instead of relying on the previous schema default
- align synthetic node-dispatch execution steps with the same single-attempt default
- update SQLite and Postgres schema baselines and add workflow integration coverage

## Why
The desired behavior for now is that new execution steps start with a single attempt by default. Setting the value explicitly in runtime inserts makes the change effective on existing databases too.

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

## Risk
Low. The change is narrow and only affects newly created execution steps. Existing rows are unchanged.

## Rollback
Revert this PR to restore the prior default and insert behavior.

Closes #1559