### PR TITLE
Add non-happy-path coverage for runtime packages

### DIFF
--- a/packages/node-sdk/tests/capability.test.ts
+++ b/packages/node-sdk/tests/capability.test.ts
@@ -1,9 +1,69 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import type { WebSocket as WsWebSocket } from "ws";
 import { TyrumClient } from "@tyrum/transport-sdk";
 import { autoExecute } from "../src/capability.js";
 import type { CapabilityProvider, TaskExecuteContext } from "../src/capability.js";
+
+type TaskExecuteMessage = {
+  request_id: string;
+  payload: {
+    run_id: string;
+    step_id: string;
+    attempt_id: string;
+    action: {
+      type: string;
+      args: Record<string, unknown>;
+    };
+  };
+};
+
+class FakeAutoExecuteClient implements Pick<TyrumClient, "on" | "respondTaskExecute"> {
+  respondTaskExecute = vi.fn();
+  private handler: ((msg: TaskExecuteMessage) => void) | undefined;
+
+  on(event: string, handler: (msg: TaskExecuteMessage) => void): void {
+    expect(event).toBe("task_execute");
+    this.handler = handler;
+  }
+
+  dispatch(message: TaskExecuteMessage): void {
+    if (!this.handler) {
+      throw new Error("task_execute handler not registered");
+    }
+    this.handler(message);
+  }
+}
+
+function makeTaskExecuteMessage(
+  action: TaskExecuteMessage["payload"]["action"],
+  overrides?: Partial<TaskExecuteMessage>,
+): TaskExecuteMessage {
+  return {
+    request_id: overrides?.request_id ?? "t-1",
+    payload: {
+      run_id: "550e8400-e29b-41d4-a716-446655440000",
+      step_id: "6f9619ff-8b86-4d11-b42d-00c04fc964ff",
+      attempt_id: "0a9d6b69-8bdb-4b1b-9d0b-9c8a0efc0d9e",
+      action,
+      ...overrides?.payload,
+    },
+  };
+}
+
+async function flushAsyncDispatch(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForRespondTaskCalls(
+  respondTaskExecute: { mock: { calls: unknown[] } },
+  count: number,
+): Promise<void> {
+  await vi.waitFor(() => {
+    expect(respondTaskExecute.mock.calls).toHaveLength(count);
+  });
+}
 
 function createTestServer(): {
   wss: WebSocketServer;
@@ -143,5 +203,178 @@ describe("autoExecute", () => {
       ok: true,
       result: { evidence: { screenshot: "base64..." } },
     });
+  });
+
+  it("routes actions through explicit capabilityIds when they are provided", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    const execute = vi.fn(
+      async (action: { type: string; args: Record<string, unknown> }, ctx?: TaskExecuteContext) => {
+        expect(action).toEqual({ type: "Desktop", args: { op: "screenshot" } });
+        expect(ctx).toEqual({
+          requestId: "t-1",
+          runId: "550e8400-e29b-41d4-a716-446655440000",
+          stepId: "6f9619ff-8b86-4d11-b42d-00c04fc964ff",
+          attemptId: "0a9d6b69-8bdb-4b1b-9d0b-9c8a0efc0d9e",
+        });
+        return { success: true, result: { ok: true } };
+      },
+    );
+    const provider: CapabilityProvider = {
+      capabilityIds: ["tyrum.desktop.screenshot"],
+      execute,
+    };
+
+    autoExecute(fakeClient, [provider]);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await waitForRespondTaskCalls(fakeClient.respondTaskExecute, 1);
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledWith(
+      "t-1",
+      true,
+      { ok: true },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("prefers capabilityIds over deprecated capability when both are present", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    const execute = vi.fn();
+    const provider: CapabilityProvider = {
+      capability: "desktop",
+      capabilityIds: ["tyrum.browser.navigate"],
+      execute,
+    };
+
+    autoExecute(fakeClient, [provider]);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await flushAsyncDispatch();
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledWith(
+      "t-1",
+      false,
+      undefined,
+      undefined,
+      "no provider for capability: tyrum.desktop.screenshot",
+    );
+  });
+
+  it("fails when no provider matches the required capability", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+
+    autoExecute(fakeClient, []);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await flushAsyncDispatch();
+
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledWith(
+      "t-1",
+      false,
+      undefined,
+      undefined,
+      "no provider for capability: tyrum.desktop.screenshot",
+    );
+  });
+
+  it("returns provider errors as failed task responses", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    const provider: CapabilityProvider = {
+      capability: "desktop",
+      execute: vi.fn(async () => {
+        throw new Error("desktop unavailable");
+      }),
+    };
+
+    autoExecute(fakeClient, [provider]);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await waitForRespondTaskCalls(fakeClient.respondTaskExecute, 1);
+
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledWith(
+      "t-1",
+      false,
+      undefined,
+      undefined,
+      "desktop unavailable",
+    );
+  });
+
+  it("passes through unsuccessful task results unchanged", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    const provider: CapabilityProvider = {
+      capability: "desktop",
+      execute: vi.fn(async () => ({
+        success: false,
+        evidence: { reason: "operator-denied" },
+        error: "approval required",
+      })),
+    };
+
+    autoExecute(fakeClient, [provider]);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await waitForRespondTaskCalls(fakeClient.respondTaskExecute, 1);
+
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledWith(
+      "t-1",
+      false,
+      undefined,
+      { reason: "operator-denied" },
+      "approval required",
+    );
+  });
+
+  it("attempts a fallback failure response when serialization fails", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    fakeClient.respondTaskExecute
+      .mockImplementationOnce(() => {
+        throw new Error("serialize failed");
+      })
+      .mockImplementationOnce(() => undefined);
+
+    const provider: CapabilityProvider = {
+      capability: "desktop",
+      execute: vi.fn(async () => ({
+        success: true,
+        result: { answer: 42 },
+      })),
+    };
+
+    autoExecute(fakeClient, [provider]);
+    fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    await waitForRespondTaskCalls(fakeClient.respondTaskExecute, 2);
+
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledTimes(2);
+    expect(fakeClient.respondTaskExecute).toHaveBeenNthCalledWith(
+      2,
+      "t-1",
+      false,
+      undefined,
+      undefined,
+      "task.execute response serialization failed: serialize failed",
+    );
+  });
+
+  it("swallows a fallback serialization failure", async () => {
+    const fakeClient = new FakeAutoExecuteClient();
+    fakeClient.respondTaskExecute.mockImplementation(() => {
+      throw new Error("still broken");
+    });
+
+    const provider: CapabilityProvider = {
+      capability: "desktop",
+      execute: vi.fn(async () => ({
+        success: true,
+        result: { ok: true },
+      })),
+    };
+
+    autoExecute(fakeClient, [provider]);
+
+    expect(() => {
+      fakeClient.dispatch(makeTaskExecuteMessage({ type: "Desktop", args: { op: "screenshot" } }));
+    }).not.toThrow();
+
+    await waitForRespondTaskCalls(fakeClient.respondTaskExecute, 2);
+    expect(fakeClient.respondTaskExecute).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/node-sdk/tests/managed-node-client.test.ts
+++ b/packages/node-sdk/tests/managed-node-client.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const autoExecuteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/capability.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../src/capability.js")>("../src/capability.js");
+  return {
+    ...actual,
+    autoExecute: autoExecuteMock,
+  };
+});
+
 import { createManagedNodeClientLifecycle, type ManagedNodeClient } from "../src/browser.js";
+import type { CapabilityProvider } from "../src/capability.js";
 
 type ManagedEventName = "connected" | "disconnected" | "transport_error";
 type ManagedEventPayloads = {
@@ -56,9 +69,17 @@ class FakeManagedNodeClient implements ManagedNodeClient {
       handler(payload);
     }
   }
