### PR TITLE
chore: replace legacy namespace references

### DIFF
--- a/.github/workflows/desktop-sandbox-image.yml
+++ b/.github/workflows/desktop-sandbox-image.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE_NAME: ghcr.io/rhernaus/tyrum-desktop-sandbox
+  IMAGE_NAME: ghcr.io/tyrumai/tyrum-desktop-sandbox
 
 jobs:
   build:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -9,7 +9,7 @@ directories:
 npmRebuild: false
 publish:
   - provider: github
-    owner: rhernaus
+    owner: tyrumai
     repo: tyrum
 files:
   - dist/**/*

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -14,7 +14,7 @@ const navbarItems = [
   { to: "/getting-started", label: "Quick Start", position: "left" },
   { to: "/architecture", label: "Architecture", position: "left" },
   {
-    href: "https://github.com/rhernaus/tyrum",
+    href: "https://github.com/tyrumai/tyrum",
     label: "GitHub",
     position: "right",
   },

--- a/docs/advanced/desktop-sandbox.md
+++ b/docs/advanced/desktop-sandbox.md
@@ -84,7 +84,7 @@ Useful environment variables:
 
 ## Notes
 
-- The published `ghcr.io/rhernaus/tyrum-desktop-sandbox:main` image is currently `linux/amd64` only. `@nut-tree-fork/libnut-linux` still bundles an x86_64 `libnut.node`, so `linux/arm64` desktop-sandbox images fail native startup.
+- The published `ghcr.io/tyrumai/tyrum-desktop-sandbox:main` image is currently `linux/amd64` only. `@nut-tree-fork/libnut-linux` still bundles an x86_64 `libnut.node`, so `linux/arm64` desktop-sandbox images fail native startup.
 - On `darwin/arm64`, gateway-managed desktop environments using the published Tyrum sandbox image are launched with Docker `--platform linux/amd64`. This relies on Docker Desktop's amd64 emulation support.
 - The sandbox image includes DBus and AT-SPI packages (`dbus`, `dbus-x11`, `at-spi2-core`) to maximize a11y availability for Linux backends.
 - Override the URL shown in the pairing UI via `TYRUM_DESKTOP_SANDBOX_TAKEOVER_URL` (useful when the host is remote).

--- a/docs/architecture/scaling-ha/data-model-map.md
+++ b/docs/architecture/scaling-ha/data-model-map.md
@@ -16,8 +16,8 @@ This page is a lightweight, human-readable map of the Gateway StateStore schema:
 
 The v2 rebuild migrations are the current source of truth:
 
-- SQLite: [`packages/gateway/migrations/sqlite/100_rebuild_v2.sql`](https://github.com/rhernaus/tyrum/blob/main/packages/gateway/migrations/sqlite/100_rebuild_v2.sql#L1)
-- Postgres: [`packages/gateway/migrations/postgres/100_rebuild_v2.sql`](https://github.com/rhernaus/tyrum/blob/main/packages/gateway/migrations/postgres/100_rebuild_v2.sql#L1)
+- SQLite: [`packages/gateway/migrations/sqlite/100_rebuild_v2.sql`](https://github.com/tyrumai/tyrum/blob/main/packages/gateway/migrations/sqlite/100_rebuild_v2.sql#L1)
+- Postgres: [`packages/gateway/migrations/postgres/100_rebuild_v2.sql`](https://github.com/tyrumai/tyrum/blob/main/packages/gateway/migrations/postgres/100_rebuild_v2.sql#L1)
 
 For the audited foreign-key vs soft-reference decisions on approval/policy linkage columns, see [Gateway FK audit](./data-model-fk-audit.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,7 @@ curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- 2026.2.18
 
 Advanced overrides:
 
-- `TYRUM_REPO` (default: `rhernaus/tyrum`)
+- `TYRUM_REPO` (default: `tyrumai/tyrum`)
 - `TYRUM_VERSION` (for non-`latest` installs)
 - `TYRUM_CHANNEL` (`stable` | `beta` | `dev`)
 

--- a/packages/contracts/src/desktop-environment.ts
+++ b/packages/contracts/src/desktop-environment.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { DateTimeSchema } from "./common.js";
 import { NodeId } from "./keys.js";
 
-export const DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF = "ghcr.io/rhernaus/tyrum-desktop-sandbox:main";
+export const DEFAULT_DESKTOP_ENVIRONMENT_IMAGE_REF = "ghcr.io/tyrumai/tyrum-desktop-sandbox:main";
 
 export const DesktopEnvironmentId = z.string().trim().min(1);
 export const DesktopEnvironmentHostId = z.string().trim().min(1);

--- a/packages/gateway/src/modules/desktop-environments/runtime-manager.ts
+++ b/packages/gateway/src/modules/desktop-environments/runtime-manager.ts
@@ -21,7 +21,7 @@ const DEFAULT_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
 const CONTAINER_NODE_HOME = "/var/lib/tyrum-node";
 const CONTAINER_IDENTITY_PATH = `${CONTAINER_NODE_HOME}/desktop-node/device-identity.json`;
 const CONTAINER_GATEWAY_TOKEN_PATH = "/run/tyrum/gateway-token";
-const OFFICIAL_DESKTOP_SANDBOX_IMAGE_REF_PREFIX = "ghcr.io/rhernaus/tyrum-desktop-sandbox:";
+const OFFICIAL_DESKTOP_SANDBOX_IMAGE_REF_PREFIX = "ghcr.io/tyrumai/tyrum-desktop-sandbox:";
 
 type DesktopEnvironmentRuntimeManagerOptions = {
   hostId: string;

--- a/packages/gateway/tests/integration/desktop-environments-routes.test.ts
+++ b/packages/gateway/tests/integration/desktop-environments-routes.test.ts
@@ -36,14 +36,14 @@ describe("desktop environment routes", () => {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+        default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
         reason: "promote stable image",
       }),
     });
 
     expect(updateRes.status).toBe(200);
     await expect(updateRes.json()).resolves.toMatchObject({
-      default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+      default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
       revision: 2,
       reason: "promote stable image",
     });
@@ -53,7 +53,7 @@ describe("desktop environment routes", () => {
     const { app, container } = await createTestApp({
       deploymentConfig: {
         desktopEnvironments: {
-          defaultImageRef: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+          defaultImageRef: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
         },
       },
     });
@@ -82,7 +82,7 @@ describe("desktop environment routes", () => {
     expect(createRes.status).toBe(201);
     await expect(createRes.json()).resolves.toMatchObject({
       environment: {
-        image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+        image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
       },
     });
   });

--- a/packages/gateway/tests/unit/desktop-environment-docker-cli.test.ts
+++ b/packages/gateway/tests/unit/desktop-environment-docker-cli.test.ts
@@ -49,7 +49,7 @@ describe("desktop environment docker cli", () => {
     resolveExec('[{"Os":"linux","Architecture":"amd64"}]\n');
 
     await expect(
-      ensureImageAvailable("ghcr.io/rhernaus/tyrum-desktop-sandbox:main", {
+      ensureImageAvailable("ghcr.io/tyrumai/tyrum-desktop-sandbox:main", {
         platform: "linux/amd64",
       }),
     ).resolves.toBeUndefined();
@@ -57,7 +57,7 @@ describe("desktop environment docker cli", () => {
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1);
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       "docker",
-      ["image", "inspect", "ghcr.io/rhernaus/tyrum-desktop-sandbox:main"],
+      ["image", "inspect", "ghcr.io/tyrumai/tyrum-desktop-sandbox:main"],
       expect.objectContaining({ encoding: "utf8", timeout: 15_000 }),
     );
   });
@@ -67,7 +67,7 @@ describe("desktop environment docker cli", () => {
     resolveExec("pulled\n");
 
     await expect(
-      ensureImageAvailable("ghcr.io/rhernaus/tyrum-desktop-sandbox:main", {
+      ensureImageAvailable("ghcr.io/tyrumai/tyrum-desktop-sandbox:main", {
         platform: "linux/amd64",
       }),
     ).resolves.toBeUndefined();
@@ -76,13 +76,13 @@ describe("desktop environment docker cli", () => {
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       1,
       "docker",
-      ["image", "inspect", "ghcr.io/rhernaus/tyrum-desktop-sandbox:main"],
+      ["image", "inspect", "ghcr.io/tyrumai/tyrum-desktop-sandbox:main"],
       expect.objectContaining({ encoding: "utf8", timeout: 15_000 }),
     );
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       "docker",
-      ["pull", "--platform", "linux/amd64", "ghcr.io/rhernaus/tyrum-desktop-sandbox:main"],
+      ["pull", "--platform", "linux/amd64", "ghcr.io/tyrumai/tyrum-desktop-sandbox:main"],
       expect.objectContaining({ encoding: "utf8", timeout: 600_000, maxBuffer: 33_554_432 }),
     );
   });
@@ -92,7 +92,7 @@ describe("desktop environment docker cli", () => {
     resolveExec("pulled\n");
 
     await expect(
-      ensureImageAvailable("ghcr.io/rhernaus/tyrum-desktop-sandbox:main", {
+      ensureImageAvailable("ghcr.io/tyrumai/tyrum-desktop-sandbox:main", {
         platform: "linux/amd64",
       }),
     ).resolves.toBeUndefined();
@@ -101,7 +101,7 @@ describe("desktop environment docker cli", () => {
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       "docker",
-      ["pull", "--platform", "linux/amd64", "ghcr.io/rhernaus/tyrum-desktop-sandbox:main"],
+      ["pull", "--platform", "linux/amd64", "ghcr.io/tyrumai/tyrum-desktop-sandbox:main"],
       expect.objectContaining({ encoding: "utf8", timeout: 600_000, maxBuffer: 33_554_432 }),
     );
   });

--- a/packages/gateway/tests/unit/desktop-environment-runtime-manager.platform.test.ts
+++ b/packages/gateway/tests/unit/desktop-environment-runtime-manager.platform.test.ts
@@ -42,7 +42,7 @@ vi.mock("../../src/modules/desktop-environments/docker-cli.js", () => ({
 
 import { DesktopEnvironmentRuntimeManager } from "../../src/modules/desktop-environments/runtime-manager.js";
 
-const OFFICIAL_SANDBOX_IMAGE = "ghcr.io/rhernaus/tyrum-desktop-sandbox:main";
+const OFFICIAL_SANDBOX_IMAGE = "ghcr.io/tyrumai/tyrum-desktop-sandbox:main";
 const TEST_IMAGE = "ghcr.io/tyrum/desktop:latest";
 const TEST_TIMESTAMP = "2026-03-12T00:00:00.000Z";
 

--- a/packages/gateway/tests/unit/rebased-pr-overwrites-data.test.ts
+++ b/packages/gateway/tests/unit/rebased-pr-overwrites-data.test.ts
@@ -25,7 +25,7 @@ describe("rebased PR overwrite analyzer git ref resolution", () => {
 
     const { getRefOid } = await loadDataModule();
 
-    expect(getRefOid("rhernaus", "tyrum", "main")).toBe("abc123");
+    expect(getRefOid("tyrumai", "tyrum", "main")).toBe("abc123");
     expect(spawnSyncMock.mock.calls).toEqual([
       ["git", ["rev-parse", "main"], expect.any(Object)],
       ["git", ["rev-parse", "origin/main"], expect.any(Object)],
@@ -40,7 +40,7 @@ describe("rebased PR overwrite analyzer git ref resolution", () => {
 
     const { getMergeBase } = await loadDataModule();
 
-    expect(getMergeBase("rhernaus", "tyrum", "main", "head789")).toBe("def456");
+    expect(getMergeBase("tyrumai", "tyrum", "main", "head789")).toBe("def456");
     expect(spawnSyncMock.mock.calls).toEqual([
       ["git", ["merge-base", "main", "head789"], expect.any(Object)],
       ["git", ["merge-base", "origin/main", "head789"], expect.any(Object)],

--- a/packages/operator-app/tests/connection-recovery.test.ts
+++ b/packages/operator-app/tests/connection-recovery.test.ts
@@ -47,7 +47,7 @@ function createFakeHttpClient() {
         async () =>
           ({
             status: "ok",
-            default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+            default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
             revision: 1,
             created_at: "2026-03-10T12:00:00.000Z",
             created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-app/tests/desktop-environments-store.test.ts
+++ b/packages/operator-app/tests/desktop-environments-store.test.ts
@@ -20,7 +20,7 @@ describe("desktop environment stores", () => {
           async () =>
             ({
               status: "ok",
-              default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+              default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
               revision: 1,
               created_at: "2026-03-10T12:00:00.000Z",
               created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-app/tests/operator-core.test-support.ts
+++ b/packages/operator-app/tests/operator-core.test-support.ts
@@ -242,7 +242,7 @@ export function createFakeHttpClient(): FakeHttpClient {
         async () =>
           ({
             status: "ok",
-            default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+            default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
             revision: 1,
             created_at: "2026-03-10T12:00:00.000Z",
             created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-ui/tests/operator-ui-theme-nesting.test.ts
+++ b/packages/operator-ui/tests/operator-ui-theme-nesting.test.ts
@@ -70,7 +70,7 @@ const stubHttp: OperatorHttpClient = {
     getDefaults: async () =>
       ({
         status: "ok",
-        default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+        default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
         revision: 1,
         created_at: "2026-03-10T12:00:00.000Z",
         created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-ui/tests/operator-ui.a11y.test.ts
+++ b/packages/operator-ui/tests/operator-ui.a11y.test.ts
@@ -241,7 +241,7 @@ function createFakeHttpClient(): { http: OperatorHttpClient } {
         async () =>
           ({
             status: "ok",
-            default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+            default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
             revision: 1,
             created_at: "2026-03-10T12:00:00.000Z",
             created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-ui/tests/operator-ui.test-fixtures.ts
+++ b/packages/operator-ui/tests/operator-ui.test-fixtures.ts
@@ -213,7 +213,7 @@ export function createFakeHttpClient(): {
     async () =>
       ({
         status: "ok",
-        default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+        default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
         revision: 1,
         created_at: "2026-03-10T12:00:00.000Z",
         created_by: { kind: "tenant.token", token_id: "token-1" },

--- a/packages/operator-ui/tests/pages/desktop-environments-page.defaults.test.ts
+++ b/packages/operator-ui/tests/pages/desktop-environments-page.defaults.test.ts
@@ -177,7 +177,7 @@ describe("DesktopEnvironmentsPage defaults and availability", () => {
     expect(createButton).not.toBeNull();
 
     await act(async () => {
-      setNativeValue(defaultImageInput!, "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234");
+      setNativeValue(defaultImageInput!, "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234");
       click(saveButton!);
       await Promise.resolve();
       await Promise.resolve();
@@ -189,13 +189,13 @@ describe("DesktopEnvironmentsPage defaults and availability", () => {
     });
 
     expect(http.desktopEnvironments.updateDefaults).toHaveBeenCalledWith({
-      default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234",
+      default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234",
       reason: undefined,
     });
     expect(http.desktopEnvironments.create).toHaveBeenLastCalledWith({
       host_id: "host-1",
       label: undefined,
-      image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234",
+      image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234",
       desired_running: false,
     });
 
@@ -235,7 +235,7 @@ describe("DesktopEnvironmentsPage defaults and availability", () => {
     expect(saveButton).not.toBeNull();
 
     await act(async () => {
-      setNativeValue(defaultImageInput!, "ghcr.io/rhernaus/tyrum-desktop-sandbox:broken");
+      setNativeValue(defaultImageInput!, "ghcr.io/tyrumai/tyrum-desktop-sandbox:broken");
       click(saveButton!);
       await Promise.resolve();
       await Promise.resolve();

--- a/packages/operator-ui/tests/pages/desktop-environments-page.test.ts
+++ b/packages/operator-ui/tests/pages/desktop-environments-page.test.ts
@@ -476,7 +476,7 @@ describe("DesktopEnvironmentsPage", () => {
     expect(desktopEnvironmentsApi.create).toHaveBeenCalledWith({
       host_id: "host-1",
       label: undefined,
-      image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+      image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
       desired_running: false,
     });
     expect(desktopEnvironmentsApi.logs).toHaveBeenCalledTimes(1);

--- a/packages/transport-sdk/tests/http-client.desktop-environments.test.ts
+++ b/packages/transport-sdk/tests/http-client.desktop-environments.test.ts
@@ -67,7 +67,7 @@ describe("desktop environment HTTP client", () => {
       if (url.endsWith("/config/desktop-environments/defaults") && init?.method === "GET") {
         return jsonResponse({
           status: "ok",
-          default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:stable",
+          default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:stable",
           revision: 1,
           created_at: "2026-01-01T00:00:00.000Z",
           created_by: { kind: "tenant.token", token_id: "token-1" },
@@ -78,7 +78,7 @@ describe("desktop environment HTTP client", () => {
       if (url.endsWith("/config/desktop-environments/defaults") && init?.method === "PUT") {
         return jsonResponse({
           status: "ok",
-          default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234",
+          default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234",
           revision: 2,
           created_at: "2026-01-01T00:00:02.000Z",
           created_by: { kind: "tenant.token", token_id: "token-1" },
@@ -142,7 +142,7 @@ describe("desktop environment HTTP client", () => {
 
     const defaults = await client.desktopEnvironments.getDefaults();
     const updatedDefaults = await client.desktopEnvironments.updateDefaults({
-      default_image_ref: "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234",
+      default_image_ref: "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234",
       reason: "roll forward",
     });
     const created = await client.desktopEnvironments.create({
@@ -154,9 +154,9 @@ describe("desktop environment HTTP client", () => {
     const started = await client.desktopEnvironments.start("env-1");
     const logs = await client.desktopEnvironments.logs("env-1");
 
-    expect(defaults.default_image_ref).toBe("ghcr.io/rhernaus/tyrum-desktop-sandbox:stable");
+    expect(defaults.default_image_ref).toBe("ghcr.io/tyrumai/tyrum-desktop-sandbox:stable");
     expect(updatedDefaults.default_image_ref).toBe(
-      "ghcr.io/rhernaus/tyrum-desktop-sandbox:sha-1234",
+      "ghcr.io/tyrumai/tyrum-desktop-sandbox:sha-1234",
     );
     expect(created.environment.environment_id).toBe("env-1");
     expect(started.environment.status).toBe("starting");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- --channel beta
 #   curl -fsSL https://get.tyrum.ai/install.sh | bash -s -- 2026.2.18
 
-REPO="${TYRUM_REPO:-rhernaus/tyrum}"
+REPO="${TYRUM_REPO:-tyrumai/tyrum}"
 CHANNEL="${TYRUM_CHANNEL:-stable}"
 REQUESTED_VERSION="${TYRUM_VERSION:-}"
 INSTALL_CMD="tyrum"


### PR DESCRIPTION
## Summary
- replace remaining `rhernaus/tyrum` repo references with `tyrumai/tyrum`
- move desktop sandbox GHCR references to `ghcr.io/tyrumai/tyrum-desktop-sandbox`
- align release config, docs, runtime defaults, and affected test fixtures with the new namespace

Closes #1579.

## Validation
- `git grep -n -E 'rhernaus/tyrum|ghcr\.io/rhernaus/tyrum-desktop-sandbox|https://github\.com/rhernaus/tyrum|owner: rhernaus|\brhernaus\b'` -> no matches in tracked files
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --coverage.enabled --coverage.reporter=text-summary` via pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string/metadata updates that mainly affect release targets and default image/repo references; runtime behavior only changes in which GHCR image/repo is used by default.
> 
> **Overview**
> Switches all remaining `rhernaus` namespace references to `tyrumai`, including **desktop sandbox GHCR image names**, the **desktop app GitHub release owner**, and documentation links/defaults.
> 
> Updates gateway defaults and validation logic to treat `ghcr.io/tyrumai/tyrum-desktop-sandbox` as the official image prefix, and adjusts installer defaults (`TYRUM_REPO`) plus affected test fixtures to match the new namespace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ce24f8a2a1867766aa7384a608707972b0abf35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->