### PR TITLE
chore: bump fast-xml-parser override to 5.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "@modelcontextprotocol/sdk>express-rate-limit": "8.3.0",
       "dmg-license>ajv": "8.18.0",
       "dbus-next>xml2js": "0.5.0",
-      "fast-xml-parser": "5.5.6",
+      "fast-xml-parser": "5.5.7",
       "file-loader>schema-utils": "4.3.3",
       "dompurify": "3.3.2",
       "immutable": "4.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@modelcontextprotocol/sdk>express-rate-limit': 8.3.0
   dmg-license>ajv: 8.18.0
   dbus-next>xml2js: 0.5.0
-  fast-xml-parser: 5.5.6
+  fast-xml-parser: 5.5.7
   file-loader>schema-utils: 4.3.3
   dompurify: 3.3.2
   immutable: 4.3.8
@@ -7332,8 +7332,8 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.5.6:
-    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
+  fast-xml-parser@5.5.7:
+    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
     hasBin: true
 
   fastq@1.20.1:
@@ -12768,7 +12768,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.12':
     dependencies:
       '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.6
+      fast-xml-parser: 5.5.7
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -20574,7 +20574,7 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.1.3
 
-  fast-xml-parser@5.5.6:
+  fast-xml-parser@5.5.7:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.1.3


### PR DESCRIPTION
## Summary
- bump the root pnpm override for fast-xml-parser from 5.5.6 to 5.5.7
- refresh pnpm-lock.yaml so the AWS SDK xml-builder path resolves to the patched release
- clear the fast-xml-parser audit finding while keeping the dependency diff minimal

## Verification
- pnpm audit
- pnpm lint
- pre-push checks (typecheck, desktop TypeScript check, and vitest)

Closes #1574