### PR TITLE
Fix transcript page stale detail and refresh behavior

### DIFF
--- a/packages/operator-app/src/stores/transcript-store.ts
+++ b/packages/operator-app/src/stores/transcript-store.ts
@@ -224,6 +224,7 @@ export function createTranscriptStore(ws: OperatorWsClient): TranscriptStore {
     setState((prev) => ({
       ...prev,
       selectedSessionKey: normalizedSessionKey,
+      detail: prev.detail?.focusSessionKey === normalizedSessionKey ? prev.detail : null,
       loadingDetail: true,
       errorDetail: null,
     }));

--- a/packages/operator-app/tests/transcript-store.test.ts
+++ b/packages/operator-app/tests/transcript-store.test.ts
@@ -320,6 +320,52 @@ describe("createTranscriptStore", () => {
     });
   });
 
+  it("clears stale detail before loading a different transcript session", async () => {
+    const ws = createFakeWs();
+    const deferred = createDeferred<ReturnType<typeof createTranscriptGetResult>>();
+    const transcript = createTranscriptStore(ws as never);
+
+    await transcript.openSession("session-child");
+    ws.transcriptGet.mockReturnValueOnce(deferred.promise);
+
+    const openSessionPromise = transcript.openSession("session-root");
+
+    expect(transcript.getSnapshot()).toMatchObject({
+      selectedSessionKey: "session-root",
+      loadingDetail: true,
+      detail: null,
+      errorDetail: null,
+    });
+
+    deferred.resolve(createTranscriptGetResult({ focus_session_key: "session-root" }));
+    await openSessionPromise;
+
+    expect(transcript.getSnapshot().detail).toMatchObject({
+      focusSessionKey: "session-root",
+    });
+  });
+
+  it("does not keep previous detail when loading a different transcript session fails", async () => {
+    const ws = createFakeWs();
+    const transcript = createTranscriptStore(ws as never);
+
+    await transcript.openSession("session-child");
+    ws.transcriptGet.mockRejectedValueOnce(new Error("transcript.get timed out"));
+
+    await transcript.openSession("session-root");
+
+    expect(transcript.getSnapshot()).toMatchObject({
+      selectedSessionKey: "session-root",
+      detail: null,
+      errorDetail: {
+        kind: "ws",
+        operation: "transcript.get",
+        code: "timeout",
+        message: "timed out",
+      },
+    });
+  });
+
   it("keeps existing sessions when loadMore fails", async () => {
     const ws = createFakeWs();
     ws.transcriptList

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-helpers.ts
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-helpers.ts
@@ -88,8 +88,12 @@ export function copyToClipboard(clipboard: ReturnType<typeof useClipboard>, valu
     });
 }
 
