### PR TITLE
ARCH-22: Replace tool.node.dispatch with dedicated browser and sensor tools (#1589)

### DIFF
--- a/packages/gateway/src/modules/agent/dedicated-capability-tools.ts
+++ b/packages/gateway/src/modules/agent/dedicated-capability-tools.ts
@@ -1,0 +1,119 @@
+import { listCapabilityCatalogEntries } from "../node/capability-catalog.js";
+import type { ToolDescriptor } from "./tools.js";
+
+type CatalogEntry = ReturnType<typeof listCapabilityCatalogEntries>[number];
+type CatalogAction = CatalogEntry["actions"][number];
+
+export type DedicatedCapabilityTool = {
+  toolId: string;
+  capabilityId: string;
+  action: CatalogAction;
+  supportsDispatchTimeout: boolean;
+};
+
+function isDedicatedCapabilityId(capabilityId: string): boolean {
+  return (
+    capabilityId.startsWith("tyrum.browser.") ||
+    capabilityId === "tyrum.location.get" ||
+    capabilityId.startsWith("tyrum.camera.") ||
+    capabilityId === "tyrum.audio.record"
+  );
+}
+
+function toDedicatedToolId(capabilityId: string): string {
+  return `tool.${capabilityId.slice("tyrum.".length)}`;
+}
+
+function hasObjectProperty(schema: Record<string, unknown>, property: string): boolean {
+  const properties = schema["properties"];
+  return (
+    properties !== null &&
+    typeof properties === "object" &&
+    !Array.isArray(properties) &&
+    property in properties
+  );
+}
+
+function buildInputSchema(tool: DedicatedCapabilityTool): Record<string, unknown> {
+  const properties =
+    tool.action.inputSchema["properties"] &&
+    typeof tool.action.inputSchema["properties"] === "object" &&
+    !Array.isArray(tool.action.inputSchema["properties"])
+      ? { ...(tool.action.inputSchema["properties"] as Record<string, unknown>) }
+      : {};
+
+  properties["node_id"] = {
+    type: "string",
+    description: "Optional node id to target explicitly.",
+  };
+  if (tool.supportsDispatchTimeout) {
+    properties["timeout_ms"] = {
+      type: "number",
+      description: "Optional dispatch timeout in milliseconds.",
+    };
+  }
+
+  return {
+    ...tool.action.inputSchema,
+    type: "object",
+    properties,
+    required: Array.isArray(tool.action.inputSchema["required"])
+      ? [...tool.action.inputSchema["required"]]
+      : [],
+    additionalProperties: false,
+  };
+}
+
+function buildKeywords(tool: DedicatedCapabilityTool): string[] {
+  const tokens = tool.capabilityId
+    .replace(/^tyrum\./, "")
+    .split(/[.-]/)
+    .filter((token) => token.length > 0);
+  return [...new Set(["node", ...tokens])];
+}
+
+function buildToolDescriptor(tool: DedicatedCapabilityTool): ToolDescriptor {
+  return {
+    id: tool.toolId,
+    description: tool.action.description,
+    effect: "state_changing",
+    keywords: buildKeywords(tool),
+    source: "builtin",
+    family: "node",
+    inputSchema: buildInputSchema(tool),
+  };
+}
+
+const DEDICATED_CAPABILITY_TOOLS: readonly DedicatedCapabilityTool[] =
+  listCapabilityCatalogEntries()
+    .filter((entry) => isDedicatedCapabilityId(entry.descriptor.id))
+    .flatMap((entry) => {
+      const action = entry.actions[0];
+      if (!action) {
+        return [];
+      }
+      return [
+        {
+          toolId: toDedicatedToolId(entry.descriptor.id),
+          capabilityId: entry.descriptor.id,
+          action,
+          supportsDispatchTimeout: !hasObjectProperty(action.inputSchema, "timeout_ms"),
+        },
+      ];
+    });
+
+const DEDICATED_CAPABILITY_TOOL_BY_ID = new Map(
+  DEDICATED_CAPABILITY_TOOLS.map((tool) => [tool.toolId, tool] as const),
+);
+
+export function listDedicatedCapabilityTools(): readonly DedicatedCapabilityTool[] {
+  return DEDICATED_CAPABILITY_TOOLS;
+}
+
+export function getDedicatedCapabilityTool(toolId: string): DedicatedCapabilityTool | undefined {
+  return DEDICATED_CAPABILITY_TOOL_BY_ID.get(toolId.trim());
+}
+
+export function listDedicatedCapabilityToolDescriptors(): ToolDescriptor[] {
+  return DEDICATED_CAPABILITY_TOOLS.map(buildToolDescriptor);
+}

--- a/packages/gateway/src/modules/agent/tool-catalog.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog.ts
@@ -2,6 +2,7 @@ import { AUTOMATION_TOOL_REGISTRY } from "./tool-catalog-automation.js";
 import { LOCATION_TOOL_REGISTRY } from "./tool-catalog-location.js";
 import type { ToolDescriptor } from "./tools.js";
 import { SUBAGENT_TOOL_REGISTRY } from "./tool-catalog-subagent.js";
+import { listDedicatedCapabilityToolDescriptors } from "./dedicated-capability-tools.js";
 import {
   ARTIFACT_DESCRIBE_TOOL_PROMPT_METADATA,
   APPLY_PATCH_TOOL_PROMPT_METADATA,
@@ -367,6 +368,7 @@ export const BUILTIN_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     },
   },
   ...LOCATION_TOOL_REGISTRY,
