### PR TITLE
fix: canonicalize cross-platform sensor args

### DIFF
--- a/packages/contracts/src/cross-platform-capabilities.ts
+++ b/packages/contracts/src/cross-platform-capabilities.ts
@@ -48,9 +48,7 @@ export type LocationGetResult = z.infer<typeof LocationGetResult>;
 
 export const CameraCapturePhotoArgs = z
   .object({
-    camera: z.enum(["front", "rear"]).optional(),
     facing_mode: z.enum(["user", "environment"]).optional(),
-    device_id: z.string().trim().min(1).optional(),
     format: z.enum(["jpeg", "png"]).default("jpeg"),
     quality: z.number().min(0).max(1).default(0.92),
   })
@@ -103,7 +101,6 @@ export const AudioRecordArgs = z
   .object({
     duration_ms: z.number().int().min(250).max(300_000).default(5_000),
     mime: z.string().trim().min(1).optional(),
-    device_id: z.string().trim().min(1).optional(),
   })
   .strict();
 export type AudioRecordArgs = z.infer<typeof AudioRecordArgs>;

--- a/packages/contracts/tests/cross-platform-capabilities.test.ts
+++ b/packages/contracts/tests/cross-platform-capabilities.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { AudioRecordArgs, CameraCapturePhotoArgs } from "../src/index.js";
+import { expectRejects } from "./test-helpers.js";
+
+describe("cross-platform sensor schemas", () => {
+  it("parses canonical camera photo args with facing_mode", () => {
+    const parsed = CameraCapturePhotoArgs.parse({ facing_mode: "user" });
+
+    expect(parsed).toEqual({
+      facing_mode: "user",
+      format: "jpeg",
+      quality: 0.92,
+    });
+  });
+
+  it("rejects platform-specific camera photo fields in the shared schema", () => {
+    expectRejects(CameraCapturePhotoArgs, { camera: "front" });
+    expectRejects(CameraCapturePhotoArgs, { device_id: "camera-1" });
+  });
+
+  it("rejects browser-only device selection in shared audio args", () => {
+    expect(AudioRecordArgs.parse({ mime: "audio/webm" })).toEqual({
+      duration_ms: 5_000,
+      mime: "audio/webm",
+    });
+    expectRejects(AudioRecordArgs, { device_id: "microphone-1" });
+  });
+});

--- a/packages/gateway/src/modules/agent/tool-executor-node-dispatch-execute.ts
+++ b/packages/gateway/src/modules/agent/tool-executor-node-dispatch-execute.ts
@@ -63,6 +63,29 @@ function primitiveKindForPlatform(platform: DevicePlatform): ActionPrimitiveKind
   return ACTION_PRIMITIVE_KIND_BY_PLATFORM[platform];
 }
 
+function adaptCrossPlatformActionArgs(
+  capabilityId: string,
+  primitiveKind: ActionPrimitiveKind,
+  actionArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (capabilityId !== "tyrum.camera.capture-photo") {
+    return actionArgs;
+  }
+
+  if (primitiveKind !== "IOS" && primitiveKind !== "Android") {
+    return actionArgs;
+  }
+
+  const { facing_mode, ...rest } = actionArgs;
+  if (facing_mode === "user") {
+    return { ...rest, camera: "front" };
+  }
+  if (facing_mode === "environment") {
+    return { ...rest, camera: "rear" };
+  }
+  return rest;
+}
+
 async function resolvePrimitiveKindFromNode(
   context: DispatchExecutionContext,
   nodeId: string,
@@ -244,7 +267,7 @@ export async function executeNodeDispatchRequest(
   }
   const primitive: ActionPrimitive = {
     type: primitiveKind,
-    args: actionArgs,
+    args: adaptCrossPlatformActionArgs(request.capability, primitiveKind, actionArgs),
   };
 
   try {

--- a/packages/gateway/tests/unit/capability-catalog.test.ts
+++ b/packages/gateway/tests/unit/capability-catalog.test.ts
@@ -78,4 +78,29 @@ describe("capability catalog", () => {
     ).not.toThrow();
     expect(() => sensorAction?.inputParser.parse({ op: "get" })).not.toThrow();
   });
+
+  it("advertises only canonical shared fields for cross-platform sensor tools", () => {
+    const cameraAction = getCapabilityCatalogAction("tyrum.camera.capture-photo", "capture_photo");
+    const audioAction = getCapabilityCatalogAction("tyrum.audio.record", "record");
+
+    expect(cameraAction?.inputSchema).toMatchObject({
+      type: "object",
+      properties: expect.objectContaining({
+        facing_mode: expect.objectContaining({ type: "string" }),
+        format: expect.objectContaining({ type: "string" }),
+        quality: expect.objectContaining({ type: "number" }),
+      }),
+    });
+    expect(cameraAction?.inputSchema.properties).not.toHaveProperty("camera");
+    expect(cameraAction?.inputSchema.properties).not.toHaveProperty("device_id");
+
+    expect(audioAction?.inputSchema).toMatchObject({
+      type: "object",
+      properties: expect.objectContaining({
+        duration_ms: expect.objectContaining({ type: "integer" }),
+        mime: expect.objectContaining({ type: "string" }),
+      }),
+    });
+    expect(audioAction?.inputSchema.properties).not.toHaveProperty("device_id");
+  });
 });