-export function formatToolState(state: string): string {
-  return state.replace(/-/g, " ");
+export function formatToolState(state: unknown): string {
+  if (typeof state !== "string") {
+    return "unknown";
+  }
+  const normalized = state.trim();
+  return normalized.length > 0 ? normalized.replace(/-/g, " ") : "unknown";
 }
 
 export function isArtifactRef(value: unknown): value is ArtifactRef {

--- a/packages/operator-ui/src/components/pages/transcripts-page.lib.ts
+++ b/packages/operator-ui/src/components/pages/transcripts-page.lib.ts
@@ -99,8 +99,14 @@ export function buildSessionTreeEntries(
   }
 
   const orderedRoots = roots.toSorted(compareSessionsByUpdatedAtDesc);
+  const orderedSessions = sessions.toSorted(compareSessionsByUpdatedAtDesc);
   const result: Array<{ session: TranscriptSessionSummary; depth: number }> = [];
+  const visited = new Set<string>();
   const visit = (session: TranscriptSessionSummary, depth: number): void => {
+    if (visited.has(session.session_key)) {
+      return;
+    }
+    visited.add(session.session_key);
     result.push({ session, depth });
     const children = (byParentKey.get(session.session_key) ?? []).toSorted(
       compareSessionsByCreatedAtAsc,
@@ -112,6 +118,9 @@ export function buildSessionTreeEntries(
 
   for (const root of orderedRoots) {
     visit(root, 0);
+  }
+  for (const session of orderedSessions) {
+    visit(session, 0);
   }
 
   return result;

--- a/packages/operator-ui/src/components/pages/transcripts-page.tsx
+++ b/packages/operator-ui/src/components/pages/transcripts-page.tsx
@@ -21,6 +21,7 @@ export function TranscriptsPage({ core }: { core: OperatorCore }) {
   const connection = useOperatorStore(core.connectionStore);
   const transcript = useOperatorStore(core.transcriptStore);
   const isConnected = connection.status === "connected";
+  const isRefreshing = transcript.loadingList || transcript.loadingDetail;
 
   const [agentOptions, setAgentOptions] = useState<AgentOption[]>([]);
   const [renderMode, setRenderMode] = useState<"markdown" | "text">("markdown");
@@ -180,10 +181,16 @@ export function TranscriptsPage({ core }: { core: OperatorCore }) {
             type="button"
             size="sm"
             variant="outline"
-            disabled={!isConnected || transcript.loadingList}
-            isLoading={transcript.loadingList}
+            disabled={!isConnected || isRefreshing}
+            isLoading={isRefreshing}
             onClick={() => {
-              void core.transcriptStore.refresh();
+              void (async () => {
+                await core.transcriptStore.refresh();
+                const snapshot = core.transcriptStore.getSnapshot();
+                if (snapshot.selectedSessionKey) {
+                  await core.transcriptStore.openSession(snapshot.selectedSessionKey);
+                }
+              })();
             }}
           >
             <RefreshCw className="h-3.5 w-3.5" />

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
@@ -181,6 +181,34 @@ describe("MessageCard", () => {
     cleanupTestRoot(testRoot);
   });
 
+  it("renders tool parts with a missing state without crashing", () => {
+    const testRoot = renderMessageCard({
+      id: "assistant-tool-missing-state",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "web_search",
+          toolCallId: "tool-call-1",
+          input: { query: "latest docs" },
+        },
+      ],
+    } as unknown as UIMessage);
+
+    const toggle = findToggle(testRoot.container, "web_search");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      click(toggle);
+    });
+
+    expect(testRoot.container.textContent).toContain("web_search");
+    expect(testRoot.container.textContent).toContain("unknown");
+    expect(testRoot.container.textContent).toContain("latest docs");
+
+    cleanupTestRoot(testRoot);
+  });
+
   it("auto-collapses tool calls once they finish and only shows input/output when expanded", () => {
     const message = {
       id: "assistant-tool-finished",

--- a/packages/operator-ui/tests/pages/transcripts-page.lib.test.ts
+++ b/packages/operator-ui/tests/pages/transcripts-page.lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionTreeEntries } from "../../src/components/pages/transcripts-page.lib.js";
+
+function createSession(overrides: Record<string, unknown> = {}) {
+  return {
+    session_id: "session-root-id",
+    session_key: "session-root",
+    agent_id: "default",
+    channel: "ui",
+    thread_id: "thread-root",
+    title: "Root session",
+    message_count: 2,
+    updated_at: "2026-03-13T12:00:00.000Z",
+    created_at: "2026-03-13T11:00:00.000Z",
+    archived: false,
+    latest_run_id: null,
+    latest_run_status: null,
+    has_active_run: false,
+    pending_approval_count: 0,
+    ...overrides,
+  };
+}
+
+describe("buildSessionTreeEntries", () => {
+  it("returns all sessions even when lineage data contains a cycle", () => {
+    const entries = buildSessionTreeEntries([
+      createSession({
+        session_id: "session-a-id",
+        session_key: "session-a",
+        parent_session_key: "session-b",
+      }),
+      createSession({
+        session_id: "session-b-id",
+        session_key: "session-b",
+        parent_session_key: "session-a",
+      }),
+    ]);
+
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => entry.session.session_key).toSorted()).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+  });
+});

--- a/packages/operator-ui/tests/pages/transcripts-page.test.ts
+++ b/packages/operator-ui/tests/pages/transcripts-page.test.ts
@@ -420,6 +420,23 @@ describe("TranscriptsPage", () => {
     cleanupTestRoot(testRoot);
   });
 
+  it("refreshes the selected transcript detail when the page refresh action is used", async () => {
+    const { core, transcriptStore, fixture } = createTranscriptCore();
+    const testRoot = renderIntoDocument(React.createElement(TranscriptsPage, { core }));
+
+    await flushPage();
+
+    act(() => {
+      click(findButtonByText(testRoot.container, "Refresh"));
+    });
+    await flushPage();
+
+    expect(transcriptStore.refresh).toHaveBeenCalledTimes(2);
+    expect(transcriptStore.openSession).toHaveBeenCalledWith(fixture.rootSession.session_key);
+
+    cleanupTestRoot(testRoot);
+  });
+
   it("keeps the selected transcript event in the inspector across transcript detail updates", async () => {
     const { core, fixture, setTranscriptState } = createTranscriptCore();
     const testRoot = renderIntoDocument(React.createElement(TranscriptsPage, { core }));


### PR DESCRIPTION
## Summary
- clear stale transcript detail when switching sessions so the page does not keep showing the previous timeline during a new load or after a failed load
- refresh the selected transcript detail when the page-level Refresh action is used and keep the button loading state aligned with list/detail fetches
- guard transcript session tree building against cyclic lineage data and harden transcript tool-state rendering when stored tool parts are missing a state value

## Testing
- pnpm vitest run packages/operator-app/tests/transcript-store.test.ts
- pnpm vitest run packages/operator-ui/tests/pages/transcripts-page.test.ts packages/operator-ui/tests/pages/transcripts-page.lib.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pnpm test

Closes #1668.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes transcript selection/refresh state transitions and session tree ordering, which could affect what timeline data is shown and when extra websocket fetches occur.
> 
> **Overview**
> Fixes stale transcript timeline behavior by clearing `detail` when switching to a different session (including when the new load fails), so the UI doesn’t keep showing the previous session’s events.
> 
> Updates the Transcripts page Refresh action to treat list+detail loads as a single “refreshing” state and to re-fetch the currently selected session’s detail after refreshing the list.
> 
> Hardens UI helpers: `buildSessionTreeEntries` now guards against cyclic parent/child lineage and still returns all sessions, and tool-call rendering now tolerates missing/blank tool state by displaying `unknown` instead of crashing. Adds targeted tests for each scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de9e4bb386a0937a2cfd5ff8203619053ef389f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->