+
+  listenerCount(event: ManagedEventName): number {
+    return this.listeners[event].size;
+  }
 }
 
 describe("createManagedNodeClientLifecycle", () => {
+  beforeEach(() => {
+    autoExecuteMock.mockReset();
+  });
+
   it("registers providers, connects, and republishes capability state on connect", async () => {
     const client = new FakeManagedNodeClient();
     const registerProviders = vi.fn();
@@ -89,5 +110,152 @@ describe("createManagedNodeClientLifecycle", () => {
       capabilities: [],
       capability_states: [],
     });
+  });
+
+  it("does not publish capability state before the first connection", async () => {
+    const client = new FakeManagedNodeClient();
+    const getCapabilityReadyPayload = vi.fn(() => ({
+      capabilities: [],
+      capability_states: [],
+    }));
+
+    const lifecycle = createManagedNodeClientLifecycle({
+      client,
+      getCapabilityReadyPayload,
+    });
+
+    await lifecycle.publishCapabilityState();
+
+    expect(getCapabilityReadyPayload).not.toHaveBeenCalled();
+    expect(client.capabilityReady).not.toHaveBeenCalled();
+  });
+
+  it("registers providers with autoExecute when registerProviders is absent", () => {
+    const client = new FakeManagedNodeClient();
+    const providers = [{ capability: "desktop", execute: vi.fn() }] satisfies CapabilityProvider[];
+
+    createManagedNodeClientLifecycle({
+      client,
+      providers,
+      getCapabilityReadyPayload: () => ({
+        capabilities: [],
+        capability_states: [],
+      }),
+    });
+
+    expect(autoExecuteMock).toHaveBeenCalledWith(client, providers);
+  });
+
+  it("prefers registerProviders over providers", () => {
+    const client = new FakeManagedNodeClient();
+    const registerProviders = vi.fn();
+    const providers = [{ capability: "desktop", execute: vi.fn() }] satisfies CapabilityProvider[];
+
+    createManagedNodeClientLifecycle({
+      client,
+      providers,
+      registerProviders,
+      getCapabilityReadyPayload: () => ({
+        capabilities: [],
+        capability_states: [],
+      }),
+    });
+
+    expect(registerProviders).toHaveBeenCalledWith(client);
+    expect(autoExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("handles disconnects, transport errors, and reconnects", async () => {
+    const client = new FakeManagedNodeClient();
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+    const onTransportError = vi.fn();
+    const getCapabilityReadyPayload = vi.fn(() => ({
+      capabilities: [],
+      capability_states: [],
+    }));
+
+    const lifecycle = createManagedNodeClientLifecycle({
+      client,
+      getCapabilityReadyPayload,
+      onConnected,
+      onDisconnected,
+      onTransportError,
+    });
+
+    client.emit("connected", { clientId: "client-1" });
+    await Promise.resolve();
+
+    expect(onConnected).toHaveBeenCalledWith({ clientId: "client-1" });
+    expect(client.capabilityReady).toHaveBeenCalledTimes(1);
+
+    client.emit("disconnected", { code: 1006, reason: "net down" });
+    expect(onDisconnected).toHaveBeenCalledWith({ code: 1006, reason: "net down" });
+
+    await lifecycle.publishCapabilityState();
+    expect(client.capabilityReady).toHaveBeenCalledTimes(1);
+
+    client.emit("transport_error", { message: "socket closed" });
+    expect(onTransportError).toHaveBeenCalledWith({ message: "socket closed" });
+
+    client.emit("connected", { clientId: "client-2" });
+    await Promise.resolve();
+
+    expect(onConnected).toHaveBeenCalledWith({ clientId: "client-2" });
+    expect(client.capabilityReady).toHaveBeenCalledTimes(2);
+  });
+
+  it("disposes idempotently and ignores future events and calls", async () => {
+    const client = new FakeManagedNodeClient();
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+    const onTransportError = vi.fn();
+    const onDispose = vi.fn();
+    const getCapabilityReadyPayload = vi.fn(() => ({
+      capabilities: [],
+      capability_states: [],
+    }));
+
+    const lifecycle = createManagedNodeClientLifecycle({
+      client,
+      getCapabilityReadyPayload,
+      onConnected,
+      onDisconnected,
+      onTransportError,
+      onDispose,
+    });
+
+    expect(client.listenerCount("connected")).toBe(1);
+    expect(client.listenerCount("disconnected")).toBe(1);
+    expect(client.listenerCount("transport_error")).toBe(1);
+
+    lifecycle.connect();
+    expect(client.connect).toHaveBeenCalledTimes(1);
+
+    client.emit("connected", { clientId: "client-1" });
+    await Promise.resolve();
+    expect(client.capabilityReady).toHaveBeenCalledTimes(1);
+
+    lifecycle.dispose();
+    lifecycle.dispose();
+
+    expect(onDispose).toHaveBeenCalledTimes(1);
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+    expect(client.listenerCount("connected")).toBe(0);
+    expect(client.listenerCount("disconnected")).toBe(0);
+    expect(client.listenerCount("transport_error")).toBe(0);
+
+    lifecycle.connect();
+    await lifecycle.publishCapabilityState();
+    client.emit("connected", { clientId: "client-2" });
+    client.emit("disconnected", { code: 1000, reason: "bye" });
+    client.emit("transport_error", { message: "ignored" });
+    await Promise.resolve();
+
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(client.capabilityReady).toHaveBeenCalledTimes(1);
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onTransportError).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime-agent/tests/agent-runtime.test.ts
+++ b/packages/runtime-agent/tests/agent-runtime.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AgentTurnRequest, AgentTurnResponse } from "@tyrum/contracts";
-import { AgentRuntime, applyDeterministicContextCompactionAndToolPruning } from "../src/index.ts";
+import type {
+  AgentRuntimeLifecycle,
+  AgentRuntimeOptions,
+  AgentRuntimeToolCatalog,
+} from "../src/index.ts";
+import { AgentRuntime } from "../src/index.ts";
 
 type ContextReport = { reportId: string };
 type ToolDescriptor = { id: string };
@@ -12,29 +17,114 @@ type Plugins = { name: string };
 type ExecutionPort = { resumeRun(token: string): Promise<string | undefined> };
 type RuntimeDeps = { shutdown: () => Promise<void> };
 
-function createRuntime() {
-  const finalizeTurnLifecycle = vi.fn(
-    async (
-      _context: unknown,
-      input: {
-        response: AgentTurnResponse;
-        contextReport?: ContextReport;
-        turnInput: AgentTurnRequest;
-      },
-    ) => input.response,
-  );
-  const turn = vi.fn(async () => ({
-    response: { reply: "done", session_id: "session-1" } satisfies AgentTurnResponse,
-    contextReport: { reportId: "ctx-1" } satisfies ContextReport,
-  }));
-  const turnStream = vi.fn(async () => ({
-    streamResult: { id: "stream-1" } satisfies StreamResult,
-    sessionId: "session-1",
-    guardianReviewDecisionCollector: { calls: 1 } satisfies GuardianCollector,
-    contextReport: { reportId: "ctx-stream" } satisfies ContextReport,
-    finalize: async () =>
-      ({ reply: "stream done", session_id: "session-1" }) satisfies AgentTurnResponse,
-  }));
+type RuntimeLifecycle = AgentRuntimeLifecycle<
+  RuntimeDeps,
+  Plugins,
+  ExecutionPort,
+  ContextReport,
+  ToolDescriptor,
+  GuardianDecision,
+  GuardianCollector,
+  SessionCompactionResult,
+  StreamResult
+>;
+
+type RuntimeOptions = AgentRuntimeOptions<
+  RuntimeDeps,
+  Plugins,
+  ExecutionPort,
+  ContextReport,
+  ToolDescriptor,
+  GuardianDecision,
+  GuardianCollector,
+  SessionCompactionResult,
+  StreamResult
+>;
+
+function makeResponse(reply: string): AgentTurnResponse {
+  return { reply, session_id: "session-1" };
+}
+
+function createRuntime(
+  overrides: {
+    options?: Partial<RuntimeOptions>;
+    lifecycle?: Partial<RuntimeLifecycle>;
+  } = {},
+) {
+  const finalizeTurnLifecycle =
+    overrides.lifecycle?.finalizeTurnLifecycle ??
+    vi.fn(
+      async (
+        _context,
+        input: {
+          response: AgentTurnResponse;
+          contextReport?: ContextReport;
+          turnInput: AgentTurnRequest;
+        },
+      ) => input.response,
+    );
+  const status = overrides.lifecycle?.status ?? vi.fn(async () => ({ enabled: true }) as never);
+  const listRegisteredTools =
+    overrides.lifecycle?.listRegisteredTools ??
+    vi.fn(async () => ({
+      allowlist: ["bash"],
+      tools: [{ id: "bash" }],
+      mcpServers: ["memory"],
+    }));
+  const turn =
+    overrides.lifecycle?.turn ??
+    vi.fn(async () => ({
+      response: makeResponse("done"),
+      contextReport: { reportId: "ctx-1" } satisfies ContextReport,
+    }));
+  const turnStream =
+    overrides.lifecycle?.turnStream ??
+    vi.fn(async () => ({
+      streamResult: { id: "stream-1" } satisfies StreamResult,
+      sessionId: "session-1",
+      guardianReviewDecisionCollector: { calls: 1 } satisfies GuardianCollector,
+      contextReport: { reportId: "ctx-stream" } satisfies ContextReport,
+      finalize: async () => makeResponse("stream done"),
+    }));
+  const compactSession =
+    overrides.lifecycle?.compactSession ??
+    vi.fn(async () => ({ checkpointId: "cp-1" }) satisfies SessionCompactionResult);
+  const executeDecideAction =
+    overrides.lifecycle?.executeDecideAction ??
+    vi.fn(async () => ({
+      response: makeResponse("decide"),
+      contextReport: { reportId: "ctx-decide" } satisfies ContextReport,
+    }));
+  const executeGuardianReview =
+    overrides.lifecycle?.executeGuardianReview ??
+    vi.fn(async () => ({
+      response: makeResponse("review"),
+      contextReport: { reportId: "ctx-review" } satisfies ContextReport,
+      decision: "allow" satisfies GuardianDecision,
+      calls: 2,
+      invalidCalls: 0,
+    }));
+
+  const lifecycle: RuntimeLifecycle = {
+    finalizeTurnLifecycle,
+    status,
+    listRegisteredTools,
+    turn,
+    turnStream,
+    compactSession,
+    executeDecideAction,
+    executeGuardianReview,
+  };
+
+  const shutdownDep = vi.fn(async () => undefined);
+  const executionPort = {
+    resumeRun: vi.fn(async () => undefined),
+  } satisfies ExecutionPort;
+  const onShutdown =
+    overrides.options?.onShutdown ??
+    vi.fn(async (context) => {
+      await context.deps.shutdown();
+    });
 
   const runtime = new AgentRuntime<
     RuntimeDeps,
@@ -48,86 +138,259 @@ function createRuntime() {
     StreamResult
   >({
     deps: {
-      shutdown: vi.fn(async () => undefined),
+      shutdown: shutdownDep,
     },
     defaultTenantId: "tenant-default",
     resolveDefaultAgentId: () => "default",
     resolveDefaultWorkspaceId: () => "default",
     resolveHome: (agentId) => `/tmp/${agentId}`,
-    executionPort: {
-      resumeRun: vi.fn(async () => undefined),
-    },
-    lifecycle: {
-      finalizeTurnLifecycle,
-      status: vi.fn(async () => ({ enabled: true }) as never),
-      listRegisteredTools: vi.fn(async () => ({
-        allowlist: ["bash"],
-        tools: [{ id: "bash" }],
-        mcpServers: ["memory"],
-      })),
-      turn,
-      turnStream,
-      compactSession: vi.fn(async () => ({ checkpointId: "cp-1" })),
-      executeDecideAction: vi.fn(async () => ({
-        response: { reply: "decide", session_id: "session-1" } satisfies AgentTurnResponse,
-        contextReport: { reportId: "ctx-decide" } satisfies ContextReport,
-      })),
-      executeGuardianReview: vi.fn(async () => ({
-        response: { reply: "review", session_id: "session-1" } satisfies AgentTurnResponse,
-        contextReport: { reportId: "ctx-review" } satisfies ContextReport,
-        decision: "allow" satisfies GuardianDecision,
-        calls: 2,
-        invalidCalls: 0,
-      })),
-    },
-    onShutdown: async (context) => {
-      await context.deps.shutdown();
-    },
+    executionPort,
+    lifecycle,
+    onShutdown,
+    ...overrides.options,
   });
 
   return {
     runtime,
-    finalizeTurnLifecycle,
-    turn,
-    turnStream,
+    lifecycle: {
+      finalizeTurnLifecycle,
+      status,
+      listRegisteredTools,
+      turn,
+      turnStream,
+      compactSession,
+      executeDecideAction,
+      executeGuardianReview,
+    },
+    shutdownDep,
+    executionPort,
+    onShutdown,
   };
 }
 
 describe("@tyrum/runtime-agent AgentRuntime", () => {
-  it("records the last context report after turn finalization", async () => {
-    const { runtime, finalizeTurnLifecycle, turn } = createRuntime();
+  it("rejects invalid agent ids", () => {
+    expect(() =>
+      createRuntime({
+        options: {
+          agentId: "bad:agent",
+        },
+      }),
+    ).toThrow(/invalid agent_id/i);
+  });
 
-    const result = await runtime.turn({
-      message: "hello",
-    } as AgentTurnRequest);
+  it("rejects invalid workspace ids", () => {
+    expect(() =>
+      createRuntime({
+        options: {
+          workspaceId: "bad:workspace",
+        },
+      }),
+    ).toThrow(/invalid workspace_id/i);
+  });
+
+  it("trims explicit identity values and clamps timing settings", () => {
+    const { runtime } = createRuntime({
+      options: {
+        agentId: " agent-1 ",
+        workspaceId: " workspace-1 ",
+        tenantId: " tenant-1 ",
+        instanceOwner: " owner-1 ",
+        home: "/tmp/custom-home",
+        plugins: { name: "plugin-a" },
+        approvalWaitMs: 1,
+        approvalPollMs: 1,
+        turnEngineWaitMs: 0,
+      },
+    });
+
+    expect(runtime.instanceOwner).toBe("owner-1");
+    expect(runtime.getContext()).toMatchObject({
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      tenantId: "tenant-1",
+      home: "/tmp/custom-home",
+      approvalWaitMs: 1_000,
+      approvalPollMs: 100,
+      turnEngineWaitMs: 1,
+      plugins: { name: "plugin-a" },
+    });
+  });
+
+  it("exposes a generated instance owner when one is not configured", () => {
+    const { runtime } = createRuntime();
+
+    expect(runtime.instanceOwner).toMatch(/^instance-/);
+    expect(runtime.getContext().instanceOwner).toBe(runtime.instanceOwner);
+  });
+
+  it("delegates status and listRegisteredTools with the runtime context", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const expectedCatalog: AgentRuntimeToolCatalog<ToolDescriptor> = {
+      allowlist: ["bash"],
+      tools: [{ id: "bash" }],
+      mcpServers: ["memory"],
+    };
+    lifecycle.listRegisteredTools.mockResolvedValueOnce(expectedCatalog);
+
+    const statusResult = await runtime.status(true);
+    const toolsResult = await runtime.listRegisteredTools();
+
+    expect(statusResult).toEqual({ enabled: true });
+    expect(lifecycle.status).toHaveBeenCalledWith(runtime.getContext(), true);
+    expect(toolsResult).toEqual(expectedCatalog);
+    expect(lifecycle.listRegisteredTools).toHaveBeenCalledWith(runtime.getContext());
+  });
+
+  it("delegates compactSession inputs unchanged", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const abortController = new AbortController();
+    const input = {
+      sessionId: "session-9",
+      keepLastMessages: 5,
+      abortSignal: abortController.signal,
+      timeoutMs: 2_500,
+    };
+
+    const result = await runtime.compactSession(input);
+
+    expect(result).toEqual({ checkpointId: "cp-1" });
+    expect(lifecycle.compactSession).toHaveBeenCalledWith(runtime.getContext(), input);
+  });
+
+  it("calls onShutdown with the runtime context", async () => {
+    const { runtime, onShutdown, shutdownDep } = createRuntime();
+
+    await runtime.shutdown();
+
+    expect(onShutdown).toHaveBeenCalledWith(runtime.getContext());
+    expect(shutdownDep).toHaveBeenCalledOnce();
+  });
+
+  it("records the last context report after turn finalization", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const request = { message: "hello" } as AgentTurnRequest;
+
+    const result = await runtime.turn(request);
 
     expect(result.reply).toBe("done");
-    expect(turn).toHaveBeenCalledOnce();
-    expect(finalizeTurnLifecycle).toHaveBeenCalledOnce();
+    expect(lifecycle.turn).toHaveBeenCalledWith(runtime.getContext(), request);
+    expect(lifecycle.finalizeTurnLifecycle).toHaveBeenCalledOnce();
     expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-1" });
   });
 
-  it("exposes stream finalization through the same lifecycle wrapper", async () => {
-    const { runtime, finalizeTurnLifecycle, turnStream } = createRuntime();
+  it("preserves the previous context report when turn returns no new report", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    lifecycle.turn
+      .mockResolvedValueOnce({
+        response: makeResponse("first"),
+        contextReport: { reportId: "ctx-first" } satisfies ContextReport,
+      })
+      .mockResolvedValueOnce({
+        response: makeResponse("second"),
+      });
 
-    const handle = await runtime.turnStream({
-      message: "hello",
-    } as AgentTurnRequest);
+    await runtime.turn({ message: "first" } as AgentTurnRequest);
+    await runtime.turn({ message: "second" } as AgentTurnRequest);
+
+    expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-first" });
+  });
+
+  it("exposes stream finalization through the same lifecycle wrapper", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const request = { message: "hello" } as AgentTurnRequest;
+
+    const handle = await runtime.turnStream(request);
     const result = await handle.finalize();
 
     expect(handle.guardianReviewDecisionCollector).toEqual({ calls: 1 });
     expect(result.reply).toBe("stream done");
-    expect(turnStream).toHaveBeenCalledOnce();
-    expect(finalizeTurnLifecycle).toHaveBeenCalledOnce();
+    expect(lifecycle.turnStream).toHaveBeenCalledWith(runtime.getContext(), request);
+    expect(lifecycle.finalizeTurnLifecycle).toHaveBeenCalledOnce();
     expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-stream" });
   });
 
-  it("keeps deterministic context pruning available from the package root", () => {
-    const compacted = applyDeterministicContextCompactionAndToolPruning([
-      { role: "system", content: "system" },
-      { role: "user", content: "hello" },
-    ]);
+  it("preserves the previous context report when stream handles omit it", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    lifecycle.turnStream
+      .mockResolvedValueOnce({
+        streamResult: { id: "stream-1" } satisfies StreamResult,
+        sessionId: "session-1",
+        guardianReviewDecisionCollector: { calls: 1 } satisfies GuardianCollector,
+        contextReport: { reportId: "ctx-stream-1" } satisfies ContextReport,
+        finalize: async () => makeResponse("stream one"),
+      })
+      .mockResolvedValueOnce({
+        streamResult: { id: "stream-2" } satisfies StreamResult,
+        sessionId: "session-2",
+        guardianReviewDecisionCollector: { calls: 2 } satisfies GuardianCollector,
+        finalize: async () => makeResponse("stream two"),
+      });
 
-    expect(compacted).toHaveLength(2);
+    const first = await runtime.turnStream({ message: "first" } as AgentTurnRequest);
+    await first.finalize();
+    const second = await runtime.turnStream({ message: "second" } as AgentTurnRequest);
+    await second.finalize();
+
+    expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-stream-1" });
+  });
+
+  it("finalizes decide actions and updates the last context report", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const request = { message: "decide" } as AgentTurnRequest;
+    const opts = { timeoutMs: 500, execution: { kind: "automation" } };
+
+    const result = await runtime.executeDecideAction(request, opts);
+
+    expect(result.reply).toBe("decide");
+    expect(lifecycle.executeDecideAction).toHaveBeenCalledWith(runtime.getContext(), request, opts);
+    expect(lifecycle.finalizeTurnLifecycle).toHaveBeenLastCalledWith(runtime.getContext(), {
+      turnInput: request,
+      response: makeResponse("decide"),
+      contextReport: { reportId: "ctx-decide" },
+    });
+    expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-decide" });
+  });
+
+  it("finalizes guardian reviews and preserves decision metadata", async () => {
+    const { runtime, lifecycle } = createRuntime();
+    const request = { message: "review" } as AgentTurnRequest;
+    const opts = { timeoutMs: 250 };
+    lifecycle.executeGuardianReview.mockResolvedValueOnce({
+      response: makeResponse("guardian"),
+      contextReport: { reportId: "ctx-guardian" } satisfies ContextReport,
+      decision: "deny" satisfies GuardianDecision,
+      calls: 4,
+      invalidCalls: 1,
+      error: "missing evidence",
+    });
+
+    const result = await runtime.executeGuardianReview(request, opts);
+
+    expect(lifecycle.executeGuardianReview).toHaveBeenCalledWith(
+      runtime.getContext(),
+      request,
+      opts,
+    );
+    expect(result).toEqual({
+      response: makeResponse("guardian"),
+      decision: "deny",
+      calls: 4,
+      invalidCalls: 1,
+      error: "missing evidence",
+    });
+    expect(runtime.getLastContextReport()).toEqual({ reportId: "ctx-guardian" });
+  });
+
+  it("sets plugins on the mutable runtime context", () => {
+    const { runtime } = createRuntime({
+      options: {
+        plugins: { name: "initial" },
+      },
+    });
+
+    runtime.setPlugins({ name: "updated" });
+
+    expect(runtime.getContext().plugins).toEqual({ name: "updated" });
   });
 });

--- a/packages/runtime-agent/tests/context-pruning.test.ts
+++ b/packages/runtime-agent/tests/context-pruning.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMessage } from "ai";
+import { applyDeterministicContextCompactionAndToolPruning } from "../src/index.ts";
+
+function makeToolCallMessage(id: string): ModelMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "tool-call", toolCallId: id, toolName: "tool.fs.read", input: {} }],
+  } as unknown as ModelMessage;
+}
+
+function makeToolResultMessage(id: string, output: string): ModelMessage {
+  return {
+    role: "tool",
+    content: [
+      {
+        type: "tool-result",
+        toolCallId: id,
+        toolName: "tool.fs.read",
+        output,
+      },
+    ],
+  } as unknown as ModelMessage;
+}
+
+describe("@tyrum/runtime-agent context pruning", () => {
+  it("preserves instruction head messages when truncating", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "sys-a" },
+      { role: "system", content: "sys-b" },
+      { role: "user", content: [{ type: "text", text: "u-a" }] },
+      { role: "user", content: [{ type: "text", text: "u-b" }] },
+      ...Array.from({ length: 10 }, (_unused, index) => ({
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: `a-${index}` }],
+      })),
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 8,
+      tool_prune_keep_last_messages: 4,
+    });
+
+    expect(compacted).toHaveLength(8);
+    expect(compacted.slice(0, 4)).toEqual(messages.slice(0, 4));
+  });
+
+  it("prunes older tool results even when message count is unlimited", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: [{ type: "text", text: "read files" }] },
+      makeToolCallMessage("tc-1"),
+      makeToolResultMessage("tc-1", "FIRST_TOOL_OUTPUT_123"),
+      makeToolCallMessage("tc-2"),
+      makeToolResultMessage("tc-2", "SECOND_TOOL_OUTPUT_456"),
+      makeToolCallMessage("tc-3"),
+      makeToolResultMessage("tc-3", "THIRD_TOOL_OUTPUT_789"),
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 0,
+      tool_prune_keep_last_messages: 4,
+    });
+    const promptText = JSON.stringify(compacted);
+
+    expect(promptText).not.toContain("FIRST_TOOL_OUTPUT_123");
+    expect(promptText).toContain("SECOND_TOOL_OUTPUT_456");
+    expect(promptText).toContain("THIRD_TOOL_OUTPUT_789");
+  });
+
+  it("normalizes max_messages to at least eight", () => {
+    const messages = Array.from({ length: 10 }, (_unused, index) => ({
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: `msg-${index}` }],
+    }));
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 1,
+      tool_prune_keep_last_messages: 4,
+    });
+
+    expect(compacted).toHaveLength(8);
+  });
+
+  it("normalizes tool_prune_keep_last_messages to at least two", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: [{ type: "text", text: "read files" }] },
+      makeToolCallMessage("tc-1"),
+      makeToolResultMessage("tc-1", "FIRST_TOOL_OUTPUT_123"),
+      makeToolCallMessage("tc-2"),
+      makeToolResultMessage("tc-2", "SECOND_TOOL_OUTPUT_456"),
+      makeToolCallMessage("tc-3"),
+      makeToolResultMessage("tc-3", "THIRD_TOOL_OUTPUT_789"),
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 0,
+      tool_prune_keep_last_messages: 1,
+    });
+    const normalized = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 0,
+      tool_prune_keep_last_messages: 2,
+    });
+
+    expect(compacted).toEqual(normalized);
+  });
+
+  it("returns empty output when pruning removes all messages", () => {
+    const compacted = applyDeterministicContextCompactionAndToolPruning(
+      [{ role: "user", content: "" }],
+      {
+        max_messages: 8,
+        tool_prune_keep_last_messages: 4,
+      },
+    );
+
+    expect(compacted).toEqual([]);
+  });
+
+  it("returns early when the pruned output already fits within max_messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "done" },
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 8,
+      tool_prune_keep_last_messages: 4,
+    });
+
+    expect(compacted).toEqual(messages);
+  });
+
+  it("keeps the first assistant message when truncation starts with assistant output", () => {
+    const messages = Array.from({ length: 11 }, (_unused, index) => ({
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: `assistant-${index}` }],
+    }));
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 8,
+      tool_prune_keep_last_messages: 4,
+    });
+
+    expect(compacted).toHaveLength(8);
+    expect(compacted[0]).toEqual(messages[0]);
+  });
+
+  it("returns the instruction head when it already fills the message budget", () => {
+    const messages: ModelMessage[] = [
+      ...Array.from({ length: 8 }, (_unused, index) => ({
+        role: "system" as const,
+        content: `system-${index}`,
+      })),
+      { role: "assistant", content: "assistant-1" },
+      { role: "assistant", content: "assistant-2" },
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 4,
+      tool_prune_keep_last_messages: 4,
+    });
+
+    expect(compacted).toEqual(messages.slice(0, 8));
+  });
+
+  it("skips leading tool messages from the retained tail window", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hello" },
+      makeToolCallMessage("tc-1"),
+      makeToolResultMessage("tc-1", "FIRST_TOOL_OUTPUT_123"),
+      makeToolCallMessage("tc-2"),
+      makeToolResultMessage("tc-2", "SECOND_TOOL_OUTPUT_456"),
+      { role: "assistant", content: "tail-1" },
+      { role: "assistant", content: "tail-2" },
+      { role: "assistant", content: "tail-3" },
+    ];
+
+    const compacted = applyDeterministicContextCompactionAndToolPruning(messages, {
+      max_messages: 8,
+      tool_prune_keep_last_messages: 4,
+    });
+    const promptText = JSON.stringify(compacted);
+
+    expect(promptText).not.toContain("FIRST_TOOL_OUTPUT_123");
+    expect(promptText).toContain("SECOND_TOOL_OUTPUT_456");
+    expect(compacted[2]?.role).not.toBe("tool");
+  });
+});