+  ...listDedicatedCapabilityToolDescriptors(),
   ...AUTOMATION_TOOL_REGISTRY,
   ...SUBAGENT_TOOL_REGISTRY,
   ...WORKBOARD_TOOL_REGISTRY,

--- a/packages/gateway/src/modules/agent/tool-executor-dedicated-node-tools.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-dedicated-node-tools.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+import {
+  NodeId,
+  type NodeActionDispatchRequest as NodeActionDispatchRequestT,
+} from "@tyrum/contracts";
+import type { NodeDispatchService, NodeInventoryService } from "@tyrum/runtime-node-control";
+import type { ArtifactStore } from "../artifact/store.js";
+import type { NodeCapabilityInspectionService } from "../node/capability-inspection-service.js";
+import type { ConnectionManager } from "../../ws/connection-manager.js";
+import type { ConnectionDirectoryDal } from "../backplane/connection-directory.js";
+import { getDedicatedCapabilityTool } from "./dedicated-capability-tools.js";
+import { tagContent } from "./provenance.js";
+import { sanitizeForModel } from "./sanitizer.js";
+import type { ToolResult, WorkspaceLeaseConfig } from "./tool-executor-shared.js";
+import {
+  executeNodeDispatchRequest,
+  type DispatchExecutionContext,
+  type NodeDispatchAudit,
+} from "./tool-executor-node-dispatch-execute.js";
+import {
+  normalizeJsonObject,
+  normalizeValidationFailure,
+  serializeToolDispatchResponse,
+} from "./tool-executor-node-dispatch-helpers.js";
+
+type DedicatedNodeToolContext = {
+  workspaceLease?: WorkspaceLeaseConfig;
+  nodeDispatchService?: NodeDispatchService;
+  nodeInventoryService?: NodeInventoryService;
+  inspectionService?: NodeCapabilityInspectionService;
+  connectionManager?: ConnectionManager;
+  connectionDirectory?: ConnectionDirectoryDal;
+  artifactStore?: ArtifactStore;
+};
+
+const DispatchTimeoutMs = z.number().int().positive().max(600_000);
+
+function errorResult(toolCallId: string, message: string): ToolResult {
+  return {
+    tool_call_id: toolCallId,
+    output: "",
+    error: message,
+  };
+}
+
+function extractRoutingArgs(
+  rawArgs: Record<string, unknown>,
+  supportsDispatchTimeout: boolean,
+): { requestedNodeId?: string; dispatchTimeoutMs?: number; actionInput: Record<string, unknown> } {
+  const actionInput = { ...rawArgs };
+  let requestedNodeId: string | undefined;
+  let dispatchTimeoutMs: number | undefined;
+
+  if ("node_id" in actionInput) {
+    const parsedNodeId = NodeId.safeParse(actionInput["node_id"]);
+    if (!parsedNodeId.success) {
+      throw new Error("invalid routed tool request: node_id must be a valid node id");
+    }
+    requestedNodeId = parsedNodeId.data;
+    delete actionInput["node_id"];
+  }
+
+  if (supportsDispatchTimeout && "timeout_ms" in actionInput) {
+    const parsedTimeout = DispatchTimeoutMs.safeParse(actionInput["timeout_ms"]);
+    if (!parsedTimeout.success) {
+      throw new Error(
+        "invalid routed tool request: timeout_ms must be a positive integer <= 600000",
+      );
+    }
+    dispatchTimeoutMs = parsedTimeout.data;
+    delete actionInput["timeout_ms"];
+  }
+
+  return { requestedNodeId, dispatchTimeoutMs, actionInput };
+}
+
+async function selectNodeId(
+  context: DedicatedNodeToolContext,
+  capabilityId: string,
+  requestedNodeId: string | undefined,
+  audit?: NodeDispatchAudit,
+): Promise<string> {
+  if (requestedNodeId) {
+    return requestedNodeId;
+  }
+  if (!context.nodeInventoryService || !context.workspaceLease?.tenantId) {
+    throw new Error("node inventory is not configured");
+  }
+
+  const inventory = await context.nodeInventoryService.list({
+    tenantId: context.workspaceLease.tenantId,
+    capability: capabilityId,
+    dispatchableOnly: true,
+    key: audit?.work_session_key,
+    lane: audit?.work_lane,
+  });
+  const attachedCandidates = inventory.nodes.filter((node) => node.attached_to_requested_lane);
+  if (attachedCandidates.length === 1) {
+    return attachedCandidates[0]!.node_id;
+  }
+  if (inventory.nodes.length === 1) {
+    return inventory.nodes[0]!.node_id;
+  }
+  if (inventory.nodes.length === 0) {
+    throw new Error(`no eligible nodes available for capability '${capabilityId}'`);
+  }
+  throw new Error("ambiguous node selection; specify node_id");
+}
+
+export async function executeDedicatedNodeTool(
+  context: DedicatedNodeToolContext,
+  toolId: string,
+  toolCallId: string,
+  args: unknown,
+  audit?: NodeDispatchAudit,
+): Promise<ToolResult | undefined> {
+  const tool = getDedicatedCapabilityTool(toolId);
+  if (!tool) {
+    return undefined;
+  }
+  const tenantId = context.workspaceLease?.tenantId;
+  if (!tenantId || !context.nodeDispatchService) {
+    return errorResult(toolCallId, "node dispatch is not configured");
+  }
+  if (!context.inspectionService) {
+    return errorResult(toolCallId, "node capability inspection is not configured");
+  }
+
+  const rawArgs = normalizeJsonObject(args);
+  if (!rawArgs) {
+    return errorResult(toolCallId, "invalid routed tool request: expected an object");
+  }
+
+  let routingArgs: ReturnType<typeof extractRoutingArgs>;
+  try {
+    routingArgs = extractRoutingArgs(rawArgs, tool.supportsDispatchTimeout);
+  } catch (error) {
+    return errorResult(toolCallId, error instanceof Error ? error.message : String(error));
+  }
+
+  let nodeId: string;
+  try {
+    nodeId = await selectNodeId(context, tool.capabilityId, routingArgs.requestedNodeId, audit);
+  } catch (error) {
+    return errorResult(toolCallId, error instanceof Error ? error.message : String(error));
+  }
+
+  let actionInput: Record<string, unknown>;
+  try {
+    actionInput = tool.action.inputParser.parse(routingArgs.actionInput) as Record<string, unknown>;
+  } catch (error) {
+    const request: NodeActionDispatchRequestT = {
+      node_id: nodeId,
+      capability: tool.capabilityId,
+      action_name: tool.action.name,
+      input: routingArgs.actionInput,
+      ...(routingArgs.dispatchTimeoutMs !== undefined
+        ? { timeout_ms: routingArgs.dispatchTimeoutMs }
+        : {}),
+    };
+    const response = {
+      status: "ok" as const,
+      task_id: "not-dispatched",
+      node_id: request.node_id,
+      capability: request.capability,
+      action_name: request.action_name,
+      ok: false,
+      payload_source: "none" as const,
+      payload: null,
+      error: normalizeValidationFailure(error),
+    };
+    const tagged = tagContent(serializeToolDispatchResponse(response), "tool");
+    return {
+      tool_call_id: toolCallId,
+      output: sanitizeForModel(tagged),
+      provenance: tagged,
+    };
+  }
+
+  const dispatchContext: DispatchExecutionContext = {
+    tenantId,
+    nodeDispatchService: context.nodeDispatchService,
+    inspectionService: context.inspectionService,
+    connectionManager: context.connectionManager,
+    connectionDirectory: context.connectionDirectory,
+    artifactStore: context.artifactStore,
+    workspaceLease: context.workspaceLease,
+  };
+
+  const response = await executeNodeDispatchRequest(
+    dispatchContext,
+    {
+      node_id: nodeId,
+      capability: tool.capabilityId,
+      action_name: tool.action.name,
+      input: actionInput,
+      ...(routingArgs.dispatchTimeoutMs !== undefined
+        ? { timeout_ms: routingArgs.dispatchTimeoutMs }
+        : {}),
+    },
+    audit,
+  );
+  const tagged = tagContent(serializeToolDispatchResponse(response), "tool");
+  return {
+    tool_call_id: toolCallId,
+    output: sanitizeForModel(tagged),
+    provenance: tagged,
+  };
+}

