### PR TITLE
ARCH-08: Migrate apps/web to @tyrum/operator-app (#1540)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,6 +16,8 @@ development and browser-focused iteration.
 
 The app:
 
+- imports shared state/actions through `@tyrum/operator-app` and presentation components through
+  `@tyrum/operator-ui` public entrypoints only
 - resolves gateway HTTP/WS URLs from local storage, Vite env vars, or the current origin
 - persists the operator bearer token in browser local storage and supports `?token=` bootstrap
 - creates the shared operator core manager and admin access controller
@@ -34,3 +36,5 @@ The app:
 - Gateway reconfiguration is stored in browser local storage (`tyrum-gateway-http`,
   `tyrum-gateway-ws`).
 - Browser auth is stored in browser local storage (`tyrum-operator-token`).
+- Browser-host concerns stay in `apps/web`: gateway URL persistence, token bootstrap, reload
+  handling, and browser node consent/runtime wiring.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,10 +13,8 @@
     "typecheck": "pnpm exec tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
-    "@tyrum/contracts": "workspace:*",
     "@tyrum/operator-app": "workspace:*",
     "@tyrum/operator-ui": "workspace:*",
-    "@tyrum/transport-sdk": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/apps/web/src/browser-node/browser-capability-provider.ts
+++ b/apps/web/src/browser-node/browser-capability-provider.ts
@@ -1,9 +1,10 @@
-import type {
-  CapabilityProvider,
-  TaskExecuteContext,
-  TaskResult,
-} from "@tyrum/operator-app/browser";
-import { BrowserActionArgs, type ActionPrimitive } from "@tyrum/contracts";
+import {
+  BrowserActionArgs,
+  type ActionPrimitive,
+  type CapabilityProvider,
+  type TaskExecuteContext,
+  type TaskResult,
+} from "./browser-runtime.js";
 
 export type BrowserConsentScope = "geolocation" | "camera" | "microphone";
 

--- a/apps/web/src/browser-node/browser-node-provider.tsx
+++ b/apps/web/src/browser-node/browser-node-provider.tsx
@@ -1,18 +1,17 @@
 import {
+  Alert,
   BrowserNodeProvider as BrowserNodeContextProvider,
-  type BrowserNodeApi,
-} from "../../../../packages/operator-ui/src/browser-node/browser-node-provider.js";
-import { Alert } from "../../../../packages/operator-ui/src/components/ui/alert.js";
-import { Button } from "../../../../packages/operator-ui/src/components/ui/button.js";
-import {
+  Button,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "../../../../packages/operator-ui/src/components/ui/dialog.js";
+  type BrowserNodeApi,
+} from "@tyrum/operator-ui";
 import {
+  BrowserActionArgs,
   createManagedNodeClientLifecycle,
   createBrowserLocalStorageDeviceIdentityStorage,
   formatDeviceIdentityError,
@@ -21,7 +20,6 @@ import {
   type ManagedNodeClientLifecycle,
   type TaskResult,
 } from "./browser-runtime.js";
-import { BrowserActionArgs } from "@tyrum/contracts";
 import {
   useCallback,
   useEffect,

--- a/apps/web/src/browser-node/browser-runtime.ts
+++ b/apps/web/src/browser-node/browser-runtime.ts
@@ -1,8 +1,15 @@
 export {
+  BrowserActionArgs,
   createManagedNodeClientLifecycle,
   createBrowserLocalStorageDeviceIdentityStorage,
   formatDeviceIdentityError,
   loadOrCreateDeviceIdentity,
   TyrumClient,
 } from "@tyrum/operator-app/browser";
-export type { ManagedNodeClientLifecycle, TaskResult } from "@tyrum/operator-app/browser";
+export type {
+  ActionPrimitive,
+  CapabilityProvider,
+  ManagedNodeClientLifecycle,
+  TaskExecuteContext,
+  TaskResult,
+} from "@tyrum/operator-app/browser";

--- a/apps/web/src/layout-harness-app.tsx
+++ b/apps/web/src/layout-harness-app.tsx
@@ -1,18 +1,17 @@
 import React from "react";
-import { AppShell } from "../../../packages/operator-ui/src/components/layout/app-shell.js";
-import { Sidebar } from "../../../packages/operator-ui/src/components/layout/sidebar.js";
-import { AgentsPage } from "../../../packages/operator-ui/src/components/pages/agents-page.js";
-import { ApprovalsPage } from "../../../packages/operator-ui/src/components/pages/approvals-page.js";
-import { AiSdkChatPage } from "../../../packages/operator-ui/src/components/pages/chat-page-ai-sdk.js";
-import { ConfigurePage } from "../../../packages/operator-ui/src/components/pages/configure-page.js";
-import { DashboardPage } from "../../../packages/operator-ui/src/components/pages/dashboard-page.js";
-import { ExtensionsPage } from "../../../packages/operator-ui/src/components/pages/extensions-page.js";
-import { FirstRunOnboardingPage } from "../../../packages/operator-ui/src/components/pages/first-run-onboarding.js";
-import { NodeConfigPage } from "../../../packages/operator-ui/src/components/pages/node-config/node-config-page.js";
-import { PairingPage } from "../../../packages/operator-ui/src/components/pages/pairing-page.js";
-import { WorkBoardPage } from "../../../packages/operator-ui/src/components/pages/workboard-page.js";
-import { AdminAccessProvider } from "../../../packages/operator-ui/src/elevated-mode.js";
-import { OperatorUiHostProvider } from "../../../packages/operator-ui/src/host/host-api.js";
+import { AdminAccessProvider, AppShell, OperatorUiHostProvider, Sidebar } from "@tyrum/operator-ui";
+import {
+  AgentsPage,
+  ApprovalsPage,
+  AiSdkChatPage,
+  ConfigurePage,
+  DashboardPage,
+  ExtensionsPage,
+  FirstRunOnboardingPage,
+  NodeConfigPage,
+  PairingPage,
+  WorkBoardPage,
+} from "@tyrum/operator-ui/pages";
 import { BrowserNodeProvider } from "./browser-node/browser-node-provider.js";
 import {
   createAgentsCore,

--- a/apps/web/src/layout-harness-chat-store-fixtures.ts
+++ b/apps/web/src/layout-harness-chat-store-fixtures.ts
@@ -1,4 +1,4 @@
-import { createStore } from "../../../packages/operator-app/src/store.js";
+import { createStore } from "@tyrum/operator-app";
 
 export function createChatStore() {
   const assistantMarkdown = [

--- a/apps/web/src/layout-harness-route-fixtures.tsx
+++ b/apps/web/src/layout-harness-route-fixtures.tsx
@@ -1,9 +1,5 @@
-import {
-  createElevatedModeStore,
-  type OperatorCore,
-} from "../../../packages/operator-app/src/index.js";
-import { createStore } from "../../../packages/operator-app/src/store.js";
-import type { DesktopApi } from "../../../packages/operator-ui/src/desktop-api.js";
+import { createElevatedModeStore, createStore, type OperatorCore } from "@tyrum/operator-app";
+import type { DesktopApi } from "@tyrum/operator-ui";
 import {
   createActivityStore,
   createAgentStatusStore,

--- a/apps/web/src/layout-harness-store-fixtures.ts
+++ b/apps/web/src/layout-harness-store-fixtures.ts
@@ -1,6 +1,5 @@
-import type { StatusResponse } from "@tyrum/transport-sdk";
-import { createStore } from "../../../packages/operator-app/src/store.js";
-import { AgentConfig, IdentityPack } from "../../../packages/contracts/src/index.js";
+import { AgentConfig, createStore, IdentityPack } from "@tyrum/operator-app";
+import type { StatusResponse } from "@tyrum/operator-app/browser";
 
 export function createConnectionStore() {
   return createStore({

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,7 +9,7 @@ import {
   createOperatorCoreManager,
   httpAuthForAuth,
 } from "@tyrum/operator-app";
-import { createDeviceIdentity, createTyrumHttpClient } from "@tyrum/transport-sdk/browser";
+import { createDeviceIdentity, createTyrumHttpClient } from "@tyrum/operator-app/browser";
 import {
   createAdminAccessController,
   OperatorUiApp,

--- a/apps/web/tests/browser-capability-provider.test.ts
+++ b/apps/web/tests/browser-capability-provider.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@tyrum/contracts", () => ({
+vi.mock("../src/browser-node/browser-runtime.js", () => ({
   BrowserActionArgs: {
     safeParse(input: unknown) {
       if (!input || typeof input !== "object" || Array.isArray(input)) {

--- a/apps/web/tests/browser-node-provider-consent.test.ts
+++ b/apps/web/tests/browser-node-provider-consent.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTestRoot } from "../../../packages/operator-ui/tests/test-utils.js";
 import {
   cleanupBrowserNodeProviderHarness,
-  clickByTestId,
   flushEffects,
   getBrowserNodeRuntimeState,
   renderProvider,
@@ -23,6 +22,16 @@ afterEach(() => {
 });
 
 describe("BrowserNodeProvider consent flow", () => {
+  function clickDialogButton(label: string): void {
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent === label,
+    );
+    expect(button).not.toBeUndefined();
+    act(() => {
+      button?.click();
+    });
+  }
+
   it("returns a disabled error before the browser node is enabled", async () => {
     stubLocalStorage();
     stubBrowserApis();
@@ -63,18 +72,26 @@ describe("BrowserNodeProvider consent flow", () => {
 
       expect(api.status).toBe("connected");
 
-      const firstRequest = api.executeLocal({
-        op: "get",
-        enable_high_accuracy: false,
-        timeout_ms: 30_000,
-        maximum_age_ms: 0,
+      let firstRequest!: ReturnType<typeof api.executeLocal>;
+      await act(async () => {
+        firstRequest = api.executeLocal({
+          op: "get",
+          enable_high_accuracy: false,
+          timeout_ms: 30_000,
+          maximum_age_ms: 0,
+        });
+        await Promise.resolve();
       });
       await flushEffects();
 
-      const secondRequest = api.executeLocal({
-        op: "capture_photo",
-        format: "jpeg",
-        quality: 0.8,
+      let secondRequest!: ReturnType<typeof api.executeLocal>;
+      await act(async () => {
+        secondRequest = api.executeLocal({
+          op: "capture_photo",
+          format: "jpeg",
+          quality: 0.8,
+        });
+        await Promise.resolve();
       });
       await flushEffects();
 
@@ -82,43 +99,47 @@ describe("BrowserNodeProvider consent flow", () => {
       expect(document.body.textContent).toContain("Attempt");
       expect(document.body.textContent).toContain("local");
 
-      clickByTestId("browser-node-dialog-close");
+      clickDialogButton("Deny");
       await flushEffects();
       await expect(firstRequest).resolves.toMatchObject({
         success: false,
         error: "location access denied",
       });
 
-      clickByTestId("browser-node-dialog-escape");
+      clickDialogButton("Deny");
       await flushEffects();
       await expect(secondRequest).resolves.toMatchObject({
         success: false,
         error: "camera access denied",
       });
 
-      const thirdRequest = api.executeLocal({
-        op: "record",
-        duration_ms: 25,
+      let thirdRequest!: ReturnType<typeof api.executeLocal>;
+      await act(async () => {
+        thirdRequest = api.executeLocal({
+          op: "record",
+          duration_ms: 25,
+        });
+        await Promise.resolve();
       });
       await flushEffects();
-      clickByTestId("browser-node-dialog-pointer-outside");
+      clickDialogButton("Deny");
       await flushEffects();
       await expect(thirdRequest).resolves.toMatchObject({
         success: false,
         error: "microphone access denied",
       });
 
-      const fourthRequest = api.executeLocal({
-        op: "record",
-        duration_ms: 25,
+      let fourthRequest!: ReturnType<typeof api.executeLocal>;
+      await act(async () => {
+        fourthRequest = api.executeLocal({
+          op: "record",
+          duration_ms: 25,
+        });
+        await Promise.resolve();
       });
       await flushEffects();
 
-      const allowButton = Array.from(document.querySelectorAll("button")).find(
-        (button) => button.textContent === "Allow",
-      );
-      expect(allowButton).not.toBeUndefined();
-      allowButton?.click();
+      clickDialogButton("Allow");
       await flushEffects();
 
       await expect(fourthRequest).resolves.toMatchObject({

--- a/apps/web/tests/browser-node-provider.test-support.ts
+++ b/apps/web/tests/browser-node-provider.test-support.ts
@@ -2,7 +2,7 @@
 
 import React, { act, useEffect } from "react";
 import { expect, vi } from "vitest";
-import type { BrowserNodeApi } from "../../../packages/operator-ui/src/browser-node/browser-node-provider.js";
+import type { BrowserNodeApi } from "@tyrum/operator-ui";
 import { createTestRoot } from "../../../packages/operator-ui/tests/test-utils.js";
 
 type BrowserNodeLifecycleInput = {
@@ -81,21 +81,6 @@ const capabilityStateMocks = vi.hoisted(() => ({
   toNodeCapabilityStates: vi.fn(),
 }));
 
-vi.mock("@tyrum/contracts", () => ({
-  BrowserActionArgs: {
-    safeParse(input: unknown) {
-      if (!input || typeof input !== "object" || Array.isArray(input)) {
-        return { success: false, error: { message: "invalid browser args" } };
-      }
-      const op = (input as { op?: unknown }).op;
-      if (op !== "get" && op !== "capture_photo" && op !== "record") {
-        return { success: false, error: { message: "invalid browser args" } };
-      }
-      return { success: true, data: input };
-    },
-  },
-}));
-
 vi.mock("../src/browser-node/browser-node-capability-state.js", async () => {
   const actual = await vi.importActual<
     typeof import("../src/browser-node/browser-node-capability-state.js")
@@ -107,107 +92,109 @@ vi.mock("../src/browser-node/browser-node-capability-state.js", async () => {
   };
 });
 
-vi.mock("../../../packages/operator-ui/src/components/ui/alert.js", () => ({
-  Alert: ({ description, title }: { description: string; title: string }) =>
-    React.createElement("div", { "data-testid": "browser-node-alert" }, `${title}:${description}`),
-}));
-
-vi.mock("../../../packages/operator-ui/src/components/ui/button.js", () => ({
-  Button: ({
-    children,
-    onClick,
-    type = "button",
-    variant,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-    type?: "button" | "submit" | "reset";
-    variant?: string;
-  }) =>
-    React.createElement(
-      "button",
-      {
-        "data-variant": variant,
-        onClick,
-        type,
-      },
+vi.mock("@tyrum/operator-ui", async () => {
+  const actual = await vi.importActual<typeof import("@tyrum/operator-ui")>("@tyrum/operator-ui");
+  return {
+    ...actual,
+    Alert: ({ description, title }: { description: string; title: string }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "browser-node-alert" },
+        `${title}:${description}`,
+      ),
+    Button: ({
       children,
-    ),
-}));
-
-vi.mock("../../../packages/operator-ui/src/components/ui/dialog.js", () => ({
-  Dialog: ({
-    children,
-    onOpenChange,
-    open,
-  }: {
-    children: React.ReactNode;
-    onOpenChange: (open: boolean) => void;
-    open: boolean;
-  }) =>
-    open
-      ? React.createElement(
-          "div",
-          { "data-testid": "browser-node-dialog-root" },
-          React.createElement(
-            "button",
-            {
-              "data-testid": "browser-node-dialog-close",
-              onClick: () => {
-                onOpenChange(false);
+      onClick,
+      type = "button",
+      variant,
+    }: {
+      children: React.ReactNode;
+      onClick?: () => void;
+      type?: "button" | "submit" | "reset";
+      variant?: string;
+    }) =>
+      React.createElement(
+        "button",
+        {
+          "data-variant": variant,
+          onClick,
+          type,
+        },
+        children,
+      ),
+    Dialog: ({
+      children,
+      onOpenChange,
+      open,
+    }: {
+      children: React.ReactNode;
+      onOpenChange: (open: boolean) => void;
+      open: boolean;
+    }) =>
+      open
+        ? React.createElement(
+            "div",
+            { "data-testid": "browser-node-dialog-root" },
+            React.createElement(
+              "button",
+              {
+                "data-testid": "browser-node-dialog-close",
+                onClick: () => {
+                  onOpenChange(false);
+                },
+                type: "button",
               },
-              type: "button",
-            },
-            "close",
-          ),
-          children,
-        )
-      : null,
-  DialogContent: ({
-    children,
-    onEscapeKeyDown,
-    onPointerDownOutside,
-    ...props
-  }: React.HTMLAttributes<HTMLDivElement> & {
-    onEscapeKeyDown: (event: { preventDefault: () => void }) => void;
-    onPointerDownOutside: (event: { preventDefault: () => void }) => void;
-  }) =>
-    React.createElement(
-      "div",
-      props,
-      React.createElement(
-        "button",
-        {
-          "data-testid": "browser-node-dialog-escape",
-          onClick: () => {
-            onEscapeKeyDown({ preventDefault: () => undefined });
-          },
-          type: "button",
-        },
-        "escape",
-      ),
-      React.createElement(
-        "button",
-        {
-          "data-testid": "browser-node-dialog-pointer-outside",
-          onClick: () => {
-            onPointerDownOutside({ preventDefault: () => undefined });
-          },
-          type: "button",
-        },
-        "outside",
-      ),
+              "close",
+            ),
+            children,
+          )
+        : null,
+    DialogContent: ({
       children,
-    ),
-  DialogDescription: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("div", { "data-testid": "browser-node-dialog-description" }, children),
-  DialogFooter: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("div", { "data-testid": "browser-node-dialog-footer" }, children),
-  DialogHeader: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("div", { "data-testid": "browser-node-dialog-header" }, children),
-  DialogTitle: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("div", { "data-testid": "browser-node-dialog-title" }, children),
-}));
+      onEscapeKeyDown,
+      onPointerDownOutside,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      onEscapeKeyDown: (event: { preventDefault: () => void }) => void;
+      onPointerDownOutside: (event: { preventDefault: () => void }) => void;
+    }) =>
+      React.createElement(
+        "div",
+        props,
+        React.createElement(
+          "button",
+          {
+            "data-testid": "browser-node-dialog-escape",
+            onClick: () => {
+              onEscapeKeyDown({ preventDefault: () => undefined });
+            },
+            type: "button",
+          },
+          "escape",
+        ),
+        React.createElement(
+          "button",
+          {
+            "data-testid": "browser-node-dialog-pointer-outside",
+            onClick: () => {
+              onPointerDownOutside({ preventDefault: () => undefined });
+            },
+            type: "button",
+          },
+          "outside",
+        ),
+        children,
+      ),
+    DialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "browser-node-dialog-description" }, children),
+    DialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "browser-node-dialog-footer" }, children),
+    DialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "browser-node-dialog-header" }, children),
+    DialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "browser-node-dialog-title" }, children),
+  };
+});
 
 vi.mock("../src/browser-node/browser-capability-provider.js", () => {
   const toConsentRequest = (op: unknown, ctx: unknown) => {
@@ -289,6 +276,18 @@ vi.mock("../src/browser-node/browser-runtime.js", () => {
   }
 
   return {
+    BrowserActionArgs: {
+      safeParse(input: unknown) {
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          return { success: false, error: { message: "invalid browser args" } };
+        }
+        const op = (input as { op?: unknown }).op;
+        if (op !== "get" && op !== "capture_photo" && op !== "record") {
+          return { success: false, error: { message: "invalid browser args" } };
+        }
+        return { success: true, data: input };
+      },
+    },
     TyrumClient: FakeTyrumClient,
     createBrowserLocalStorageDeviceIdentityStorage: vi.fn((key: string) => ({ key })),
     createManagedNodeClientLifecycle: vi.fn((input: BrowserNodeLifecycleInput) => {
@@ -391,7 +390,7 @@ export async function flushEffects(): Promise<void> {
 export async function renderProvider(wsUrl = "ws://example.test/ws") {
   const [{ BrowserNodeProvider }, { useBrowserNode }] = await Promise.all([
     import("../src/browser-node/browser-node-provider.js"),
-    import("../../../packages/operator-ui/src/browser-node/browser-node-provider.js"),
+    import("@tyrum/operator-ui"),
   ]);
   let api: BrowserNodeApi | null = null;
 
@@ -430,7 +429,9 @@ export async function renderProvider(wsUrl = "ws://example.test/ws") {
 export function clickByTestId(testId: string): void {
   const element = document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
   expect(element).not.toBeNull();
-  element?.click();
+  act(() => {
+    element?.click();
+  });
 }
 
 export function resetBrowserNodeProviderHarness(): void {

--- a/apps/web/tests/integration-boundary.test.ts
+++ b/apps/web/tests/integration-boundary.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const APP_ROOT = join(process.cwd(), "apps/web");
+const APP_SRC = join(APP_ROOT, "src");
+const BANNED_PACKAGES = ["@tyrum/client", "@tyrum/contracts", "@tyrum/transport-sdk"] as const;
+const BANNED_SOURCE_PATHS = [
+  "packages/operator-app/src/",
+  "packages/operator-ui/src/",
+  "packages/contracts/src/",
+] as const;
+
+function collectSourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(path));
+      continue;
+    }
+    if (entry.isFile() && /\.[cm]?[jt]sx?$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function collectBannedImports(filePath: string): string[] {
+  const source = readFileSync(filePath, "utf8");
+  const imports = new Set<string>();
+  const pattern = /\b(?:import|export)\b[\s\S]*?\bfrom\s+["']([^"']+)["']/g;
+  for (const match of source.matchAll(pattern)) {
+    const specifier = match[1];
+    if (!specifier) {
+      continue;
+    }
+
+    for (const bannedPackage of BANNED_PACKAGES) {
+      if (specifier === bannedPackage || specifier.startsWith(`${bannedPackage}/`)) {
+        imports.add(specifier);
+      }
+    }
+
+    for (const bannedSourcePath of BANNED_SOURCE_PATHS) {
+      if (specifier.includes(bannedSourcePath)) {
+        imports.add(specifier);
+      }
+    }
+  }
+  return [...imports];
+}
+
+describe("@tyrum/web integration boundary", () => {
+  it("uses public operator-app/operator-ui entrypoints from apps/web/src", () => {
+    const failures = collectSourceFiles(APP_SRC)
+      .map((filePath) => ({
+        filePath,
+        imports: collectBannedImports(filePath),
+      }))
+      .filter((entry) => entry.imports.length > 0)
+      .map((entry) => ({
+        filePath: relative(process.cwd(), entry.filePath),
+        imports: entry.imports,
+      }));
+
+    expect(failures).toEqual([]);
+  });
+
+  it("does not declare deprecated transport or contract package dependencies", () => {
+    const manifest = JSON.parse(readFileSync(join(APP_ROOT, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const declared = [
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+      ...Object.keys(manifest.optionalDependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
+    ];
+
+    expect(
+      declared.filter((pkg) => BANNED_PACKAGES.includes(pkg as (typeof BANNED_PACKAGES)[number])),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/tests/main.test-support.ts
+++ b/apps/web/tests/main.test-support.ts
@@ -1,6 +1,6 @@
 import { expect, vi } from "vitest";
 import type * as OperatorApp from "@tyrum/operator-app";
-import type * as TransportBrowser from "@tyrum/transport-sdk/browser";
+import type * as OperatorAppBrowser from "@tyrum/operator-app/browser";
 import type * as UrlAuthModule from "../src/url-auth.js";
 
 vi.mock("@tyrum/operator-app", () => ({
@@ -13,7 +13,7 @@ vi.mock("@tyrum/operator-app", () => ({
   httpAuthForAuth: vi.fn(),
 }));
 
-vi.mock("@tyrum/transport-sdk/browser", () => ({
+vi.mock("@tyrum/operator-app/browser", () => ({
   createDeviceIdentity: vi.fn(),
   createTyrumHttpClient: vi.fn(),
 }));
@@ -48,7 +48,7 @@ vi.mock("../src/reload-page.js", () => ({
   reloadPage: vi.fn(),
 }));
 
-type OperatorCoreBrowserModule = typeof OperatorApp & typeof TransportBrowser;
+type OperatorCoreBrowserModule = typeof OperatorApp & typeof OperatorAppBrowser;
 type UrlAuthModuleT = typeof UrlAuthModule;
 
 export type RootMock = { render: ReturnType<typeof vi.fn> };
@@ -164,8 +164,8 @@ export function expectDisposedOnUnload(params: {
 export async function arrangeBootstrap(initialUrl: string) {
   const replaceStateSpy = setupDom(initialUrl);
   const operatorApp = await import("@tyrum/operator-app");
-  const transportBrowser = await import("@tyrum/transport-sdk/browser");
-  const operatorCore = { ...operatorApp, ...transportBrowser } as OperatorCoreBrowserModule;
+  const operatorAppBrowser = await import("@tyrum/operator-app/browser");
+  const operatorCore = { ...operatorApp, ...operatorAppBrowser } as OperatorCoreBrowserModule;
   const reloadPage = await import("../src/reload-page.js");
   const urlAuth = await import("../src/url-auth.js");
   const reactDomClient = await import("react-dom/client");
@@ -179,8 +179,10 @@ export async function arrangeBootstrap(initialUrl: string) {
     publicKey: "test-public-key",
     privateKey: "test-private-key",
   };
-  vi.mocked(transportBrowser.createDeviceIdentity).mockResolvedValue(
-    deviceIdentity as unknown as Awaited<ReturnType<typeof transportBrowser.createDeviceIdentity>>,
+  vi.mocked(operatorAppBrowser.createDeviceIdentity).mockResolvedValue(
+    deviceIdentity as unknown as Awaited<
+      ReturnType<typeof operatorAppBrowser.createDeviceIdentity>
+    >,
   );
   vi.mocked(operatorApp.createOperatorCore).mockReturnValue({} as never);
   vi.mocked(operatorApp.createGatewayAuthSession).mockResolvedValue(
@@ -190,7 +192,7 @@ export async function arrangeBootstrap(initialUrl: string) {
     new Response(null, { status: 204 }),
   );
   vi.mocked(operatorApp.httpAuthForAuth).mockReturnValue({ type: "bearer", token: "baseline" });
-  vi.mocked(transportBrowser.createTyrumHttpClient).mockReturnValue({
+  vi.mocked(operatorAppBrowser.createTyrumHttpClient).mockReturnValue({
     deviceTokens: { issue: vi.fn(), revoke: vi.fn() },
   } as never);
   vi.mocked(operatorApp.createBearerTokenAuth).mockImplementation(((token: string) => ({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       "@tyrum/operator-app/node": resolve(repoRoot, "packages/operator-app/src/node.ts"),
       "@tyrum/operator-app": resolve(repoRoot, "packages/operator-app/src/index.ts"),
       "@tyrum/operator-ui/globals.css": resolve(repoRoot, "packages/operator-ui/src/globals.css"),
+      "@tyrum/operator-ui/pages": resolve(repoRoot, "packages/operator-ui/src/pages.ts"),
       "@tyrum/operator-ui": resolve(repoRoot, "packages/operator-ui/src/index.ts"),
       mitt: resolvePnpmPackageDir("mitt"),
     },

--- a/packages/operator-app/src/browser.ts
+++ b/packages/operator-app/src/browser.ts
@@ -12,6 +12,7 @@ export { autoExecute } from "@tyrum/node-sdk/browser";
 export { createManagedNodeClientLifecycle };
 export {
   createBrowserLocalStorageDeviceIdentityStorage,
+  createTyrumHttpClient,
   createDeviceIdentity,
   formatDeviceIdentityError,
   loadOrCreateDeviceIdentity,

--- a/packages/operator-app/src/index.ts
+++ b/packages/operator-app/src/index.ts
@@ -64,8 +64,10 @@ export type {
 } from "@tyrum/client/browser";
 
 export type { ExternalStore, Unsubscribe } from "./store.js";
+export { createStore } from "./store.js";
 
 export type { OperatorCoreError, OperatorCoreErrorKind } from "./operator-error.js";
+export { AgentConfig, IdentityPack } from "@tyrum/contracts";
 
 export {
   createElevatedModeStore,

--- a/packages/operator-ui/src/pages.ts
+++ b/packages/operator-ui/src/pages.ts
@@ -11,5 +11,7 @@ export { DesktopEnvironmentsPage } from "./components/pages/desktop-environments
 export type { ConfigurePageProps } from "./components/pages/configure-page.js";
 export { ConfigurePage } from "./components/pages/configure-page.js";
 export { AiSdkChatPage } from "./components/pages/chat-page-ai-sdk.js";
+export { ExtensionsPage } from "./components/pages/extensions-page.js";
+export { FirstRunOnboardingPage } from "./components/pages/first-run-onboarding.js";
 export { SettingsPage } from "./components/pages/settings-page.js";
 export { NodeConfigPage } from "./components/pages/node-config/node-config-page.js";

--- a/packages/operator-ui/tests/browser-node/browser-capability-provider.test.ts
+++ b/packages/operator-ui/tests/browser-node/browser-capability-provider.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@tyrum/contracts", () => ({
+vi.mock("../../../../apps/web/src/browser-node/browser-runtime.js", () => ({
   BrowserActionArgs: {
     safeParse(input: unknown) {
       if (!input || typeof input !== "object" || Array.isArray(input)) {

--- a/packages/operator-ui/tests/browser-node/browser-node-provider.test.ts
+++ b/packages/operator-ui/tests/browser-node/browser-node-provider.test.ts
@@ -14,21 +14,6 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("@tyrum/contracts", () => ({
-  BrowserActionArgs: {
-    safeParse(input: unknown) {
-      if (!input || typeof input !== "object" || Array.isArray(input)) {
-        return { success: false, error: { message: "invalid browser args" } };
-      }
-      const op = (input as { op?: unknown }).op;
-      if (op !== "get" && op !== "capture_photo" && op !== "record") {
-        return { success: false, error: { message: "invalid browser args" } };
-      }
-      return { success: true, data: input };
-    },
-  },
-}));
-
 type TyrumClientHandler = (evt?: unknown) => void;
 
 class FakeTyrumClient {
@@ -75,6 +60,18 @@ vi.mock("../../../../apps/web/src/browser-node/browser-runtime.js", () => {
   const autoExecute = vi.fn();
 
   return {
+    BrowserActionArgs: {
+      safeParse(input: unknown) {
+        if (!input || typeof input !== "object" || Array.isArray(input)) {
+          return { success: false, error: { message: "invalid browser args" } };
+        }
+        const op = (input as { op?: unknown }).op;
+        if (op !== "get" && op !== "capture_photo" && op !== "record") {
+          return { success: false, error: { message: "invalid browser args" } };
+        }
+        return { success: true, data: input };
+      },
+    },
     createManagedNodeClientLifecycle: createManagedNodeClientLifecycleMock({
       autoExecute,
       requireConnectedObject: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,18 +297,12 @@ importers:
 
   apps/web:
     dependencies:
-      '@tyrum/contracts':
-        specifier: workspace:*
-        version: link:../../packages/contracts
       '@tyrum/operator-app':
         specifier: workspace:*
         version: link:../../packages/operator-app
       '@tyrum/operator-ui':
         specifier: workspace:*
         version: link:../../packages/operator-ui
-      '@tyrum/transport-sdk':
-        specifier: workspace:*
-        version: link:../../packages/transport-sdk
       react:
         specifier: ^19.2.4
         version: 19.2.4


### PR DESCRIPTION
Closes #1540

## Summary
- migrate `apps/web` to consume `@tyrum/operator-app` and `@tyrum/operator-ui` public entrypoints instead of deprecated direct package and reach-through imports
- add an integration-boundary test to keep the web host off deprecated dependencies and `packages/*/src` imports
- expose the public operator-app and operator-ui exports needed by the web host and update the web host README to document the boundary

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm --filter @tyrum/web build`
- `pnpm exec vitest run apps/web/tests`
- `pnpm test`
- `git push -u origin 1540-arch-08-migrate-apps-web-to-tyrum-operator-app` (pre-push hook passed: `pnpm lint`, `pnpm typecheck`, desktop TS check, and `pnpm test --coverage.enabled --coverage.reporter=text-summary`)

## Notes
- No Playwright flow was needed for this migration; browser-host behavior is covered by the existing `apps/web` Vitest integration and regression tests.
