### PR TITLE
fix(desktop): harden packaged startup and bootstrap tests

### DIFF
--- a/apps/desktop/src/main/background-mode.ts
+++ b/apps/desktop/src/main/background-mode.ts
@@ -200,7 +200,11 @@ export class BackgroundModeController {
     try {
       return this.syncFromConfig(config);
     } catch (error) {
-      this.syncAutoStart(false);
+      try {
+        this.syncAutoStart(false);
+      } catch (autoStartError) {
+        console.error("Failed to reset background auto start", autoStartError);
+      }
       this.state = {
         enabled: Boolean(config.background?.enabled),
         supported: false,
@@ -439,20 +443,35 @@ export class BackgroundModeController {
       return false;
     }
 
+    const currentOpenAtLogin = this.readLoginItemOpenAtLogin();
+    if (!enabled && currentOpenAtLogin !== true) {
+      return false;
+    }
+
     const command = resolveAutoLaunchCommand({
       electronApp: this.electronApp,
       processExecPath: this.processExecPath,
       isPackaged: this.electronApp.isPackaged ?? false,
     });
 
-    this.electronApp.setLoginItemSettings({
-      openAtLogin: enabled,
-      openAsHidden: enabled,
-      path: command.command,
-      args: command.args,
-    });
+    let didSync = false;
+    try {
+      this.electronApp.setLoginItemSettings({
+        openAtLogin: enabled,
+        openAsHidden: enabled,
+        path: command.command,
+        args: command.args,
+      });
+      didSync = true;
+    } catch (error) {
+      console.error("Failed to sync login item settings", error);
+    }
 
-    return Boolean(this.electronApp.getLoginItemSettings?.().openAtLogin ?? enabled);
+    const nextOpenAtLogin = this.readLoginItemOpenAtLogin();
+    if (nextOpenAtLogin !== null) {
+      return nextOpenAtLogin;
+    }
+    return didSync ? enabled : false;
   }
 
   private syncLinuxAutoStart(enabled: boolean): boolean {
@@ -473,6 +492,16 @@ export class BackgroundModeController {
       mode: 0o600,
     });
     return existsSync(autostartPath);
+  }
+
+  private readLoginItemOpenAtLogin(): boolean | null {
+    try {
+      const value = this.electronApp.getLoginItemSettings?.().openAtLogin;
+      return typeof value === "boolean" ? value : null;
+    } catch (error) {
+      console.error("Failed to read login item settings", error);
+      return null;
+    }
   }
 }
 

