### PR TITLE
fix: avoid false onboarding failure on policy sync

### DIFF
--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -1,6 +1,7 @@
 import type { OperatorCore } from "@tyrum/operator-app";
 import * as React from "react";
 import { CheckCircle2 } from "lucide-react";
+import { toast } from "sonner";
 import { useOperatorStore } from "../../use-operator-store.js";
 import { formatErrorMessage } from "../../utils/format-error-message.js";
 import { AppPage } from "../layout/app-page.js";
@@ -377,10 +378,16 @@ export function FirstRunOnboardingPage({
                 config,
                 reason: "onboarding: configure primary agent",
               });
-              await mutationHttp.policyConfig.updateAgent(nextAgentKey, {
-                bundle: buildAgentPolicyBundle(drafts.agentPolicyPreset),
-                reason: "onboarding: configure primary agent policy",
-              });
+              try {
+                await mutationHttp.policyConfig.updateAgent(nextAgentKey, {
+                  bundle: buildAgentPolicyBundle(drafts.agentPolicyPreset),
+                  reason: "onboarding: configure primary agent policy",
+                });
+              } catch (error) {
+                toast.warning("Agent created with limited setup", {
+                  description: `${formatErrorMessage(error)}. The agent was configured, but the policy preset was not applied.`,
+                });
+              }
             });
           },
           onToneChange: drafts.setAgentTone,

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-policy-warning-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-policy-warning-test-support.ts
@@ -1,0 +1,256 @@
+import { expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { toast } from "sonner";
+import { createBearerTokenAuth, createOperatorCore } from "../../operator-app/src/index.js";
+import { OperatorUiApp } from "../src/index.js";
+import {
+  TEST_DEVICE_IDENTITY,
+  requestInfoToUrl,
+  stubPersistentStorage,
+  waitForSelector,
+} from "./operator-ui.test-support.js";
+import { createFakeHttpClient, FakeWsClient } from "./operator-ui.test-fixtures.js";
+import {
+  buildIssueStatusResponse,
+  cleanup,
+  createAgentConfigResponse,
+  createConfiguredProviderGroup,
+  findButtonByText,
+  setInputByLabel,
+} from "./operator-ui.first-run-onboarding.helpers.js";
+
+export function registerFirstRunOnboardingPolicyWarningTests(): void {
+  it("shows a warning instead of a fatal error when the agent policy route is unavailable", async () => {
+    const toastWarningMock = vi.spyOn(toast, "warning").mockImplementation(() => "");
+    stubPersistentStorage();
+    const ws = new FakeWsClient();
+    const { http, statusGet, agentConfigGet } = createFakeHttpClient();
+    let primaryAgentKey = "default";
+    let agentConfigResponse = createAgentConfigResponse({
+      agentKey: primaryAgentKey,
+      modelRef: null,
+    });
+    statusGet.mockResolvedValue(
+      buildIssueStatusResponse([
+        {
+          code: "agent_model_unconfigured",
+          severity: "error",
+          message: "Agent 'default' has no primary model configured.",
+          target: { kind: "agent", id: primaryAgentKey },
+        },
+      ]),
+    );
+    http.providerConfig.listProviders = vi.fn(async () => ({
+      status: "ok" as const,
+      providers: [createConfiguredProviderGroup()],
+    }));
+    http.modelConfig.listPresets = vi.fn(async () => ({
+      status: "ok" as const,
+      presets: [
+        {
+          preset_id: "00000000-0000-4000-8000-000000000301",
+          preset_key: "preset-openai",
+          display_name: "OpenAI Default",
+          provider_key: "openai",
+          model_id: "gpt-4.1",
+          options: {},
+          created_at: "2026-03-01T00:00:00.000Z",
+          updated_at: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    }));
+    http.agents.list = vi.fn(
+      async () => ({ agents: [{ agent_key: primaryAgentKey, is_primary: true }] }) as const,
+    );
+    agentConfigGet.mockImplementation(async () => agentConfigResponse);
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestInfoToUrl(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url.endsWith("/config/providers/registry")) {
+        return new Response(JSON.stringify(await http.providerConfig.listRegistry()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.endsWith("/config/providers")) {
+        return new Response(JSON.stringify(await http.providerConfig.listProviders()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.endsWith("/config/models/presets")) {
+        return new Response(JSON.stringify(await http.modelConfig.listPresets()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.endsWith("/config/models/presets/available")) {
+        return new Response(JSON.stringify(await http.modelConfig.listAvailable()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.endsWith("/config/models/assignments")) {
+        return new Response(JSON.stringify(await http.modelConfig.listAssignments()), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (method === "GET" && url.endsWith("/agents")) {
+        return new Response(
+          JSON.stringify({
+            agents: [
+              {
+                agent_id: "11111111-1111-4111-8111-111111111111",
+                agent_key: primaryAgentKey,
+                created_at: "2026-03-01T00:00:00.000Z",
+                updated_at: "2026-03-01T00:00:00.000Z",
+                has_config: true,
+                has_identity: true,
+                is_primary: true,
+                can_delete: false,
+                persona: agentConfigResponse.persona,
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (
+        method === "GET" &&
+        url.endsWith(`/config/agents/${encodeURIComponent(primaryAgentKey)}`)
+      ) {
+        return new Response(JSON.stringify(agentConfigResponse), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (
+        method === "POST" &&
+        url.endsWith(`/agents/${encodeURIComponent(primaryAgentKey)}/rename`)
+      ) {
+        const body = JSON.parse(String(init?.body)) as { agent_key: string };
+        primaryAgentKey = body.agent_key;
+        agentConfigResponse = { ...agentConfigResponse, agent_key: primaryAgentKey };
+        return new Response(
+          JSON.stringify({
+            agent_key: primaryAgentKey,
+            agent_id: "11111111-1111-4111-8111-111111111111",
+            created_at: "2026-03-01T00:00:00.000Z",
+            updated_at: "2026-03-01T00:00:00.000Z",
+            has_config: true,
+            has_identity: true,
+            is_primary: true,
+            can_delete: false,
+            persona: agentConfigResponse.persona,
+            config: agentConfigResponse.config,
+            identity: {
+              meta: {
+                name: agentConfigResponse.persona.name,
+                style: { tone: agentConfigResponse.persona.tone },
+              },
+            },
+            config_revision: 1,
+            identity_revision: 1,
+            config_sha256: "a".repeat(64),
+            identity_sha256: "b".repeat(64),
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (method === "PUT" && url.endsWith(`/agents/${encodeURIComponent(primaryAgentKey)}`)) {
+        const body = JSON.parse(String(init?.body)) as {
+          config: { model: { model: string | null }; persona: { name: string; tone: string } };
+        };
+        agentConfigResponse = createAgentConfigResponse({
+          agentKey: primaryAgentKey,
+          modelRef: body.config.model.model,
+          name: body.config.persona.name,
+          tone: body.config.persona.tone,
+        });
+        return new Response(
+          JSON.stringify({
+            agent_id: "11111111-1111-4111-8111-111111111111",
+            agent_key: primaryAgentKey,
+            created_at: "2026-03-01T00:00:00.000Z",
+            updated_at: "2026-03-02T00:00:00.000Z",
+            has_config: true,
+            has_identity: true,
+            is_primary: true,
+            can_delete: false,
+            persona: agentConfigResponse.persona,
+            config: agentConfigResponse.config,
+            identity: {
+              meta: {
+                name: agentConfigResponse.persona.name,
+                style: { tone: agentConfigResponse.persona.tone },
+              },
+            },
+            config_revision: 1,
+            identity_revision: 1,
+            config_sha256: "a".repeat(64),
+            identity_sha256: "b".repeat(64),
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (
+        method === "PUT" &&
+        url.endsWith(`/config/policy/agents/${encodeURIComponent(primaryAgentKey)}`)
+      ) {
+        return new Response(JSON.stringify({ error: "not_found", message: "route not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const core = createOperatorCore({
+      wsUrl: "ws://example.test/ws",
+      httpBaseUrl: "http://example.test",
+      auth: createBearerTokenAuth("baseline"),
+      deviceIdentity: TEST_DEVICE_IDENTITY,
+      deps: { ws, http },
+    });
+    core.elevatedModeStore.enter({
+      elevatedToken: "test-elevated-token",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let root: Root | null = null;
+    await act(async () => {
+      root = createRoot(container);
+      root.render(React.createElement(OperatorUiApp, { core, mode: "desktop" }));
+      await Promise.resolve();
+    });
+
+    await waitForSelector(container, '[data-testid="first-run-onboarding-step-agent"]', 200);
+    setInputByLabel(container, "Agent name", "Research Agent");
+
+    const saveButton = findButtonByText(container, "Save agent");
+    expect(saveButton).not.toBeNull();
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("Unable to save onboarding step");
+    expect(toastWarningMock).toHaveBeenCalledWith("Agent created with limited setup", {
+      description:
+        "HTTP request failed. The agent was configured, but the policy preset was not applied.",
+    });
+
+    cleanup(root, container);
+  });
+}

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-test-support.ts
@@ -1,6 +1,7 @@
 import { registerFirstRunOnboardingAgentConfigTests } from "./operator-ui.first-run-onboarding-agent-config-test-support.js";
 import { registerFirstRunOnboardingFlowTests } from "./operator-ui.first-run-onboarding-flow-test-support.js";
 import { registerFirstRunOnboardingModelPickerTests } from "./operator-ui.first-run-onboarding-model-picker-test-support.js";
+import { registerFirstRunOnboardingPolicyWarningTests } from "./operator-ui.first-run-onboarding-policy-warning-test-support.js";
 import { registerFirstRunOnboardingProviderPickerTests } from "./operator-ui.first-run-onboarding-provider-picker-test-support.js";
 import { registerFirstRunOnboardingStateTests } from "./operator-ui.first-run-onboarding-state-test-support.js";
 
@@ -8,6 +9,7 @@ export function registerFirstRunOnboardingTests(): void {
   registerFirstRunOnboardingStateTests();
   registerFirstRunOnboardingFlowTests();
   registerFirstRunOnboardingAgentConfigTests();
+  registerFirstRunOnboardingPolicyWarningTests();
   registerFirstRunOnboardingModelPickerTests();
   registerFirstRunOnboardingProviderPickerTests();
 }


### PR DESCRIPTION
## Summary
- downgrade the first-run onboarding agent policy sync failure to a warning instead of a fatal onboarding step error
- keep the successful primary agent rename/config save path intact
- add regression coverage for the missing policy route case in onboarding

## Testing
- pnpm vitest run packages/operator-ui/tests/operator-ui.test.ts
- pre-push hook: pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test

Fixes #1641

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-flow change: onboarding no longer fails hard when the policy preset update endpoint errors (e.g., 404), but it still mutates agent config/rename, so behavior should be validated against real gateways.
> 
> **Overview**
> First-run onboarding now treats failures applying the agent policy preset as **non-fatal**: the primary agent rename/config update still completes, and any `policyConfig.updateAgent` error is caught and surfaced via a `toast.warning` (“Agent created with limited setup”) instead of failing the onboarding step.
> 
> Adds a regression test that simulates the policy route returning `404` and asserts onboarding does not show the “Unable to save onboarding step” error while emitting the warning toast, and wires this test into the onboarding test suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4706b3a328bfe9020f831a6a97ce9f51a24c1df9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->