### PR TITLE
fix(desktop): bootstrap Electron-as-Node child scripts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "type": "module",
   "packageManager": "pnpm@10.28.0",
-  "main": "dist/main/index.mjs",
+  "main": "dist/main/bootstrap.mjs",
   "scripts": {
-    "dev": "electron dist/main/index.mjs",
+    "dev": "electron dist/main/bootstrap.mjs",
     "pretest": "pnpm --filter @tyrum/contracts build && pnpm --filter @tyrum/runtime-policy build && pnpm --filter @tyrum/transport-sdk build && pnpm --filter @tyrum/node-sdk build && pnpm --filter @tyrum/cli-utils build && pnpm --filter @tyrum/operator-app build && pnpm --filter @tyrum/operator-ui build && pnpm --filter @tyrum/runtime-node-control build && pnpm --filter @tyrum/runtime-execution build && pnpm --filter @tyrum/runtime-agent build && pnpm --filter @tyrum/runtime-workboard build && pnpm --filter @tyrum/desktop-node build",
     "test": "pnpm -w vitest run apps/desktop/tests",
     "build:main": "tsdown --config tsdown.config.ts --filter desktop-main",

--- a/apps/desktop/src/main/bootstrap-target.ts
+++ b/apps/desktop/src/main/bootstrap-target.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+export type BootstrapTarget = { kind: "app" } | { kind: "delegate"; scriptPath: string };
+
+export function resolveBootstrapTarget(options?: {
+  env?: NodeJS.ProcessEnv;
+  argv?: readonly string[];
+  bootstrapModuleUrl?: string;
+}): BootstrapTarget {
+  const env = options?.env ?? process.env;
+  if (env["ELECTRON_RUN_AS_NODE"] !== "1") {
+    return { kind: "app" };
+  }
+
+  const argv = options?.argv ?? process.argv;
+  const scriptPath = argv[1];
+  if (!scriptPath) {
+    return { kind: "app" };
+  }
+
+  const bootstrapModuleUrl = options?.bootstrapModuleUrl ?? import.meta.url;
+  const bootstrapPath = resolve(fileURLToPath(bootstrapModuleUrl));
+  const resolvedScriptPath = resolve(scriptPath);
+  if (resolvedScriptPath === bootstrapPath) {
+    return { kind: "app" };
+  }
+
+  return { kind: "delegate", scriptPath: resolvedScriptPath };
+}

--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -1,0 +1,17 @@
+import { pathToFileURL } from "node:url";
+import { resolveBootstrapTarget } from "./bootstrap-target.js";
+
+async function bootstrap(): Promise<void> {
+  const target = resolveBootstrapTarget({ bootstrapModuleUrl: import.meta.url });
+  if (target.kind === "delegate") {
+    await import(pathToFileURL(target.scriptPath).href);
+    return;
+  }
+
+  await import("./index.js");
+}
+
+void bootstrap().catch((error: unknown) => {
+  console.error("Failed to bootstrap desktop main process", error);
+  process.exitCode = 1;
+});

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -26,7 +26,7 @@ import { runWithLock } from "./run-with-lock.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const REPO_ROOT = resolve(__dirname, "../../../../");
-const DESKTOP_MAIN_ENTRYPOINT = resolve(REPO_ROOT, "apps/desktop/dist/main/index.mjs");
+const DESKTOP_MAIN_ENTRYPOINT = resolve(REPO_ROOT, "apps/desktop/dist/main/bootstrap.mjs");
 const DESKTOP_RELEASE_DIR = resolve(REPO_ROOT, "apps/desktop/release");
 const electronPackageExport = require("electron");
 if (typeof electronPackageExport !== "string") {

--- a/apps/desktop/tests/main-bootstrap-target.test.ts
+++ b/apps/desktop/tests/main-bootstrap-target.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveBootstrapTarget } from "../src/main/bootstrap-target.js";
+
+describe("resolveBootstrapTarget", () => {
+  it("starts the desktop app when not running under Electron-as-Node", () => {
+    expect(
+      resolveBootstrapTarget({
+        env: {},
+        argv: ["/Applications/Tyrum.app/Contents/MacOS/Tyrum"],
+        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap-target.ts",
+      }),
+    ).toEqual({ kind: "app" });
+  });
+
+  it("delegates to the requested script when Electron-as-Node passes a child entrypoint", () => {
+    expect(
+      resolveBootstrapTarget({
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        argv: [
+          "/Applications/Tyrum.app/Contents/MacOS/Tyrum",
+          "/Applications/Tyrum.app/Contents/Resources/app.asar/dist/gateway/index.mjs",
+          "start",
+        ],
+        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap.ts",
+      }),
+    ).toEqual({
+      kind: "delegate",
+      scriptPath: "/Applications/Tyrum.app/Contents/Resources/app.asar/dist/gateway/index.mjs",
+    });
+  });
+
+  it("does not recurse when Electron-as-Node points back at the bootstrap entrypoint", () => {
+    expect(
+      resolveBootstrapTarget({
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        argv: [
+          "/Applications/Tyrum.app/Contents/MacOS/Tyrum",
+          "/repo/apps/desktop/src/main/bootstrap.ts",
+        ],
+        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap.ts",
+      }),
+    ).toEqual({ kind: "app" });
+  });
+});

--- a/apps/desktop/tsdown.config.ts
+++ b/apps/desktop/tsdown.config.ts
@@ -7,7 +7,7 @@ const externalElectron = {
 export default defineConfig([
   {
     name: "desktop-main",
-    entry: ["src/main/index.ts", "src/main/desktop-screenshot-helper.ts"],
+    entry: ["src/main/bootstrap.ts", "src/main/index.ts", "src/main/desktop-screenshot-helper.ts"],
     format: "esm",
     outDir: "dist/main",
     deps: externalElectron,


### PR DESCRIPTION
## Summary
- add a desktop bootstrap entrypoint that delegates `ELECTRON_RUN_AS_NODE` child launches to the requested script instead of re-entering the app main module
- point the desktop package/dev/integration entrypoint at the bootstrap module
- add focused tests for the bootstrap target resolution logic

## Root cause
On macOS packaged Electron builds, child launches that rely on `ELECTRON_RUN_AS_NODE` can recurse back into the packaged app entrypoint instead of executing the requested child script. Our desktop packaged smoke test hits that path when the app tries to start the embedded gateway, so the gateway never becomes healthy and CI times out.

## Validation
- `pnpm exec vitest run apps/desktop/tests/main-bootstrap-target.test.ts apps/desktop/tests/gateway-manager.test.ts apps/desktop/tests/gateway-bin-path.test.ts apps/desktop/tests/packaging-config.test.ts`
- `pnpm --filter tyrum-desktop build:main`
- `pnpm exec vitest run apps/desktop/tests/integration/electron-process-smoke.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- pre-push hook suite during `git push` (`pnpm lint`, `pnpm typecheck`, repo test suite)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Electron main-process entrypoint and startup flow; a mistake could prevent the desktop app or embedded gateway from launching in dev/packaged builds.
> 
> **Overview**
> Adds a new desktop main-process `bootstrap` entrypoint that detects `ELECTRON_RUN_AS_NODE` launches and *delegates to the requested script* instead of re-entering the app’s main module (with a guard to avoid self-recursion).
> 
> Updates the desktop package `main`/`dev` entrypoint, build config, and the integration smoke test to use `dist/main/bootstrap.mjs`, and adds unit tests covering the bootstrap target resolution behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38747ec868441c23e10aa4c2583dde3dd85e0499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->