### PR TITLE
fix(desktop): stabilize packaged smoke startup updates

### DIFF
--- a/apps/desktop/src/main/ipc/update-ipc.ts
+++ b/apps/desktop/src/main/ipc/update-ipc.ts
@@ -37,6 +37,16 @@ export interface UpdateIpcOptions {
   clearQuitForUpdate?: () => void;
 }
 
+function isStartupUpdateCheckDisabled(): boolean {
+  const value = process.env["TYRUM_DISABLE_STARTUP_UPDATE_CHECK"];
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function ensureUpdateOsIntegration(): ReturnType<typeof createDesktopUpdateOsIntegration> {
   if (updateOsIntegration) return updateOsIntegration;
 
@@ -175,5 +185,7 @@ export function registerUpdateIpc(window: BrowserWindow, options: UpdateIpcOptio
     });
   }
 
-  void service.checkForUpdatesOnStartup();
+  if (!isStartupUpdateCheckDisabled()) {
+    void service.checkForUpdatesOnStartup();
+  }
 }

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -418,6 +418,7 @@ async function runDesktopGatewaySmoke(
     env: {
       ...process.env,
       TYRUM_HOME: tyrumHome,
+      TYRUM_DISABLE_STARTUP_UPDATE_CHECK: "1",
       NODE_ENV: "test",
       ELECTRON_DISABLE_SANDBOX: "1",
       ...envOverrides,

--- a/apps/desktop/tests/update-ipc-handlers.test.ts
+++ b/apps/desktop/tests/update-ipc-handlers.test.ts
@@ -109,6 +109,7 @@ describe("registerUpdateIpc handlers", () => {
         registeredHandlers.set(channel, handler);
       },
     );
+    delete process.env["TYRUM_DISABLE_STARTUP_UPDATE_CHECK"];
   });
 
   it("registers update handlers and returns initial state", async () => {
@@ -134,6 +135,33 @@ describe("registerUpdateIpc handlers", () => {
     expect(state.stage).toBe("checking");
     expect(state.currentVersion).toBe("1.0.0");
     expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the startup update check when explicitly disabled", async () => {
+    process.env["TYRUM_DISABLE_STARTUP_UPDATE_CHECK"] = "1";
+
+    const { registerUpdateIpc } = await import("../src/main/ipc/update-ipc.js");
+
+    const windowStub = {
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        send: vi.fn(),
+      },
+    } as never;
+
+    registerUpdateIpc(windowStub);
+
+    const stateHandler = registeredHandlers.get("updates:state");
+    expect(stateHandler).toBeDefined();
+
+    const state = stateHandler!({} as never) as {
+      stage: string;
+      currentVersion: string;
+    };
+    expect(state.stage).toBe("idle");
+    expect(state.currentVersion).toBe("1.0.0");
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
   });
 
   it("opens a selected installer file", async () => {


### PR DESCRIPTION
## Summary

Closes #1649.

This makes the packaged desktop smoke test deterministic by allowing startup update checks to be explicitly disabled in test environments. The packaged Electron smoke harness now sets that opt-out so CI validates packaged boot and embedded gateway startup without depending on a live GitHub releases feed.

## Why

The failing `push` run on March 21, 2026 (`ci` run `23374540006`, job `68004699095`) showed the packaged macOS app performing a startup update check and failing while resolving `https://github.com/tyrumai/tyrum/releases/latest`. This repository currently does not have a `latest` release API response, so the smoke test had an avoidable external dependency during boot.

## Changes

- add `TYRUM_DISABLE_STARTUP_UPDATE_CHECK` handling in desktop update IPC startup wiring
- set that env var in the packaged Electron smoke harness
- add regression coverage proving the startup check is skipped when explicitly disabled

## Validation

- `pnpm exec vitest run apps/desktop/tests/update-ipc-handlers.test.ts`
- `pnpm exec vitest run apps/desktop/tests/updater.test.ts`
- `TYRUM_RUN_PACKAGED_SMOKE=1 pnpm exec vitest run apps/desktop/tests/integration/electron-process-smoke.test.ts -t "launches the packaged desktop app and starts the embedded gateway"`
- repo pre-push gate passed during `git push -u origin 1649-fix-macos-desktop-push-smoke`
  - `pnpm lint`
  - `pnpm typecheck`
  - `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
  - `pnpm test`

## Risk

Low. Production behavior is unchanged unless `TYRUM_DISABLE_STARTUP_UPDATE_CHECK` is set. The new branch is only used by tests/CI where we want packaged boot coverage without release-feed coupling.

## Rollback

Revert this PR to restore unconditional startup update checks in all environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: production behavior only changes when `TYRUM_DISABLE_STARTUP_UPDATE_CHECK` is set; otherwise update startup flow is unchanged. Main impact is on test/CI determinism by removing reliance on external release lookups during boot.
> 
> **Overview**
> Makes desktop startup update checks *explicitly opt-out* via `TYRUM_DISABLE_STARTUP_UPDATE_CHECK` (accepting `1`/`true`/`yes`), so `registerUpdateIpc` skips `checkForUpdatesOnStartup()` when set.
> 
> Updates the packaged Electron smoke test harness to set this env var, and adds a regression test asserting the startup check is skipped (state remains `idle` and `checkForUpdates` is not called).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71465e47ccf8eaca2a540ecdd797c0d7a0028a3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->