--- a/packages/runtime-execution/tests/task-result-registry.test.ts
+++ b/packages/runtime-execution/tests/task-result-registry.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaskResultRegistry, type TaskResult } from "../src/task-result-registry.js";
+
+const RESULT: TaskResult = { ok: true, evidence: { a: 1 } };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("TaskResultRegistry", () => {
+  it("resolves a waiting task and rejects duplicate resolution after cleanup", async () => {
+    const registry = new TaskResultRegistry();
+
+    const pending = registry.wait("task-1", { timeoutMs: 5_000 });
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+
+    await expect(pending).resolves.toEqual(RESULT);
+    expect(registry.resolve("task-1", { ok: true })).toBe(false);
+  });
+
+  it("delivers buffered results when resolve happens before wait", async () => {
+    const registry = new TaskResultRegistry();
+
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+    await expect(registry.wait("task-1", { timeoutMs: 5_000 })).resolves.toEqual(RESULT);
+    expect(registry.resolve("task-1", { ok: true })).toBe(false);
+  });
+
+  it("rejects blank task ids and trims association lookups", async () => {
+    const registry = new TaskResultRegistry();
+
+    registry.associate(" task-1 ", " conn-1 ");
+    expect(registry.getAssociatedConnectionId(" task-1 ")).toBe("conn-1");
+    expect(registry.getAssociatedConnectionId("   ")).toBeUndefined();
+    await expect(registry.wait("   ")).rejects.toThrow("taskId is required");
+  });
+
+  it("ignores blank associations and terminal-task reassociation", async () => {
+    const registry = new TaskResultRegistry();
+
+    registry.associate(" ", "conn-1");
+    registry.associate("task-1", " ");
+    expect(registry.getAssociatedConnectionId("task-1")).toBeUndefined();
+
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+    await expect(registry.wait("task-1")).resolves.toEqual(RESULT);
+
+    registry.associate("task-1", "conn-2");
+    expect(registry.getAssociatedConnectionId("task-1")).toBeUndefined();
+  });
+
+  it("returns the same pending promise for repeated waits", async () => {
+    const registry = new TaskResultRegistry();
+
+    const first = registry.wait("task-1", { timeoutMs: 5_000 });
+    const second = registry.wait("task-1", { timeoutMs: 5_000 });
+
+    expect(second).toBe(first);
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+    await expect(first).resolves.toEqual(RESULT);
+    await expect(second).resolves.toEqual(RESULT);
+  });
+
+  it("records explicit wait connection ids and reuses existing associations", async () => {
+    const registry = new TaskResultRegistry();
+
+    const pendingWithExplicitConnection = registry.wait("task-1", {
+      timeoutMs: 5_000,
+      connectionId: " conn-1 ",
+    });
+    expect(registry.getAssociatedConnectionId("task-1")).toBe("conn-1");
+    expect(registry.rejectAllForConnection("conn-1")).toBe(1);
+    await expect(pendingWithExplicitConnection).rejects.toThrow(/disconnected/i);
+
+    const reusedAssociationRegistry = new TaskResultRegistry();
+    reusedAssociationRegistry.associate("task-2", "conn-2");
+    const pendingWithAssociatedConnection = reusedAssociationRegistry.wait("task-2", {
+      timeoutMs: 5_000,
+    });
+    expect(reusedAssociationRegistry.getAssociatedConnectionId("task-2")).toBe("conn-2");
+    expect(reusedAssociationRegistry.rejectAllForConnection("conn-2")).toBe(1);
+    await expect(pendingWithAssociatedConnection).rejects.toThrow(/disconnected/i);
+  });
+
+  it("rejects waits that time out and makes later resolve return false", async () => {
+    vi.useFakeTimers();
+
+    const registry = new TaskResultRegistry();
+    const pending = registry.wait("task-1", { timeoutMs: 10 });
+    const rejection = expect(pending).rejects.toThrow(/timeout/i);
+
+    await vi.advanceTimersByTimeAsync(11);
+
+    await rejection;
+    expect(registry.resolve("task-1", { ok: true })).toBe(false);
+  });
+
+  it("stores a pre-wait disconnect error and then marks the task terminal", async () => {
+    vi.useFakeTimers();
+
+    const registry = new TaskResultRegistry();
+    registry.associate("task-1", "conn-1");
+    expect(registry.rejectAllForConnection("conn-1")).toBe(0);
+
+    const firstWait = registry.wait("task-1", { timeoutMs: 10 });
+    await expect(firstWait).rejects.toThrow(/disconnected/i);
+
+    const secondWait = registry.wait("task-1", { timeoutMs: 10 });
+    await expect(secondWait).rejects.toThrow(/no longer available/i);
+  });
+
+  it("returns zero for blank connection ids", () => {
+    const registry = new TaskResultRegistry();
+
+    expect(registry.rejectAllForConnection("   ")).toBe(0);
+  });
+
+  it("evicts the oldest buffered result when maxBufferedResults is exceeded", async () => {
+    vi.useFakeTimers();
+
+    const registry = new TaskResultRegistry({ maxBufferedResults: 1 });
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+    expect(registry.resolve("task-2", { ok: true, evidence: { b: 2 } })).toBe(true);
+
+    const evictedWait = registry.wait("task-1", { timeoutMs: 10 });
+    const timedOut = expect(evictedWait).rejects.toThrow(/timeout/i);
+    await vi.advanceTimersByTimeAsync(11);
+    await timedOut;
+
+    await expect(registry.wait("task-2", { timeoutMs: 10 })).resolves.toEqual({
+      ok: true,
+      evidence: { b: 2 },
+    });
+  });
+
+  it("evicts the oldest terminal state when maxTerminalTasks is exceeded", async () => {
+    vi.useFakeTimers();
+
+    const registry = new TaskResultRegistry({ maxTerminalTasks: 1 });
+
+    expect(registry.resolve("task-1", RESULT)).toBe(true);
+    await expect(registry.wait("task-1", { timeoutMs: 10 })).resolves.toEqual(RESULT);
+
+    expect(registry.resolve("task-2", { ok: true, evidence: { b: 2 } })).toBe(true);
+    await expect(registry.wait("task-2", { timeoutMs: 10 })).resolves.toEqual({
+      ok: true,
+      evidence: { b: 2 },
+    });
+
+    await expect(registry.wait("task-2", { timeoutMs: 10 })).rejects.toThrow(
+      /no longer available/i,
+    );
+
+    const evictedTerminalWait = registry.wait("task-1", { timeoutMs: 10 });
+    const timedOut = expect(evictedTerminalWait).rejects.toThrow(/timeout/i);
+    await vi.advanceTimersByTimeAsync(11);
+    await timedOut;
+  });
+
+  it("evicts the oldest association when maxTaskAssociations is exceeded", () => {
+    const registry = new TaskResultRegistry({ maxTaskAssociations: 1 });
+
+    registry.associate("task-1", "conn-1");
+    registry.associate("task-2", "conn-2");
+
+    expect(registry.getAssociatedConnectionId("task-1")).toBeUndefined();
+    expect(registry.getAssociatedConnectionId("task-2")).toBe("conn-2");
+    expect(registry.rejectAllForConnection("conn-1")).toBe(0);
+  });
+
+  it("reassociates tasks to the new connection and removes the old index entry", async () => {
+    const registry = new TaskResultRegistry();
+
+    registry.associate("task-1", "conn-1");
+    registry.associate("task-1", "conn-2");
+    expect(registry.getAssociatedConnectionId("task-1")).toBe("conn-2");
+    expect(registry.rejectAllForConnection("conn-1")).toBe(0);
+
+    const pending = registry.wait("task-1", { timeoutMs: 5_000 });
+    expect(registry.rejectAllForConnection("conn-2")).toBe(1);
+    await expect(pending).rejects.toThrow(/conn-2/);
+  });
+});

--- a/packages/runtime-execution/tests/worker-loop.test.ts
+++ b/packages/runtime-execution/tests/worker-loop.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StepExecutor } from "../src/engine/types.js";
+import type { ExecutionWorkerEngine, ExecutionWorkerLogger } from "../src/worker-loop.js";
+import { startExecutionWorkerLoop } from "../src/worker-loop.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function waitForCalls(mockFn: { mock: { calls: unknown[] } }, count: number): Promise<void> {
+  for (let index = 0; index < 100; index += 1) {
+    if (mockFn.mock.calls.length >= count) return;
+    await Promise.resolve();
+  }
+  throw new Error(`timed out waiting for ${count} call(s)`);
+}
+
+function createExecutor(): StepExecutor {
+  return {
+    execute: vi.fn(async () => ({ success: true })),
+  };
+}
+
+function createLogger(): ExecutionWorkerLogger & {
+  info: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("Execution worker loop", () => {
+  it("logs started and stopped messages and resolves done after stop", async () => {
+    vi.useFakeTimers();
+
+    const logger = createLogger();
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => false),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-1",
+      executor,
+      logger,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "worker.loop.started",
+      expect.objectContaining({ worker_id: "worker-1" }),
+    );
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 1);
+      expect(engine.workerTick).toHaveBeenCalledWith({
+        workerId: "worker-1",
+        executor,
+      });
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "worker.loop.stopped",
+      expect.objectContaining({ worker_id: "worker-1" }),
+    );
+  });
+
+  it("waits for the clamped idle sleep when no work is done", async () => {
+    vi.useFakeTimers();
+
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => false),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-idle",
+      executor,
+      idleSleepMs: 2,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 1);
+
+      await vi.advanceTimersByTimeAsync(9);
+      expect(engine.workerTick).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 2);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("yields with a 0ms sleep after a cycle that did work", async () => {
+    vi.useFakeTimers();
+
+    let calls = 0;
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => {
+        calls += 1;
+        return calls === 1;
+      }),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-yield",
+      executor,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 5,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 2);
+
+      await vi.advanceTimersByTimeAsync(0);
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 3);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("recovers from workerTick errors after the clamped error sleep", async () => {
+    vi.useFakeTimers();
+
+    const logger = createLogger();
+    let calls = 0;
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          const error = new Error("db down") as Error & { run_id?: string };
+          error.run_id = "run-1";
+          throw error;
+        }
+        return false;
+      }),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-error",
+      executor,
+      logger,
+      idleSleepMs: 10,
+      errorSleepMs: 4,
+      maxTicksPerCycle: 1,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 1);
+      expect(logger.error).toHaveBeenCalledWith(
+        "worker.loop.error",
+        expect.objectContaining({
+          worker_id: "worker-error",
+          run_id: "run-1",
+          error: "db down",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(9);
+      expect(engine.workerTick).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 2);
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("logs camelCase runId values and non-Error throws", async () => {
+    vi.useFakeTimers();
+
+    const logger = createLogger();
+    let calls = 0;
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw { runId: " run-2 ", message: "ignored object" };
+        }
+        if (calls === 2) {
+          throw "plain failure";
+        }
+        return false;
+      }),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-runid",
+      executor,
+      logger,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 1,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 1);
+      expect(logger.error).toHaveBeenNthCalledWith(
+        1,
+        "worker.loop.error",
+        expect.objectContaining({
+          worker_id: "worker-runid",
+          run_id: "run-2",
+          error: "[object Object]",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 2);
+      expect(logger.error).toHaveBeenNthCalledWith(
+        2,
+        "worker.loop.error",
+        expect.objectContaining({
+          worker_id: "worker-runid",
+          run_id: undefined,
+          error: "plain failure",
+        }),
+      );
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+
+  it("does not exceed the clamped max ticks per cycle", async () => {
+    vi.useFakeTimers();
+
+    const logger = createLogger();
+    const engine: ExecutionWorkerEngine = {
+      workerTick: vi.fn(async () => true),
+    };
+    const executor = createExecutor();
+
+    const loop = startExecutionWorkerLoop({
+      engine,
+      workerId: "worker-max",
+      executor,
+      logger,
+      idleSleepMs: 10,
+      errorSleepMs: 10,
+      maxTicksPerCycle: 0,
+    });
+
+    try {
+      await waitForCalls(engine.workerTick as { mock: { calls: unknown[] } }, 1);
+      await Promise.resolve();
+      expect(engine.workerTick).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        "worker.loop.started",
+        expect.objectContaining({
+          idle_sleep_ms: 10,
+          error_sleep_ms: 10,
+          max_ticks_per_cycle: 1,
+        }),
+      );
+    } finally {
+      loop.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await loop.done;
+    }
+  });
+});

--- a/packages/runtime-policy/tests/unit/bundle-merge.test.ts
+++ b/packages/runtime-policy/tests/unit/bundle-merge.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { PolicyBundle } from "@tyrum/contracts";
+import { mergePolicyBundles } from "@tyrum/runtime-policy";
+
+describe("mergePolicyBundles", () => {
+  it("unions tool patterns and keeps the most restrictive domain defaults", () => {
+    const merged = mergePolicyBundles([
+      PolicyBundle.parse({
+        v: 1,
+        tools: {
+          allow: ["bash"],
+          require_approval: ["webfetch"],
+          deny: [],
+        },
+        network_egress: {
+          default: "allow",
+          allow: ["https://example.com/*"],
+          require_approval: [],
+          deny: [],
+        },
+      }),
+      PolicyBundle.parse({
+        v: 1,
+        tools: {
+          allow: ["bash"],
+          require_approval: [],
+          deny: ["rm"],
+        },
+        network_egress: {
+          default: "deny",
+          allow: [],
+          require_approval: ["https://review.example.com/*"],
+          deny: [],
+        },
+      }),
+    ]);
+
+    expect(merged.tools).toEqual({
+      allow: ["bash"],
+      require_approval: ["webfetch"],
+      deny: ["rm"],
+    });
+    expect(merged.network_egress.default).toBe("deny");
+    expect(merged.network_egress.allow).toContain("https://example.com/*");
+    expect(merged.network_egress.require_approval).toContain("https://review.example.com/*");
+  });
+
+  it("chooses minimum positive artifact retention and quota values", () => {
+    const merged = mergePolicyBundles([
+      PolicyBundle.parse({
+        v: 1,
+        artifacts: {
+          default: "allow",
+          retention: {
+            default_days: 30,
+            by_sensitivity: { normal: 20, sensitive: 10 },
+            by_label: { logs: 14 },
+            by_label_sensitivity: { docs: { normal: 9, sensitive: 5 } },
+          },
+          quota: {
+            default_max_bytes: 2_000,
+            by_sensitivity: { normal: 1_500, sensitive: 1_000 },
+            by_label: { logs: 900 },
+            by_label_sensitivity: { docs: { normal: 700, sensitive: 500 } },
+          },
+        },
+      }),
+      PolicyBundle.parse({
+        v: 1,
+        artifacts: {
+          default: "require_approval",
+          retention: {
+            default_days: 10,
+            by_sensitivity: { normal: 15, sensitive: 6 },
+            by_label: { logs: 7 },
+            by_label_sensitivity: { docs: { normal: 4, sensitive: 3 } },
+          },
+          quota: {
+            default_max_bytes: 1_000,
+            by_sensitivity: { normal: 1_200, sensitive: 800 },
+            by_label: { logs: 600 },
+            by_label_sensitivity: { docs: { normal: 300, sensitive: 250 } },
+          },
+        },
+      }),
+    ]);
+
+    expect(merged.artifacts.default).toBe("require_approval");
+    expect(merged.artifacts.retention).toEqual({
+      default_days: 10,
+      by_sensitivity: { normal: 15, sensitive: 6 },
+      by_label: { logs: 7 },
+      by_label_sensitivity: { docs: { normal: 4, sensitive: 3 } },
+    });
+    expect(merged.artifacts.quota).toEqual({
+      default_max_bytes: 1_000,
+      by_sensitivity: { normal: 1_200, sensitive: 800 },
+      by_label: { logs: 600 },
+      by_label_sensitivity: { docs: { normal: 300, sensitive: 250 } },
+    });
+  });
+
+  it("ignores non-positive and non-finite artifact values", () => {
+    const invalidBundle = {
+      v: 1,
+      artifacts: {
+        retention: {
+          default_days: 0,
+          by_label: { logs: -1 },
+        },
+        quota: {
+          default_max_bytes: Number.NaN,
+          by_label: { logs: Number.POSITIVE_INFINITY },
+        },
+      },
+    } as unknown as ReturnType<typeof PolicyBundle.parse>;
+
+    const merged = mergePolicyBundles([invalidBundle]);
+
+    expect(merged.artifacts.retention).toBeUndefined();
+    expect(merged.artifacts.quota).toBeUndefined();
+  });
+
+  it("merges provenance booleans conservatively", () => {
+    expect(
+      mergePolicyBundles([
+        PolicyBundle.parse({ v: 1 }),
+        PolicyBundle.parse({ v: 1, provenance: { untrusted_shell_requires_approval: false } }),
+      ]).provenance.untrusted_shell_requires_approval,
+    ).toBe(false);
+
+    expect(
+      mergePolicyBundles([
+        PolicyBundle.parse({ v: 1, provenance: { untrusted_shell_requires_approval: false } }),
+        PolicyBundle.parse({ v: 1, provenance: { untrusted_shell_requires_approval: true } }),
+      ]).provenance.untrusted_shell_requires_approval,
+    ).toBe(true);
+  });
+});

--- a/packages/runtime-policy/tests/unit/canonical-json.test.ts
+++ b/packages/runtime-policy/tests/unit/canonical-json.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { sha256HexFromString, stableJsonStringify } from "@tyrum/runtime-policy";
+
+describe("runtime-policy canonical json", () => {
+  it("sorts object keys recursively including objects nested inside arrays", () => {
+    expect(
+      stableJsonStringify({
+        b: 1,
+        a: [{ d: 1, c: 2 }],
+      }),
+    ).toBe('{"a":[{"c":2,"d":1}],"b":1}');
+  });
+
+  it("serializes undefined as null", () => {
+    expect(stableJsonStringify(undefined)).toBe("null");
+  });
+
+  it("produces deterministic sha256 digests", () => {
+    const value = stableJsonStringify({ b: 1, a: 2 });
+    expect(sha256HexFromString(value)).toBe(sha256HexFromString(value));
+    expect(sha256HexFromString(value)).toHaveLength(64);
+  });
+});

--- a/packages/runtime-policy/tests/unit/domain.test.ts
+++ b/packages/runtime-policy/tests/unit/domain.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateDomain,
+  mostRestrictiveDecision,
+  normalizeDomain,
+  normalizeUrlForPolicy,
+} from "@tyrum/runtime-policy";
+
+describe("runtime-policy domain helpers", () => {
+  it("applies most restrictive decision precedence", () => {
+    expect(mostRestrictiveDecision("allow", "allow")).toBe("allow");
+    expect(mostRestrictiveDecision("allow", "require_approval")).toBe("require_approval");
+    expect(mostRestrictiveDecision("require_approval", "deny")).toBe("deny");
+  });
+
+  it("normalizes missing domains with the fallback default", () => {
+    expect(normalizeDomain(undefined, "require_approval")).toEqual({
+      default: "require_approval",
+      allow: [],
+      require_approval: [],
+      deny: [],
+    });
+  });
+
+  it("uses deny, approval, then allow precedence when patterns overlap", () => {
+    const domain = normalizeDomain(
+      {
+        default: "allow",
+        allow: ["bash"],
+        require_approval: ["ba*"],
+        deny: ["bash"],
+      },
+      "require_approval",
+    );
+
+    expect(evaluateDomain(domain, "bash")).toBe("deny");
+    expect(evaluateDomain({ ...domain, deny: [] }, "bash")).toBe("require_approval");
+    expect(evaluateDomain({ ...domain, deny: [], require_approval: [] }, "bash")).toBe("allow");
+    expect(evaluateDomain({ ...domain, deny: [], require_approval: [], allow: [] }, "other")).toBe(
+      "allow",
+    );
+  });
+
+  it("normalizes valid urls by stripping query strings and preserving protocol host and path", () => {
+    expect(normalizeUrlForPolicy(" https://example.com/a/b?q=1#frag ")).toBe(
+      "https://example.com/a/b",
+    );
+  });
+
+  it("falls back cleanly for invalid strings and blank input", () => {
+    expect(normalizeUrlForPolicy("host/path?x=1")).toBe("host/path");
+    expect(normalizeUrlForPolicy("")).toBe("");
+  });
+});