--- a/packages/gateway/tests/unit/tool-executor-node-dispatch-execute.test.ts
+++ b/packages/gateway/tests/unit/tool-executor-node-dispatch-execute.test.ts
@@ -101,4 +101,114 @@ describe("executeNodeDispatchRequest", () => {
     expect(response.ok).toBe(true);
     expect(response.payload_source).toBe("evidence");
   });
+
+  it("maps canonical facing_mode to a mobile camera target before dispatch", async () => {
+    const connectionManager = new ConnectionManager();
+    const nodeWs = { on: vi.fn(), send: vi.fn(), readyState: 1 } as never;
+    connectionManager.addClient(nodeWs, [], {
+      id: "conn-1",
+      role: "node",
+      deviceId: "node-1",
+      devicePlatform: "ios",
+      protocolRev: 2,
+    });
+
+    const dispatchAndWait = vi.fn(async () => ({
+      taskId: "task-1",
+      result: {
+        ok: true,
+        evidence: { mime: "image/jpeg" },
+        result: undefined,
+        error: undefined,
+      },
+    }));
+
+    await executeNodeDispatchRequest(
+      {
+        tenantId: DEFAULT_TENANT_ID,
+        connectionManager,
+        inspectionService: {
+          inspect: vi.fn(async () =>
+            sampleInspection("tyrum.camera.capture-photo", "capture_photo"),
+          ),
+        } as never,
+        nodeDispatchService: { dispatchAndWait } as never,
+      },
+      {
+        node_id: "node-1",
+        capability: "tyrum.camera.capture-photo",
+        action_name: "capture_photo",
+        input: { facing_mode: "user", format: "jpeg", quality: 0.9 },
+      },
+    );
+
+    expect(dispatchAndWait).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "IOS",
+        args: expect.objectContaining({
+          op: "capture_photo",
+          camera: "front",
+          format: "jpeg",
+          quality: 0.9,
+        }),
+      }),
+      expect.any(Object),
+      expect.objectContaining({ nodeId: "node-1" }),
+    );
+  });
+
+  it("preserves canonical camera args for browser dispatch", async () => {
+    const connectionManager = new ConnectionManager();
+    const nodeWs = { on: vi.fn(), send: vi.fn(), readyState: 1 } as never;
+    connectionManager.addClient(nodeWs, [], {
+      id: "conn-1",
+      role: "node",
+      deviceId: "node-1",
+      devicePlatform: "web",
+      protocolRev: 2,
+    });
+
+    const dispatchAndWait = vi.fn(async () => ({
+      taskId: "task-1",
+      result: {
+        ok: true,
+        evidence: { mime: "image/jpeg" },
+        result: undefined,
+        error: undefined,
+      },
+    }));
+
+    await executeNodeDispatchRequest(
+      {
+        tenantId: DEFAULT_TENANT_ID,
+        connectionManager,
+        inspectionService: {
+          inspect: vi.fn(async () =>
+            sampleInspection("tyrum.camera.capture-photo", "capture_photo"),
+          ),
+        } as never,
+        nodeDispatchService: { dispatchAndWait } as never,
+      },
+      {
+        node_id: "node-1",
+        capability: "tyrum.camera.capture-photo",
+        action_name: "capture_photo",
+        input: { facing_mode: "environment", format: "jpeg", quality: 0.92 },
+      },
+    );
+
+    expect(dispatchAndWait).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "Browser",
+        args: expect.objectContaining({
+          op: "capture_photo",
+          facing_mode: "environment",
+          format: "jpeg",
+          quality: 0.92,
+        }),
+      }),
+      expect.any(Object),
+      expect.objectContaining({ nodeId: "node-1" }),
+    );
+  });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -330,6 +330,43 @@ describe("tool registry routes", () => {
         }),
       }),
     );