--- a/apps/desktop/tests/background-mode.test.ts
+++ b/apps/desktop/tests/background-mode.test.ts
@@ -34,8 +34,15 @@ function createController(options?: {
   platform?: NodeJS.Platform;
   config?: DesktopNodeConfig;
   appIsPackaged?: boolean;
+  openAtLogin?: boolean;
   resourcesPath?: string;
   moduleDir?: string;
+  setLoginItemSettings?: (settings: {
+    openAtLogin: boolean;
+    openAsHidden?: boolean;
+    path?: string;
+    args?: string[];
+  }) => void;
   nativeImageImpl?: {
     createFromDataURL: (dataUrl: string) => { setTemplateImage?: (template: boolean) => void };
     createFromPath: (path: string) => unknown;
@@ -45,14 +52,17 @@ function createController(options?: {
   const menu = {
     buildFromTemplate: vi.fn(() => ({}) as Electron.Menu),
   };
-  let openAtLogin = false;
+  let openAtLogin = options?.openAtLogin ?? false;
   const app = {
     isPackaged: options?.appIsPackaged ?? true,
     getAppPath: vi.fn(() => "/tmp/Tyrum.app"),
     getLoginItemSettings: vi.fn(() => ({ openAtLogin })),
-    setLoginItemSettings: vi.fn((settings: { openAtLogin: boolean }) => {
-      openAtLogin = settings.openAtLogin;
-    }),
+    setLoginItemSettings: vi.fn(
+      options?.setLoginItemSettings ??
+        ((settings: { openAtLogin: boolean }) => {
+          openAtLogin = settings.openAtLogin;
+        }),
+    ),
     quit: vi.fn(),
   };
 
@@ -158,11 +168,7 @@ describe("BackgroundModeController", () => {
       loginAutoStartActive: false,
       mode: "remote",
     });
-    expect(app.setLoginItemSettings).toHaveBeenCalledWith(
-      expect.objectContaining({
-        openAtLogin: false,
-      }),
-    );
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled();
     expect(controller.shouldHideOnClose()).toBe(false);
   });
 
@@ -207,5 +213,58 @@ describe("BackgroundModeController", () => {
       expect.stringContaining("data:image/svg+xml;base64,"),
     );
     expect(setTemplateImage).toHaveBeenCalledWith(true);
+  });
+
+  it("skips redundant macOS login item writes when background mode is already disabled", () => {
+    const { app, controller } = createController({
+      platform: "darwin",
+      setLoginItemSettings: () => {
+        throw new Error("Operation not permitted");
+      },
+    });
+
+    const state = controller.initialize();
+
+    expect(state).toMatchObject({
+      enabled: false,
+      trayAvailable: false,
+      loginAutoStartActive: false,
+      mode: "embedded",
+    });
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled();
+  });
+
+  it("keeps background mode enabled when macOS login item sync fails", () => {
+    const resourcesPath = mkdtempSync(join(tmpdir(), "tyrum-tray-template-"));
+    tempDirs.push(resourcesPath);
+    const trayDir = join(resourcesPath, "tray");
+    mkdirSync(trayDir, { recursive: true });
+    writeFileSync(
+      join(trayDir, "macos-template.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg"><path fill="black" d="M0 0h16v16H0z"/></svg>',
+    );
+
+    const { app, controller } = createController({
+      platform: "darwin",
+      config: {
+        ...DEFAULT_CONFIG,
+        background: { enabled: true },
+      },
+      resourcesPath,
+      setLoginItemSettings: () => {
+        throw new Error("Operation not permitted");
+      },
+    });
+
+    const state = controller.initialize();
+
+    expect(state).toMatchObject({
+      enabled: true,
+      supported: true,
+      trayAvailable: true,
+      loginAutoStartActive: false,
+      mode: "embedded",
+    });
+    expect(app.setLoginItemSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/tests/main-bootstrap-target.test.ts
+++ b/apps/desktop/tests/main-bootstrap-target.test.ts
@@ -1,43 +1,59 @@
+import { pathToFileURL } from "node:url";
+import { posix, win32 } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveBootstrapTarget } from "../src/main/bootstrap-target.js";
+
+function absolutePath(path: string): string {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  return process.platform === "win32"
+    ? win32.join("C:\\", ...segments)
+    : posix.join("/", ...segments);
+}
+
+function absoluteFileUrl(path: string): string {
+  return pathToFileURL(absolutePath(path)).href;
+}
 
 describe("resolveBootstrapTarget", () => {
   it("starts the desktop app when not running under Electron-as-Node", () => {
     expect(
       resolveBootstrapTarget({
         env: {},
-        argv: ["/Applications/Tyrum.app/Contents/MacOS/Tyrum"],
-        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap-target.ts",
+        argv: [absolutePath("/Applications/Tyrum.app/Contents/MacOS/Tyrum")],
+        bootstrapModuleUrl: absoluteFileUrl("/repo/apps/desktop/src/main/bootstrap-target.ts"),
       }),
     ).toEqual({ kind: "app" });
   });
 
   it("delegates to the requested script when Electron-as-Node passes a child entrypoint", () => {
+    const packagedScriptPath = absolutePath(
+      "/Applications/Tyrum.app/Contents/Resources/app.asar/dist/gateway/index.mjs",
+    );
+
     expect(
       resolveBootstrapTarget({
         env: { ELECTRON_RUN_AS_NODE: "1" },
         argv: [
-          "/Applications/Tyrum.app/Contents/MacOS/Tyrum",
-          "/Applications/Tyrum.app/Contents/Resources/app.asar/dist/gateway/index.mjs",
+          absolutePath("/Applications/Tyrum.app/Contents/MacOS/Tyrum"),
+          packagedScriptPath,
           "start",
         ],
-        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap.ts",
+        bootstrapModuleUrl: absoluteFileUrl("/repo/apps/desktop/src/main/bootstrap.ts"),
       }),
     ).toEqual({
       kind: "delegate",
-      scriptPath: "/Applications/Tyrum.app/Contents/Resources/app.asar/dist/gateway/index.mjs",
+      scriptPath: packagedScriptPath,
     });
   });
 
   it("does not recurse when Electron-as-Node points back at the bootstrap entrypoint", () => {
+    const bootstrapScriptPath = absolutePath("/repo/apps/desktop/src/main/bootstrap.ts");
+
     expect(
       resolveBootstrapTarget({
         env: { ELECTRON_RUN_AS_NODE: "1" },
-        argv: [
-          "/Applications/Tyrum.app/Contents/MacOS/Tyrum",
-          "/repo/apps/desktop/src/main/bootstrap.ts",
-        ],
-        bootstrapModuleUrl: "file:///repo/apps/desktop/src/main/bootstrap.ts",
+        argv: [absolutePath("/Applications/Tyrum.app/Contents/MacOS/Tyrum"), bootstrapScriptPath],
+        bootstrapModuleUrl: absoluteFileUrl("/repo/apps/desktop/src/main/bootstrap.ts"),
       }),
     ).toEqual({ kind: "app" });
   });


### PR DESCRIPTION
## Summary

- harden desktop background-mode startup so packaged smoke does not depend on macOS login-item writes succeeding
- skip redundant disabled login-item writes and make login-item sync best-effort
- make `resolveBootstrapTarget` test fixtures generate host-native absolute paths and file URLs so they pass on Windows

## Why

Fixes #1660.

Recent `main` push macOS desktop jobs failed in packaged smoke with `Unable to set login item: Operation not permitted`, while Windows failed after `fix(desktop): bootstrap electron-as-node child scripts` because the new bootstrap-target test fixture used POSIX-only `file:///repo/...` URLs. The desktop workflow itself is the same on PR and push; the macOS failure came from a startup path that was too sensitive to runner-specific login-item behavior.

## How To Test

- `pnpm exec vitest run apps/desktop/tests/background-mode.test.ts apps/desktop/tests/main-bootstrap-target.test.ts`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm exec vitest run apps/desktop/tests --passWithNoTests`
- `git push` pre-push hooks passed locally: lint, typecheck, desktop app typecheck, full test suite

## Risk

- Low and localized to desktop startup/background-mode behavior plus test fixtures.
- Background mode still works even when launch-at-login cannot be synced, which matches the current UI copy better than failing startup.

## Rollback

- Revert commit `5268fef5`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup/autostart behavior on macOS/Windows; failures are now swallowed and redundant writes skipped, which could mask real autostart misconfigurations but is localized.
> 
> **Overview**
> Desktop background-mode initialization is hardened so failures syncing launch-at-login no longer fail startup: `initialize()` now best-effort resets autostart on error, and `syncLoginItemSettings()` skips redundant disables, catches `setLoginItemSettings`/`getLoginItemSettings` errors, and falls back safely.
> 
> Tests are updated to reflect the new autostart behavior (no write when already disabled, background mode stays enabled if login-item sync fails) and `resolveBootstrapTarget` fixtures now generate host-native absolute paths and `file://` URLs so they pass on Windows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5268fef55ad8c2ca87c526fa55fd4173938b90ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->