--- a/packages/runtime-policy/tests/unit/engine.test.ts
+++ b/packages/runtime-policy/tests/unit/engine.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  currencyMinorUnits,
+  evaluateConnectorScope,
+  evaluateLegal,
+  evaluatePii,
+  evaluatePolicy,
+  evaluateSpend,
+  formatMoney,
+  overallDecision,
+} from "@tyrum/runtime-policy";
+
+describe("runtime-policy engine", () => {
+  it("handles currency minor units and money formatting", () => {
+    expect(currencyMinorUnits("JPY")).toBe(0);
+    expect(currencyMinorUnits("BHD")).toBe(3);
+    expect(currencyMinorUnits("eur")).toBe(2);
+    expect(formatMoney(1_234, "JPY")).toBe("JPY 1234");
+    expect(formatMoney(12_345, "BHD")).toBe("BHD 12.345");
+    expect(formatMoney(12_345, "EUR")).toBe("EUR 123.45");
+  });
+
+  it("evaluates spend context across missing, approval, deny, and allow cases", () => {
+    expect(evaluateSpend().outcome).toBe("require_approval");
+    expect(
+      evaluateSpend({ amount_minor_units: 60_000, currency: "EUR", user_limit_minor_units: 90_000 })
+        .outcome,
+    ).toBe("deny");
+    expect(
+      evaluateSpend({ amount_minor_units: 15_000, currency: "EUR", user_limit_minor_units: 12_000 })
+        .outcome,
+    ).toBe("require_approval");
+    expect(evaluateSpend({ amount_minor_units: 8_000, currency: "EUR" }).outcome).toBe("allow");
+  });
+
+  it("evaluates pii context across missing, empty, approval, deny, and allow cases", () => {
+    expect(evaluatePii().outcome).toBe("require_approval");
+    expect(evaluatePii({ categories: [] }).outcome).toBe("allow");
+    expect(evaluatePii({ categories: ["basic_contact"] }).outcome).toBe("allow");
+    expect(evaluatePii({ categories: ["financial"] }).outcome).toBe("require_approval");
+    expect(evaluatePii({ categories: ["government_id"] }).outcome).toBe("deny");
+  });
+
+  it("evaluates legal context across missing, empty, approval, deny, and allow cases", () => {
+    expect(evaluateLegal().outcome).toBe("require_approval");
+    expect(evaluateLegal({ flags: [] }).outcome).toBe("allow");
+    expect(evaluateLegal({ flags: ["terms_unknown"] }).outcome).toBe("require_approval");
+    expect(evaluateLegal({ flags: ["prohibited_content"] }).outcome).toBe("deny");
+    expect(evaluateLegal({ flags: ["copyright_ok"] }).outcome).toBe("allow");
+  });
+
+  it("evaluates connector scopes across undefined, blank, allow, approval, and deny cases", () => {
+    expect(evaluateConnectorScope()).toBeUndefined();
+    expect(evaluateConnectorScope({ scope: " " })?.outcome).toBe("require_approval");
+    expect(evaluateConnectorScope({ scope: "mcp://calendar" })?.outcome).toBe("allow");
+    expect(evaluateConnectorScope({ scope: "mcp://analytics" })?.outcome).toBe("require_approval");
+    expect(evaluateConnectorScope({ scope: "mcp://admin" })?.outcome).toBe("deny");
+  });
+
+  it("applies overall decision precedence", () => {
+    expect(overallDecision([{ outcome: "allow" } as never])).toBe("allow");
+    expect(
+      overallDecision([{ outcome: "allow" } as never, { outcome: "require_approval" } as never]),
+    ).toBe("require_approval");
+    expect(overallDecision([{ outcome: "deny" } as never, { outcome: "allow" } as never])).toBe(
+      "deny",
+    );
+  });
+
+  it("aggregates policy decisions using the most restrictive outcome", () => {
+    expect(
+      evaluatePolicy({
+        spend: { amount_minor_units: 1_000, currency: "EUR" },
+        pii: { categories: ["basic_contact"] },
+        legal: { flags: [] },
+      }).decision,
+    ).toBe("allow");
+
+    expect(
+      evaluatePolicy({
+        spend: { amount_minor_units: 1_000, currency: "EUR" },
+        pii: { categories: ["basic_contact"] },
+        legal: { flags: [] },
+        connector: { scope: "mcp://analytics" },
+      }).decision,
+    ).toBe("require_approval");
+
+    expect(
+      evaluatePolicy({
+        spend: { amount_minor_units: 1_000, currency: "EUR" },
+        pii: { categories: ["biometric"] },
+        legal: { flags: [] },
+      }).decision,
+    ).toBe("deny");
+  });
+});

--- a/packages/runtime-policy/tests/unit/override-guardrails.test.ts
+++ b/packages/runtime-policy/tests/unit/override-guardrails.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isSafeSuggestedOverridePattern } from "@tyrum/runtime-policy";
+
+describe("isSafeSuggestedOverridePattern", () => {
+  it("allows exact-match patterns", () => {
+    expect(isSafeSuggestedOverridePattern("echo hi")).toBe(true);
+  });
+
+  it("allows a single trailing '*' prefix match", () => {
+    expect(isSafeSuggestedOverridePattern("git status*")).toBe(true);
+  });
+
+  it("rejects patterns that include '?'", () => {
+    expect(isSafeSuggestedOverridePattern("git status ?")).toBe(false);
+  });
+
+  it("rejects leading wildcards", () => {
+    expect(isSafeSuggestedOverridePattern("*")).toBe(false);
+    expect(isSafeSuggestedOverridePattern("*foo")).toBe(false);
+  });
+
+  it("rejects multiple wildcards or wildcards not at the end", () => {
+    expect(isSafeSuggestedOverridePattern("git*status*")).toBe(false);
+    expect(isSafeSuggestedOverridePattern("git* status")).toBe(false);
+  });
+
+  it("rejects patterns that look like shell globs", () => {
+    expect(isSafeSuggestedOverridePattern("echo *")).toBe(false);
+  });
+});

--- a/packages/runtime-policy/tests/unit/policy-admin-service.test.ts
+++ b/packages/runtime-policy/tests/unit/policy-admin-service.test.ts
@@ -1,51 +1,178 @@
-import { describe, expect, it } from "vitest";
-import { PolicyAdminService } from "@tyrum/runtime-policy";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PolicyAdminService,
+  type PolicyOverrideStore,
+  type PolicyOverrideRow,
+} from "@tyrum/runtime-policy";
+
+function makeOverride(id = "override-1"): PolicyOverrideRow {
+  return {
+    policy_override_id: id,
+    tenant_id: "tenant-1",
+    agent_id: "agent-1",
+    workspace_id: "workspace-1",
+    tool_id: "tool.desktop.act",
+    pattern: "tool.desktop.act",
+    status: "active",
+    created_at: "2026-03-20T00:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    revoked_reason: null,
+    created_by: null,
+    created_from_approval_id: null,
+    created_from_policy_snapshot_id: null,
+  };
+}
 
 describe("PolicyAdminService", () => {
+  const list = vi.fn<PolicyOverrideStore["list"]>();
+  const expireStale = vi.fn<PolicyOverrideStore["expireStale"]>();
+  const create = vi.fn<PolicyOverrideStore["create"]>();
+  const revoke = vi.fn<PolicyOverrideStore["revoke"]>();
+
+  let service: PolicyAdminService;
+
+  beforeEach(() => {
+    list.mockReset();
+    expireStale.mockReset();
+    create.mockReset();
+    revoke.mockReset();
+    service = new PolicyAdminService({
+      policyOverrideStore: {
+        list,
+        expireStale,
+        create,
+        revoke,
+      },
+    });
+  });
+
   it("creates dedicated routed tool overrides without generic node-dispatch validation", async () => {
-    const create = async (input: {
-      tenantId: string;
-      agentId: string;
-      toolId: string;
-      pattern: string;
-    }) => ({
-      policy_override_id: "override-1",
+    create.mockImplementation(async (input) => ({
+      ...makeOverride(),
       tenant_id: input.tenantId,
       agent_id: input.agentId,
+      workspace_id: input.workspaceId ?? null,
       tool_id: input.toolId,
       pattern: input.pattern,
-    });
-    const service = new PolicyAdminService({
+      created_by: input.createdBy ?? null,
+      created_from_approval_id: input.createdFromApprovalId ?? null,
+      created_from_policy_snapshot_id: input.createdFromPolicySnapshotId ?? null,
+      expires_at: input.expiresAt ?? null,
+    }));
+
+    const isolatedService = new PolicyAdminService({
       policyOverrideStore: {
-        async list() {
-          return [];
-        },
-        async expireStale() {
-          return [];
-        },
+        list,
+        expireStale,
         create,
-        async revoke() {
-          return undefined;
-        },
+        revoke,
       },
     });
 
-    const result = await service.createOverride({
+    const result = await isolatedService.createOverride({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      toolId: "tool.desktop.act",
+      pattern: "tool.desktop.act",
+      createdBy: { kind: "tenant.token", token_id: "token-1" },
+      createdFromApprovalId: "approval-1",
+      createdFromPolicySnapshotId: "snapshot-1",
+      expiresAt: "2026-03-21T00:00:00.000Z",
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      toolId: "tool.desktop.act",
+      pattern: "tool.desktop.act",
+      createdBy: { kind: "tenant.token", token_id: "token-1" },
+      createdFromApprovalId: "approval-1",
+      createdFromPolicySnapshotId: "snapshot-1",
+      expiresAt: "2026-03-21T00:00:00.000Z",
+    });
+    expect(result).toEqual({
+      ok: true,
+      override: expect.objectContaining({
+        tenant_id: "tenant-1",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+        tool_id: "tool.desktop.act",
+        pattern: "tool.desktop.act",
+        created_from_approval_id: "approval-1",
+        created_from_policy_snapshot_id: "snapshot-1",
+        expires_at: "2026-03-21T00:00:00.000Z",
+      }),
+    });
+  });
+
+  it("expires stale overrides before listing", async () => {
+    list.mockResolvedValue([makeOverride()]);
+    expireStale.mockResolvedValue([]);
+
+    const result = await service.listOverrides({
       tenantId: "tenant-1",
       agentId: "agent-1",
       toolId: "tool.desktop.act",
-      pattern: "tool.desktop.act",
+      status: "active",
+      limit: 10,
     });
 
-    expect(result).toEqual({
-      ok: true,
-      override: {
-        policy_override_id: "override-1",
-        tenant_id: "tenant-1",
-        agent_id: "agent-1",
-        tool_id: "tool.desktop.act",
-        pattern: "tool.desktop.act",
-      },
+    expect(expireStale).toHaveBeenCalledWith({ tenantId: "tenant-1" });
+    expect(list).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      toolId: "tool.desktop.act",
+      status: "active",
+      limit: 10,
     });
+    expect(result).toEqual([makeOverride()]);
+  });
+
+  it("forwards revoke requests and returns undefined when missing", async () => {
+    revoke.mockResolvedValue(undefined);
+
+    await expect(
+      service.revokeOverride({
+        tenantId: "tenant-1",
+        policyOverrideId: "override-404",
+        revokedBy: { kind: "tenant.token", token_id: "token-1" },
+        reason: "expired manually",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(revoke).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      policyOverrideId: "override-404",
+      revokedBy: { kind: "tenant.token", token_id: "token-1" },
+      reason: "expired manually",
+    });
+  });
+
+  it("propagates store failures", async () => {
+    const listError = new Error("list failed");
+    const createError = new Error("create failed");
+    const revokeError = new Error("revoke failed");
+    expireStale.mockRejectedValueOnce(listError);
+    create.mockRejectedValueOnce(createError);
+    revoke.mockRejectedValueOnce(revokeError);
+
+    await expect(service.listOverrides({ tenantId: "tenant-1" })).rejects.toThrow("list failed");
+    await expect(
+      service.createOverride({
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        toolId: "tool.desktop.act",
+        pattern: "tool.desktop.act",
+      }),
+    ).rejects.toThrow("create failed");
+    await expect(
+      service.revokeOverride({
+        tenantId: "tenant-1",
+        policyOverrideId: "override-1",
+      }),
+    ).rejects.toThrow("revoke failed");
   });
 });

--- a/packages/runtime-policy/tests/unit/policy-service.test.ts
+++ b/packages/runtime-policy/tests/unit/policy-service.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from "vitest";
+import { PolicyBundle } from "@tyrum/contracts";
+import {
+  PolicyService,
+  mergePolicyBundles,
+  sha256HexFromString,
+  stableJsonStringify,
+  type PolicyBundleStore,
+  type PolicyOverrideRow,
+  type PolicyOverrideStore,
+  type PolicySnapshotRow,
+  type PolicySnapshotStore,
+} from "@tyrum/runtime-policy";
+
+function makeSnapshot(
+  bundle: ReturnType<typeof PolicyBundle.parse>,
+  id = "snapshot-1",
+): PolicySnapshotRow {
+  return {
+    policy_snapshot_id: id,
+    sha256: sha256HexFromString(stableJsonStringify(bundle)),
+    created_at: "2026-03-20T00:00:00.000Z",
+    bundle,
+  };
+}
+
+function makeOverride(pattern: string, id = "override-1"): PolicyOverrideRow {
+  return {
+    policy_override_id: id,
+    tenant_id: "tenant-1",
+    agent_id: "agent-1",
+    workspace_id: "workspace-1",
+    tool_id: "connector.send",
+    pattern,
+    status: "active",
+    created_at: "2026-03-20T00:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    revoked_reason: null,
+    created_by: null,
+    created_from_approval_id: null,
+    created_from_policy_snapshot_id: null,
+  };
+}
+
+function createStores(input?: {
+  snapshotById?: Record<string, PolicySnapshotRow>;
+  deploymentBundle?: ReturnType<typeof PolicyBundle.parse> | null;
+  agentBundle?: ReturnType<typeof PolicyBundle.parse> | null;
+  activeOverrides?: PolicyOverrideRow[];
+}) {
+  const snapshotDal = {
+    getById: vi.fn<PolicySnapshotStore["getById"]>(
+      async (_tenantId, policySnapshotId) => input?.snapshotById?.[policySnapshotId],
+    ),
+    getOrCreate: vi.fn<PolicySnapshotStore["getOrCreate"]>(async (_tenantId, bundle) =>
+      makeSnapshot(bundle),
+    ),
+  };
+
+  const overrideDal = {
+    list: vi.fn<PolicyOverrideStore["list"]>(async () => []),
+    create: vi.fn<PolicyOverrideStore["create"]>(async () => makeOverride("echo ok")),
+    revoke: vi.fn<PolicyOverrideStore["revoke"]>(async () => undefined),
+    expireStale: vi.fn<PolicyOverrideStore["expireStale"]>(async () => []),
+    listActiveForTool: vi.fn<PolicyOverrideStore["listActiveForTool"]>(
+      async () => input?.activeOverrides ?? [],
+    ),
+  };
+
+  const configStore = {
+    getDeploymentPolicyBundle: vi.fn<PolicyBundleStore["getDeploymentPolicyBundle"]>(
+      async () => input?.deploymentBundle,
+    ),
+    getAgentPolicyBundle: vi.fn<PolicyBundleStore["getAgentPolicyBundle"]>(
+      async () => input?.agentBundle,
+    ),
+  };
+
+  return { snapshotDal, overrideDal, configStore };
+}
+
+describe("PolicyService", () => {
+  it("reports observe-only modes and treats unknown modes as enforce", () => {
+    expect(
+      new PolicyService({
+        snapshotDal: createStores().snapshotDal,
+        overrideDal: createStores().overrideDal,
+        deploymentPolicy: { mode: "observe" },
+      }).isObserveOnly(),
+    ).toBe(true);
+    expect(
+      new PolicyService({
+        snapshotDal: createStores().snapshotDal,
+        overrideDal: createStores().overrideDal,
+        deploymentPolicy: { mode: "observe-only" },
+      }).isObserveOnly(),
+    ).toBe(true);
+    expect(
+      new PolicyService({
+        snapshotDal: createStores().snapshotDal,
+        overrideDal: createStores().overrideDal,
+        deploymentPolicy: { mode: "enforce" },
+      }).isObserveOnly(),
+    ).toBe(false);
+    expect(
+      new PolicyService({
+        snapshotDal: createStores().snapshotDal,
+        overrideDal: createStores().overrideDal,
+        deploymentPolicy: { mode: "unknown" },
+      }).isObserveOnly(),
+    ).toBe(false);
+  });
+
+  it("fails closed when tenant ids are blank for bundle load and status", async () => {
+    const stores = createStores();
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+      configStore: stores.configStore,
+    });
+
+    await expect(service.loadEffectiveBundle({ tenantId: " " })).rejects.toThrow(
+      "tenantId is required",
+    );
+    await expect(service.getStatus({ tenantId: " " })).rejects.toThrow("tenantId is required");
+  });
+
+  it("merges deployment, agent, and playbook bundles and reports deterministic sources", async () => {
+    const deploymentBundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: [],
+        deny: [],
+      },
+    });
+    const agentBundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: [],
+        require_approval: ["bash"],
+        deny: [],
+      },
+    });
+    const playbookBundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: [],
+        require_approval: [],
+        deny: ["rm"],
+      },
+    });
+    const stores = createStores({
+      deploymentBundle,
+      agentBundle,
+    });
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+      configStore: stores.configStore,
+    });
+
+    const result = await service.loadEffectiveBundle({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+      playbookBundle,
+    });
+
+    const expectedBundle = mergePolicyBundles([deploymentBundle, agentBundle, playbookBundle]);
+    expect(result.bundle).toEqual(expectedBundle);
+    expect(result.sha256).toBe(sha256HexFromString(stableJsonStringify(expectedBundle)));
+    expect(result.sources).toEqual({
+      deployment: "shared",
+      agent: "shared",
+      playbook: "inline",
+    });
+  });
+
+  it("returns approval records when a snapshot is missing", async () => {
+    const stores = createStores();
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+    });
+
+    const result = await service.evaluateToolCallFromSnapshot({
+      tenantId: "tenant-1",
+      policySnapshotId: "missing",
+      agentId: "agent-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.decision_record?.rules[0]?.detail).toContain("missing policy snapshot");
+  });
+
+  it("evaluates tool calls from existing snapshots", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: [],
+        deny: [],
+      },
+    });
+    const snapshot = makeSnapshot(bundle);
+    const stores = createStores({
+      snapshotById: { "snapshot-1": snapshot },
+    });
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+    });
+
+    const result = await service.evaluateToolCallFromSnapshot({
+      tenantId: "tenant-1",
+      policySnapshotId: "snapshot-1",
+      agentId: "agent-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.policy_snapshot).toEqual(snapshot);
+  });
+
+  it("evaluates secrets from snapshots across empty, missing-id, missing-row, and existing cases", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      secrets: {
+        default: "allow",
+        allow: [],
+        require_approval: ["scope:user"],
+        deny: ["scope:admin"],
+      },
+    });
+    const snapshot = makeSnapshot(bundle);
+    const stores = createStores({
+      snapshotById: { "snapshot-1": snapshot },
+    });
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+    });
+
+    await expect(
+      service.evaluateSecretsFromSnapshot({
+        tenantId: "tenant-1",
+        policySnapshotId: "snapshot-1",
+        secretScopes: [],
+      }),
+    ).resolves.toEqual({
+      decision: "allow",
+      decision_record: { decision: "allow", rules: [] },
+    });
+
+    await expect(
+      service.evaluateSecretsFromSnapshot({
+        tenantId: "tenant-1",
+        policySnapshotId: " ",
+        secretScopes: ["scope:user"],
+      }),
+    ).resolves.toMatchObject({
+      decision: "require_approval",
+    });
+
+    await expect(
+      service.evaluateSecretsFromSnapshot({
+        tenantId: "tenant-1",
+        policySnapshotId: "missing",
+        secretScopes: ["scope:user"],
+      }),
+    ).resolves.toMatchObject({
+      decision: "require_approval",
+    });
+
+    await expect(
+      service.evaluateSecretsFromSnapshot({
+        tenantId: "tenant-1",
+        policySnapshotId: "snapshot-1",
+        secretScopes: ["scope:user", "scope:admin"],
+      }),
+    ).resolves.toMatchObject({
+      decision: "deny",
+      policy_snapshot: snapshot,
+    });
+  });
+
+  it("applies connector overrides only when connector policy requires approval", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      connectors: {
+        default: "require_approval",
+        allow: [],
+        require_approval: [],
+        deny: [],
+      },
+    });
+    const stores = createStores({
+      deploymentBundle: bundle,
+      activeOverrides: [makeOverride("telegram:thread-1")],
+    });
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+      configStore: stores.configStore,
+    });
+
+    await expect(
+      service.evaluateConnectorAction({
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        matchTarget: "telegram:thread-1",
+      }),
+    ).resolves.toMatchObject({
+      decision: "allow",
+      applied_override_ids: ["override-1"],
+    });
+
+    stores.overrideDal.listActiveForTool.mockClear();
+    const denyBundle = PolicyBundle.parse({
+      v: 1,
+      connectors: {
+        default: "allow",
+        allow: [],
+        require_approval: [],
+        deny: ["telegram:blocked"],
+      },
+    });
+    stores.configStore.getDeploymentPolicyBundle.mockResolvedValueOnce(denyBundle);
+
+    await expect(
+      service.evaluateConnectorAction({
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        matchTarget: "telegram:blocked",
+      }),
+    ).resolves.toMatchObject({
+      decision: "deny",
+      applied_override_ids: undefined,
+    });
+  });
+
+  it("reports status with observe_only, hash, and effective sources", async () => {
+    const deploymentBundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: [],
+        deny: [],
+      },
+    });
+    const stores = createStores({ deploymentBundle });
+    const service = new PolicyService({
+      snapshotDal: stores.snapshotDal,
+      overrideDal: stores.overrideDal,
+      configStore: stores.configStore,
+      deploymentPolicy: { mode: "observe-only" },
+    });
+
+    const status = await service.getStatus({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+    });
+    const expectedEffectiveBundle = mergePolicyBundles([deploymentBundle]);
+
+    expect(status.observe_only).toBe(true);
+    expect(status.effective_sha256).toBe(
+      sha256HexFromString(stableJsonStringify(expectedEffectiveBundle)),
+    );
+    expect(status.sources).toEqual({
+      deployment: "shared",
+      agent: null,
+    });
+  });
+});