+    const cameraTool = body.tools.find(
+      (tool: { canonical_id?: string }) => tool.canonical_id === "tool.camera.capture-photo",
+    );
+    expect(cameraTool).toMatchObject({
+      source: "builtin",
+      canonical_id: "tool.camera.capture-photo",
+      input_schema: expect.objectContaining({
+        type: "object",
+        properties: expect.objectContaining({
+          facing_mode: expect.objectContaining({ type: "string" }),
+          format: expect.objectContaining({ type: "string" }),
+          quality: expect.objectContaining({ type: "number" }),
+          node_id: expect.objectContaining({ type: "string" }),
+          timeout_ms: expect.objectContaining({ type: "number" }),
+        }),
+      }),
+    });
+    expect(cameraTool?.input_schema?.properties).not.toHaveProperty("camera");
+    expect(cameraTool?.input_schema?.properties).not.toHaveProperty("device_id");
+
+    const audioTool = body.tools.find(
+      (tool: { canonical_id?: string }) => tool.canonical_id === "tool.audio.record",
+    );
+    expect(audioTool).toMatchObject({
+      source: "builtin",
+      canonical_id: "tool.audio.record",
+      input_schema: expect.objectContaining({
+        type: "object",
+        properties: expect.objectContaining({
+          duration_ms: expect.objectContaining({ type: "integer" }),
+          mime: expect.objectContaining({ type: "string" }),
+          node_id: expect.objectContaining({ type: "string" }),
+          timeout_ms: expect.objectContaining({ type: "number" }),
+        }),
+      }),
+    });
+    expect(audioTool?.input_schema?.properties).not.toHaveProperty("device_id");
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         source: "builtin",


### PR DESCRIPTION
## Summary
- narrow shared cross-platform sensor args to canonical portable fields
- adapt camera `facing_mode` to mobile-native `camera` when dispatching to iOS and Android nodes
- add regression coverage for shared schemas, gateway dispatch, and dedicated tool registry schemas

## Why
Shared sensor capability schemas were advertising platform-specific fields, which let browser camera dispatches receive mobile-only input and fail validation. This keeps the shared contract portable and moves the platform translation into the gateway dispatch layer.

## Testing
- pnpm exec vitest run packages/contracts/tests/cross-platform-capabilities.test.ts packages/contracts/tests/browser.test.ts packages/contracts/tests/mobile.test.ts packages/gateway/tests/unit/capability-catalog.test.ts packages/gateway/tests/unit/tool-executor-node-dispatch-execute.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts apps/web/tests/browser-capability-provider.test.ts
- pnpm typecheck
- pre-push hook: pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test

Closes #1642

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes shared sensor input contracts and introduces argument translation in the gateway dispatch path, which could break existing callers relying on removed fields or affect mobile camera routing.
> 
> **Overview**
> Tightens the shared cross-platform sensor contracts by **removing platform-specific input fields** from `CameraCapturePhotoArgs` (drops `camera`/`device_id`) and `AudioRecordArgs` (drops `device_id`), ensuring only canonical portable fields are accepted/advertised.
> 
> Updates gateway node dispatch to **translate canonical `facing_mode` into mobile-native `camera`** when dispatching `tyrum.camera.capture-photo` to iOS/Android primitives, while leaving browser dispatch args unchanged.
> 
> Adds regression tests verifying schema rejection of removed fields, capability catalog/tool registry schemas no longer advertise them, and dispatch performs the mobile mapping correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad9fb9bdbea772ca99e1cd1293bb0a7b02bd4cf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->