### PR TITLE
ARCH-24: Update tool registry and operator UI for dedicated routed tools (#1591)

### DIFF
--- a/packages/gateway/src/modules/agent/dedicated-capability-tools.ts
+++ b/packages/gateway/src/modules/agent/dedicated-capability-tools.ts
@@ -11,6 +11,25 @@ export type DedicatedCapabilityTool = {
   supportsDispatchTimeout: boolean;
 };
 
+const DEDICATED_ROUTED_TOOL_PROMPT_GUIDANCE = [
+  "Pass action-specific fields directly and use node_id only when you need to target a specific node.",
+  "Omit node_id when any eligible attached node can satisfy the request.",
+  "Use timeout_ms only when you need to override the default dispatch timeout.",
+] as const;
+
+const DEDICATED_ROUTED_TOOL_EXAMPLES_BY_ID: ReadonlyMap<string, readonly string[]> = new Map([
+  [
+    "tool.browser.navigate",
+    ['{"url":"https://example.com","node_id":"node_456","timeout_ms":30000}'],
+  ],
+  ["tool.location.get", ['{"enable_high_accuracy":true,"timeout_ms":30000}']],
+  [
+    "tool.camera.capture-photo",
+    ['{"format":"jpeg","quality":0.9,"node_id":"node_789","timeout_ms":30000}'],
+  ],
+  ["tool.audio.record", ['{"duration_ms":5000,"node_id":"node_789","timeout_ms":30000}']],
+]);
+
 function isDedicatedCapabilityId(capabilityId: string): boolean {
   return (
     capabilityId.startsWith("tyrum.browser.") ||
@@ -72,12 +91,178 @@ function buildKeywords(tool: DedicatedCapabilityTool): string[] {
   return [...new Set(["node", ...tokens])];
 }
 
+function objectProperties(
+  schema: Record<string, unknown>,
+): Record<string, Record<string, unknown>> {
+  const properties = schema["properties"];
+  if (properties === null || typeof properties !== "object" || Array.isArray(properties)) {
+    return {};
+  }
+
+  const entries = Object.entries(properties).filter(
+    (entry): entry is [string, Record<string, unknown>] =>
+      entry[1] !== null && typeof entry[1] === "object" && !Array.isArray(entry[1]),
+  );
+  return Object.fromEntries(entries);
+}
+
+function sampleEnumValue(schema: Record<string, unknown>): unknown {
+  const values = schema["enum"];
+  return Array.isArray(values) && values.length > 0 ? values[0] : undefined;
+}
+
+function sampleObjectValue(schema: Record<string, unknown>): Record<string, unknown> | undefined {
+  const properties = objectProperties(schema);
+  const required = Array.isArray(schema["required"])
+    ? schema["required"].filter((value): value is string => typeof value === "string")
+    : [];
+  if (required.length === 0) {
+    return undefined;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const property of required) {
+    const sample = sampleValueForProperty(property, properties[property]);
+    if (sample === undefined) {
+      return undefined;
+    }
+    result[property] = sample;
+  }
+  return result;
+}
+
+function sampleValueForProperty(
+  propertyName: string,
+  schema: Record<string, unknown> | undefined,
+): unknown {
+  if (!schema) {
+    return undefined;
+  }
+
+  if ("default" in schema) {
+    return schema["default"];
+  }
+
+  const enumValue = sampleEnumValue(schema);
+  if (enumValue !== undefined) {
+    return enumValue;
+  }
+
+  switch (propertyName) {
+    case "url":
+      return "https://example.com";
+    case "selector":
+      return "#submit";
+    case "source_selector":
+      return "#source";
+    case "target_selector":
+      return "#target";
+    case "text":
+      return "hello";
+    case "expression":
+      return "document.title";
+    case "path":
+    case "file_path":
+      return "/tmp/report.pdf";
+    case "device_id":
+      return "default";
+    case "query":
+      return "console.error";
+    case "enable_high_accuracy":
+    case "clear":
+      return true;
+    case "width":
+      return 1280;
+    case "height":
+      return 720;
+    case "duration_ms":
+      return 5000;
+    case "quality":
+      return 0.9;
+    case "count":
+      return 1;
+    case "position":
+      return { x: 100, y: 120 };
+    case "viewport":
+      return { width: 1280, height: 720 };
+    default:
+      break;
+  }
+
+  const type = schema["type"];
+  if (type === "string") {
+    return "example";
+  }
+  if (type === "boolean") {
+    return true;
+  }
+  if (type === "integer") {
+    return typeof schema["minimum"] === "number" ? Math.max(1, schema["minimum"]) : 1;
+  }
+  if (type === "number") {
+    return typeof schema["minimum"] === "number" ? Math.max(1, schema["minimum"]) : 1;
+  }
+  if (type === "array") {
+    const items = schema["items"];
+    if (items !== null && typeof items === "object" && !Array.isArray(items)) {
+      const item = sampleValueForProperty(propertyName, items as Record<string, unknown>);
+      return item === undefined ? undefined : [item];
+    }
+    return [];
+  }
+  if (type === "object") {
+    return sampleObjectValue(schema);
+  }
+
+  return undefined;
+}
+
+function buildFallbackPromptExample(tool: DedicatedCapabilityTool): string | undefined {
+  const properties = objectProperties(tool.action.inputSchema);
+  const required = Array.isArray(tool.action.inputSchema["required"])
+    ? tool.action.inputSchema["required"].filter(
+        (value): value is string => typeof value === "string",
+      )
+    : [];
+  const exampleArgs: Record<string, unknown> = {};
+
+  for (const property of required) {
+    const value = sampleValueForProperty(property, properties[property]);
+    if (value === undefined) {
+      return undefined;
+    }
+    exampleArgs[property] = value;
+  }
+
+  if (tool.toolId !== "tool.location.get") {
+    exampleArgs["node_id"] = "node_456";
+  }
+  if (tool.supportsDispatchTimeout) {
+    exampleArgs["timeout_ms"] = 30000;
+  }
+
+  return JSON.stringify(exampleArgs);
+}
+
+function buildPromptExamples(tool: DedicatedCapabilityTool): readonly string[] | undefined {
+  const explicit = DEDICATED_ROUTED_TOOL_EXAMPLES_BY_ID.get(tool.toolId);
+  if (explicit) {
+    return explicit;
+  }
+
+  const fallback = buildFallbackPromptExample(tool);
+  return fallback ? [fallback] : undefined;
+}
+
 function buildToolDescriptor(tool: DedicatedCapabilityTool): ToolDescriptor {
+  const promptExamples = buildPromptExamples(tool);
   return {
     id: tool.toolId,
     description: tool.action.description,
     effect: "state_changing",
     keywords: buildKeywords(tool),
+    promptGuidance: DEDICATED_ROUTED_TOOL_PROMPT_GUIDANCE,
+    ...(promptExamples ? { promptExamples } : {}),
     source: "builtin",
     family: "node",
     inputSchema: buildInputSchema(tool),

--- a/packages/gateway/src/modules/agent/tool-catalog.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog.ts
@@ -12,7 +12,6 @@ import {
   GLOB_TOOL_PROMPT_METADATA,
   GREP_TOOL_PROMPT_METADATA,
   READ_TOOL_PROMPT_METADATA,
-  TOOL_NODE_INSPECT_PROMPT_METADATA,
   TOOL_NODE_LIST_PROMPT_METADATA,
   WRITE_TOOL_PROMPT_METADATA,
 } from "./tool-catalog-prompt-metadata.js";
@@ -295,76 +294,6 @@ export const BUILTIN_TOOL_REGISTRY: readonly ToolDescriptor[] = [
           description: "Optional lane used to resolve lane attachment.",
         },
       },
-      additionalProperties: false,
-    },
-  },
-  {
-    id: "tool.node.inspect",
-    description: "Inspect the enabled actions for a specific connected node capability.",
-    effect: "read_only",
-    keywords: ["node", "device", "inspect", "capability", "actions"],
-    ...TOOL_NODE_INSPECT_PROMPT_METADATA,
-    source: "builtin",
-    family: "node",
-    inputSchema: {
-      type: "object",
-      properties: {
-        node_id: {
-          type: "string",
-          description: "Target node id returned by tool.node.list.",
-        },
-        capability: {
-          type: "string",
-          description: "Exact capability descriptor id (example: tyrum.camera.capture-photo).",
-        },
-      },
-      required: ["node_id", "capability"],
-      additionalProperties: false,
-    },
-  },
-  {
-    id: "tool.node.dispatch",
-    description: "Dispatch a specific capability action to a connected node.",
-    effect: "state_changing",
-    keywords: ["node", "device", "screen", "automation", "dispatch"],
-    promptGuidance: [
-      "Inspect the capability first so you know the exact action_name and input shape.",
-      "Put action-specific arguments inside the input object.",
-      "Do not add the transport op field yourself; the dispatcher derives it from action_name.",
-      "Use node device metadata (type, platform, last_tyrum_interaction_at) to choose the best node for an action. Prefer nodes the user is actively using.",
-    ],
-    promptExamples: [
-      '{"node_id":"node_456","capability":"tyrum.browser.navigate","action_name":"navigate","input":{"url":"https://example.com"},"timeout_ms":30000}',
-      '{"node_id":"node_789","capability":"tyrum.location.get","action_name":"get","timeout_ms":30000}',
-    ],
-    source: "builtin",
-    family: "node",
-    inputSchema: {
-      type: "object",
-      properties: {
-        node_id: {
-          type: "string",
-          description: "Target node id returned by tool.node.list.",
-        },
-        capability: {
-          type: "string",
-          description: "Exact capability descriptor id (example: tyrum.audio.record).",
-        },
-        action_name: {
-          type: "string",
-          description: "Capability action name discovered via tool.node.inspect.",
-        },
-        input: {
-          type: "object",
-          additionalProperties: {},
-          description: "Action input object excluding the transport op field.",
-        },
-        timeout_ms: {
-          type: "number",
-          description: "Optional timeout in milliseconds (default: 30000).",
-        },
-      },
-      required: ["node_id", "capability", "action_name"],
       additionalProperties: false,
     },
   },

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -202,6 +202,16 @@ describe("tool registry routes", () => {
     };
     expect(body.status).toBe("ok");
     expect(body.tools.some((tool) => tool.source === "builtin")).toBe(true);
+    expect(body.tools).not.toContainEqual(
+      expect.objectContaining({
+        canonical_id: "tool.node.inspect",
+      }),
+    );
+    expect(body.tools).not.toContainEqual(
+      expect.objectContaining({
+        canonical_id: "tool.node.dispatch",
+      }),
+    );
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         source: "builtin_mcp",
@@ -291,6 +301,29 @@ describe("tool registry routes", () => {
           enabled: false,
           reason: "disabled_invalid_schema",
           agent_key: "default",
+        }),
+      }),
+    );
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
+        source: "builtin",
+        canonical_id: "tool.browser.navigate",
+        family: "node",
+        input_schema: expect.objectContaining({
+          type: "object",
+          properties: expect.objectContaining({
+            url: expect.objectContaining({ type: "string" }),
+            node_id: expect.objectContaining({
+              type: "string",
+              description: "Optional node id to target explicitly.",
+            }),
+            timeout_ms: expect.objectContaining({
+              type: "number",
+              description: "Optional dispatch timeout in milliseconds.",
+            }),
+          }),
+          required: ["url"],
+          additionalProperties: false,
         }),
       }),
     );