--- a/packages/runtime-policy/tests/unit/review-policy.test.ts
+++ b/packages/runtime-policy/tests/unit/review-policy.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  approvalStatusForReviewMode,
+  extractPolicySnapshotId,
+  pairingStatusForReviewMode,
+  resolveAutoReviewMode,
+  withPolicySnapshotContext,
+} from "@tyrum/runtime-policy";
+
+describe("runtime-policy review helpers", () => {
+  it("extracts policy snapshot ids from direct and nested contexts", () => {
+    expect(extractPolicySnapshotId({ policy_snapshot_id: " direct-id " })).toBe("direct-id");
+    expect(extractPolicySnapshotId({ policy: { policy_snapshot_id: " nested-id " } })).toBe(
+      "nested-id",
+    );
+    expect(extractPolicySnapshotId({ policy_snapshot_id: " ", policy: {} })).toBeUndefined();
+    expect(extractPolicySnapshotId(null)).toBeUndefined();
+  });
+
+  it("fills missing policy snapshot context without overwriting existing values", () => {
+    expect(
+      withPolicySnapshotContext({
+        context: {},
+        policySnapshotId: "snapshot-1",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+      }),
+    ).toEqual({
+      policy: {
+        policy_snapshot_id: "snapshot-1",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+      },
+    });
+
+    expect(
+      withPolicySnapshotContext({
+        context: {
+          policy: {
+            policy_snapshot_id: "snapshot-2",
+            agent_id: "agent-2",
+            workspace_id: "workspace-2",
+          },
+        },
+        policySnapshotId: "snapshot-1",
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+      }),
+    ).toEqual({
+      policy: {
+        policy_snapshot_id: "snapshot-2",
+        agent_id: "agent-2",
+        workspace_id: "workspace-2",
+      },
+    });
+  });
+
+  it("resolves auto review mode from policy service and fails open", async () => {
+    await expect(
+      resolveAutoReviewMode({
+        tenantId: "tenant-1",
+      }),
+    ).resolves.toBe("auto_review");
+
+    const failingService = {
+      loadEffectiveBundle: vi.fn(async () => {
+        throw new Error("backend unavailable");
+      }),
+    };
+    await expect(
+      resolveAutoReviewMode({
+        policyService: failingService as never,
+        tenantId: "tenant-1",
+      }),
+    ).resolves.toBe("auto_review");
+
+    const policyService = {
+      loadEffectiveBundle: vi.fn(async () => ({
+        bundle: { approvals: { auto_review: { mode: "manual_only" } } },
+      })),
+    };
+    await expect(
+      resolveAutoReviewMode({
+        policyService: policyService as never,
+        tenantId: "tenant-1",
+        agentId: "agent-1",
+      }),
+    ).resolves.toBe("manual_only");
+    expect(policyService.loadEffectiveBundle).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      agentId: "agent-1",
+    });
+  });
+
+  it("maps review modes to queued and awaiting_human statuses", () => {
+    expect(approvalStatusForReviewMode("auto_review")).toBe("queued");
+    expect(approvalStatusForReviewMode("manual_only")).toBe("awaiting_human");
+    expect(pairingStatusForReviewMode("auto_review")).toBe("queued");
+    expect(pairingStatusForReviewMode("manual_only")).toBe("awaiting_human");
+  });
+});

--- a/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
+++ b/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { suggestedOverridesForToolCall } from "@tyrum/runtime-policy";
+
+describe("suggestedOverridesForToolCall", () => {
+  it("suggests exact heartbeat schedule creation overrides", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.automation.schedule.create",
+        matchTarget: "kind:heartbeat;execution:agent_turn;delivery:quiet",
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual([
+      {
+        tool_id: "tool.automation.schedule.create",
+        pattern: "kind:heartbeat;execution:agent_turn;delivery:quiet",
+        workspace_id: "11111111-1111-4111-8111-111111111111",
+      },
+    ]);
+  });
+
+  it("omits schedule create suggestions for custom step schedules", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.automation.schedule.create",
+        matchTarget: "kind:cron;execution:steps;delivery:notify",
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for blank match targets", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.desktop.act",
+        matchTarget: "   ",
+        workspaceId: "workspace-1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for unsafe patterns", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.desktop.act",
+        matchTarget: "echo *",
+        workspaceId: "workspace-1",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/runtime-policy/tests/unit/tool-evaluation.test.ts
+++ b/packages/runtime-policy/tests/unit/tool-evaluation.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it, vi } from "vitest";
+import { PolicyBundle } from "@tyrum/contracts";
+import {
+  evaluateToolCallAgainstBundle,
+  type PolicyOverrideRow,
+  type PolicySnapshotRow,
+} from "@tyrum/runtime-policy";
+
+function makeSnapshot(bundle: ReturnType<typeof PolicyBundle.parse>): PolicySnapshotRow {
+  return {
+    policy_snapshot_id: "snapshot-1",
+    sha256: "sha-1",
+    created_at: "2026-03-20T00:00:00.000Z",
+    bundle,
+  };
+}
+
+function makeOverride(pattern: string, id = "override-1"): PolicyOverrideRow {
+  return {
+    policy_override_id: id,
+    tenant_id: "tenant-1",
+    agent_id: "agent-1",
+    workspace_id: "workspace-1",
+    tool_id: "bash",
+    pattern,
+    status: "active",
+    created_at: "2026-03-20T00:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    revoked_reason: null,
+    created_by: null,
+    created_from_approval_id: null,
+    created_from_policy_snapshot_id: null,
+  };
+}
+
+describe("evaluateToolCallAgainstBundle", () => {
+  it("uses explicit tool-rule precedence with deny over require_approval and allow", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: ["ba*"],
+        deny: ["bash"],
+      },
+    });
+    const overrideStore = { listActiveForTool: vi.fn(async () => []) };
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+      overrideStore,
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.decision_record?.rules).toContainEqual(
+      expect.objectContaining({
+        rule: "tool_policy",
+        outcome: "deny",
+        detail: "tool_id=bash;source=explicit_rule",
+      }),
+    );
+    expect(overrideStore.listActiveForTool).not.toHaveBeenCalled();
+  });
+
+  it("denies immediately when role ceilings disallow the tool", async () => {
+    const bundle = PolicyBundle.parse({ v: 1 });
+    const overrideStore = { listActiveForTool: vi.fn(async () => []) };
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+      roleAllowed: false,
+      overrideStore,
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.decision_record?.rules).toContainEqual(
+      expect.objectContaining({
+        rule: "tool_policy",
+        outcome: "deny",
+        detail: "tool_id=bash;source=role_ceiling",
+      }),
+    );
+    expect(overrideStore.listActiveForTool).not.toHaveBeenCalled();
+  });
+
+  it("applies implicit tool defaults for read_only, state_changing, memory writes, and bundle fallback", async () => {
+    const overrideStore = { listActiveForTool: vi.fn(async () => []) };
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: [],
+        deny: [],
+      },
+    });
+
+    await expect(
+      evaluateToolCallAgainstBundle({
+        tenantId: "tenant-1",
+        bundle,
+        snapshot: makeSnapshot(bundle),
+        agentId: "agent-1",
+        toolId: "filesystem.read",
+        toolMatchTarget: "read",
+        toolEffect: "read_only",
+        overrideStore,
+      }).then((result) => result.decision),
+    ).resolves.toBe("allow");
+
+    await expect(
+      evaluateToolCallAgainstBundle({
+        tenantId: "tenant-1",
+        bundle,
+        snapshot: makeSnapshot(bundle),
+        agentId: "agent-1",
+        toolId: "filesystem.write",
+        toolMatchTarget: "write",
+        toolEffect: "state_changing",
+        overrideStore,
+      }).then((result) => result.decision),
+    ).resolves.toBe("require_approval");
+
+    await expect(
+      evaluateToolCallAgainstBundle({
+        tenantId: "tenant-1",
+        bundle,
+        snapshot: makeSnapshot(bundle),
+        agentId: "agent-1",
+        toolId: "mcp.memory.write",
+        toolMatchTarget: "write",
+        toolEffect: "state_changing",
+        overrideStore,
+      }).then((result) => result.decision),
+    ).resolves.toBe("allow");
+
+    await expect(
+      evaluateToolCallAgainstBundle({
+        tenantId: "tenant-1",
+        bundle,
+        snapshot: makeSnapshot(bundle),
+        agentId: "agent-1",
+        toolId: "bash",
+        toolMatchTarget: "echo ok",
+        overrideStore,
+      }).then((result) => result.decision),
+    ).resolves.toBe("allow");
+  });
+
+  it("escalates untrusted bash when provenance guardrail is enabled", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["bash"],
+        require_approval: [],
+        deny: [],
+      },
+      provenance: {
+        untrusted_shell_requires_approval: true,
+      },
+    });
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+      inputProvenance: { source: "upload", trusted: false },
+      overrideStore: { listActiveForTool: vi.fn(async () => []) },
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.decision_record?.rules).toContainEqual(
+      expect.objectContaining({
+        rule: "provenance",
+        outcome: "require_approval",
+      }),
+    );
+  });
+
+  it("adds network egress and secret-scope rules only when applicable and uses the most restrictive result", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["webfetch"],
+        require_approval: [],
+        deny: [],
+      },
+      network_egress: {
+        default: "allow",
+        allow: [],
+        require_approval: ["https://example.com/*"],
+        deny: [],
+      },
+      secrets: {
+        default: "allow",
+        allow: [],
+        require_approval: ["scope:user"],
+        deny: ["scope:admin"],
+      },
+    });
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      toolId: "webfetch",
+      toolMatchTarget: "https://example.com/api",
+      url: "https://example.com/api?q=1",
+      secretScopes: ["scope:user", "scope:admin"],
+      overrideStore: { listActiveForTool: vi.fn(async () => []) },
+    });
+
+    expect(result.decision).toBe("deny");
+    expect(result.decision_record?.rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: "network_egress",
+          outcome: "require_approval",
+          detail: "https://example.com/api",
+        }),
+        expect.objectContaining({
+          rule: "secrets",
+          outcome: "deny",
+          detail: "scopes=2",
+        }),
+      ]),
+    );
+  });
+
+  it("omits network egress rules for blank urls", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["webfetch"],
+        require_approval: [],
+        deny: [],
+      },
+    });
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      toolId: "webfetch",
+      toolMatchTarget: "https://example.com/api",
+      url: "   ",
+      overrideStore: { listActiveForTool: vi.fn(async () => []) },
+    });
+
+    expect(result.decision_record?.rules.some((rule) => rule.rule === "network_egress")).toBe(
+      false,
+    );
+  });
+
+  it("applies matching policy overrides only for tool-rule approvals", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: [],
+        require_approval: ["bash"],
+        deny: [],
+      },
+    });
+    const overrideStore = {
+      listActiveForTool: vi.fn(async () => [makeOverride("echo ok")]),
+    };
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      toolId: "bash",
+      toolMatchTarget: "echo ok",
+      overrideStore,
+    });
+
+    expect(result.decision).toBe("allow");
+    expect(result.applied_override_ids).toEqual(["override-1"]);
+    expect(result.decision_record?.rules).toContainEqual(
+      expect.objectContaining({
+        rule: "policy_override",
+        outcome: "allow",
+      }),
+    );
+  });
+
+  it("does not apply overrides when approval comes from non-tool gates", async () => {
+    const bundle = PolicyBundle.parse({
+      v: 1,
+      tools: {
+        allow: ["webfetch"],
+        require_approval: [],
+        deny: [],
+      },
+      network_egress: {
+        default: "require_approval",
+        allow: [],
+        require_approval: [],
+        deny: [],
+      },
+    });
+    const overrideStore = {
+      listActiveForTool: vi.fn(async () => [makeOverride("https://example.com/api")]),
+    };
+
+    const result = await evaluateToolCallAgainstBundle({
+      tenantId: "tenant-1",
+      bundle,
+      snapshot: makeSnapshot(bundle),
+      agentId: "agent-1",
+      workspaceId: "workspace-1",
+      toolId: "webfetch",
+      toolMatchTarget: "https://example.com/api",
+      url: "https://example.com/api",
+      overrideStore,
+    });
+
+    expect(result.decision).toBe("require_approval");
+    expect(result.applied_override_ids).toBeUndefined();
+    expect(overrideStore.listActiveForTool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime-policy/tests/unit/wildcard.test.ts
+++ b/packages/runtime-policy/tests/unit/wildcard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { wildcardMatch } from "@tyrum/runtime-policy";
+
+describe("runtime-policy wildcard matching", () => {
+  it("matches exact strings", () => {
+    expect(wildcardMatch("echo hi", "echo hi")).toBe(true);
+  });
+
+  it("supports single-character matches with '?'", () => {
+    expect(wildcardMatch("file-?.txt", "file-a.txt")).toBe(true);
+    expect(wildcardMatch("file-?.txt", "file-ab.txt")).toBe(false);
+  });
+
+  it("supports '*' backtracking in the middle of a pattern", () => {
+    expect(wildcardMatch("ab*cd", "abXYZcd")).toBe(true);
+  });
+
+  it("returns false when no wildcard path matches", () => {
+    expect(wildcardMatch("ab*cd", "abXYZef")).toBe(false);
+  });
+
+  it("consumes trailing '*' after input end", () => {
+    expect(wildcardMatch("status*", "status")).toBe(true);
+  });
+});

--- a/packages/runtime-workboard/tests/dispatcher.test.ts
+++ b/packages/runtime-workboard/tests/dispatcher.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WorkboardDispatcher,
+  type ManagedDesktopProvisioner,
+  type WorkboardDispatcherRepository,
+  type WorkboardSubagentRuntime,
+} from "../src/index.js";
+import { TEST_SCOPE, createLogger, makeSubagent, makeTask, makeWorkItem } from "./test-support.js";
+
+const TEST_ITEM_SCOPE = {
+  ...TEST_SCOPE,
+  work_item_id: "work-1",
+} as const;
+
+function createRepository(): WorkboardDispatcherRepository {
+  return {
+    listReadyItems: vi.fn(async () => []),
+    getItem: vi.fn(async () => makeWorkItem({ status: "ready" })),
+    listTasks: vi.fn(async () => []),
+    createTask: vi.fn(async ({ task }) => makeTask(task)),
+    updateTask: vi.fn(async () => undefined),
+    leaseRunnableTasks: vi.fn(async () => ({ leased: [] })),
+    transitionItem: vi.fn(async () => makeWorkItem({ status: "doing" })),
+    getStateKv: vi.fn(async () => undefined),
+    markSubagentClosed: vi.fn(async () => undefined),
+    markSubagentFailed: vi.fn(async () => undefined),
+    createSubagent: vi.fn(async ({ subagentId, subagent }) =>
+      makeSubagent({
+        subagent_id: subagentId ?? "subagent-1",
+        execution_profile: subagent.execution_profile,
+        session_key: subagent.session_key ?? `agent:default:subagent:${subagentId ?? "subagent-1"}`,
+        parent_session_key: subagent.parent_session_key,
+        work_item_id: subagent.work_item_id,
+        work_item_task_id: subagent.work_item_task_id,
+        lane: subagent.lane ?? "subagent",
+        status: subagent.status ?? "running",
+        desktop_environment_id: subagent.desktop_environment_id,
+        attached_node_id: subagent.attached_node_id,
+      }),
+    ),
+    listSubagents: vi.fn(async () => ({ subagents: [] })),
+    getSubagent: vi.fn(async () => undefined),
+    closeSubagent: vi.fn(async () => undefined),
+    updateSubagent: vi.fn(async () => undefined),
+  };
+}
+
+function createRuntime(): WorkboardSubagentRuntime {
+  return {
+    buildSessionKey: vi.fn(async (_scope, subagentId) => `agent:default:subagent:${subagentId}`),
+    runTurn: vi.fn(async () => "executor complete"),
+  };
+}
+
+describe("WorkboardDispatcher", () => {
+  it("continues scanning until it finds a ready item it can dispatch", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([
+      { ...TEST_SCOPE, work_item_id: "work-missing" },
+      { ...TEST_SCOPE, work_item_id: "work-blocked" },
+      { ...TEST_SCOPE, work_item_id: "work-ready" },
+    ]);
+    repository.getItem
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-blocked", status: "blocked" }))
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-ready", status: "ready" }))
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-ready", status: "doing" }));
+    repository.listTasks
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeTask({ work_item_id: "work-ready", status: "completed" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [
+        {
+          task: makeTask({
+            work_item_id: "work-ready",
+            status: "leased",
+            execution_profile: "executor_rw",
+          }),
+        },
+      ],
+    });
+    const runtime = createRuntime();
+    const dispatcher = new WorkboardDispatcher({ repository, runtime });
+
+    await dispatcher.tick();
+
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: { ...TEST_SCOPE, work_item_id: "work-ready" },
+      work_item_id: "work-ready",
+      status: "doing",
+      reason: "Auto-dispatched to executor.",
+    });
+    expect(runtime.runTurn).toHaveBeenCalledOnce();
+  });
+
+  it("creates a default execution task when none exist", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([]);
+    const dispatcher = new WorkboardDispatcher({ repository, runtime: createRuntime() });
+
+    await dispatcher.tick();
+
+    expect(repository.createTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task: {
+        work_item_id: "work-1",
+        status: "queued",
+        execution_profile: "executor_rw",
+        side_effect_class: "workspace",
+        result_summary: "Default execution task",
+      },
+    });
+  });
+
+  it("does not create a duplicate task when an active execution task exists", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "running" }),
+    ]);
+    const dispatcher = new WorkboardDispatcher({ repository, runtime: createRuntime() });
+
+    await dispatcher.tick();
+
+    expect(repository.createTask).not.toHaveBeenCalled();
+  });
+
+  it("replaces only terminal failed execution tasks", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "failed" }),
+    ]);
+    const dispatcher = new WorkboardDispatcher({ repository, runtime: createRuntime() });
+
+    await dispatcher.tick();
+
+    expect(repository.createTask).toHaveBeenCalledOnce();
+  });
+
+  it("does not replace successful execution tasks", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "completed" }),
+    ]);
+    const dispatcher = new WorkboardDispatcher({ repository, runtime: createRuntime() });
+
+    await dispatcher.tick();
+
+    expect(repository.createTask).not.toHaveBeenCalled();
+  });
+
+  it("requeues non-selected leases and returns when no execution task is leased", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "queued" }),
+    ]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [
+        {
+          task: makeTask({ task_id: "planner-1", execution_profile: "planner", status: "leased" }),
+        },
+      ],
+    });
+    const runtime = createRuntime();
+    const dispatcher = new WorkboardDispatcher({ repository, runtime });
+
+    await dispatcher.tick();
+
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "planner-1",
+      lease_owner: "workboard-dispatcher:work-1",
+      patch: { status: "queued" },
+    });
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("requeues the execution task when transitioning the item to doing fails", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "queued" }),
+    ]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [{ task: makeTask({ execution_profile: "executor_rw", status: "leased" }) }],
+    });
+    repository.transitionItem.mockRejectedValue(new Error("transition failed"));
+    const runtime = createRuntime();
+    const dispatcher = new WorkboardDispatcher({ repository, runtime });
+
+    await dispatcher.tick();
+
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      lease_owner: "workboard-dispatcher:work-1",
+      patch: { status: "queued" },
+    });
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("provisions desktops when requested and includes the attached node in the instruction", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks
+      .mockResolvedValueOnce([makeTask({ execution_profile: "integrator", status: "queued" })])
+      .mockResolvedValueOnce([makeTask({ execution_profile: "integrator", status: "completed" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [{ task: makeTask({ execution_profile: "integrator", status: "leased" }) }],
+    });
+    repository.getStateKv.mockResolvedValue({ value_json: true });
+    repository.getItem
+      .mockResolvedValueOnce(makeWorkItem({ status: "ready" }))
+      .mockResolvedValueOnce(makeWorkItem({ status: "doing" }));
+    const runtime = createRuntime();
+    const desktopProvisioner: ManagedDesktopProvisioner = {
+      provisionManagedDesktop: vi.fn(async () => ({
+        desktopEnvironmentId: "desktop-1",
+        attachedNodeId: "node-1",
+      })),
+    };
+    const dispatcher = new WorkboardDispatcher({
+      repository,
+      runtime,
+      desktopProvisioner,
+    });
+
+    await dispatcher.tick();
+
+    expect(desktopProvisioner.provisionManagedDesktop).toHaveBeenCalledWith({
+      tenantId: TEST_SCOPE.tenant_id,
+      subagentSessionKey: expect.stringContaining("agent:default:subagent:"),
+      subagentLane: "subagent",
+      label: "executor:work-1",
+    });
+    expect(repository.createSubagent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: TEST_ITEM_SCOPE,
+        subagentId: expect.any(String),
+        subagent: expect.objectContaining({
+          execution_profile: "executor_rw",
+          desktop_environment_id: "desktop-1",
+          attached_node_id: "node-1",
+        }),
+      }),
+    );
+    expect(runtime.runTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("A managed desktop node is attached for this run: node-1"),
+      }),
+    );
+  });
+
+  it("dispatches without attachments when desktop provisioning is unavailable", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks
+      .mockResolvedValueOnce([makeTask({ execution_profile: "executor_rw", status: "queued" })])
+      .mockResolvedValueOnce([makeTask({ execution_profile: "executor_rw", status: "completed" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [{ task: makeTask({ execution_profile: "executor_rw", status: "leased" }) }],
+    });
+    repository.getStateKv.mockResolvedValue({ value_json: true });
+    repository.getItem
+      .mockResolvedValueOnce(makeWorkItem({ status: "ready" }))
+      .mockResolvedValueOnce(makeWorkItem({ status: "doing" }));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "");
+    const dispatcher = new WorkboardDispatcher({ repository, runtime });
+
+    await dispatcher.tick();
+
+    expect(repository.createSubagent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: TEST_ITEM_SCOPE,
+        subagentId: expect.any(String),
+        subagent: expect.objectContaining({
+          desktop_environment_id: undefined,
+          attached_node_id: undefined,
+        }),
+      }),
+    );
+    expect(runtime.runTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.not.stringContaining("managed desktop node"),
+      }),
+    );
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      patch: expect.objectContaining({
+        status: "completed",
+        result_summary: "Executor task completed.",
+      }),
+    });
+  });
+
+  it("marks execution failures, attempts to block the item, and swallows block-transition errors", async () => {
+    const repository = createRepository();
+    repository.listReadyItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ execution_profile: "executor_rw", status: "queued" }),
+    ]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [{ task: makeTask({ execution_profile: "executor_rw", status: "leased" }) }],
+    });
+    repository.transitionItem
+      .mockResolvedValueOnce(makeWorkItem({ status: "doing" }))
+      .mockRejectedValueOnce(new Error("block failed"));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn().mockRejectedValue(new Error("executor failed"));
+    const logger = createLogger();
+    const dispatcher = new WorkboardDispatcher({ repository, runtime, logger });
+
+    await dispatcher.tick();
+
+    expect(repository.markSubagentFailed).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: expect.any(String),
+      reason: "executor failed",
+    });
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      patch: expect.objectContaining({
+        status: "failed",
+        result_summary: "executor failed",
+      }),
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "workboard.executor_turn_failed",
+      expect.objectContaining({
+        work_item_id: "work-1",
+        task_id: "task-1",
+        error: "executor failed",
+      }),
+    );
+  });
+});