--- a/packages/gateway/src/modules/agent/tool-executor.ts
+++ b/packages/gateway/src/modules/agent/tool-executor.ts
@@ -13,6 +13,7 @@ import { executeBuiltinMemoryMcpTool } from "../memory/builtin-mcp.js";
 import type { LocationService } from "../location/service.js";
 import { executeCoreTool, executeMcpTool } from "./tool-executor-core-tools.js";
 import { executeLocationPlaceTool } from "./tool-executor-location-tools.js";
+import { executeDedicatedNodeTool } from "./tool-executor-dedicated-node-tools.js";
 import {
   executeNodeDispatchTool,
   executeNodeInspectTool,
@@ -180,6 +181,24 @@ export class ToolExecutor {
         return builtinMemoryResult;
       }
       return await executeMcpTool(coreContext, toolId, toolCallId, args);
+    }
+    const dedicatedNodeResult = await executeDedicatedNodeTool(
+      {
+        workspaceLease: this.workspaceLease,
+        nodeDispatchService: this.nodeDispatchService,
+        nodeInventoryService: this.nodeInventoryService,
+        inspectionService: this.nodeCapabilityInspectionService,
+        connectionManager: this.connectionManager,
+        connectionDirectory: this.connectionDirectory,
+        artifactStore: this.artifactStore,
+      },
+      toolId,
+      toolCallId,
+      args,
+      audit,
+    );
+    if (dedicatedNodeResult) {
+      return dedicatedNodeResult;
     }
     if (toolId === "tool.node.dispatch") {
       if (!this.nodeDispatchService) {

--- a/packages/gateway/tests/unit/tool-executor.dedicated-node-tools-test-support.ts
+++ b/packages/gateway/tests/unit/tool-executor.dedicated-node-tools-test-support.ts
@@ -1,0 +1,296 @@
+import { CAPABILITY_DESCRIPTOR_DEFAULT_VERSION } from "@tyrum/contracts";
+import { expect, it, vi } from "vitest";
+import { DEFAULT_TENANT_ID, DEFAULT_WORKSPACE_ID } from "../../src/modules/identity/scope.js";
+import { ConnectionManager } from "../../src/ws/connection-manager.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import {
+  createToolExecutor,
+  requireHomeDir,
+  type HomeDirState,
+} from "./tool-executor.shared-test-support.js";
+
+function createWorkspaceLease(db: ReturnType<typeof openTestSqliteDb>) {
+  return {
+    db,
+    tenantId: DEFAULT_TENANT_ID,
+    agentId: null,
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  };
+}
+
+function createInspection(capability: string, actionName: string) {
+  return {
+    status: "ok" as const,
+    generated_at: new Date().toISOString(),
+    node_id: "node-1",
+    capability,
+    capability_version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+    connected: true,
+    paired: true,
+    dispatchable: true,
+    source_of_truth: {
+      schema: "gateway_catalog" as const,
+      state: "node_capability_state" as const,
+    },
+    actions: [
+      {
+        name: actionName,
+        description: "Dedicated tool action.",
+        supported: true,
+        enabled: true,
+        availability_status: "unknown" as const,
+        input_schema: {},
+        output_schema: {},
+        consent: {
+          requires_operator_enable: true,
+          requires_runtime_consent: false,
+          may_prompt_user: false,
+          sensitive_data_category: "none" as const,
+        },
+        permissions: {
+          secure_context_required: false,
+          browser_apis: [],
+          hardware_may_be_required: false,
+        },
+        transport: {
+          primitive_kind: "Web" as const,
+          op_field: "op",
+          op_value: actionName,
+          result_channel: "result_or_evidence" as const,
+          artifactize_binary_fields: [],
+        },
+      },
+    ],
+  };
+}
+
+function createWebNodeConnectionManager(...nodeIds: string[]) {
+  const connectionManager = new ConnectionManager();
+  for (const [index, nodeId] of nodeIds.entries()) {
+    connectionManager.addClient({ on: vi.fn(), send: vi.fn(), readyState: 1 } as never, [], {
+      id: `conn-${String(index + 1)}`,
+      role: "node",
+      deviceId: nodeId,
+      devicePlatform: "web",
+      protocolRev: 2,
+      authClaims: { tenant_id: DEFAULT_TENANT_ID } as never,
+    });
+  }
+  return connectionManager;
+}
+
+export function registerToolExecutorDedicatedNodeToolTests(home: HomeDirState): void {
+  it("executes tool.browser.navigate through dedicated browser routing without generic dispatch args", async () => {
+    const db = openTestSqliteDb();
+    const dispatchAndWait = vi.fn(async () => ({
+      taskId: "task-browser-1",
+      result: { ok: true, result: { url: "https://example.com", title: "Example" } },
+    }));
+
+    try {
+      const result = await createToolExecutor({
+        homeDir: requireHomeDir(home),
+        workspaceLease: createWorkspaceLease(db),
+        nodeDispatchService: { dispatchAndWait } as never,
+        nodeCapabilityInspectionService: {
+          inspect: vi.fn(async () => createInspection("tyrum.browser.navigate", "navigate")),
+        } as never,
+      }).execute("tool.browser.navigate", "call-browser-1", {
+        node_id: "node-1",
+        url: "https://example.com",
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(dispatchAndWait).toHaveBeenCalledWith(
+        {
+          type: "Web",
+          args: {
+            op: "navigate",
+            url: "https://example.com",
+          },
+        },
+        expect.any(Object),
+        { timeoutMs: 30_000, nodeId: "node-1" },
+      );
+      expect(result.output).toContain('"capability":"tyrum.browser.navigate"');
+      expect(result.output).toContain('"action_name":"navigate"');
+      expect(result.output).toContain('"node_id":"node-1"');
+      expect(result.output).toContain('"url":"https://example.com"');
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("uses the attached dispatchable node when node_id is omitted for tool.location.get", async () => {
+    const db = openTestSqliteDb();
+    const dispatchAndWait = vi.fn(async () => ({
+      taskId: "task-location-1",
+      result: {
+        ok: true,
+        evidence: { coords: { latitude: 52.37, longitude: 4.89, accuracy_m: 8 } },
+      },
+    }));
+    const connectionManager = createWebNodeConnectionManager("node-1", "node-2");
+
+    try {
+      const result = await createToolExecutor({
+        homeDir: requireHomeDir(home),
+        workspaceLease: createWorkspaceLease(db),
+        nodeDispatchService: { dispatchAndWait } as never,
+        nodeCapabilityInspectionService: {
+          inspect: vi.fn(async () => ({
+            ...createInspection("tyrum.location.get", "get"),
+            actions: [
+              {
+                ...createInspection("tyrum.location.get", "get").actions[0],
+                transport: {
+                  primitive_kind: null,
+                  op_field: "op",
+                  op_value: "get",
+                  result_channel: "evidence" as const,
+                  artifactize_binary_fields: [],
+                },
+              },
+            ],
+          })),
+        } as never,
+        nodeInventoryService: {
+          list: vi.fn(async () => ({
+            key: "agent:default:ui:default:channel:thread-1",
+            lane: "main",
+            nodes: [
+              {
+                node_id: "node-1",
+                connected: true,
+                paired_status: "approved",
+                attached_to_requested_lane: true,
+                capabilities: [
+                  {
+                    capability: "tyrum.location.get",
+                    capability_version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+                    connected: true,
+                    paired: true,
+                    dispatchable: true,
+                    supported_action_count: 1,
+                    enabled_action_count: 1,
+                    available_action_count: 1,
+                    unknown_action_count: 0,
+                  },
+                ],
+              },
+              {
+                node_id: "node-2",
+                connected: true,
+                paired_status: "approved",
+                attached_to_requested_lane: false,
+                capabilities: [
+                  {
+                    capability: "tyrum.location.get",
+                    capability_version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+                    connected: true,
+                    paired: true,
+                    dispatchable: true,
+                    supported_action_count: 1,
+                    enabled_action_count: 1,
+                    available_action_count: 1,
+                    unknown_action_count: 0,
+                  },
+                ],
+              },
+            ],
+          })),
+        } as never,
+        connectionManager,
+      }).execute(
+        "tool.location.get",
+        "call-location-1",
+        { enable_high_accuracy: true },
+        {
+          work_session_key: "agent:default:ui:default:channel:thread-1",
+          work_lane: "main",
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(dispatchAndWait).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: expect.objectContaining({ op: "get", enable_high_accuracy: true }),
+        }),
+        expect.any(Object),
+        { timeoutMs: 30_000, nodeId: "node-1" },
+      );
+      expect(result.output).toContain('"node_id":"node-1"');
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("fails fast instead of guessing when multiple eligible nodes exist without an attached node", async () => {
+    const db = openTestSqliteDb();
+    const dispatchAndWait = vi.fn(async () => ({
+      taskId: "task-location-2",
+      result: { ok: true, evidence: { ok: true } },
+    }));
+
+    try {
+      const result = await createToolExecutor({
+        homeDir: requireHomeDir(home),
+        workspaceLease: createWorkspaceLease(db),
+        nodeDispatchService: { dispatchAndWait } as never,
+        nodeCapabilityInspectionService: {
+          inspect: vi.fn(async () => createInspection("tyrum.location.get", "get")),
+        } as never,
+        nodeInventoryService: {
+          list: vi.fn(async () => ({
+            nodes: [
+              {
+                node_id: "node-1",
+                connected: true,
+                paired_status: "approved",
+                attached_to_requested_lane: false,
+                capabilities: [
+                  {
+                    capability: "tyrum.location.get",
+                    capability_version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+                    connected: true,
+                    paired: true,
+                    dispatchable: true,
+                    supported_action_count: 1,
+                    enabled_action_count: 1,
+                    available_action_count: 1,
+                    unknown_action_count: 0,
+                  },
+                ],
+              },
+              {
+                node_id: "node-2",
+                connected: true,
+                paired_status: "approved",
+                attached_to_requested_lane: false,
+                capabilities: [
+                  {
+                    capability: "tyrum.location.get",
+                    capability_version: CAPABILITY_DESCRIPTOR_DEFAULT_VERSION,
+                    connected: true,
+                    paired: true,
+                    dispatchable: true,
+                    supported_action_count: 1,
+                    enabled_action_count: 1,
+                    available_action_count: 1,
+                    unknown_action_count: 0,
+                  },
+                ],
+              },
+            ],
+          })),
+        } as never,
+      }).execute("tool.location.get", "call-location-2", {});
+
+      expect(result.output).toBe("");
+      expect(result.error).toContain("ambiguous node selection");
+      expect(dispatchAndWait).not.toHaveBeenCalled();
+    } finally {
+      await db.close();
+    }
+  });
+}

--- a/packages/gateway/tests/unit/tool-executor.shared-test-support.ts
+++ b/packages/gateway/tests/unit/tool-executor.shared-test-support.ts
@@ -24,6 +24,8 @@ type ToolExecutorFactoryOptions = {
   identityScopeDal?: ToolExecutorCtor[11];
   nodeInventoryService?: ToolExecutorCtor[12];
   nodeCapabilityInspectionService?: ToolExecutorCtor[13];
+  connectionManager?: ToolExecutorCtor[14];
+  connectionDirectory?: ToolExecutorCtor[15];
   memoryToolRuntime?: ToolExecutorCtor[16];
   artifactDescribeRuntime?: ToolExecutorCtor[19];
   locationService?: ToolExecutorCtor[20];
@@ -80,6 +82,8 @@ export function createToolExecutor({
   identityScopeDal,
   nodeInventoryService,
   nodeCapabilityInspectionService,
+  connectionManager,
+  connectionDirectory,
   memoryToolRuntime,
   artifactDescribeRuntime,
   locationService,
@@ -99,8 +103,8 @@ export function createToolExecutor({
     identityScopeDal,
     nodeInventoryService,
     nodeCapabilityInspectionService,
-    undefined,
-    undefined,
+    connectionManager,
+    connectionDirectory,
     memoryToolRuntime,
     undefined,
     undefined,

--- a/packages/gateway/tests/unit/tool-executor.test.ts
+++ b/packages/gateway/tests/unit/tool-executor.test.ts
@@ -11,6 +11,7 @@ import {
   registerSsrfProtectionTests,
 } from "./tool-executor.security-test-support.js";
 import { registerTempHomeLifecycle } from "./tool-executor.shared-test-support.js";
+import { registerToolExecutorDedicatedNodeToolTests } from "./tool-executor.dedicated-node-tools-test-support.js";
 import { registerToolExecutorNodeDispatchTests } from "./tool-executor.node-dispatch-test-support.js";
 import { registerToolExecutorNodeToolTests } from "./tool-executor.node-tools-test-support.js";
 
@@ -20,6 +21,7 @@ describe("ToolExecutor", () => {
   describe("builtin routing", () => {
     registerToolExecutorBuiltinCoreTests(home);
     registerToolExecutorLocationToolTests(home);
+    registerToolExecutorDedicatedNodeToolTests(home);
     registerToolExecutorNodeDispatchTests(home);
     registerToolExecutorNodeToolTests(home);
   });

--- a/packages/gateway/tests/unit/tools.test.ts
+++ b/packages/gateway/tests/unit/tools.test.ts
@@ -214,6 +214,47 @@ describe("model tool naming", () => {
     expect(builtinIds.filter((id) => id === "tool.node.inspect")).toHaveLength(1);
   });
 
+  it("includes dedicated browser and sensor node-backed tools with action-shaped schemas", () => {
+    const builtinIds = listBuiltinToolDescriptors().map((tool) => tool.id);
+    const browserNavigate = listBuiltinToolDescriptors().find(
+      (tool) => tool.id === "tool.browser.navigate",
+    );
+    const locationGet = listBuiltinToolDescriptors().find(
+      (tool) => tool.id === "tool.location.get",
+    );
+
+    expect(builtinIds).toContain("tool.browser.navigate");
+    expect(builtinIds).toContain("tool.browser.screenshot");
+    expect(builtinIds).toContain("tool.location.get");
+    expect(builtinIds).toContain("tool.camera.capture-photo");
+    expect(builtinIds).toContain("tool.camera.capture-video");
+    expect(builtinIds).toContain("tool.audio.record");
+    expect(browserNavigate?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        url: { type: "string" },
+        node_id: { type: "string" },
+        timeout_ms: { type: "number" },
+      },
+    });
+    expect(browserNavigate?.inputSchema).not.toMatchObject({
+      properties: {
+        capability: expect.anything(),
+        action_name: expect.anything(),
+        input: expect.anything(),
+        op: expect.anything(),
+      },
+    });
+    expect(locationGet?.inputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        enable_high_accuracy: { type: "boolean" },
+        timeout_ms: { type: "integer" },
+        node_id: { type: "string" },
+      },
+    });
+  });
+
   it("includes the location place tool family", () => {
     const builtinIds = listBuiltinToolDescriptors().map((tool) => tool.id);
 


### PR DESCRIPTION
Closes #1589

## Summary
- register dedicated browser and cross-platform sensor tool descriptors from the capability catalog instead of requiring `tool.node.dispatch`
- route dedicated tool execution through the existing node-dispatch path with explicit or inventory-based node selection
- add regression coverage for dedicated tool schemas and routing behavior

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- pre-push hook passed: lint, typecheck, desktop typecheck, and full test suite

## Playwright Evidence
- Not used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new builtin tool descriptors and a new execution path that auto-selects nodes via inventory when `node_id` is omitted, which could change which device receives browser/sensor actions. While it reuses existing node-dispatch machinery, the new routing and schema generation may affect tool selection and dispatch behavior in production.
> 
> **Overview**
> Registers **dedicated node-backed tools** (e.g. `tool.browser.*`, `tool.location.get`, `tool.camera.*`, `tool.audio.record`) directly from the capability catalog, exposing *action-shaped* input schemas with optional `node_id` and `timeout_ms` instead of requiring callers to use `tool.node.dispatch`.
> 
> Adds a dedicated executor path (`executeDedicatedNodeTool`) that routes these tool calls through the existing node-dispatch execution, including validation, optional dispatch timeouts, and **inventory-based node selection** (prefer attached lane node; error on ambiguity). Updates unit tests to cover descriptor presence/schema shape and routing/selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef6080777874ee81f8f21a9492e106a2dadc9f93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->