### PR TITLE
Trim redundant CI validation checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,11 +286,6 @@ jobs:
           fi
           node scripts/lint/oxlint-new-files.mjs --base "$base"
 
-      - name: Oxlint report (warn)
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        run: pnpm lint:oxlint:report
-
       - name: Typecheck (packages)
         run: pnpm typecheck
 
@@ -305,9 +300,6 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: A11y (operator-ui)
-        run: pnpm test:a11y:operator-ui
 
   test-shards:
     name: Test shards (ubuntu-latest) (${{ matrix.shard }}/4)
@@ -540,12 +532,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Typecheck mobile app
-        run: pnpm --filter @tyrum/mobile typecheck
-
-      - name: Test mobile app
-        run: pnpm --filter @tyrum/mobile test
-
       - name: Sync native iOS project
         run: pnpm --filter @tyrum/mobile ios:sync
 
@@ -591,12 +577,6 @@ jobs:
           sdkmanager "platform-tools" "build-tools;36.0.0" "platforms;android-36"
 
       - run: pnpm install --frozen-lockfile
-
-      - name: Typecheck mobile app
-        run: pnpm --filter @tyrum/mobile typecheck
-
-      - name: Test mobile app
-        run: pnpm --filter @tyrum/mobile test
 
       - name: Sync native Android project
         run: pnpm --filter @tyrum/mobile android:sync


### PR DESCRIPTION
## Summary

- remove the duplicate PR-only non-blocking oxlint report from CI validation
- remove the standalone operator UI a11y step that is already covered by the Vitest shard suite
- remove repeated mobile typecheck and Vitest runs from the native iOS and Android jobs while keeping sync and native build coverage

## Issue

Closes #1611

## Validation

- [x] `pnpm test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`

## Architecture

- [x] I reviewed the target-state architecture in `docs/architecture/target-state.md`.
- [x] This change belongs to target package/layer: repo CI infrastructure in `.github/workflows`.
- [x] I kept the change on the documented package surface, and shared contract changes land in `@tyrum/contracts`.

## Risk / Rollback

- low risk: this only removes checks already covered elsewhere in the workflow graph
- rollback is a revert of commit `7e32dabf`

## Notes

- pre-push checks passed before the branch was pushed
- the push surfaced existing Vitest warnings about non-top-level `vi.hoisted()` / `vi.mock()` usage in `packages/gateway/tests/unit/ws-memory-and-subagent-handler-extraction.test.ts`; they are warnings only and unrelated to this diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk CI-only change, but it reduces the number of independent gates; regressions could slip through if the removed steps weren’t fully redundant in practice.
> 
> **Overview**
> Simplifies the CI workflow by removing several redundant checks.
> 
> In `validation`, drops the PR-only non-blocking `oxlint` report step and removes the standalone operator UI a11y job step.
> 
> In the native mobile iOS/Android jobs, removes the repeated mobile `typecheck`/test runs while keeping the native sync, scaffold diff verification, and platform build steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e32dabf35a0d99c0418eaaa5357b6e11518e865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->