--- a/packages/runtime-workboard/tests/orchestration-support.test.ts
+++ b/packages/runtime-workboard/tests/orchestration-support.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildExecutorInstruction,
+  buildPlannerInstruction,
+  maybeFinalizeWorkItem,
+  type WorkboardRepository,
+} from "../src/index.js";
+import { TEST_SCOPE, makeTask, makeWorkItem } from "./test-support.js";
+
+function createRepository() {
+  return {
+    getItem: vi.fn(),
+    listTasks: vi.fn(),
+    transitionItem: vi.fn(),
+  } satisfies Pick<WorkboardRepository, "getItem" | "listTasks" | "transitionItem">;
+}
+
+describe("buildPlannerInstruction", () => {
+  it("includes the work item identity and planning guidance", () => {
+    const instruction = buildPlannerInstruction(makeWorkItem({ work_item_id: "work-42" }));
+
+    expect(instruction).toContain("You own refinement for WorkItem work-42: Ship runtime split");
+    expect(instruction).toContain("Use WorkBoard tools to inspect state");
+    expect(instruction).toContain("Request clarification through workboard.clarification.request");
+    expect(instruction).toContain("transition the work item to ready");
+  });
+});
+
+describe("buildExecutorInstruction", () => {
+  it("includes the work item and task identity", () => {
+    const instruction = buildExecutorInstruction({
+      item: makeWorkItem({ work_item_id: "work-42" }),
+      task: makeTask({ task_id: "task-42", execution_profile: "executor_rw" }),
+    });
+
+    expect(instruction).toContain("You own execution for WorkItem work-42: Ship runtime split");
+    expect(instruction).toContain("Task task-42 profile=executor_rw");
+    expect(instruction).not.toContain("managed desktop node");
+  });
+
+  it("includes the attached node when one is present", () => {
+    const instruction = buildExecutorInstruction({
+      item: makeWorkItem(),
+      task: makeTask(),
+      attachedNodeId: "node-7",
+    });
+
+    expect(instruction).toContain("A managed desktop node is attached for this run: node-7");
+  });
+});
+
+describe("maybeFinalizeWorkItem", () => {
+  it("does nothing when there are no tasks", async () => {
+    const repository = createRepository();
+    repository.listTasks.mockResolvedValue([]);
+
+    await maybeFinalizeWorkItem({
+      repository,
+      scope: TEST_SCOPE,
+      workItemId: "work-1",
+    });
+
+    expect(repository.getItem).not.toHaveBeenCalled();
+    expect(repository.transitionItem).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when execution tasks are incomplete", async () => {
+    const repository = createRepository();
+    repository.listTasks.mockResolvedValue([makeTask({ status: "running" })]);
+
+    await maybeFinalizeWorkItem({
+      repository,
+      scope: TEST_SCOPE,
+      workItemId: "work-1",
+    });
+
+    expect(repository.getItem).not.toHaveBeenCalled();
+    expect(repository.transitionItem).not.toHaveBeenCalled();
+  });
+
+  it("transitions doing items to done when all tasks are completed or skipped", async () => {
+    const repository = createRepository();
+    repository.listTasks.mockResolvedValue([
+      makeTask({ status: "completed" }),
+      makeTask({ task_id: "task-2", status: "skipped" }),
+    ]);
+    repository.getItem.mockResolvedValue(makeWorkItem({ status: "doing" }));
+
+    await maybeFinalizeWorkItem({
+      repository,
+      scope: TEST_SCOPE,
+      workItemId: "work-1",
+    });
+
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      status: "done",
+      reason: "All execution tasks completed.",
+    });
+  });
+
+  it("does not transition non-doing items", async () => {
+    const repository = createRepository();
+    repository.listTasks.mockResolvedValue([makeTask({ status: "completed" })]);
+    repository.getItem.mockResolvedValue(makeWorkItem({ status: "ready" }));
+
+    await maybeFinalizeWorkItem({
+      repository,
+      scope: TEST_SCOPE,
+      workItemId: "work-1",
+    });
+
+    expect(repository.transitionItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime-workboard/tests/orchestrator.test.ts
+++ b/packages/runtime-workboard/tests/orchestrator.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WorkboardOrchestrator,
+  type WorkboardOrchestratorRepository,
+  type WorkboardSubagentRuntime,
+} from "../src/index.js";
+import {
+  TEST_SCOPE,
+  createLogger,
+  makeClarification,
+  makeSubagent,
+  makeTask,
+  makeWorkItem,
+} from "./test-support.js";
+
+const TEST_ITEM_SCOPE = {
+  ...TEST_SCOPE,
+  work_item_id: "work-1",
+} as const;
+
+function createRepository(): WorkboardOrchestratorRepository {
+  return {
+    listBacklogItems: vi.fn(async () => []),
+    listPlannerSubagentsOutsideBacklog: vi.fn(async () => []),
+    listClarifications: vi.fn(async () => ({ clarifications: [] })),
+    getItem: vi.fn(async () => makeWorkItem()),
+    transitionItem: vi.fn(async () => makeWorkItem()),
+    listTasks: vi.fn(async () => []),
+    createTask: vi.fn(async ({ task }) => makeTask(task)),
+    updateTask: vi.fn(async () => undefined),
+    leaseRunnableTasks: vi.fn(async () => ({ leased: [] })),
+    getStateKv: vi.fn(async () => undefined),
+    setStateKv: vi.fn(async () => undefined),
+    requeueOrphanedTasks: vi.fn(async () => undefined),
+    createSubagent: vi.fn(async ({ subagentId, subagent }) =>
+      makeSubagent({
+        subagent_id: subagentId ?? "subagent-1",
+        execution_profile: subagent.execution_profile,
+        session_key: subagent.session_key ?? `agent:default:subagent:${subagentId ?? "subagent-1"}`,
+        parent_session_key: subagent.parent_session_key,
+        work_item_id: subagent.work_item_id,
+        work_item_task_id: subagent.work_item_task_id,
+        lane: subagent.lane ?? "subagent",
+        status: subagent.status ?? "paused",
+      }),
+    ),
+    listSubagents: vi.fn(async () => ({ subagents: [] })),
+    getSubagent: vi.fn(async () => undefined),
+    closeSubagent: vi.fn(async () => undefined),
+    markSubagentClosed: vi.fn(async () => undefined),
+    markSubagentFailed: vi.fn(async () => undefined),
+    updateSubagent: vi.fn(async () => undefined),
+  };
+}
+
+function createRuntime(): WorkboardSubagentRuntime {
+  return {
+    buildSessionKey: vi.fn(async (_scope, subagentId) => `agent:default:subagent:${subagentId}`),
+    runTurn: vi.fn(async () => "planner refinement complete"),
+  };
+}
+
+describe("WorkboardOrchestrator", () => {
+  it("pauses running planners when open clarifications exist", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listClarifications.mockResolvedValue({ clarifications: [makeClarification()] });
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "running" })],
+    });
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime: createRuntime() });
+
+    await orchestrator.tick();
+
+    expect(repository.updateSubagent).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: "subagent-1",
+      patch: { status: "paused" },
+    });
+    expect(repository.createTask).not.toHaveBeenCalled();
+  });
+
+  it("does not update already paused planners when clarifications are open", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listClarifications.mockResolvedValue({ clarifications: [makeClarification()] });
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime: createRuntime() });
+
+    await orchestrator.tick();
+
+    expect(repository.updateSubagent).not.toHaveBeenCalled();
+  });
+
+  it("creates a planner task when no active planner task exists", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    repository.listTasks.mockResolvedValue([]);
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime: createRuntime() });
+
+    await orchestrator.tick();
+
+    expect(repository.createTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task: {
+        work_item_id: "work-1",
+        status: "queued",
+        execution_profile: "planner",
+        side_effect_class: "workspace",
+        result_summary: "Planner refinement task",
+      },
+    });
+  });
+
+  it("does not create a duplicate planner task and requeues non-planner leases", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [makeTask({ task_id: "task-2", execution_profile: "executor_rw" })].map((task) => ({
+        task,
+      })),
+    });
+    const runtime = createRuntime();
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime });
+
+    await orchestrator.tick();
+
+    expect(repository.createTask).not.toHaveBeenCalled();
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-2",
+      lease_owner: "workboard-orchestrator:work-1",
+      patch: { status: "queued" },
+    });
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("returns early when the work item disappears after leasing the planner task", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [makeTask({ status: "leased" })].map((task) => ({ task })),
+    });
+    repository.getItem.mockResolvedValue(undefined);
+    const runtime = createRuntime();
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime });
+
+    await orchestrator.tick();
+
+    expect(repository.updateSubagent).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: "subagent-1",
+      patch: { status: "running" },
+    });
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("completes planner tasks and pauses the planner when the item stays in backlog", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    const plannerTask = makeTask({ status: "leased" });
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({ leased: [{ task: plannerTask }] });
+    repository.getItem
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-1", status: "backlog" }))
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-1", status: "backlog" }));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "planner reply");
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime });
+
+    await orchestrator.tick();
+
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      lease_owner: "workboard-orchestrator:work-1",
+      patch: expect.objectContaining({
+        status: "completed",
+        result_summary: "planner reply",
+      }),
+    });
+    expect(repository.updateSubagent).toHaveBeenNthCalledWith(2, {
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: "subagent-1",
+      patch: { status: "paused" },
+    });
+  });
+
+  it("uses the default completion summary and closes the planner when work leaves backlog", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    const plannerTask = makeTask({ status: "leased" });
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({ leased: [{ task: plannerTask }] });
+    repository.getItem
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-1", status: "backlog" }))
+      .mockResolvedValueOnce(makeWorkItem({ work_item_id: "work-1", status: "ready" }));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "");
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime });
+
+    await orchestrator.tick();
+
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      lease_owner: "workboard-orchestrator:work-1",
+      patch: expect.objectContaining({
+        status: "completed",
+        result_summary: "Planner refinement turn completed.",
+      }),
+    });
+    expect(repository.markSubagentClosed).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: "subagent-1",
+    });
+  });
+
+  it("marks planner failures on the task and subagent and emits a warning", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "paused" })],
+    });
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    repository.leaseRunnableTasks.mockResolvedValue({
+      leased: [makeTask({ status: "leased" })].map((task) => ({ task })),
+    });
+    repository.getItem.mockResolvedValue(makeWorkItem());
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn().mockRejectedValue(new Error("planner failed"));
+    const logger = createLogger();
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime, logger });
+
+    await orchestrator.tick();
+
+    expect(repository.updateTask).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      task_id: "task-1",
+      lease_owner: "workboard-orchestrator:work-1",
+      patch: expect.objectContaining({
+        status: "failed",
+        result_summary: "planner failed",
+      }),
+    });
+    expect(repository.markSubagentFailed).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagent_id: "subagent-1",
+      reason: "planner failed",
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "workboard.planner_turn_failed",
+      expect.objectContaining({
+        work_item_id: "work-1",
+        subagent_id: "subagent-1",
+        error: "planner failed",
+      }),
+    );
+  });
+
+  it("creates a planner subagent when one does not already exist", async () => {
+    const repository = createRepository();
+    repository.listBacklogItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({ subagents: [] });
+    repository.getItem.mockResolvedValue(
+      makeWorkItem({
+        work_item_id: "work-1",
+        created_from_session_key: "agent:default:main",
+      }),
+    );
+    repository.listTasks.mockResolvedValue([makeTask({ status: "queued" })]);
+    const runtime = createRuntime();
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime });
+
+    await orchestrator.tick();
+
+    expect(repository.createSubagent).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      subagentId: expect.any(String),
+      subagent: expect.objectContaining({
+        parent_session_key: "agent:default:main",
+        work_item_id: "work-1",
+        execution_profile: "planner",
+        lane: "subagent",
+        status: "paused",
+        session_key: expect.stringMatching(/^agent:default:subagent:/),
+      }),
+    });
+  });
+
+  it("closes planner subagents that are outside backlog", async () => {
+    const repository = createRepository();
+    repository.listPlannerSubagentsOutsideBacklog.mockResolvedValue([
+      { ...TEST_SCOPE, subagent_id: "subagent-1", work_item_id: "work-1" },
+      { ...TEST_SCOPE, subagent_id: "subagent-2", work_item_id: "work-2" },
+    ]);
+    const orchestrator = new WorkboardOrchestrator({ repository, runtime: createRuntime() });
+
+    await orchestrator.tick();
+
+    expect(repository.markSubagentClosed).toHaveBeenCalledTimes(2);
+    expect(repository.markSubagentClosed).toHaveBeenNthCalledWith(1, {
+      scope: TEST_SCOPE,
+      subagent_id: "subagent-1",
+    });
+    expect(repository.markSubagentClosed).toHaveBeenNthCalledWith(2, {
+      scope: TEST_SCOPE,
+      subagent_id: "subagent-2",
+    });
+  });
+});

