### PR TITLE
ARCH-19: Publish dedicated node-backed tool architecture and routing contract (#1586)

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -225,6 +225,7 @@ const sidebars: SidebarsConfig = {
           items: [
             "architecture/reference/doc-templates",
             "architecture/reference/arch-01-clean-break-target-state",
+            "architecture/reference/arch-19-dedicated-node-backed-tools",
             "architecture/reference/glossary",
           ],
         },

--- a/apps/docs/tests/target-state-architecture.test.ts
+++ b/apps/docs/tests/target-state-architecture.test.ts
@@ -7,7 +7,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../..");
 const targetStateDocPath = "docs/architecture/target-state.md";
 const targetStateDecisionPath = "docs/architecture/reference/arch-01-clean-break-target-state.md";
+const dedicatedNodeToolsDecisionPath =
+  "docs/architecture/reference/arch-19-dedicated-node-backed-tools.md";
 const gatewayDocPath = "docs/architecture/gateway/index.md";
+const toolsDocPath = "docs/architecture/gateway/tools.md";
+const secretsDocPath = "docs/architecture/gateway/secrets.md";
+const sidebarsPath = "apps/docs/sidebars.ts";
 const prTemplatePath = ".github/pull_request_template.md";
 const contributorEntryPoints = [
   "README.md",
@@ -78,6 +83,36 @@ describe("Target-state architecture docs", () => {
     expect(decisionRecord).toMatch(/reference decision record/i);
     expect(decisionRecord).toMatch(/clean-break/i);
     expect(decisionRecord).toMatch(/target package graph/i);
+  });
+
+  it("publishes the dedicated node-backed tool decision as a linked architecture reference", async () => {
+    const [sidebars, toolsDoc, secretsDoc, decisionRecord] = await Promise.all([
+      readRepoFile(sidebarsPath),
+      readRepoFile(toolsDocPath),
+      readRepoFile(secretsDocPath),
+      readRepoFile(dedicatedNodeToolsDecisionPath),
+    ]);
+
+    expect(sidebars).toMatch(/architecture\/reference\/arch-19-dedicated-node-backed-tools/);
+    expect(toolsDoc).toMatch(/arch-19-dedicated-node-backed-tools/);
+    expect(secretsDoc).toMatch(/arch-19-dedicated-node-backed-tools/);
+    expect(decisionRecord).toMatch(/reference decision record/i);
+    expect(decisionRecord).toMatch(/#1586/);
+    expect(decisionRecord).toMatch(/#1585/);
+    expect(decisionRecord).toMatch(/tool\.desktop\.screenshot/);
+    expect(decisionRecord).toMatch(/tool\.browser\.navigate/);
+    expect(decisionRecord).toMatch(/tool\.location\.get/);
+    expect(decisionRecord).toMatch(/tool\.secret\.copy-to-node-clipboard/);
+    expect(decisionRecord).toMatch(/tool\.node\.list/);
+    expect(decisionRecord).toMatch(/tool\.node\.inspect/);
+    expect(decisionRecord).toMatch(/tool\.node\.dispatch/);
+    expect(decisionRecord).toMatch(/removed from the supported model-facing surface/i);
+    expect(decisionRecord).toMatch(/exactly one eligible node/i);
+    expect(decisionRecord).toMatch(/ambiguous/i);
+    expect(decisionRecord).toMatch(/secret_ref_id/);
+    expect(decisionRecord).toMatch(/secret_alias/);
+    expect(decisionRecord).toMatch(/allowlist/i);
+    expect(decisionRecord).toMatch(/clipboard/i);
   });
 
   it("describes the gateway page as the public runtime entrypoint composition root", async () => {

--- a/docs/architecture/gateway/secrets.md
+++ b/docs/architecture/gateway/secrets.md
@@ -10,7 +10,7 @@ Tyrum is built around one hard rule: models and ordinary runtime state should no
 
 - Read this if: you need the handle model, resolution boundary, and audit expectations.
 - Skip this if: you only need provider-specific storage mechanics.
-- Go deeper: [Provider auth and onboarding](/architecture/auth), [Sandbox and policy](/architecture/sandbox-policy), [Execution engine](/architecture/execution-engine).
+- Go deeper: [Provider auth and onboarding](/architecture/auth), [Sandbox and policy](/architecture/sandbox-policy), [Execution engine](/architecture/execution-engine), [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools).
 
 ## Secret resolution boundary
 
@@ -28,6 +28,8 @@ flowchart LR
 ```
 
 The handle can travel through plans, approvals, run state, and logs. The raw secret value cannot.
+
+The dedicated secret-to-node-clipboard flow is specified in [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools). That record is the canonical source for `tool.secret.copy-to-node-clipboard`, the `secret_ref_id` / `secret_alias` contract, and the stricter ambiguity rules for clipboard delivery.
 
 ## What lives where
 
@@ -72,3 +74,4 @@ Common trusted patterns are:
 - [Sandbox and policy](/architecture/sandbox-policy)
 - [Execution engine](/architecture/execution-engine)
 - [Approvals](/architecture/approvals)
+- [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools)

--- a/docs/architecture/gateway/tools.md
+++ b/docs/architecture/gateway/tools.md
@@ -10,7 +10,7 @@ Tools are the gateway's execution surface for the agent runtime. They are how mo
 
 - Read this if: you need the tool architecture and enforcement boundary.
 - Skip this if: you need exact matcher internals for a specific tool class.
-- Go deeper: [Sandbox and policy](/architecture/sandbox-policy), [Approvals](/architecture/approvals), [Gateway plugins](/architecture/plugins).
+- Go deeper: [Sandbox and policy](/architecture/sandbox-policy), [Approvals](/architecture/approvals), [Gateway plugins](/architecture/plugins), [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools).
 
 ## Tool ecosystem and boundaries
 
@@ -31,6 +31,8 @@ flowchart TB
 ```
 
 The router is the hard boundary: prompt text suggests actions, but policy decides whether a tool call is allowed, denied, or requires approval.
+
+The clean-break model-facing replacement for generic node dispatch is defined in [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools). This page stays focused on the shared gateway enforcement pipeline that all tool families pass through.
 
 For model-facing prompts, each tool exposes two layers:
 
@@ -115,3 +117,4 @@ High-risk tools should include canonical examples in their prompt-facing descrip
 - [Approvals](/architecture/approvals)
 - [Gateway plugins](/architecture/plugins)
 - [Execution engine](/architecture/execution-engine)
+- [ARCH-19 dedicated node-backed tool and routing decision](/architecture/arch-19-dedicated-node-backed-tools)

--- a/docs/architecture/reference/arch-19-dedicated-node-backed-tools.md
+++ b/docs/architecture/reference/arch-19-dedicated-node-backed-tools.md
@@ -1,0 +1,133 @@
+---
+slug: /architecture/arch-19-dedicated-node-backed-tools
+---
+
+# ARCH-19 dedicated node-backed tool and routing decision
+
+This is a reference decision record for issue `#1586` and epic `#1585`.
+
+## Quick orientation
+
+- **Read this if:** you need the canonical model-facing tool IDs, routing rules, or secret-delivery boundary for dedicated node-backed tools.
+- **Skip this if:** you only need the general gateway enforcement pipeline; start with [Tools](/architecture/tools) and [Secrets](/architecture/secrets).
+- **Go deeper:** use [Tools](/architecture/tools), [Secrets](/architecture/secrets), and [Capabilities](/architecture/capabilities) for the surrounding runtime mechanics.
+
+## Decision snapshot
+
+```mermaid
+flowchart LR
+  Agent["Agent tool call<br/>tool.desktop.screenshot / tool.browser.navigate / tool.secret.copy-to-node-clipboard"] --> Route["Routing contract"]
+  Route --> Explicit["Explicit node_id"]
+  Route --> Implicit["Attached node or sole eligible node"]
+  Explicit --> Policy["Policy + approval keyed by dedicated tool_id"]
+  Implicit --> Policy
+  Policy --> Secret{"Secret delivery?"}
+  Secret -->|no| Execute["Execute canonical node capability"]
+  Secret -->|yes| Resolve["Resolve allowlisted secret ref at trusted boundary"]
+  Resolve --> Execute
+  Execute --> Audit["Audit requested/selected node metadata<br/>without payload contents"]
+```
+
+## Decision
+
+- Capability-backed model-facing tools mirror canonical capability descriptor IDs under the `tool.` namespace by replacing the `tyrum.` prefix with `tool.`. Examples: `tyrum.desktop.screenshot` becomes `tool.desktop.screenshot`, `tyrum.browser.navigate-back` becomes `tool.browser.navigate-back`, and `tyrum.location.get` becomes `tool.location.get`.
+- Dedicated tool schemas expose action-specific business inputs plus shared routing metadata such as optional `node_id` and `timeout_ms` when the routed action needs them.
+- Agents never send `capability`, `action_name`, or transport `op` fields on the supported model-facing surface.
+- `tool.node.list` remains the only generic node discovery helper. It should report dedicated routed tool availability directly so agents do not need a second inspection step to discover schemas.
+- `tool.node.inspect` and `tool.node.dispatch` are removed from the supported model-facing surface.
+- Secret delivery is a composed gateway action rather than a raw capability mirror. Its dedicated model-facing tool ID is `tool.secret.copy-to-node-clipboard`.
+
+## Supported tool taxonomy
+
+The dedicated tool ID rule is:
+
+`tool.<canonical capability id without the tyrum prefix>`
+
+Current capability-backed families covered by this decision:
+
+- Desktop: `tool.desktop.screenshot`, `tool.desktop.snapshot`, `tool.desktop.query`, `tool.desktop.act`, `tool.desktop.mouse`, `tool.desktop.keyboard`, `tool.desktop.wait-for`
+- Browser: `tool.browser.launch`, `tool.browser.navigate`, `tool.browser.navigate-back`, `tool.browser.snapshot`, `tool.browser.click`, `tool.browser.type`, `tool.browser.fill-form`, `tool.browser.select-option`, `tool.browser.hover`, `tool.browser.drag`, `tool.browser.press-key`, `tool.browser.screenshot`, `tool.browser.evaluate`, `tool.browser.wait-for`, `tool.browser.tabs`, `tool.browser.upload-file`, `tool.browser.console-messages`, `tool.browser.network-requests`, `tool.browser.resize`, `tool.browser.close`, `tool.browser.handle-dialog`, `tool.browser.run-code`
+- Cross-platform sensors: `tool.location.get`, `tool.camera.capture-photo`, `tool.camera.capture-video`, `tool.audio.record`
+- Discovery helper retained: `tool.node.list`
+- Generic execution helpers removed: `tool.node.inspect`, `tool.node.dispatch`
+- Secret delivery: `tool.secret.copy-to-node-clipboard`
+
+If a new canonical node capability becomes model-facing later, the new tool ID must follow the same mirroring rule in the same PR that introduces the capability.
+
+## Routing contract
+
+An eligible node is paired, allowlisted for the routed capability, ready, and not denied by tool-specific policy.
+
+### Explicit targeting
+
+When `node_id` is present, the gateway must target only that node. The call fails if the node does not exist, is not paired, does not advertise the routed capability, is not ready, or is denied by policy.
+
+### Omitted `node_id` for capability-backed tools
+
+When `node_id` is omitted for dedicated capability-backed tools, the gateway may auto-select only through one of these stable paths:
+
+1. The current lane or session has exactly one attached node and that node is eligible for the requested tool.
+2. Exactly one eligible node exists for the requested tool.
+
+Otherwise the gateway must fail with an ambiguous-node-selection error rather than guessing from labels, recency, platform, or any other heuristic.
+
+The only supported implicit selection modes are `attached_node` and `sole_eligible_node`.
+
+### Omitted `node_id` for secret clipboard delivery
+
+`tool.secret.copy-to-node-clipboard` is stricter. Omitted `node_id` is allowed only when exactly one eligible clipboard-capable node exists after pairing, capability, and policy checks.
+
+If more than one eligible clipboard-capable node exists, the gateway must fail fast and require an explicit `node_id`. Lane attachment, recent activity, display labels, or platform hints must not break ties for secret delivery.
+
+## Approval, policy, and audit contract
+
+- Policy matching, approval prompts, suggested overrides, and audit entries must anchor on the dedicated `tool_id` such as `tool.desktop.act`, not on generic `tool.node.dispatch` payload decoding.
+- Routed tool metadata may expose `requested_node_id`, `selected_node_id`, and `selection_mode` (`explicit`, `attached_node`, or `sole_eligible_node`) plus a bounded node summary such as label, platform, and trust level.
+- Approval and audit surfaces must not persist arbitrary routed payload contents only to explain selection. Tool inputs stay bounded by their own schemas and evidence contracts; routing metadata is recorded separately from payload data.
+- Secret-adjacent approvals and audit entries may include safe identifiers such as `secret_ref_id` or `secret_alias`, but they must never include resolved secret values or clipboard payload text.
+
+## Secret reference contract
+
+Agent-visible secret references are allowlisted metadata records, not raw secret handles and never raw secret values.
+
+| Field              | Meaning                                                                |
+| ------------------ | ---------------------------------------------------------------------- |
+| `secret_ref_id`    | Stable opaque identifier for an allowlisted secret reference           |
+| `secret_alias`     | Optional agent-scoped alias; ergonomic shorthand, unique within scope  |
+| `allowed_tool_ids` | Explicit dedicated tool IDs this reference may be used with            |
+| `display_name`     | Optional operator-safe label that can appear in model-visible metadata |
+
+Rules:
+
+- `tool.secret.copy-to-node-clipboard` accepts exactly one secret selector: `secret_ref_id` or `secret_alias`, plus optional `node_id`.
+- Aliases are resolved only inside the agent's allowlist. Unknown, duplicate, or disallowed aliases fail validation before secret resolution.
+- The gateway resolves `secret_ref_id` or `secret_alias` to the underlying secret handle only after policy and approval gates pass, and only immediately before clipboard delivery.
+- Clipboard delivery returns acknowledgement-only results. Outputs, errors, logs, traces, approvals, and resume state may mention the selected node and the safe secret reference metadata, but never the plaintext secret.
+
+## Why this decision
+
+- Generic node dispatch leaks transport details into prompts, policy, and approvals.
+- Mirroring canonical capability IDs keeps model-facing tools aligned with the shared contracts catalog instead of creating a second naming system.
+- A dedicated secret-to-node-clipboard tool gives secret delivery a tighter audit and ambiguity boundary than ordinary capability routing.
+
+## Non-negotiable rules
+
+- No backwards-compatibility shims and no merged state where both the old and new model-facing tool IDs remain registered.
+- Temporary coexistence is allowed only inside a PR while the next clean-break step lands safely.
+- No new docs, prompts, tests, or UI copy may instruct agents to use `tool.node.dispatch` or `tool.node.inspect`.
+- Secret flows stay reference-based end to end. Raw secret values never become model-visible data.
+
+## Consequences
+
+- `#1587` must define the shared schema surface for dedicated routed tools, clipboard capability support, routed metadata, and secret reference validation.
+- `#1588` and `#1589` implement the dedicated desktop, browser, and sensor execution surface defined here.
+- `#1590` moves policy, approvals, and audit matching onto dedicated tool IDs and the routing metadata defined here.
+- `#1593` implements `tool.secret.copy-to-node-clipboard` using the `secret_ref_id` / `secret_alias` contract and the stricter ambiguity rule for clipboard delivery.
+
+## Related docs
+
+- [Tools](/architecture/tools)
+- [Secrets](/architecture/secrets)
+- [Capabilities](/architecture/capabilities)
+- [Gateway](/architecture/gateway)
+- [Epic #1585](https://github.com/tyrumai/tyrum/issues/1585)


### PR DESCRIPTION
Closes #1586

## What changed
- publish ARCH-19 as the canonical dedicated node-backed tool and routing decision record
- link the new ADR from the gateway tools and secrets architecture docs
- add docs coverage that locks the new reference doc into the architecture sidebar and contract checks

## Validation
- `pnpm exec vitest run apps/docs/tests/architecture-docs-rewrite.test.ts apps/docs/tests/target-state-architecture.test.ts`
- `pnpm --filter @tyrum/docs build`
- `pnpm docs:public-check`
- `pnpm lint`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm format:check`

## Notes
- `pnpm install --frozen-lockfile` was needed locally to repair an incomplete workspace install before validation.
- I pushed with `--no-verify` after explicit approval because the repo pre-push hook is currently blocked by unrelated baseline test failures in:
  - `packages/gateway/tests/unit/agent-runtime-engine-timing.test.ts`
  - `packages/gateway/tests/unit/command-dispatcher-support.test.ts`
  - `packages/gateway/tests/unit/guardian-review-processor-support.test.ts`
- No Playwright validation was used for this docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add a new architecture decision record and link/validate it; low risk aside from potential broken doc links or overly strict doc-content tests.
> 
> **Overview**
> Publishes **ARCH-19** as a new architecture reference decision record defining the model-facing `tool.*` ID taxonomy, node routing/ambiguity rules, and the secret reference/clipboard delivery contract.
> 
> Links this ADR from the Gateway `Tools` and `Secrets` docs, adds it to the Architecture sidebar, and extends docs tests to assert the new page is published and contains key contract language (tool IDs, removal of `tool.node.dispatch`/`inspect`, secret reference fields, and ambiguity rules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc5ada8d5f37350dba37dfb3afe7e2371fd665a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->