### PR TITLE
fix(operator-ui): use full viewport height in setup wizard

### DIFF
--- a/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
+++ b/packages/operator-ui/src/components/pages/first-run-onboarding.tsx
@@ -400,9 +400,13 @@ export function FirstRunOnboardingPage({
   };
 
   return (
-    <AppPage contentClassName="max-w-5xl gap-6" data-testid="first-run-onboarding">
+    <AppPage
+      contentLayout="fill"
+      contentClassName="max-w-5xl gap-6"
+      data-testid="first-run-onboarding"
+    >
       <section
-        className="grid gap-4 rounded-2xl border border-border bg-bg-card px-5 py-5 shadow-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start"
+        className="shrink-0 grid gap-4 rounded-2xl border border-border bg-bg-card px-5 py-5 shadow-sm md:grid-cols-[minmax(0,1fr)_auto] md:items-start"
         data-testid="first-run-onboarding-header"
       >
         <div className="grid gap-2">
@@ -469,12 +473,11 @@ export function FirstRunOnboardingPage({
           </CardContent>
         </Card>
       ) : (
-        <div className="grid items-start gap-4 xl:grid-cols-[19rem_minmax(0,1fr)]">
+        <div className="grid flex-1 min-h-0 items-start gap-4 xl:grid-cols-[19rem_minmax(0,1fr)]">
           <OnboardingProgressCard items={progressItems} />
           <Card
-            className="flex min-h-0 flex-col overflow-hidden"
+            className="flex min-h-0 flex-col self-stretch overflow-hidden"
             data-testid="first-run-onboarding-card"
-            style={{ maxHeight: "calc(100vh - 18rem)" }}
           >
             <CardContent
               className="grid min-h-0 flex-1 gap-4 overflow-auto pt-6"


### PR DESCRIPTION
## Summary

- Switch the onboarding page from `contentLayout="stack"` to `contentLayout="fill"` so the right-panel card fills the remaining viewport height
- Remove the hardcoded `maxHeight: calc(100vh - 18rem)` which was a rough approximation that wasted vertical space
- Add `shrink-0` on the header, `flex-1 min-h-0` on the two-panel grid, and `self-stretch` on the right card to complete the flex chain

Closes #1651

## Test plan

- [x] `operator-ui` package builds cleanly
- [x] Existing onboarding bootstrap tests pass (3/3)
- [ ] Visual check at `xl`+ viewport: right card extends to near the bottom of the viewport
- [ ] Visual check at narrow viewport (<1280px): progress card stacks above the main card, form scrolls inside
- [ ] "Done" step: card is compact/content-sized, not stretched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, UI-only layout adjustments to the onboarding page; main risk is unintended scroll/height behavior at different breakpoints.
> 
> **Overview**
> Updates the first-run onboarding page layout to use `AppPage`’s `contentLayout="fill"`, allowing the wizard content to occupy the remaining viewport height.
> 
> Removes the hardcoded `maxHeight: calc(100vh - 18rem)` and instead completes the flex/height chain (`shrink-0` header, `flex-1 min-h-0` container, `self-stretch` card) so the right-hand card stretches and the step content scrolls within the card.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 063b2925ca40048fc48e3cde43136e5e1813583d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->