--- a/packages/gateway/tests/unit/tools.test.ts
+++ b/packages/gateway/tests/unit/tools.test.ts
@@ -235,16 +235,14 @@ describe("model tool naming", () => {
     });
   });
 
-  it("includes distinct inspect and dispatch node tools", () => {
+  it("does not expose legacy inspect and dispatch node tools once dedicated routed tools are available", () => {
     const builtinIds = listBuiltinToolDescriptors().map((tool) => tool.id);
 
-    expect(builtinIds).toContain("tool.node.inspect");
-    expect(builtinIds).toContain("tool.node.dispatch");
-    expect(builtinIds.filter((id) => id === "tool.node.dispatch")).toHaveLength(1);
-    expect(builtinIds.filter((id) => id === "tool.node.inspect")).toHaveLength(1);
+    expect(builtinIds).not.toContain("tool.node.inspect");
+    expect(builtinIds).not.toContain("tool.node.dispatch");
   });
 
-  it("includes dedicated browser and sensor node-backed tools with action-shaped schemas", () => {
+  it("includes dedicated browser and sensor node-backed tools with action-shaped schemas and direct-call guidance", () => {
     const builtinIds = listBuiltinToolDescriptors().map((tool) => tool.id);
     const browserNavigate = listBuiltinToolDescriptors().find(
       (tool) => tool.id === "tool.browser.navigate",
@@ -283,6 +281,15 @@ describe("model tool naming", () => {
         node_id: { type: "string" },
       },
     });
+    expect(browserNavigate?.promptGuidance).toContain(
+      "Pass action-specific fields directly and use node_id only when you need to target a specific node.",
+    );
+    expect(browserNavigate?.promptExamples).toContain(
+      '{"url":"https://example.com","node_id":"node_456","timeout_ms":30000}',
+    );
+    expect(locationGet?.promptGuidance).toContain(
+      "Omit node_id when any eligible attached node can satisfy the request.",
+    );
   });
 
   it("includes the location place tool family", () => {

--- a/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
@@ -47,6 +47,7 @@ describe("ConfigurePage (HTTP) tools", () => {
     expect(
       page.container.querySelector("[data-testid='admin-http-tools-group-extensions']"),
     ).not.toBeNull();
+    expect(page.container.textContent).toContain("tool.browser.navigate");
     expect(page.container.textContent).toContain("read");
     expect(page.container.textContent).toContain("websearch");
     expect(page.container.textContent).toContain("mcp.exa.web_search_exa");
@@ -81,25 +82,30 @@ describe("ConfigurePage (HTTP) tools", () => {
     act(() => {
       setNativeValue(
         getByTestId<HTMLInputElement>(page.container, "admin-http-tools-filter"),
-        "read",
+        "tool.browser.navigate",
       );
     });
     await flush();
 
-    expect(page.container.textContent).toContain("read");
+    expect(page.container.textContent).toContain("tool.browser.navigate");
     expect(page.container.textContent).not.toContain("plugin.echo.say");
 
     await clickAndFlush(
-      getByTestId<HTMLButtonElement>(page.container, "admin-http-tools-toggle-read"),
+      getByTestId<HTMLButtonElement>(
+        page.container,
+        "admin-http-tools-toggle-tool.browser.navigate",
+      ),
     );
 
-    const details = getByTestId<HTMLElement>(page.container, "admin-http-tools-details-read");
+    const details = getByTestId<HTMLElement>(
+      page.container,
+      "admin-http-tools-details-tool.browser.navigate",
+    );
     expect(details.textContent).toContain("Input fields");
-    expect(details.textContent).toContain("path");
-    expect(details.textContent).toContain("options");
-    expect(details.textContent).toContain("offset");
-    expect(details.textContent).toContain("boolean");
-    expect(details.textContent).not.toContain("root");
+    expect(details.textContent).toContain("url");
+    expect(details.textContent).toContain("node_id");
+    expect(details.textContent).toContain("timeout_ms");
+    expect(details.textContent).toContain("Optional dispatch timeout in milliseconds.");
 
     cleanupAdminHttpPage(page);
   });

--- a/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
@@ -3,6 +3,38 @@ export const DETAILED_TOOL_REGISTRY_FIXTURE = {
   tools: [
     {
       source: "builtin",
+      canonical_id: "tool.browser.navigate",
+      description: "Navigate to a URL.",
+      effect: "state_changing",
+      effective_exposure: {
+        enabled: true,
+        reason: "enabled",
+        agent_key: "default",
+      },
+      family: "node",
+      keywords: ["node", "browser", "navigate"],
+      input_schema: {
+        type: "object",
+        properties: {
+          url: {
+            type: "string",
+            description: "URL to open.",
+          },
+          node_id: {
+            type: "string",
+            description: "Optional node id to target explicitly.",
+          },
+          timeout_ms: {
+            type: "number",
+            description: "Optional dispatch timeout in milliseconds.",
+          },
+        },
+        required: ["url"],
+        additionalProperties: false,
+      },
+    },
+    {
+      source: "builtin",
       canonical_id: "read",
       description: "Read files from disk.",
       effect: "read_only",

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card-tool-output.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card-tool-output.test.ts
@@ -103,24 +103,24 @@ describe("MessageCard tool output rendering", () => {
       parts: [
         {
           type: "dynamic-tool",
-          toolName: "tool.node.inspect",
+          toolName: "tool.browser.snapshot",
           toolCallId: "tool-call-object",
           state: "output-available",
           output: {
             status: "ok",
-            actions: [{ name: "screenshot" }],
+            snapshot: { title: "Example" },
           },
         },
       ],
     } as unknown as UIMessage);
 
     act(() => {
-      click(findToggle(testRoot.container, "tool.node.inspect"));
+      click(findToggle(testRoot.container, "tool.browser.snapshot"));
     });
 
     expectStructuredJsonViewer(testRoot.container, "root: {2}");
-    expect(testRoot.container.textContent).toContain("actions");
-    expect(testRoot.container.textContent).toContain("screenshot");
+    expect(testRoot.container.textContent).toContain("snapshot");
+    expect(testRoot.container.textContent).toContain("Example");
 
     cleanupTestRoot(testRoot);
   });
@@ -188,7 +188,7 @@ describe("MessageCard tool output rendering", () => {
         parts: [
           {
             type: "dynamic-tool",
-            toolName: "tool.node.dispatch",
+            toolName: "tool.camera.capture-photo",
             toolCallId: "tool-call-2",
             state: "output-available",
             output: `<data source="tool">\n${outputJson}\n</data>`,
@@ -198,7 +198,7 @@ describe("MessageCard tool output rendering", () => {
       core,
     );
 
-    const toggle = findToggle(testRoot.container, "tool.node.dispatch");
+    const toggle = findToggle(testRoot.container, "tool.camera.capture-photo");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
     act(() => {
@@ -277,7 +277,7 @@ describe("MessageCard tool output rendering", () => {
       parts: [
         {
           type: "dynamic-tool",
-          toolName: "tool.node.dispatch",
+          toolName: "tool.camera.capture-photo",
           toolCallId: "tool-call-partial",
           state: "output-available",
           output: rawOutput,
@@ -286,7 +286,7 @@ describe("MessageCard tool output rendering", () => {
     } as unknown as UIMessage);
 
     act(() => {
-      click(findToggle(testRoot.container, "tool.node.dispatch"));
+      click(findToggle(testRoot.container, "tool.camera.capture-photo"));
     });
 
     const pre = testRoot.container.querySelector("pre") as HTMLPreElement | null;

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
@@ -245,10 +245,10 @@ describe("MessageCard", () => {
       parts: [
         {
           type: "dynamic-tool",
-          toolName: "tool.node.dispatch",
+          toolName: "tool.camera.capture-photo",
           toolCallId: "tool-call-artifact",
           state: "input-available",
-          input: { action_name: "capture_photo" },
+          input: { format: "jpeg" },
         },
       ],
     } as unknown as UIMessage;
@@ -263,10 +263,10 @@ describe("MessageCard", () => {
             parts: [
               {
                 type: "dynamic-tool",
-                toolName: "tool.node.dispatch",
+                toolName: "tool.camera.capture-photo",
                 toolCallId: "tool-call-artifact",
                 state: "output-available",
-                input: { action_name: "capture_photo" },
+                input: { format: "jpeg" },
                 output: {
                   run_id: "11111111-1111-1111-1111-111111111111",
                   payload: {
@@ -288,7 +288,7 @@ describe("MessageCard", () => {
       );
     });
 
-    const toggle = findToggle(testRoot.container, "tool.node.dispatch");
+    const toggle = findToggle(testRoot.container, "tool.camera.capture-photo");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(testRoot.container.textContent).not.toContain("artifact_id");
 


### PR DESCRIPTION
Closes #1591

## Summary
- remove model-facing `tool.node.inspect` and `tool.node.dispatch` entries from the built-in tool registry
- add shared prompt guidance/examples for dedicated routed node-backed tools so agents see direct-call shapes
- update operator UI fixtures and message-card coverage to use dedicated routed tool ids in config and chat surfaces

## Verification
- `pnpm format:check`
- `pnpm format`
- `pnpm vitest packages/gateway/tests/unit/tools.test.ts`
- `pnpm vitest packages/gateway/tests/unit/tool-registry-routes.test.ts`
- `pnpm vitest packages/gateway/tests/integration/tool-registry.test.ts`
- `pnpm vitest packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts`
- `pnpm vitest packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card-tool-output.test.ts`
- `pnpm vitest packages/operator-ui/tests/pages/admin-http-tools.page.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes which node tools are advertised to models/admin UI and adds auto-generated prompt examples based on action schemas, which could affect tool selection and invocation formatting.
> 
> **Overview**
> **Shifts model-facing node tooling to dedicated routed tools.** The built-in tool registry no longer exposes `tool.node.inspect` or `tool.node.dispatch`, and tests now assert they are absent from `/config/tools` and `listBuiltinToolDescriptors()`.
> 
> **Improves dedicated routed tool usability.** Dedicated node-backed tools (e.g. `tool.browser.navigate`, `tool.location.get`, camera/audio tools) now include shared `promptGuidance` plus `promptExamples`, with a fallback generator that derives example arguments from each action’s `inputSchema`.
> 
> **Updates operator UI coverage to the new tool ids.** Admin HTTP tools fixtures/tests and chat MessageCard tool-output tests switch from legacy node helper ids to dedicated routed tool ids (e.g. `tool.browser.navigate`, `tool.camera.capture-photo`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f560b66208ec76a626fc482554bc9cdab82cb62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->