### PR TITLE
ARCH-17: Reduce @tyrum/gateway to composition root (#1549)

### DIFF
--- a/apps/docs/tests/target-state-architecture.test.ts
+++ b/apps/docs/tests/target-state-architecture.test.ts
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 const targetStateDocPath = "docs/architecture/target-state.md";
 const targetStateDecisionPath = "docs/architecture/reference/arch-01-clean-break-target-state.md";
+const gatewayDocPath = "docs/architecture/gateway/index.md";
 const prTemplatePath = ".github/pull_request_template.md";
 const contributorEntryPoints = [
   "README.md",
@@ -75,6 +76,15 @@ describe("Target-state architecture docs", () => {
     expect(decisionRecord).toMatch(/reference decision record/i);
     expect(decisionRecord).toMatch(/clean-break/i);
     expect(decisionRecord).toMatch(/target package graph/i);
+  });
+
+  it("describes the gateway page as the public runtime entrypoint composition root", async () => {
+    const gatewayDoc = await readRepoFile(gatewayDocPath);
+
+    expect(gatewayDoc).toMatch(/public runtime entrypoint/i);
+    expect(gatewayDoc).toMatch(/composition root/i);
+    expect(gatewayDoc).toMatch(/transport adapters/i);
+    expect(gatewayDoc).toMatch(/bundled operator/i);
   });
 
   it("adds a PR template architecture checklist for the migration", async () => {

--- a/docs/architecture/gateway/index.md
+++ b/docs/architecture/gateway/index.md
@@ -1,6 +1,6 @@
 # Gateway
 
-The gateway is Tyrum's control plane. It is the trusted boundary that keeps interactive control, durable orchestration, policy enforcement, and extension routing in one place.
+`@tyrum/gateway` is Tyrum's public runtime entrypoint and composition root. It owns bootstrap, transport adapters, dependency wiring across the runtime packages, and bundled operator asset serving at the trusted control-plane boundary.
 
 ## Read this page
 
@@ -40,14 +40,16 @@ flowchart TB
 
 ### What the gateway owns
 
-- Long-lived client and node connectivity over typed request/response/event surfaces.
-- Contract validation, auth/authz enforcement, policy checks, and approval/review gates.
-- Runtime routing across agent turns, execution runs, node dispatch, and extension calls.
-- Durable coordination through StateStore records and backplane delivery.
+- CLI/bootstrap entrypoints, runtime startup, shutdown, and cross-package dependency wiring.
+- Long-lived client and node connectivity through HTTP and WebSocket transport adapters.
+- Contract validation, auth/authz enforcement, and translation between transport envelopes and runtime package calls.
+- Bundled operator asset serving for `/ui` and other public gateway-hosted runtime surfaces.
 - Control-plane administration for managed runtime features such as desktop environments and location automation.
 
 ### What the gateway does not own
 
+- Agent, execution, workboard, node-control, or policy business logic that belongs in the focused runtime packages.
+- DAL-heavy orchestration inside route handlers or WebSocket handlers beyond auth, parsing, and translation.
 - Client UX rendering and host-specific presentation logic.
 - Node-local device execution internals.
 - Secret storage plaintext handling outside trusted providers.
@@ -57,18 +59,19 @@ flowchart TB
 ### Interactive control flow
 
 1. A client request enters through typed transport and is validated at the gateway boundary.
-2. The gateway routes into the agent or execution path and applies policy/approval controls before risky side effects.
-3. State transitions and evidence are persisted, then streamed back as server-push events.
+2. The gateway authenticates, authorizes, and translates the request onto the appropriate runtime package boundary.
+3. Runtime packages execute the business flow; resulting state transitions and evidence are persisted, then streamed back through gateway transport adapters.
 
 ### Durable execution flow
 
 1. Work is captured and handed to execution coordination.
-2. The gateway coordinates tools, nodes, approvals, retries, and evidence with durable state behind each transition.
-3. Outcomes are recorded and made observable through events, audit surfaces, and operator state.
+2. The gateway composes runtime packages that coordinate tools, nodes, approvals, retries, and evidence with durable state behind each transition.
+3. Outcomes are recorded and made observable through gateway-served events, audit surfaces, and operator state.
 
 ## Invariants for this boundary
 
 - Trusted inputs are validated and deny-by-default.
+- `@tyrum/gateway` remains the public runtime entrypoint and composition root, not the home for new runtime business logic.
 - Policy and approvals remain runtime controls, not prompt-only conventions.
 - Node capability execution is always gateway-mediated.
 - Durable state is authoritative for recovery across reconnects and scale changes.

--- a/packages/gateway/src/modules/workboard/runtime-workboard-adapters.ts
+++ b/packages/gateway/src/modules/workboard/runtime-workboard-adapters.ts
@@ -1,22 +1,28 @@
-import type { DeploymentConfig as DeploymentConfigT } from "@tyrum/contracts";
-import type {
-  ManagedDesktopProvisioner,
-  WorkboardRepository,
-  WorkboardSessionKeyBuilder,
-  WorkboardSubagentRuntime,
+import { WorkItemLink, type DeploymentConfig as DeploymentConfigT } from "@tyrum/contracts";
+import {
+  WorkboardService as RuntimeWorkboardService,
+  type ManagedDesktopProvisioner,
+  type WorkboardCrudRepository,
+  type WorkboardRepository,
+  type WorkboardSessionKeyBuilder,
+  type WorkboardSubagentRuntime,
 } from "@tyrum/runtime-workboard";
 import type { SqlDb } from "../../statestore/types.js";
 import type { AgentRegistry } from "../agent/registry.js";
 import type { SessionLaneNodeAttachmentDal } from "../agent/session-lane-node-attachment-dal.js";
+import type { RedactionEngine } from "../redaction/engine.js";
 import { WorkboardDal } from "./dal.js";
 import { provisionManagedDesktop } from "./orchestration-support.js";
 import { resolveAgentKeyById, runSubagentTurn } from "./subagent-runtime-support.js";
 
-class GatewayWorkboardRepository implements WorkboardRepository {
+class GatewayWorkboardRepository implements WorkboardRepository, WorkboardCrudRepository {
   private readonly workboard: WorkboardDal;
 
-  constructor(private readonly db: SqlDb) {
-    this.workboard = new WorkboardDal(db);
+  constructor(
+    private readonly db: SqlDb,
+    redactionEngine?: RedactionEngine,
+  ) {
+    this.workboard = new WorkboardDal(db, redactionEngine);
   }
 
   async listBacklogItems(limit: number) {
@@ -90,6 +96,18 @@ class GatewayWorkboardRepository implements WorkboardRepository {
     return await this.workboard.getItem(params);
   }
 
+  async createItem(params: Parameters<WorkboardDal["createItem"]>[0]) {
+    return await this.workboard.createItem(params);
+  }
+
+  async listItems(params: Parameters<WorkboardDal["listItems"]>[0]) {
+    return await this.workboard.listItems(params);
+  }
+
+  async updateItem(params: Parameters<WorkboardDal["updateItem"]>[0]) {
+    return await this.workboard.updateItem(params);
+  }
+
   async transitionItem(params: Parameters<WorkboardDal["transitionItem"]>[0]) {
     return await this.workboard.transitionItem(params);
   }
@@ -116,6 +134,10 @@ class GatewayWorkboardRepository implements WorkboardRepository {
 
   async setStateKv(params: Parameters<WorkboardDal["setStateKv"]>[0]) {
     return await this.workboard.setStateKv(params);
+  }
+
+  async listStateKv(params: Parameters<WorkboardDal["listStateKv"]>[0]) {
+    return await this.workboard.listStateKv(params);
   }
 
   async requeueOrphanedTasks(params: {
@@ -168,10 +190,75 @@ class GatewayWorkboardRepository implements WorkboardRepository {
   async updateSubagent(params: Parameters<WorkboardDal["updateSubagent"]>[0]) {
     return await this.workboard.updateSubagent(params);
   }
+
+  async createLink(params: Parameters<WorkboardDal["createLink"]>[0]) {
+    return WorkItemLink.parse(await this.workboard.createLink(params));
+  }
+
+  async listLinks(params: Parameters<WorkboardDal["listLinks"]>[0]) {
+    const { links } = await this.workboard.listLinks(params);
+    return { links: links.map((link) => WorkItemLink.parse(link)) };
+  }
+
+  async listArtifacts(params: Parameters<WorkboardDal["listArtifacts"]>[0]) {
+    return await this.workboard.listArtifacts(params);
+  }
+
+  async getArtifact(params: Parameters<WorkboardDal["getArtifact"]>[0]) {
+    return await this.workboard.getArtifact(params);
+  }
+
+  async createArtifact(params: Parameters<WorkboardDal["createArtifact"]>[0]) {
+    return await this.workboard.createArtifact(params);
+  }
+
+  async listDecisions(params: Parameters<WorkboardDal["listDecisions"]>[0]) {
+    return await this.workboard.listDecisions(params);
+  }
+
+  async getDecision(params: Parameters<WorkboardDal["getDecision"]>[0]) {
+    return await this.workboard.getDecision(params);
+  }
+
+  async createDecision(params: Parameters<WorkboardDal["createDecision"]>[0]) {
+    return await this.workboard.createDecision(params);
+  }
+
+  async listSignals(params: Parameters<WorkboardDal["listSignals"]>[0]) {
+    return await this.workboard.listSignals(params);
+  }
+
+  async getSignal(params: Parameters<WorkboardDal["getSignal"]>[0]) {
+    return await this.workboard.getSignal(params);
+  }
+
+  async createSignal(params: Parameters<WorkboardDal["createSignal"]>[0]) {
+    return await this.workboard.createSignal(params);
+  }
+
+  async updateSignal(params: Parameters<WorkboardDal["updateSignal"]>[0]) {
+    return await this.workboard.updateSignal(params);
+  }
 }
 
 export function createGatewayWorkboardRepository(db: SqlDb): WorkboardRepository {
   return new GatewayWorkboardRepository(db);
+}
+
+export function createGatewayWorkboardCrudRepository(opts: {
+  db: SqlDb;
+  redactionEngine?: RedactionEngine;
+}): WorkboardCrudRepository {
+  return new GatewayWorkboardRepository(opts.db, opts.redactionEngine);
+}
+
+export function createGatewayWorkboardService(opts: {
+  db: SqlDb;
+  redactionEngine?: RedactionEngine;
+}): RuntimeWorkboardService {
+  return new RuntimeWorkboardService({
+    repository: createGatewayWorkboardCrudRepository(opts),
+  });
 }
 
 export function createGatewaySessionKeyBuilder(opts: { db: SqlDb }): WorkboardSessionKeyBuilder {

--- a/packages/gateway/src/modules/workboard/service.ts
+++ b/packages/gateway/src/modules/workboard/service.ts
@@ -1,0 +1,11 @@
+import type { WorkboardService } from "@tyrum/runtime-workboard";
+import type { SqlDb } from "../../statestore/types.js";
+import type { RedactionEngine } from "../redaction/engine.js";
+import { createGatewayWorkboardService as createService } from "./runtime-workboard-adapters.js";
+
+export function createGatewayWorkboardService(opts: {
+  db: SqlDb;
+  redactionEngine?: RedactionEngine;
+}): WorkboardService {
+  return createService(opts);
+}

--- a/packages/gateway/src/ws/protocol/workboard-handlers-shared.ts
+++ b/packages/gateway/src/ws/protocol/workboard-handlers-shared.ts
@@ -1,12 +1,13 @@
-import type { WsResponseEnvelope } from "@tyrum/contracts";
+import type { WorkItem, WsResponseEnvelope } from "@tyrum/contracts";
+import type { WorkboardService } from "@tyrum/runtime-workboard";
 import type { ConnectedClient } from "../connection-manager.js";
 import { WORKBOARD_WS_AUDIENCE } from "../workboard-audience.js";
-import { WorkboardDal } from "../../modules/workboard/dal.js";
 import {
   IdentityScopeDal,
   ScopeNotFoundError,
   normalizeScopeKeys,
 } from "../../modules/identity/scope.js";
+import { createGatewayWorkboardService } from "../../modules/workboard/service.js";
 import type { ProtocolDeps, ProtocolRequestEnvelope } from "./types.js";
 import { broadcastEvent, errorResponse, workboardErrorResponse } from "./helpers.js";
 
@@ -73,7 +74,7 @@ export async function resolveExistingWorkScope(params: {
 }
 
 export type WorkScope = Awaited<ReturnType<typeof ensureWorkScope>>["scope"];
-export type TransitionItem = NonNullable<Awaited<ReturnType<WorkboardDal["transitionItem"]>>>;
+export type TransitionItem = WorkItem;
 export type StateKvScopePayload = ScopeKeysPayload &
   ({ kind: "agent" } | { kind: "work_item"; work_item_id: string });
 export type RequestSchema<T> = {
@@ -88,7 +89,7 @@ export type ClientRequestContext = {
   tenantId: string;
 };
 export type ScopedHandlerContext = ClientRequestContext & {
-  dal: WorkboardDal;
+  workboardService: WorkboardService;
   db: NonNullable<ProtocolDeps["db"]>;
 };
 export type WorkboardHandler = (ctx: ClientRequestContext) => Promise<WsResponseEnvelope>;
@@ -112,7 +113,14 @@ export function requireClientWorkboardAccess(
       "unsupported_request",
       unsupportedMessage ?? `${ctx.msg.type} not supported`,
     );
-  return { ...ctx, db: ctx.deps.db, dal: new WorkboardDal(ctx.deps.db, ctx.deps.redactionEngine) };
+  return {
+    ...ctx,
+    db: ctx.deps.db,
+    workboardService: createGatewayWorkboardService({
+      db: ctx.deps.db,
+      redactionEngine: ctx.deps.redactionEngine,
+    }),
+  };
 }
 
 export function parseRequest<T>(
@@ -162,7 +170,7 @@ export function withClientDal(
 ): WorkboardHandler {
   return async (ctx) => {
     const access = requireClientWorkboardAccess(ctx, action, unsupportedMessage);
-    return "dal" in access ? handler(access) : access;
+    return "workboardService" in access ? handler(access) : access;
   };
 }
 

--- a/packages/gateway/src/ws/protocol/workboard-handlers.ts
+++ b/packages/gateway/src/ws/protocol/workboard-handlers.ts
@@ -97,15 +97,15 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
     action: "create work items",
     unsupportedMessage: "work.create not supported",
     schema: WsWorkCreateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope, keys } = await ensureWorkScope({ deps, tenantId, payload });
-      const item = await dal.createItem({
+      const item = await workboardService.createItem({
         scope,
         item: payload.item,
         createdFromSessionKey: `agent:${keys.agentKey}:main`,
       });
       broadcastWorkItemCreated({ item, deps });
-      await maybeEmitWorkItemOverlapWarningArtifact({ dal, scope, item, deps });
+      await maybeEmitWorkItemOverlapWarningArtifact({ workboardService, scope, item, deps });
       return okResult(msg, WsWorkCreateResult.parse({ item }));
     },
   }),
@@ -113,9 +113,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
     action: "list work items",
     unsupportedMessage: "work.list not supported",
     schema: WsWorkListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const { items, next_cursor } = await dal.listItems({
+      const { items, next_cursor } = await workboardService.listItems({
         scope,
         statuses: payload.statuses,
         kinds: payload.kinds,
@@ -129,9 +129,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
     action: "fetch work items",
     unsupportedMessage: "work.get not supported",
     schema: WsWorkGetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const item = await dal.getItem({ scope, work_item_id: payload.work_item_id });
+      const item = await workboardService.getItem({ scope, work_item_id: payload.work_item_id });
       return item ? okResult(msg, WsWorkGetResult.parse({ item })) : notFound(msg, "work item");
     },
   }),
@@ -139,9 +139,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
     action: "update work items",
     unsupportedMessage: "work.update not supported",
     schema: WsWorkUpdateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const item = await dal.updateItem({
+      const item = await workboardService.updateItem({
         scope,
         work_item_id: payload.work_item_id,
         patch: payload.patch,
@@ -149,7 +149,7 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
       if (!item) return notFound(msg, "work item");
       broadcastAgentEvent(scope.tenant_id, "work.item.updated", item.agent_id, { item }, deps);
       await maybeEmitWorkItemOverlapWarningArtifact({
-        dal,
+        workboardService,
         scope,
         item,
         deps,
@@ -163,9 +163,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
     unsupportedMessage: "work.transition not supported",
     schema: WsWorkTransitionRequest,
     run: async (ctx, payload) => {
-      const { msg, deps, tenantId, dal } = ctx;
+      const { msg, deps, tenantId, workboardService } = ctx;
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const item = await dal.transitionItem({
+      const item = await workboardService.transitionItem({
         scope,
         work_item_id: payload.work_item_id,
         status: payload.status,
@@ -186,17 +186,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.link.create": createHandler({
     action: "manage work item links",
     schema: WsWorkLinkCreateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      if (payload.work_item_id === payload.linked_work_item_id) {
-        return errorResponse(
-          msg.request_id,
-          msg.type,
-          "invalid_request",
-          "work item cannot link to itself",
-        );
-      }
-      const link = await dal.createLink({
+      const link = await workboardService.createLink({
         scope,
         work_item_id: payload.work_item_id,
         linked_work_item_id: payload.linked_work_item_id,
@@ -221,9 +213,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.link.list": createHandler({
     action: "manage work item links",
     schema: WsWorkLinkListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const { links } = await dal.listLinks({
+      const { links } = await workboardService.listLinks({
         scope,
         work_item_id: payload.work_item_id,
         limit: payload.limit,
@@ -234,9 +226,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.artifact.list": createHandler({
     action: "access work artifacts",
     schema: WsWorkArtifactListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const { artifacts, next_cursor } = await dal.listArtifacts({
+      const { artifacts, next_cursor } = await workboardService.listArtifacts({
         scope,
         work_item_id: payload.work_item_id,
         limit: payload.limit,
@@ -248,9 +240,12 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.artifact.get": createHandler({
     action: "access work artifacts",
     schema: WsWorkArtifactGetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const artifact = await dal.getArtifact({ scope, artifact_id: payload.artifact_id });
+      const artifact = await workboardService.getArtifact({
+        scope,
+        artifact_id: payload.artifact_id,
+      });
       return artifact
         ? okResult(msg, WsWorkArtifactGetResult.parse({ artifact }))
         : notFound(msg, "artifact");
@@ -259,9 +254,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.artifact.create": createHandler({
     action: "access work artifacts",
     schema: WsWorkArtifactCreateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const artifact = await dal.createArtifact({ scope, artifact: payload.artifact });
+      const artifact = await workboardService.createArtifact({ scope, artifact: payload.artifact });
       broadcastAgentEvent(
         scope.tenant_id,
         "work.artifact.created",
@@ -275,9 +270,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.decision.list": createHandler({
     action: "access decision records",
     schema: WsWorkDecisionListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const { decisions, next_cursor } = await dal.listDecisions({
+      const { decisions, next_cursor } = await workboardService.listDecisions({
         scope,
         work_item_id: payload.work_item_id,
         limit: payload.limit,
@@ -289,9 +284,12 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.decision.get": createHandler({
     action: "access decision records",
     schema: WsWorkDecisionGetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const decision = await dal.getDecision({ scope, decision_id: payload.decision_id });
+      const decision = await workboardService.getDecision({
+        scope,
+        decision_id: payload.decision_id,
+      });
       return decision
         ? okResult(msg, WsWorkDecisionGetResult.parse({ decision }))
         : notFound(msg, "decision");
@@ -300,9 +298,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.decision.create": createHandler({
     action: "access decision records",
     schema: WsWorkDecisionCreateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const decision = await dal.createDecision({ scope, decision: payload.decision });
+      const decision = await workboardService.createDecision({ scope, decision: payload.decision });
       broadcastAgentEvent(
         scope.tenant_id,
         "work.decision.created",
@@ -316,9 +314,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.signal.list": createHandler({
     action: "access work signals",
     schema: WsWorkSignalListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const { signals, next_cursor } = await dal.listSignals({
+      const { signals, next_cursor } = await workboardService.listSignals({
         scope,
         work_item_id: payload.work_item_id,
         statuses: payload.statuses,
@@ -331,9 +329,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.signal.get": createHandler({
     action: "access work signals",
     schema: WsWorkSignalGetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const signal = await dal.getSignal({ scope, signal_id: payload.signal_id });
+      const signal = await workboardService.getSignal({ scope, signal_id: payload.signal_id });
       return signal
         ? okResult(msg, WsWorkSignalGetResult.parse({ signal }))
         : notFound(msg, "signal");
@@ -342,9 +340,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.signal.create": createHandler({
     action: "access work signals",
     schema: WsWorkSignalCreateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const signal = await dal.createSignal({ scope, signal: payload.signal });
+      const signal = await workboardService.createSignal({ scope, signal: payload.signal });
       broadcastAgentEvent(
         scope.tenant_id,
         "work.signal.created",
@@ -358,9 +356,9 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.signal.update": createHandler({
     action: "access work signals",
     schema: WsWorkSignalUpdateRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const { scope } = await resolveExistingWorkScope({ deps, tenantId, payload });
-      const updated = await dal.updateSignal({
+      const updated = await workboardService.updateSignal({
         scope,
         signal_id: payload.signal_id,
         patch: payload.patch,
@@ -383,27 +381,27 @@ const workboardHandlers: Record<string, WorkboardHandler> = {
   "work.state_kv.get": createHandler({
     action: "access work state kv",
     schema: WsWorkStateKvGetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const scope = await resolveExistingStateKvScope(deps, tenantId, payload.scope);
-      const entry = (await dal.getStateKv({ scope, key: payload.key })) ?? null;
+      const entry = (await workboardService.getStateKv({ scope, key: payload.key })) ?? null;
       return okResult(msg, WsWorkStateKvGetResult.parse({ entry }));
     },
   }),
   "work.state_kv.list": createHandler({
     action: "access work state kv",
     schema: WsWorkStateKvListRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const scope = await resolveExistingStateKvScope(deps, tenantId, payload.scope);
-      const { entries } = await dal.listStateKv({ scope, prefix: payload.prefix });
+      const { entries } = await workboardService.listStateKv({ scope, prefix: payload.prefix });
       return okResult(msg, WsWorkStateKvListResult.parse({ entries }));
     },
   }),
   "work.state_kv.set": createHandler({
     action: "access work state kv",
     schema: WsWorkStateKvSetRequest,
-    run: async ({ msg, deps, tenantId, dal }, payload) => {
+    run: async ({ msg, deps, tenantId, workboardService }, payload) => {
       const scope = await ensureStateKvScope(deps, tenantId, payload.scope);
-      const entry = await dal.setStateKv({
+      const entry = await workboardService.setStateKv({
         scope,
         key: payload.key,
         value_json: payload.value_json,

--- a/packages/gateway/src/ws/protocol/workboard-overlap-warning.ts
+++ b/packages/gateway/src/ws/protocol/workboard-overlap-warning.ts
@@ -1,11 +1,11 @@
+import type { WorkboardService } from "@tyrum/runtime-workboard";
 import type { ProtocolDeps } from "./types.js";
 import { WORKBOARD_WS_AUDIENCE } from "../workboard-audience.js";
 import { broadcastEvent } from "./helpers.js";
-import type { WorkboardDal } from "../../modules/workboard/dal.js";
 
 export async function maybeEmitWorkItemOverlapWarningArtifact(params: {
-  dal: WorkboardDal;
-  scope: Parameters<WorkboardDal["listItems"]>[0]["scope"];
+  workboardService: WorkboardService;
+  scope: Parameters<WorkboardService["listItems"]>[0]["scope"];
   item: { work_item_id: string; title: string; fingerprint?: { resources: string[] } };
   deps: ProtocolDeps;
   fingerprintTouched?: boolean;
@@ -16,7 +16,7 @@ export async function maybeEmitWorkItemOverlapWarningArtifact(params: {
     const fingerprint = params.item.fingerprint;
     if (!fingerprint || fingerprint.resources.length === 0) return;
 
-    const { items: active } = await params.dal.listItems({
+    const { items: active } = await params.workboardService.listItems({
       scope: params.scope,
       statuses: ["doing", "blocked"],
       limit: 200,
@@ -45,13 +45,14 @@ export async function maybeEmitWorkItemOverlapWarningArtifact(params: {
       "Suggested next steps: queue this WorkItem, link it as a dependency, or explicitly merge.",
     ].join("\n");
 
-    const artifact = await params.dal.createArtifact({
+    const artifact = await params.workboardService.createArtifact({
       scope: params.scope,
       artifact: {
         work_item_id: params.item.work_item_id,
         kind: "risk",
         title: "WorkItem overlap detected",
         body_md,
+        refs: [],
       },
     });
 

--- a/packages/gateway/tests/unit/ws-workboard-service-extraction.test.ts
+++ b/packages/gateway/tests/unit/ws-workboard-service-extraction.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAdminWsClient } from "../helpers/ws-protocol-test-helpers.js";
+
+const { createGatewayWorkboardServiceMock } = vi.hoisted(() => ({
+  createGatewayWorkboardServiceMock: vi.fn(() => ({ mocked: true })),
+}));
+
+vi.mock("../../src/modules/workboard/service.js", () => {
+  return { createGatewayWorkboardService: createGatewayWorkboardServiceMock };
+});
+
+describe("workboard WS service extraction", () => {
+  afterEach(() => {
+    createGatewayWorkboardServiceMock.mockClear();
+    vi.resetModules();
+  });
+
+  it("builds workboard access from the extracted gateway service adapter", async () => {
+    const { requireClientWorkboardAccess } =
+      await import("../../src/ws/protocol/workboard-handlers-shared.js");
+
+    const db = { kind: "sqlite" } as never;
+    const access = requireClientWorkboardAccess(
+      {
+        client: createAdminWsClient({ role: "client" }),
+        msg: { request_id: "req-1", type: "work.list", payload: {} } as never,
+        deps: { db, redactionEngine: { redactText: vi.fn() } as never },
+        tenantId: "default",
+      },
+      "list work items",
+    );
+
+    expect(createGatewayWorkboardServiceMock).toHaveBeenCalledWith({
+      db,
+      redactionEngine: expect.anything(),
+    });
+    expect(access).toMatchObject({ workboardService: { mocked: true }, db });
+  });
+});

--- a/packages/runtime-workboard/src/index.ts
+++ b/packages/runtime-workboard/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  WorkboardCrudRepository,
   ManagedDesktopAttachment,
   ManagedDesktopProvisioner,
   SubagentRepository,
@@ -23,6 +24,7 @@ export {
 } from "./orchestration-support.js";
 export type { CreateSubagentParams } from "./subagent-service.js";
 export { SubagentService } from "./subagent-service.js";
+export { WorkboardService } from "./workboard-service.js";
 export { WorkboardOrchestrator } from "./orchestrator.js";
 export { WorkboardDispatcher } from "./dispatcher.js";
 export { WorkboardReconciler } from "./reconciler.js";

--- a/packages/runtime-workboard/src/types.ts
+++ b/packages/runtime-workboard/src/types.ts
@@ -1,13 +1,26 @@
 import type {
+  AgentStateKVEntry,
+  DecisionRecord,
+  WorkArtifact,
   Lane,
   SubagentDescriptor,
   SubagentStatus,
   WorkClarification,
+  WorkItemLink,
   WorkItem,
   WorkItemState,
   WorkItemTask,
   WorkItemTaskState,
   WorkScope,
+  WorkSignal,
+  WorkStateKVScopeIds,
+  WorkItemStateKVEntry,
+  WsWorkArtifactCreateInput,
+  WsWorkCreateItemInput,
+  WsWorkDecisionCreateInput,
+  WsWorkSignalCreateInput,
+  WsWorkSignalUpdatePatch,
+  WsWorkUpdatePatch,
 } from "@tyrum/contracts";
 
 export interface WorkboardLogger {
@@ -157,6 +170,98 @@ export interface WorkboardRepository {
     subagent_id: string;
     patch: UpdateSubagentPatch;
   }): Promise<SubagentDescriptor | undefined>;
+}
+
+export interface WorkboardCrudRepository {
+  createItem(params: {
+    scope: WorkScope;
+    item: WsWorkCreateItemInput;
+    createdFromSessionKey?: string;
+  }): Promise<WorkItem>;
+  listItems(params: {
+    scope: WorkScope;
+    statuses?: WorkItemState[];
+    kinds?: WorkItem["kind"][];
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ items: WorkItem[]; next_cursor?: string }>;
+  getItem(params: { scope: WorkScope; work_item_id: string }): Promise<WorkItem | undefined>;
+  updateItem(params: {
+    scope: WorkScope;
+    work_item_id: string;
+    patch: WsWorkUpdatePatch;
+  }): Promise<WorkItem | undefined>;
+  transitionItem(params: {
+    scope: WorkScope;
+    work_item_id: string;
+    status: WorkItemState;
+    reason?: string;
+  }): Promise<WorkItem | undefined>;
+  createLink(params: {
+    scope: WorkScope;
+    work_item_id: string;
+    linked_work_item_id: string;
+    kind: WorkItemLink["kind"];
+    meta_json?: unknown;
+  }): Promise<WorkItemLink>;
+  listLinks(params: {
+    scope: WorkScope;
+    work_item_id: string;
+    limit?: number;
+  }): Promise<{ links: WorkItemLink[] }>;
+  listArtifacts(params: {
+    scope: WorkScope;
+    work_item_id?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ artifacts: WorkArtifact[]; next_cursor?: string }>;
+  getArtifact(params: { scope: WorkScope; artifact_id: string }): Promise<WorkArtifact | undefined>;
+  createArtifact(params: {
+    scope: WorkScope;
+    artifact: WsWorkArtifactCreateInput;
+  }): Promise<WorkArtifact>;
+  listDecisions(params: {
+    scope: WorkScope;
+    work_item_id?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ decisions: DecisionRecord[]; next_cursor?: string }>;
+  getDecision(params: {
+    scope: WorkScope;
+    decision_id: string;
+  }): Promise<DecisionRecord | undefined>;
+  createDecision(params: {
+    scope: WorkScope;
+    decision: WsWorkDecisionCreateInput;
+  }): Promise<DecisionRecord>;
+  listSignals(params: {
+    scope: WorkScope;
+    work_item_id?: string;
+    statuses?: WorkSignal["status"][];
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ signals: WorkSignal[]; next_cursor?: string }>;
+  getSignal(params: { scope: WorkScope; signal_id: string }): Promise<WorkSignal | undefined>;
+  createSignal(params: { scope: WorkScope; signal: WsWorkSignalCreateInput }): Promise<WorkSignal>;
+  updateSignal(params: {
+    scope: WorkScope;
+    signal_id: string;
+    patch: WsWorkSignalUpdatePatch;
+  }): Promise<{ signal: WorkSignal; changed: boolean } | undefined>;
+  getStateKv(params: {
+    scope: WorkStateKVScopeIds;
+    key: string;
+  }): Promise<AgentStateKVEntry | WorkItemStateKVEntry | undefined>;
+  listStateKv(params: {
+    scope: WorkStateKVScopeIds;
+    prefix?: string;
+  }): Promise<{ entries: Array<AgentStateKVEntry | WorkItemStateKVEntry> }>;
+  setStateKv(params: {
+    scope: WorkStateKVScopeIds;
+    key: string;
+    value_json: unknown;
+    provenance_json?: unknown;
+  }): Promise<AgentStateKVEntry | WorkItemStateKVEntry>;
 }
 
 export type SubagentRepository = Pick<

--- a/packages/runtime-workboard/src/workboard-service.ts
+++ b/packages/runtime-workboard/src/workboard-service.ts
@@ -1,0 +1,88 @@
+import type { WorkboardCrudRepository } from "./types.js";
+
+export class WorkboardService {
+  constructor(private readonly opts: { repository: WorkboardCrudRepository }) {}
+
+  async createItem(params: Parameters<WorkboardCrudRepository["createItem"]>[0]) {
+    return await this.opts.repository.createItem(params);
+  }
+
+  async listItems(params: Parameters<WorkboardCrudRepository["listItems"]>[0]) {
+    return await this.opts.repository.listItems(params);
+  }
+
+  async getItem(params: Parameters<WorkboardCrudRepository["getItem"]>[0]) {
+    return await this.opts.repository.getItem(params);
+  }
+
+  async updateItem(params: Parameters<WorkboardCrudRepository["updateItem"]>[0]) {
+    return await this.opts.repository.updateItem(params);
+  }
+
+  async transitionItem(params: Parameters<WorkboardCrudRepository["transitionItem"]>[0]) {
+    return await this.opts.repository.transitionItem(params);
+  }
+
+  async createLink(params: Parameters<WorkboardCrudRepository["createLink"]>[0]) {
+    if (params.work_item_id === params.linked_work_item_id) {
+      throw new Error("work item cannot link to itself");
+    }
+    return await this.opts.repository.createLink(params);
+  }
+
+  async listLinks(params: Parameters<WorkboardCrudRepository["listLinks"]>[0]) {
+    return await this.opts.repository.listLinks(params);
+  }
+
+  async listArtifacts(params: Parameters<WorkboardCrudRepository["listArtifacts"]>[0]) {
+    return await this.opts.repository.listArtifacts(params);
+  }
+
+  async getArtifact(params: Parameters<WorkboardCrudRepository["getArtifact"]>[0]) {
+    return await this.opts.repository.getArtifact(params);
+  }
+
+  async createArtifact(params: Parameters<WorkboardCrudRepository["createArtifact"]>[0]) {
+    return await this.opts.repository.createArtifact(params);
+  }
+
+  async listDecisions(params: Parameters<WorkboardCrudRepository["listDecisions"]>[0]) {
+    return await this.opts.repository.listDecisions(params);
+  }
+
+  async getDecision(params: Parameters<WorkboardCrudRepository["getDecision"]>[0]) {
+    return await this.opts.repository.getDecision(params);
+  }
+
+  async createDecision(params: Parameters<WorkboardCrudRepository["createDecision"]>[0]) {
+    return await this.opts.repository.createDecision(params);
+  }
+
+  async listSignals(params: Parameters<WorkboardCrudRepository["listSignals"]>[0]) {
+    return await this.opts.repository.listSignals(params);
+  }
+
+  async getSignal(params: Parameters<WorkboardCrudRepository["getSignal"]>[0]) {
+    return await this.opts.repository.getSignal(params);
+  }
+
+  async createSignal(params: Parameters<WorkboardCrudRepository["createSignal"]>[0]) {
+    return await this.opts.repository.createSignal(params);
+  }
+
+  async updateSignal(params: Parameters<WorkboardCrudRepository["updateSignal"]>[0]) {
+    return await this.opts.repository.updateSignal(params);
+  }
+
+  async getStateKv(params: Parameters<WorkboardCrudRepository["getStateKv"]>[0]) {
+    return await this.opts.repository.getStateKv(params);
+  }
+
+  async listStateKv(params: Parameters<WorkboardCrudRepository["listStateKv"]>[0]) {
+    return await this.opts.repository.listStateKv(params);
+  }
+
+  async setStateKv(params: Parameters<WorkboardCrudRepository["setStateKv"]>[0]) {
+    return await this.opts.repository.setStateKv(params);
+  }
+}

--- a/packages/runtime-workboard/tests/workboard-service.test.ts
+++ b/packages/runtime-workboard/tests/workboard-service.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { WorkboardService, type WorkboardCrudRepository } from "../src/index.js";
+
+function createRepository(): WorkboardCrudRepository {
+  return {
+    createItem: vi.fn(),
+    listItems: vi.fn(),
+    getItem: vi.fn(),
+    updateItem: vi.fn(),
+    transitionItem: vi.fn(),
+    createLink: vi.fn(),
+    listLinks: vi.fn(),
+    listArtifacts: vi.fn(),
+    getArtifact: vi.fn(),
+    createArtifact: vi.fn(),
+    listDecisions: vi.fn(),
+    getDecision: vi.fn(),
+    createDecision: vi.fn(),
+    listSignals: vi.fn(),
+    getSignal: vi.fn(),
+    createSignal: vi.fn(),
+    updateSignal: vi.fn(),
+    getStateKv: vi.fn(),
+    listStateKv: vi.fn(),
+    setStateKv: vi.fn(),
+  };
+}
+
+describe("WorkboardService", () => {
+  it("rejects self-referential work item links before reaching the repository", async () => {
+    const repository = createRepository();
+    const service = new WorkboardService({ repository });
+
+    await expect(
+      service.createLink({
+        scope: {
+          tenant_id: "default",
+          agent_id: "agent-1",
+          workspace_id: "workspace-1",
+        },
+        work_item_id: "work-1",
+        linked_work_item_id: "work-1",
+        kind: "blocks",
+      }),
+    ).rejects.toThrow("work item cannot link to itself");
+
+    expect(repository.createLink).not.toHaveBeenCalled();
+  });
+
+  it("delegates work item creation through the injected repository", async () => {
+    const repository = createRepository();
+    repository.createItem = vi.fn().mockResolvedValue({
+      tenant_id: "default",
+      agent_id: "agent-1",
+      workspace_id: "workspace-1",
+      work_item_id: "work-1",
+      parent_work_item_id: null,
+      kind: "task",
+      title: "Ship runtime split",
+      description: null,
+      status: "backlog",
+      priority: 1,
+      created_from_session_key: "agent:default:main",
+      fingerprint_json: null,
+      acceptance_json: null,
+      metadata_json: null,
+      created_at: "2026-03-19T00:00:00.000Z",
+      updated_at: "2026-03-19T00:00:00.000Z",
+    });
+
+    const service = new WorkboardService({ repository });
+    const item = await service.createItem({
+      scope: {
+        tenant_id: "default",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+      },
+      item: {
+        kind: "task",
+        title: "Ship runtime split",
+      },
+      createdFromSessionKey: "agent:default:main",
+    });
+
+    expect(repository.createItem).toHaveBeenCalledWith({
+      scope: {
+        tenant_id: "default",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+      },
+      item: {
+        kind: "task",
+        title: "Ship runtime split",
+      },
+      createdFromSessionKey: "agent:default:main",
+    });
+    expect(item.work_item_id).toBe("work-1");
+  });
+});


### PR DESCRIPTION
Closes #1549

## Summary
- add a `WorkboardService` boundary to `@tyrum/runtime-workboard` for work item CRUD, drilldown, and state-kv operations
- rewire gateway `work.*` WebSocket handlers to compose the extracted runtime service instead of reaching straight into `WorkboardDal`
- document `@tyrum/gateway` as the public runtime entrypoint and composition root, with docs coverage for that contract

## Target package/layer
- `@tyrum/runtime-workboard` for workboard-domain service logic
- `@tyrum/gateway` for transport adapter composition and architecture docs only

## Legacy package touch
- touched `@tyrum/gateway` only to thin the transport boundary and update the gateway architecture page for the clean-break target state

## Test evidence
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`
- `pnpm exec vitest run packages/gateway/tests/unit/ws-workboard-handler-extraction.test.ts packages/gateway/tests/unit/ws-workboard-overlap-warning-dedup.test.ts packages/gateway/tests/unit/ws-workboard-service-extraction.test.ts packages/gateway/tests/unit/ws-workboard.test.ts packages/runtime-workboard/tests/workboard-service.test.ts`
- `pnpm exec vitest run apps/docs/tests/target-state-architecture.test.ts`

## Playwright evidence
- not used