--- a/packages/runtime-workboard/tests/reconciler.test.ts
+++ b/packages/runtime-workboard/tests/reconciler.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import { WorkboardReconciler, type WorkboardReconcilerRepository } from "../src/index.js";
+import { TEST_SCOPE, makeSubagent, makeTask, makeWorkItem } from "./test-support.js";
+
+const TEST_ITEM_SCOPE = {
+  ...TEST_SCOPE,
+  work_item_id: "work-1",
+} as const;
+
+function createRepository(): WorkboardReconcilerRepository {
+  return {
+    listDoingItems: vi.fn(async () => []),
+    listSubagents: vi.fn(async () => ({ subagents: [] })),
+    listTasks: vi.fn(async () => []),
+    transitionItem: vi.fn(async () => makeWorkItem({ status: "ready" })),
+    setStateKv: vi.fn(async () => undefined),
+    requeueOrphanedTasks: vi.fn(async () => undefined),
+    getItem: vi.fn(async () => makeWorkItem({ status: "doing" })),
+  };
+}
+
+describe("WorkboardReconciler", () => {
+  it("does nothing when active subagents still exist", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listSubagents.mockResolvedValue({
+      subagents: [makeSubagent({ status: "running" })],
+    });
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.listTasks).not.toHaveBeenCalled();
+    expect(repository.transitionItem).not.toHaveBeenCalled();
+  });
+
+  it("blocks work when a failed task has no active subagent", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([makeTask({ status: "failed" })]);
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      status: "blocked",
+      reason: "Execution task failed without an active subagent.",
+    });
+  });
+
+  it("swallows failures while trying to block failed work", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([makeTask({ status: "failed" })]);
+    repository.transitionItem.mockRejectedValue(new Error("db busy"));
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await expect(reconciler.tick()).resolves.toBeUndefined();
+  });
+
+  it("finalizes doing items when all tasks are completed or skipped", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ status: "completed" }),
+      makeTask({ task_id: "task-2", status: "skipped" }),
+    ]);
+    repository.getItem.mockResolvedValue(makeWorkItem({ status: "doing" }));
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      status: "done",
+      reason: "All execution tasks completed.",
+    });
+  });
+
+  it("does not transition non-doing items during finalization", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([makeTask({ status: "completed" })]);
+    repository.getItem.mockResolvedValue(makeWorkItem({ status: "ready" }));
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.transitionItem).not.toHaveBeenCalled();
+  });
+
+  it("blocks cancelled tasks with no active subagent", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ status: "cancelled" }),
+      makeTask({ task_id: "task-2", status: "completed" }),
+    ]);
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      status: "blocked",
+      reason: "Execution task cancelled without an active subagent.",
+    });
+  });
+
+  it("swallows failures while blocking cancelled work", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([makeTask({ status: "cancelled" })]);
+    repository.transitionItem.mockRejectedValue(new Error("db busy"));
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await expect(reconciler.tick()).resolves.toBeUndefined();
+  });
+
+  it("requeues orphaned work when no tasks exist", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([]);
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.requeueOrphanedTasks).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      updated_at: expect.any(String),
+    });
+    expect(repository.setStateKv).toHaveBeenCalledWith({
+      scope: { kind: "work_item", ...TEST_ITEM_SCOPE },
+      key: "work.dispatch.phase",
+      value_json: "unassigned",
+      provenance_json: { source: "workboard.reconciler" },
+    });
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      status: "ready",
+      reason: "Automatically requeued orphaned execution work.",
+    });
+  });
+
+  it("requeues orphaned work for queued, leased, running, and paused tasks", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([
+      makeTask({ status: "queued" }),
+      makeTask({ task_id: "task-2", status: "leased" }),
+      makeTask({ task_id: "task-3", status: "running" }),
+      makeTask({ task_id: "task-4", status: "paused" }),
+    ]);
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await reconciler.tick();
+
+    expect(repository.requeueOrphanedTasks).toHaveBeenCalledOnce();
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_ITEM_SCOPE,
+      work_item_id: "work-1",
+      status: "ready",
+      reason: "Automatically requeued orphaned execution work.",
+    });
+  });
+
+  it("swallows transition failures while requeueing orphaned work", async () => {
+    const repository = createRepository();
+    repository.listDoingItems.mockResolvedValue([{ ...TEST_SCOPE, work_item_id: "work-1" }]);
+    repository.listTasks.mockResolvedValue([makeTask({ status: "running" })]);
+    repository.transitionItem.mockRejectedValue(new Error("db busy"));
+    const reconciler = new WorkboardReconciler({ repository });
+
+    await expect(reconciler.tick()).resolves.toBeUndefined();
+    expect(repository.requeueOrphanedTasks).toHaveBeenCalledOnce();
+    expect(repository.setStateKv).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/runtime-workboard/tests/subagent-service.test.ts
+++ b/packages/runtime-workboard/tests/subagent-service.test.ts
@@ -5,6 +5,7 @@ import {
   type WorkboardSessionKeyBuilder,
   type WorkboardSubagentRuntime,
 } from "../src/index.js";
+import { TEST_SCOPE, makeSubagent } from "./test-support.js";
 
 function createRepository() {
   return {
@@ -27,20 +28,17 @@ function createRepository() {
   >;
 }
 
+function createRuntime(): WorkboardSubagentRuntime {
+  return {
+    buildSessionKey: vi.fn(async (_scope, subagentId) => `agent:default:subagent:${subagentId}`),
+    runTurn: vi.fn(async () => "done"),
+  };
+}
+
 describe("SubagentService", () => {
   it("builds a session key through the injected session-key builder when one is not provided", async () => {
     const repository = createRepository();
-    repository.createSubagent.mockResolvedValue({
-      subagent_id: "123e4567-e89b-12d3-a456-426614174111",
-      tenant_id: "default",
-      agent_id: "123e4567-e89b-12d3-a456-426614174000",
-      workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      execution_profile: "planner",
-      session_key: "agent:default:subagent:123e4567-e89b-12d3-a456-426614174111",
-      lane: "subagent",
-      status: "paused",
-      created_at: "2026-03-19T00:00:00.000Z",
-    });
+    repository.createSubagent.mockResolvedValue(makeSubagent());
 
     const sessionKeyBuilder: WorkboardSessionKeyBuilder = {
       buildSessionKey: vi
@@ -50,11 +48,7 @@ describe("SubagentService", () => {
 
     const service = new SubagentService({ repository, sessionKeyBuilder });
     await service.createSubagent({
-      scope: {
-        tenant_id: "default",
-        agent_id: "123e4567-e89b-12d3-a456-426614174000",
-        workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      },
+      scope: TEST_SCOPE,
       subagentId: "123e4567-e89b-12d3-a456-426614174111",
       subagent: {
         execution_profile: "planner",
@@ -64,19 +58,11 @@ describe("SubagentService", () => {
     });
 
     expect(sessionKeyBuilder.buildSessionKey).toHaveBeenCalledWith(
-      {
-        tenant_id: "default",
-        agent_id: "123e4567-e89b-12d3-a456-426614174000",
-        workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      },
+      TEST_SCOPE,
       "123e4567-e89b-12d3-a456-426614174111",
     );
     expect(repository.createSubagent).toHaveBeenCalledWith({
-      scope: {
-        tenant_id: "default",
-        agent_id: "123e4567-e89b-12d3-a456-426614174000",
-        workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      },
+      scope: TEST_SCOPE,
       subagentId: "123e4567-e89b-12d3-a456-426614174111",
       subagent: expect.objectContaining({
         execution_profile: "planner",
@@ -85,19 +71,286 @@ describe("SubagentService", () => {
     });
   });
 
+  it("uses a provided session key without consulting the builder", async () => {
+    const repository = createRepository();
+    repository.createSubagent.mockResolvedValue(
+      makeSubagent({ session_key: "agent:default:subagent:provided" }),
+    );
+    const sessionKeyBuilder: WorkboardSessionKeyBuilder = {
+      buildSessionKey: vi.fn(),
+    };
+
+    const service = new SubagentService({ repository, sessionKeyBuilder });
+    await service.createSubagent({
+      scope: TEST_SCOPE,
+      subagentId: "subagent-provided",
+      subagent: {
+        execution_profile: "planner",
+        session_key: "agent:default:subagent:provided",
+      },
+    });
+
+    expect(sessionKeyBuilder.buildSessionKey).not.toHaveBeenCalled();
+    expect(repository.createSubagent).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagentId: "subagent-provided",
+      subagent: expect.objectContaining({
+        session_key: "agent:default:subagent:provided",
+      }),
+    });
+  });
+
+  it("requires a session key builder when no session key is provided", async () => {
+    const service = new SubagentService({ repository: createRepository() });
+
+    await expect(
+      service.createSubagent({
+        scope: TEST_SCOPE,
+        subagent: {
+          execution_profile: "planner",
+        },
+      }),
+    ).rejects.toThrow("createSubagent requires session key builder");
+  });
+
+  it("returns undefined when closing a missing subagent", async () => {
+    const repository = createRepository();
+    repository.getSubagent.mockResolvedValue(undefined);
+    const service = new SubagentService({ repository });
+
+    await expect(
+      service.closeSubagent({
+        scope: TEST_SCOPE,
+        subagent_id: "missing-subagent",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(repository.closeSubagent).not.toHaveBeenCalled();
+  });
+
+  it("delegates closeSubagent when the subagent exists", async () => {
+    const repository = createRepository();
+    const subagent = makeSubagent({ subagent_id: "subagent-2" });
+    repository.getSubagent.mockResolvedValue(subagent);
+    repository.closeSubagent.mockResolvedValue(makeSubagent({ status: "closing" }));
+    const service = new SubagentService({ repository });
+
+    await expect(
+      service.closeSubagent({
+        scope: TEST_SCOPE,
+        subagent_id: "subagent-2",
+        reason: "Done",
+      }),
+    ).resolves.toEqual(expect.objectContaining({ status: "closing" }));
+
+    expect(repository.closeSubagent).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent_id: "subagent-2",
+      reason: "Done",
+    });
+  });
+
+  it("requires runtime access for sendSubagentMessage", async () => {
+    const service = new SubagentService({ repository: createRepository() });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: "subagent-1",
+        message: "hello",
+      }),
+    ).rejects.toThrow("sendSubagentMessage requires agent runtime access");
+  });
+
+  it("fails when the target subagent does not exist", async () => {
+    const repository = createRepository();
+    repository.getSubagent.mockResolvedValue(undefined);
+    const service = new SubagentService({ repository, runtime: createRuntime() });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: "missing-subagent",
+        message: "hello",
+      }),
+    ).rejects.toThrow("subagent not found");
+  });
+
+  it.each(["closing", "closed", "failed"] as const)(
+    "rejects %s subagents before calling the runtime",
+    async (status) => {
+      const repository = createRepository();
+      repository.getSubagent.mockResolvedValue(makeSubagent({ status }));
+      const runtime = createRuntime();
+      const service = new SubagentService({ repository, runtime });
+
+      await expect(
+        service.sendSubagentMessage({
+          scope: TEST_SCOPE,
+          subagent_id: "subagent-1",
+          message: "hello",
+        }),
+      ).rejects.toThrow(`subagent is ${status}`);
+
+      expect(runtime.runTurn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("marks paused subagents running before executing the turn", async () => {
+    const repository = createRepository();
+    const subagent = makeSubagent({ status: "paused" });
+    repository.getSubagent.mockResolvedValue(subagent);
+    repository.updateSubagent.mockResolvedValue(makeSubagent({ status: "running" }));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "reply");
+    const service = new SubagentService({ repository, runtime });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: subagent.subagent_id,
+        message: "hello",
+      }),
+    ).resolves.toEqual({ subagent, reply: "reply" });
+
+    expect(repository.updateSubagent).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent_id: subagent.subagent_id,
+      patch: { status: "running" },
+    });
+    expect(runtime.runTurn).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent,
+      message: "hello",
+    });
+  });
+
+  it("marks the subagent failed when status promotion fails", async () => {
+    const repository = createRepository();
+    const subagent = makeSubagent({ status: "paused" });
+    repository.getSubagent.mockResolvedValue(subagent);
+    repository.updateSubagent.mockRejectedValue(new Error("status update failed"));
+    repository.markSubagentFailed.mockResolvedValue(undefined);
+    const runtime = createRuntime();
+    const service = new SubagentService({ repository, runtime });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: subagent.subagent_id,
+        message: "hello",
+      }),
+    ).rejects.toThrow("status update failed");
+
+    expect(repository.markSubagentFailed).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent_id: subagent.subagent_id,
+      reason: "status update failed",
+    });
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("marks the subagent failed when the runtime turn errors", async () => {
+    const repository = createRepository();
+    const subagent = makeSubagent({ status: "running" });
+    repository.getSubagent.mockResolvedValue(subagent);
+    repository.markSubagentFailed.mockResolvedValue(undefined);
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn().mockRejectedValue(new Error("runtime unavailable"));
+    const service = new SubagentService({ repository, runtime });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: subagent.subagent_id,
+        message: "hello",
+      }),
+    ).rejects.toThrow("runtime unavailable");
+
+    expect(repository.markSubagentFailed).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent_id: subagent.subagent_id,
+      reason: "runtime unavailable",
+    });
+  });
+
+  it("uses a caller-provided subagent without reloading it", async () => {
+    const repository = createRepository();
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "reply");
+    const subagent = makeSubagent({ status: "running" });
+    const service = new SubagentService({ repository, runtime });
+
+    await expect(
+      service.sendSubagentMessage({
+        scope: TEST_SCOPE,
+        subagent_id: subagent.subagent_id,
+        message: "hello",
+        subagent,
+      }),
+    ).resolves.toEqual({ subagent, reply: "reply" });
+
+    expect(repository.getSubagent).not.toHaveBeenCalled();
+    expect(runtime.runTurn).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent,
+      message: "hello",
+    });
+  });
+
+  it("closes the subagent after a successful spawnAndRunSubagent when requested", async () => {
+    const repository = createRepository();
+    repository.createSubagent.mockResolvedValue(makeSubagent({ status: "running" }));
+    repository.markSubagentClosed.mockResolvedValue(makeSubagent({ status: "closed" }));
+    const runtime = createRuntime();
+    runtime.runTurn = vi.fn(async () => "done");
+
+    const service = new SubagentService({ repository, runtime });
+    const result = await service.spawnAndRunSubagent({
+      scope: TEST_SCOPE,
+      subagent: {
+        execution_profile: "executor_rw",
+        lane: "subagent",
+        status: "running",
+      },
+      message: "execute this",
+      close_on_success: true,
+    });
+
+    expect(result.reply).toBe("done");
+    expect(result.subagent.status).toBe("closed");
+    expect(repository.markSubagentClosed).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      subagent_id: "subagent-1",
+    });
+  });
+
+  it("falls back to the created subagent when close_on_success cannot reload it", async () => {
+    const repository = createRepository();
+    const created = makeSubagent({ status: "running" });
+    repository.createSubagent.mockResolvedValue(created);
+    repository.markSubagentClosed.mockResolvedValue(undefined);
+    const runtime = createRuntime();
+
+    const service = new SubagentService({ repository, runtime });
+    const result = await service.spawnAndRunSubagent({
+      scope: TEST_SCOPE,
+      subagent: {
+        execution_profile: "executor_rw",
+        lane: "subagent",
+        status: "running",
+      },
+      message: "execute this",
+      close_on_success: true,
+    });
+
+    expect(result.reply).toBe("done");
+    expect(result.subagent).toEqual(created);
+  });
+
   it("marks a subagent failed when the injected runtime port errors", async () => {
     const repository = createRepository();
-    repository.createSubagent.mockResolvedValue({
-      subagent_id: "123e4567-e89b-12d3-a456-426614174111",
-      tenant_id: "default",
-      agent_id: "123e4567-e89b-12d3-a456-426614174000",
-      workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      execution_profile: "executor_rw",
-      session_key: "agent:default:subagent:123e4567-e89b-12d3-a456-426614174111",
-      lane: "subagent",
-      status: "running",
-      created_at: "2026-03-19T00:00:00.000Z",
-    });
+    repository.createSubagent.mockResolvedValue(makeSubagent({ status: "running" }));
     repository.markSubagentFailed.mockResolvedValue(undefined);
 
     const runtime: WorkboardSubagentRuntime = {
@@ -111,11 +364,7 @@ describe("SubagentService", () => {
 
     await expect(
       service.spawnAndRunSubagent({
-        scope: {
-          tenant_id: "default",
-          agent_id: "123e4567-e89b-12d3-a456-426614174000",
-          workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-        },
+        scope: TEST_SCOPE,
         subagent: {
           execution_profile: "executor_rw",
           lane: "subagent",
@@ -126,12 +375,8 @@ describe("SubagentService", () => {
     ).rejects.toThrow("runtime unavailable");
 
     expect(repository.markSubagentFailed).toHaveBeenCalledWith({
-      scope: {
-        tenant_id: "default",
-        agent_id: "123e4567-e89b-12d3-a456-426614174000",
-        workspace_id: "123e4567-e89b-12d3-a456-426614174001",
-      },
-      subagent_id: "123e4567-e89b-12d3-a456-426614174111",
+      scope: TEST_SCOPE,
+      subagent_id: "subagent-1",
       reason: "runtime unavailable",
     });
   });

--- a/packages/runtime-workboard/tests/task-helpers.test.ts
+++ b/packages/runtime-workboard/tests/task-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isTerminalTaskState } from "../src/index.js";
+
+describe("isTerminalTaskState", () => {
+  it.each([
+    ["completed", true],
+    ["skipped", true],
+    ["cancelled", true],
+    ["failed", true],
+    ["queued", false],
+    ["leased", false],
+    ["running", false],
+    ["paused", false],
+    [undefined, false],
+  ] as const)("returns %s for %s", (status, expected) => {
+    expect(isTerminalTaskState(status)).toBe(expected);
+  });
+});

--- a/packages/runtime-workboard/tests/test-support.ts
+++ b/packages/runtime-workboard/tests/test-support.ts
@@ -1,0 +1,96 @@
+import { vi } from "vitest";
+import type {
+  SubagentDescriptor,
+  WorkClarification,
+  WorkItem,
+  WorkItemTask,
+  WorkScope,
+} from "@tyrum/contracts";
+import type { WorkboardLogger } from "../src/index.js";
+
+export const TEST_SCOPE = {
+  tenant_id: "tenant-1",
+  agent_id: "agent-1",
+  workspace_id: "workspace-1",
+} satisfies WorkScope;
+
+const DEFAULT_TIMESTAMP = "2026-03-19T00:00:00.000Z";
+
+export function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    work_item_id: "work-1",
+    tenant_id: TEST_SCOPE.tenant_id,
+    agent_id: TEST_SCOPE.agent_id,
+    workspace_id: TEST_SCOPE.workspace_id,
+    kind: "action",
+    title: "Ship runtime split",
+    status: "backlog",
+    priority: 1,
+    created_at: DEFAULT_TIMESTAMP,
+    created_from_session_key: "agent:default:main",
+    last_active_at: null,
+    updated_at: DEFAULT_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+export function makeTask(overrides: Partial<WorkItemTask> = {}): WorkItemTask {
+  return {
+    task_id: "task-1",
+    work_item_id: "work-1",
+    status: "queued",
+    depends_on: [],
+    execution_profile: "planner",
+    side_effect_class: "workspace",
+    artifacts: [],
+    started_at: null,
+    finished_at: null,
+    result_summary: "Task summary",
+    ...overrides,
+  };
+}
+
+export function makeSubagent(overrides: Partial<SubagentDescriptor> = {}): SubagentDescriptor {
+  return {
+    subagent_id: "subagent-1",
+    tenant_id: TEST_SCOPE.tenant_id,
+    agent_id: TEST_SCOPE.agent_id,
+    workspace_id: TEST_SCOPE.workspace_id,
+    execution_profile: "planner",
+    session_key: "agent:default:subagent:subagent-1",
+    lane: "subagent",
+    status: "paused",
+    created_at: DEFAULT_TIMESTAMP,
+    updated_at: DEFAULT_TIMESTAMP,
+    last_heartbeat_at: null,
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+export function makeClarification(overrides: Partial<WorkClarification> = {}): WorkClarification {
+  return {
+    clarification_id: "clarification-1",
+    tenant_id: TEST_SCOPE.tenant_id,
+    agent_id: TEST_SCOPE.agent_id,
+    workspace_id: TEST_SCOPE.workspace_id,
+    work_item_id: "work-1",
+    status: "open",
+    question: "Need more detail?",
+    requested_for_session_key: "agent:default:main",
+    requested_at: DEFAULT_TIMESTAMP,
+    updated_at: DEFAULT_TIMESTAMP,
+    answered_at: null,
+    ...overrides,
+  };
+}
+
+export function createLogger(): WorkboardLogger & {
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+} {
+  return {
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}

--- a/packages/runtime-workboard/tests/workboard-service.test.ts
+++ b/packages/runtime-workboard/tests/workboard-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { WorkboardService, type WorkboardCrudRepository } from "../src/index.js";
+import { TEST_SCOPE, makeWorkItem } from "./test-support.js";
 
 function createRepository(): WorkboardCrudRepository {
   return {
@@ -49,51 +50,336 @@ describe("WorkboardService", () => {
 
   it("delegates work item creation through the injected repository", async () => {
     const repository = createRepository();
-    repository.createItem = vi.fn().mockResolvedValue({
-      tenant_id: "default",
-      agent_id: "agent-1",
-      workspace_id: "workspace-1",
-      work_item_id: "work-1",
-      parent_work_item_id: null,
-      kind: "task",
-      title: "Ship runtime split",
-      description: null,
-      status: "backlog",
-      priority: 1,
-      created_from_session_key: "agent:default:main",
-      fingerprint_json: null,
-      acceptance_json: null,
-      metadata_json: null,
-      created_at: "2026-03-19T00:00:00.000Z",
-      updated_at: "2026-03-19T00:00:00.000Z",
-    });
+    repository.createItem = vi.fn().mockResolvedValue(makeWorkItem());
 
     const service = new WorkboardService({ repository });
     const item = await service.createItem({
-      scope: {
-        tenant_id: "default",
-        agent_id: "agent-1",
-        workspace_id: "workspace-1",
-      },
+      scope: TEST_SCOPE,
       item: {
-        kind: "task",
+        kind: "action",
         title: "Ship runtime split",
       },
       createdFromSessionKey: "agent:default:main",
     });
 
     expect(repository.createItem).toHaveBeenCalledWith({
-      scope: {
-        tenant_id: "default",
-        agent_id: "agent-1",
-        workspace_id: "workspace-1",
-      },
+      scope: TEST_SCOPE,
       item: {
-        kind: "task",
+        kind: "action",
         title: "Ship runtime split",
       },
       createdFromSessionKey: "agent:default:main",
     });
     expect(item.work_item_id).toBe("work-1");
+  });
+
+  it("delegates the remaining repository-backed operations", async () => {
+    const repository = createRepository();
+    const service = new WorkboardService({ repository });
+
+    const listItemsResult = { items: [makeWorkItem()], next_cursor: "next-items" };
+    const getItemResult = makeWorkItem({ work_item_id: "work-2" });
+    const updateItemResult = makeWorkItem({ title: "Updated title" });
+    const transitionItemResult = makeWorkItem({ status: "doing" });
+    const linkResult = {
+      work_item_id: "work-1",
+      linked_work_item_id: "work-2",
+      kind: "depends_on" as const,
+      meta_json: { source: "test" },
+      created_at: "2026-03-19T00:00:00.000Z",
+    };
+    const listLinksResult = { links: [linkResult] };
+    const artifact = {
+      artifact_id: "artifact-1",
+      tenant_id: TEST_SCOPE.tenant_id,
+      agent_id: TEST_SCOPE.agent_id,
+      workspace_id: TEST_SCOPE.workspace_id,
+      scope: "work_item" as const,
+      work_item_id: "work-1",
+      kind: "text/plain",
+      label: "Artifact",
+      storage_uri: "file:///tmp/artifact-1",
+      sha256: "abc",
+      size_bytes: 10,
+      sensitivity: "operational" as const,
+      created_at: "2026-03-19T00:00:00.000Z",
+    };
+    const listArtifactsResult = { artifacts: [artifact], next_cursor: "next-artifacts" };
+    const decision = {
+      decision_id: "decision-1",
+      tenant_id: TEST_SCOPE.tenant_id,
+      agent_id: TEST_SCOPE.agent_id,
+      workspace_id: TEST_SCOPE.workspace_id,
+      work_item_id: "work-1",
+      summary: "Ship it",
+      rationale: "Looks good",
+      created_at: "2026-03-19T00:00:00.000Z",
+    };
+    const listDecisionsResult = { decisions: [decision], next_cursor: "next-decisions" };
+    const signal = {
+      signal_id: "signal-1",
+      tenant_id: TEST_SCOPE.tenant_id,
+      agent_id: TEST_SCOPE.agent_id,
+      workspace_id: TEST_SCOPE.workspace_id,
+      work_item_id: "work-1",
+      kind: "clarification",
+      status: "open" as const,
+      summary: "Need review",
+      created_at: "2026-03-19T00:00:00.000Z",
+      updated_at: "2026-03-19T00:00:00.000Z",
+    };
+    const listSignalsResult = { signals: [signal], next_cursor: "next-signals" };
+    const stateEntry = {
+      key: "work.dispatch.phase",
+      value_json: "unassigned",
+      provenance_json: { source: "test" },
+      updated_at: "2026-03-19T00:00:00.000Z",
+    };
+    const stateEntriesResult = { entries: [stateEntry] };
+    const updateSignalResult = { signal, changed: true };
+
+    repository.listItems = vi.fn().mockResolvedValue(listItemsResult);
+    repository.getItem = vi.fn().mockResolvedValue(getItemResult);
+    repository.updateItem = vi.fn().mockResolvedValue(updateItemResult);
+    repository.transitionItem = vi.fn().mockResolvedValue(transitionItemResult);
+    repository.createLink = vi.fn().mockResolvedValue(linkResult);
+    repository.listLinks = vi.fn().mockResolvedValue(listLinksResult);
+    repository.listArtifacts = vi.fn().mockResolvedValue(listArtifactsResult);
+    repository.getArtifact = vi.fn().mockResolvedValue(artifact);
+    repository.createArtifact = vi.fn().mockResolvedValue(artifact);
+    repository.listDecisions = vi.fn().mockResolvedValue(listDecisionsResult);
+    repository.getDecision = vi.fn().mockResolvedValue(decision);
+    repository.createDecision = vi.fn().mockResolvedValue(decision);
+    repository.listSignals = vi.fn().mockResolvedValue(listSignalsResult);
+    repository.getSignal = vi.fn().mockResolvedValue(signal);
+    repository.createSignal = vi.fn().mockResolvedValue(signal);
+    repository.updateSignal = vi.fn().mockResolvedValue(updateSignalResult);
+    repository.getStateKv = vi.fn().mockResolvedValue(stateEntry);
+    repository.listStateKv = vi.fn().mockResolvedValue(stateEntriesResult);
+    repository.setStateKv = vi.fn().mockResolvedValue(stateEntry);
+
+    await expect(
+      service.listItems({
+        scope: TEST_SCOPE,
+        statuses: ["backlog"],
+        kinds: ["action"],
+        limit: 10,
+      }),
+    ).resolves.toBe(listItemsResult);
+    await expect(service.getItem({ scope: TEST_SCOPE, work_item_id: "work-2" })).resolves.toBe(
+      getItemResult,
+    );
+    await expect(
+      service.updateItem({
+        scope: TEST_SCOPE,
+        work_item_id: "work-2",
+        patch: { title: "Updated title" },
+      }),
+    ).resolves.toBe(updateItemResult);
+    await expect(
+      service.transitionItem({
+        scope: TEST_SCOPE,
+        work_item_id: "work-2",
+        status: "doing",
+        reason: "Start work",
+      }),
+    ).resolves.toBe(transitionItemResult);
+    await expect(
+      service.createLink({
+        scope: TEST_SCOPE,
+        work_item_id: "work-1",
+        linked_work_item_id: "work-2",
+        kind: "depends_on",
+      }),
+    ).resolves.toBe(linkResult);
+    await expect(
+      service.listLinks({ scope: TEST_SCOPE, work_item_id: "work-1", limit: 10 }),
+    ).resolves.toBe(listLinksResult);
+    await expect(
+      service.listArtifacts({ scope: TEST_SCOPE, work_item_id: "work-1", limit: 10 }),
+    ).resolves.toBe(listArtifactsResult);
+    await expect(
+      service.getArtifact({ scope: TEST_SCOPE, artifact_id: "artifact-1" }),
+    ).resolves.toBe(artifact);
+    await expect(
+      service.createArtifact({
+        scope: TEST_SCOPE,
+        artifact: {
+          work_item_id: "work-1",
+          kind: "text/plain",
+          label: "Artifact",
+          storage_uri: "file:///tmp/artifact-1",
+          sha256: "abc",
+          size_bytes: 10,
+          sensitivity: "operational",
+        },
+      }),
+    ).resolves.toBe(artifact);
+    await expect(
+      service.listDecisions({ scope: TEST_SCOPE, work_item_id: "work-1", limit: 10 }),
+    ).resolves.toBe(listDecisionsResult);
+    await expect(
+      service.getDecision({ scope: TEST_SCOPE, decision_id: "decision-1" }),
+    ).resolves.toBe(decision);
+    await expect(
+      service.createDecision({
+        scope: TEST_SCOPE,
+        decision: { work_item_id: "work-1", summary: "Ship it", rationale: "Looks good" },
+      }),
+    ).resolves.toBe(decision);
+    await expect(
+      service.listSignals({
+        scope: TEST_SCOPE,
+        work_item_id: "work-1",
+        statuses: ["open"],
+        limit: 10,
+      }),
+    ).resolves.toBe(listSignalsResult);
+    await expect(service.getSignal({ scope: TEST_SCOPE, signal_id: "signal-1" })).resolves.toBe(
+      signal,
+    );
+    await expect(
+      service.createSignal({
+        scope: TEST_SCOPE,
+        signal: {
+          work_item_id: "work-1",
+          kind: "clarification",
+          status: "open",
+          summary: "Need review",
+        },
+      }),
+    ).resolves.toBe(signal);
+    await expect(
+      service.updateSignal({
+        scope: TEST_SCOPE,
+        signal_id: "signal-1",
+        patch: { status: "resolved", summary: "Done" },
+      }),
+    ).resolves.toBe(updateSignalResult);
+    await expect(
+      service.getStateKv({
+        scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+        key: "work.dispatch.phase",
+      }),
+    ).resolves.toBe(stateEntry);
+    await expect(
+      service.listStateKv({
+        scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+        prefix: "work.",
+      }),
+    ).resolves.toBe(stateEntriesResult);
+    await expect(
+      service.setStateKv({
+        scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+        key: "work.dispatch.phase",
+        value_json: "assigned",
+        provenance_json: { source: "test" },
+      }),
+    ).resolves.toBe(stateEntry);
+
+    expect(repository.listItems).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      statuses: ["backlog"],
+      kinds: ["action"],
+      limit: 10,
+    });
+    expect(repository.getItem).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-2",
+    });
+    expect(repository.updateItem).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-2",
+      patch: { title: "Updated title" },
+    });
+    expect(repository.transitionItem).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-2",
+      status: "doing",
+      reason: "Start work",
+    });
+    expect(repository.createLink).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      linked_work_item_id: "work-2",
+      kind: "depends_on",
+    });
+    expect(repository.listLinks).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      limit: 10,
+    });
+    expect(repository.listArtifacts).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      limit: 10,
+    });
+    expect(repository.getArtifact).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      artifact_id: "artifact-1",
+    });
+    expect(repository.createArtifact).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      artifact: {
+        work_item_id: "work-1",
+        kind: "text/plain",
+        label: "Artifact",
+        storage_uri: "file:///tmp/artifact-1",
+        sha256: "abc",
+        size_bytes: 10,
+        sensitivity: "operational",
+      },
+    });
+    expect(repository.listDecisions).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      limit: 10,
+    });
+    expect(repository.getDecision).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      decision_id: "decision-1",
+    });
+    expect(repository.createDecision).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      decision: { work_item_id: "work-1", summary: "Ship it", rationale: "Looks good" },
+    });
+    expect(repository.listSignals).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      work_item_id: "work-1",
+      statuses: ["open"],
+      limit: 10,
+    });
+    expect(repository.getSignal).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      signal_id: "signal-1",
+    });
+    expect(repository.createSignal).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      signal: {
+        work_item_id: "work-1",
+        kind: "clarification",
+        status: "open",
+        summary: "Need review",
+      },
+    });
+    expect(repository.updateSignal).toHaveBeenCalledWith({
+      scope: TEST_SCOPE,
+      signal_id: "signal-1",
+      patch: { status: "resolved", summary: "Done" },
+    });
+    expect(repository.getStateKv).toHaveBeenCalledWith({
+      scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+      key: "work.dispatch.phase",
+    });
+    expect(repository.listStateKv).toHaveBeenCalledWith({
+      scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+      prefix: "work.",
+    });
+    expect(repository.setStateKv).toHaveBeenCalledWith({
+      scope: { kind: "work_item", ...TEST_SCOPE, work_item_id: "work-1" },
+      key: "work.dispatch.phase",
+      value_json: "assigned",
+      provenance_json: { source: "test" },
+    });
   });
 });


