### PR TITLE
ARCH-10: Migrate apps/desktop and @tyrum/desktop-node (#1542)

### DIFF
--- a/apps/desktop/src/main/node-runtime.ts
+++ b/apps/desktop/src/main/node-runtime.ts
@@ -8,11 +8,11 @@ import {
   type WsCapabilityReadyPayload,
 } from "@tyrum/contracts";
 import {
+  TyrumClient,
   createManagedNodeClientLifecycle,
   type CapabilityProvider,
   type ManagedNodeClientLifecycle,
 } from "@tyrum/node-sdk/node";
-import { TyrumClient } from "@tyrum/transport-sdk/node";
 import type { DesktopNodeConfig } from "./config/schema.js";
 import type { ResolvedPermissions } from "./config/permissions.js";
 import { saveConfig } from "./config/store.js";

--- a/apps/desktop/src/renderer/lib/desktop-operator-core.ts
+++ b/apps/desktop/src/renderer/lib/desktop-operator-core.ts
@@ -9,8 +9,8 @@ import {
   type OperatorCore,
   type OperatorCoreManager,
 } from "@tyrum/operator-app";
+import { createDeviceIdentity, createOperatorHttpClient } from "@tyrum/operator-app/browser";
 import { createAdminAccessController, type AdminAccessController } from "@tyrum/operator-ui";
-import { createDeviceIdentity, createTyrumHttpClient } from "@tyrum/transport-sdk/browser";
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import { toErrorMessage } from "./errors.js";
 
@@ -106,7 +106,7 @@ function createDesktopOperatorCoreManager({
     baselineAuth,
     elevatedModeStore,
     createCore(coreOptions) {
-      const http = createTyrumHttpClient({
+      const http = createOperatorHttpClient({
         baseUrl: coreOptions.httpBaseUrl,
         auth: httpAuthForAuth(coreOptions.auth),
         fetch: ipcFetch,
@@ -126,7 +126,7 @@ function createDesktopOperatorCoreManager({
               return null;
             }
 
-            return createTyrumHttpClient({
+            return createOperatorHttpClient({
               baseUrl: coreOptions.httpBaseUrl,
               auth: { type: "bearer", token },
               fetch: ipcFetch,
@@ -150,7 +150,7 @@ function createDesktopElevatedModeController({
   elevatedModeStore: ElevatedModeStore;
 }): AdminAccessController {
   const baselineAuth = createBearerTokenAuth(connection.token);
-  const http = createTyrumHttpClient({
+  const http = createOperatorHttpClient({
     baseUrl: connection.httpBaseUrl,
     auth: httpAuthForAuth(baselineAuth),
     fetch: ipcFetch,

--- a/apps/desktop/tests/desktop-operator-boundary.test.ts
+++ b/apps/desktop/tests/desktop-operator-boundary.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const DESKTOP_OPERATOR_CORE_PATH = resolve(
+  process.cwd(),
+  "apps/desktop/src/renderer/lib/desktop-operator-core.ts",
+);
+
+describe("desktop operator renderer boundary", () => {
+  it("uses @tyrum/operator-app browser helpers instead of transport-sdk directly", () => {
+    const source = readFileSync(DESKTOP_OPERATOR_CORE_PATH, "utf8");
+
+    expect(source).toContain('from "@tyrum/operator-app/browser"');
+    expect(source).not.toContain('from "@tyrum/transport-sdk/browser"');
+  });
+});

--- a/apps/desktop/tests/desktop-operator-core-hook.test.ts
+++ b/apps/desktop/tests/desktop-operator-core-hook.test.ts
@@ -13,8 +13,8 @@ const {
   createDeviceIdentityMock,
   createElevatedModeStoreMock,
   createOperatorCoreManagerMock,
+  createOperatorHttpClientMock,
   createAdminAccessControllerMock,
-  createTyrumHttpClientMock,
   gatewayGetOperatorConnectionMock,
   managerDisposeMock,
   retryingConnectionMock,
@@ -35,7 +35,7 @@ const {
   }));
   const storeDisposeMockInner = vi.fn();
   const createElevatedModeStoreMockInner = vi.fn(() => ({ dispose: storeDisposeMockInner }));
-  const createTyrumHttpClientMockInner = vi.fn(() => ({}));
+  const createOperatorHttpClientMockInner = vi.fn(() => ({}));
   const createOperatorCoreManagerMockInner = vi.fn(() => ({
     getCore: vi.fn(() => ({ connect: connectMockInner })),
     subscribe: managerSubscribeMockInner,
@@ -49,8 +49,8 @@ const {
     createAdminAccessControllerMock: createAdminAccessControllerMockInner,
     createDeviceIdentityMock: createDeviceIdentityMockInner,
     createElevatedModeStoreMock: createElevatedModeStoreMockInner,
+    createOperatorHttpClientMock: createOperatorHttpClientMockInner,
     createOperatorCoreManagerMock: createOperatorCoreManagerMockInner,
-    createTyrumHttpClientMock: createTyrumHttpClientMockInner,
     gatewayGetOperatorConnectionMock: gatewayGetOperatorConnectionMockInner,
     managerDisposeMock: managerDisposeMockInner,
     retryingConnectionMock: retryingConnectionMockInner,
@@ -66,9 +66,9 @@ vi.mock("@tyrum/operator-app", () => ({
   httpAuthForAuth: vi.fn((auth: unknown) => auth),
 }));
 
-vi.mock("@tyrum/transport-sdk/browser", () => ({
+vi.mock("@tyrum/operator-app/browser", () => ({
   createDeviceIdentity: createDeviceIdentityMock,
-  createTyrumHttpClient: createTyrumHttpClientMock,
+  createOperatorHttpClient: createOperatorHttpClientMock,
 }));
 
 vi.mock("@tyrum/operator-ui", () => ({

--- a/apps/desktop/tests/node-runtime-boundary.test.ts
+++ b/apps/desktop/tests/node-runtime-boundary.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const NODE_RUNTIME_PATH = resolve(process.cwd(), "apps/desktop/src/main/node-runtime.ts");
+
+describe("desktop node runtime boundary", () => {
+  it("uses @tyrum/node-sdk for generic node client wiring", () => {
+    const source = readFileSync(NODE_RUNTIME_PATH, "utf8");
+
+    expect(source).toContain('from "@tyrum/node-sdk/node"');
+    expect(source).not.toContain('from "@tyrum/transport-sdk/node"');
+  });
+});

--- a/apps/desktop/tests/node-runtime-tls-pinning.test.ts
+++ b/apps/desktop/tests/node-runtime-tls-pinning.test.ts
@@ -4,7 +4,7 @@ const { ctorSpy } = vi.hoisted(() => ({
   ctorSpy: vi.fn(),
 }));
 
-vi.mock("@tyrum/transport-sdk/node", () => {
+vi.mock("@tyrum/node-sdk/node", () => {
   class TyrumClient {
     on = vi.fn();
     connect = vi.fn();
@@ -17,17 +17,16 @@ vi.mock("@tyrum/transport-sdk/node", () => {
 
   return {
     TyrumClient,
+    createManagedNodeClientLifecycle: vi.fn(
+      (input: { client: unknown; providers?: unknown[] }) => ({
+        client: input.client,
+        connect: vi.fn(),
+        publishCapabilityState: vi.fn(),
+        dispose: vi.fn(),
+      }),
+    ),
   };
 });
-
-vi.mock("@tyrum/node-sdk/node", () => ({
-  createManagedNodeClientLifecycle: vi.fn((input: { client: unknown; providers?: unknown[] }) => ({
-    client: input.client,
-    connect: vi.fn(),
-    publishCapabilityState: vi.fn(),
-    dispose: vi.fn(),
-  })),
-}));
 
 describe("NodeRuntime remote TLS pinning", () => {
   it(

--- a/packages/desktop-node/package.json
+++ b/packages/desktop-node/package.json
@@ -26,7 +26,6 @@
     "@tyrum/cli-utils": "workspace:*",
     "@tyrum/contracts": "workspace:*",
     "@tyrum/node-sdk": "workspace:*",
-    "@tyrum/transport-sdk": "workspace:*",
     "commander": "^14.0.3",
     "dbus-next": "^0.10.2",
     "tesseract.js": "^7.0.0"

--- a/packages/desktop-node/tests/boundary.test.ts
+++ b/packages/desktop-node/tests/boundary.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PACKAGE_JSON_PATH = resolve(process.cwd(), "packages/desktop-node/package.json");
+
+describe("@tyrum/desktop-node package boundary", () => {
+  it("does not declare a direct transport-sdk dependency", () => {
+    const manifest = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(manifest.dependencies).not.toHaveProperty("@tyrum/transport-sdk");
+  });
+});

--- a/packages/operator-app/src/browser.ts
+++ b/packages/operator-app/src/browser.ts
@@ -6,6 +6,7 @@ import {
   type BrowserTyrumHttpClientOptions,
 } from "@tyrum/transport-sdk/browser";
 import type { OperatorAdminClient } from "./operator-core.types.js";
+import type { OperatorHttpClient } from "./deps.js";
 
 export * from "./index.js";
 export { autoExecute } from "@tyrum/node-sdk/browser";
@@ -51,10 +52,16 @@ export type * from "@tyrum/transport-sdk";
 export type OperatorAdminClientOptions = BrowserTyrumHttpClientOptions;
 export type OperatorCommandClientOptions = Pick<BrowserTyrumClientOptions, "url" | "token">;
 
+export function createOperatorHttpClient(
+  options: BrowserTyrumHttpClientOptions,
+): OperatorHttpClient {
+  return createTyrumHttpClient(options);
+}
+
 export function createOperatorAdminClient(
   options: OperatorAdminClientOptions,
 ): OperatorAdminClient {
-  return createTyrumHttpClient(options);
+  return createOperatorHttpClient(options);
 }
 
 export async function executeOperatorCommand(

--- a/packages/operator-app/tests/entrypoints.test.ts
+++ b/packages/operator-app/tests/entrypoints.test.ts
@@ -11,6 +11,7 @@ describe("@tyrum/operator-app entrypoints", () => {
     const nodeEntry = (await import("../src/node.js")) as Record<string, unknown>;
 
     expect(typeof browserEntry["autoExecute"]).toBe("function");
+    expect(typeof browserEntry["createOperatorHttpClient"]).toBe("function");
     expect(typeof browserEntry["createManagedNodeClientLifecycle"]).toBe("function");
     expect(typeof browserEntry["TyrumClient"]).toBe("function");
     expect(typeof browserEntry["createBrowserLocalStorageDeviceIdentityStorage"]).toBe("function");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,9 +427,6 @@ importers:
       '@tyrum/node-sdk':
         specifier: workspace:*
         version: link:../node-sdk
-      '@tyrum/transport-sdk':
-        specifier: workspace:*
-        version: link:../transport-sdk
       commander:
         specifier: ^14.0.3
         version: 14.0.3


### PR DESCRIPTION
Closes #1542

## Summary
- route the desktop renderer's operator HTTP wiring through `@tyrum/operator-app/browser` and move `NodeRuntime`'s client import onto `@tyrum/node-sdk/node`
- remove the leftover direct `@tyrum/transport-sdk` dependency from `@tyrum/desktop-node`
- add regression tests that lock the new desktop/operator/node package boundaries in place

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

## Notes
- during verification, `pnpm typecheck` initially failed because the local workspace links for workspace packages were missing; `pnpm install --ignore-scripts` restored the links and the full gate passed afterward.