### PR TITLE
fix: narrow @tyrum/operator-core/node exports

### DIFF
--- a/packages/operator-core/src/node.ts
+++ b/packages/operator-core/src/node.ts
@@ -1,3 +1,27 @@
 export * from "./index.js";
-export * from "@tyrum/node-sdk/node";
-export type * from "@tyrum/node-sdk/node";
+export { autoExecute, createManagedNodeClientLifecycle } from "@tyrum/node-sdk/node";
+export {
+  TyrumClient,
+  normalizeFingerprint256,
+  createDeviceIdentity,
+  createNodeFileDeviceIdentityStorage,
+  createPinnedNodeTransportState,
+  createPinnedNodeWebSocket,
+  destroyPinnedNodeDispatcher,
+  createTyrumHttpClient,
+  loadOrCreateDeviceIdentity,
+} from "@tyrum/transport-sdk/node";
+export type {
+  CapabilityProvider,
+  ManagedNodeClientLifecycle,
+  TaskResult,
+} from "@tyrum/node-sdk/node";
+export type { ExecutionAttempt, ExecutionRun, ExecutionStep, MemoryItem } from "@tyrum/client/node";
+export type {
+  DeviceIdentity,
+  NodePinnedTlsOptions,
+  NodePinnedTransportState,
+  NodePinnedWebSocketOptions,
+  NodeTyrumClientOptions,
+  NodeTyrumHttpClientOptions,
+} from "@tyrum/transport-sdk/node";

--- a/packages/operator-core/tests/entrypoints.test.ts
+++ b/packages/operator-core/tests/entrypoints.test.ts
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("@tyrum/operator-core entrypoints", () => {
+  it("keeps browser and node helper entrypoints on the intended public surface", async () => {
+    const browserEntry = (await import("../src/browser.js")) as Record<string, unknown>;
+    const nodeEntry = (await import("../src/node.js")) as Record<string, unknown>;
+
+    expect(typeof browserEntry["autoExecute"]).toBe("function");
+    expect(typeof browserEntry["createManagedNodeClientLifecycle"]).toBe("function");
+    expect(typeof browserEntry["TyrumClient"]).toBe("function");
+    expect(typeof browserEntry["createBrowserLocalStorageDeviceIdentityStorage"]).toBe("function");
+    expect(typeof browserEntry["TyrumHttpClientError"]).toBe("function");
+    expect(typeof browserEntry["formatDeviceIdentityError"]).toBe("function");
+
+    expect(typeof nodeEntry["autoExecute"]).toBe("function");
+    expect(typeof nodeEntry["createManagedNodeClientLifecycle"]).toBe("function");
+    expect(typeof nodeEntry["TyrumClient"]).toBe("function");
+    expect(typeof nodeEntry["createNodeFileDeviceIdentityStorage"]).toBe("function");
+
+    for (const unexpected of [
+      "VERSION",
+      "DeviceIdentityError",
+      "buildConnectProofTranscript",
+      "computeDeviceIdFromPublicKeyDer",
+      "parseStoredDeviceIdentity",
+      "signProofWithPrivateKey",
+    ]) {
+      expect(unexpected in browserEntry).toBe(false);
+      expect(unexpected in nodeEntry).toBe(false);
+    }
+
+    expect("TyrumHttpClientError" in nodeEntry).toBe(false);
+    expect("formatDeviceIdentityError" in nodeEntry).toBe(false);
+  });
+
+  it("avoids wildcard forwarding from the node sdk helper entrypoints", async () => {
+    const [browserSource, nodeSource] = await Promise.all([
+      readFile(resolve(__dirname, "../src/browser.ts"), "utf8"),
+      readFile(resolve(__dirname, "../src/node.ts"), "utf8"),
+    ]);
+
+    expect(browserSource).not.toContain('export * from "@tyrum/node-sdk/browser";');
+    expect(nodeSource).not.toContain('export * from "@tyrum/node-sdk/node";');
+    expect(nodeSource).not.toContain('export type * from "@tyrum/node-sdk/node";');
+  });
+});

--- a/scripts/lint/package-boundaries-baseline.json
+++ b/scripts/lint/package-boundaries-baseline.json
@@ -241,6 +241,11 @@
       "toPackage": "@tyrum/client"
     },
     {
+      "fromFile": "packages/operator-core/src/node.ts",
+      "reason": "#1537 temporary coexistence while operator surfaces still move off @tyrum/client during the operator-app migration",
+      "toPackage": "@tyrum/client"
+    },
+    {
       "fromFile": "packages/operator-core/src/index.ts",
       "reason": "#1537 temporary coexistence while operator surfaces still move off @tyrum/client during the operator-app migration",
       "toPackage": "@tyrum/client"


### PR DESCRIPTION
## Summary
- replace the wildcard `@tyrum/node-sdk/node` re-export in `@tyrum/operator-core/node` with the explicit compatibility surface that existed before the node-sdk split
- add an entrypoint regression test that pins the intended browser/node public API and forbids wildcard forwarding from the helper entrypoints
- extend the temporary package-boundary coexistence baseline for the remaining `@tyrum/client` type bridge in `packages/operator-core/src/node.ts`

## Context
- follow-up to #1562 after review feedback on the widened `@tyrum/operator-core/node` public API
- the `packages/operator-core/src/node.ts` report was real
- the `packages/operator-core/src/browser.ts` location was reviewed; it already uses explicit exports rather than wildcard forwarding

## Verification
- `pnpm exec vitest run packages/operator-core/tests/entrypoints.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- pre-push suite on this branch: `832` test files passed, `4576` tests passed, `2` skipped, coverage summary emitted by the repo hook