### PR DESCRIPTION
Closes #1634.\n\nAdds branch-sweep non-happy-path coverage across runtime-execution, runtime-agent, node-sdk, runtime-workboard, and runtime-policy. This is test-only; no production source files were changed.\n\nVerification:\n- pnpm typecheck\n- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json\n- pnpm test\n- pnpm lint\n- pnpm format:check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are entirely test additions/updates with no production code modifications. Main risk is increased CI time or brittle async/timer-based tests.
> 
> **Overview**
> Adds broad *non-happy-path* test coverage across several runtime packages, focusing on error handling, lifecycle edge cases, and deterministic behaviors.
> 
> Notable additions include: expanded `node-sdk` coverage for `autoExecute` routing/fallback serialization failures and managed client lifecycle disposal/reconnect behavior; new `runtime-agent` tests for runtime option validation/clamping, lifecycle delegation, context-report retention, and deterministic context/tool pruning; new `runtime-execution` tests for `TaskResultRegistry` buffering/eviction/timeouts and `startExecutionWorkerLoop` sleep/clamping/logging/error recovery; and new `runtime-policy` and `runtime-workboard` unit suites covering policy merging/evaluation/override helpers plus workboard dispatcher/orchestrator/reconciler/subagent/service behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5277aa6867f8d99a703fa80491bc758cc9e02fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->