### PR TITLE
fix(gateway): stabilize workboard delete cleanup

### DIFF
--- a/packages/gateway/src/modules/workboard/items-dal.ts
+++ b/packages/gateway/src/modules/workboard/items-dal.ts
@@ -206,69 +206,160 @@ export class WorkboardItemsDal {
     scope: WorkScope;
     work_item_id: string;
   }): Promise<WorkItem | undefined> {
-    const existing = await this.getItem(params);
-    if (!existing) {
-      return undefined;
-    }
+    return await this.db.transaction(async (tx) => {
+      const existing = await tx.get<DalHelpers.RawWorkItemRow>(
+        `SELECT *
+         FROM work_items
+         WHERE tenant_id = ?
+           AND agent_id = ?
+           AND workspace_id = ?
+           AND work_item_id = ?`,
+        [
+          params.scope.tenant_id,
+          params.scope.agent_id,
+          params.scope.workspace_id,
+          params.work_item_id,
+        ],
+      );
+      if (!existing) {
+        return undefined;
+      }
 
-    const activeSubagent = await this.db.get<{ subagent_id: string }>(
-      `SELECT subagent_id
-       FROM subagents
-       WHERE tenant_id = ?
-         AND agent_id = ?
-         AND workspace_id = ?
-         AND work_item_id = ?
-         AND status IN ('running', 'paused', 'closing')
-       LIMIT 1`,
-      [
-        params.scope.tenant_id,
-        params.scope.agent_id,
-        params.scope.workspace_id,
-        params.work_item_id,
-      ],
-    );
-    if (activeSubagent) {
-      throw new Error("cannot delete work item with active subagents");
-    }
+      const activeSubagent = await tx.get<{ subagent_id: string }>(
+        `SELECT subagent_id
+         FROM subagents
+         WHERE tenant_id = ?
+           AND agent_id = ?
+           AND workspace_id = ?
+           AND work_item_id = ?
+           AND status IN ('running', 'paused', 'closing')
+         LIMIT 1`,
+        [
+          params.scope.tenant_id,
+          params.scope.agent_id,
+          params.scope.workspace_id,
+          params.work_item_id,
+        ],
+      );
+      if (activeSubagent) {
+        throw new Error("cannot delete work item with active subagents");
+      }
 
-    const activeTask = await this.db.get<{ task_id: string }>(
-      `SELECT t.task_id
-       FROM work_item_tasks t
-       JOIN work_items i ON i.tenant_id = t.tenant_id AND i.work_item_id = t.work_item_id
-       WHERE i.tenant_id = ?
-         AND i.agent_id = ?
-         AND i.workspace_id = ?
-         AND t.tenant_id = ?
-         AND t.work_item_id = ?
-         AND t.status IN ('leased', 'running', 'paused')
-       LIMIT 1`,
-      [
-        params.scope.tenant_id,
-        params.scope.agent_id,
-        params.scope.workspace_id,
-        params.scope.tenant_id,
-        params.work_item_id,
-      ],
-    );
-    if (activeTask) {
-      throw new Error("cannot delete work item with active tasks");
-    }
+      const activeTask = await tx.get<{ task_id: string }>(
+        `SELECT t.task_id
+         FROM work_item_tasks t
+         JOIN work_items i ON i.tenant_id = t.tenant_id AND i.work_item_id = t.work_item_id
+         WHERE i.tenant_id = ?
+           AND i.agent_id = ?
+           AND i.workspace_id = ?
+           AND t.tenant_id = ?
+           AND t.work_item_id = ?
+           AND t.status IN ('leased', 'running', 'paused')
+         LIMIT 1`,
+        [
+          params.scope.tenant_id,
+          params.scope.agent_id,
+          params.scope.workspace_id,
+          params.scope.tenant_id,
+          params.work_item_id,
+        ],
+      );
+      if (activeTask) {
+        throw new Error("cannot delete work item with active tasks");
+      }
 
-    const row = await this.db.get<DalHelpers.RawWorkItemRow>(
-      `DELETE FROM work_items
-       WHERE tenant_id = ?
-         AND agent_id = ?
-         AND workspace_id = ?
-         AND work_item_id = ?
-       RETURNING *`,
-      [
-        params.scope.tenant_id,
-        params.scope.agent_id,
-        params.scope.workspace_id,
-        params.work_item_id,
-      ],
-    );
-    return row ? dalHelpers.toWorkItem(row) : undefined;
+      // SQLite/Postgres composite FKs with ON DELETE SET NULL will null every key column,
+      // including tenant_id. Clear the optional work-item references explicitly first.
+      await Promise.all([
+        tx.run(
+          `UPDATE work_items
+           SET parent_work_item_id = NULL
+           WHERE tenant_id = ?
+             AND agent_id = ?
+             AND workspace_id = ?
+             AND parent_work_item_id = ?`,
+          [
+            params.scope.tenant_id,
+            params.scope.agent_id,
+            params.scope.workspace_id,
+            params.work_item_id,
+          ],
+        ),
+        tx.run(
+          `UPDATE subagents
+           SET work_item_id = NULL,
+               work_item_task_id = NULL
+           WHERE tenant_id = ?
+             AND agent_id = ?
+             AND workspace_id = ?
+             AND work_item_id = ?`,
+          [
+            params.scope.tenant_id,
+            params.scope.agent_id,
+            params.scope.workspace_id,
+            params.work_item_id,
+          ],
+        ),
+        tx.run(
+          `UPDATE work_artifacts
+           SET work_item_id = NULL
+           WHERE tenant_id = ?
+             AND agent_id = ?
+             AND workspace_id = ?
+             AND work_item_id = ?`,
+          [
+            params.scope.tenant_id,
+            params.scope.agent_id,
+            params.scope.workspace_id,
+            params.work_item_id,
+          ],
+        ),
+        tx.run(
+          `UPDATE work_decisions
+           SET work_item_id = NULL
+           WHERE tenant_id = ?
+             AND agent_id = ?
+             AND workspace_id = ?
+             AND work_item_id = ?`,
+          [
+            params.scope.tenant_id,
+            params.scope.agent_id,
+            params.scope.workspace_id,
+            params.work_item_id,
+          ],
+        ),
+        tx.run(
+          `UPDATE work_signals
+           SET work_item_id = NULL
+           WHERE tenant_id = ?
+             AND agent_id = ?
+             AND workspace_id = ?
+             AND work_item_id = ?`,
+          [
+            params.scope.tenant_id,
+            params.scope.agent_id,
+            params.scope.workspace_id,
+            params.work_item_id,
+          ],
+        ),
+      ]);
+
+      const row = await tx.get<DalHelpers.RawWorkItemRow>(
+        `DELETE FROM work_items
+         WHERE tenant_id = ?
+           AND agent_id = ?
+           AND workspace_id = ?
+           AND work_item_id = ?
+         RETURNING *`,
+        [
+          params.scope.tenant_id,
+          params.scope.agent_id,
+          params.scope.workspace_id,
+          params.work_item_id,
+        ],
+      );
+      return row ? dalHelpers.toWorkItem(row) : undefined;
+    });
   }
 
   private async assertParentInScope(scope: WorkScope, workItemId: string): Promise<void> {

--- a/packages/gateway/src/modules/workboard/service-delete.ts
+++ b/packages/gateway/src/modules/workboard/service-delete.ts
@@ -1,0 +1,87 @@
+import type { WorkScope } from "@tyrum/contracts";
+import type { SqlDb } from "../../statestore/types.js";
+import type { ProtocolDeps } from "../../ws/protocol/types.js";
+import type { ApprovalDal } from "../approval/dal.js";
+import type { RedactionEngine } from "../redaction/engine.js";
+import type { WorkboardDal } from "./dal.js";
+import {
+  assertItemMutable,
+  cancelPausedTasks,
+  closePausedSubagents,
+  completePendingInterventionApprovals,
+  emitDeleteEffects,
+  emitItemEvent,
+  loadDeleteEffects,
+} from "./service-support.js";
+
+export async function deleteWorkItem(params: {
+  db: SqlDb;
+  workboard: WorkboardDal;
+  redactionEngine?: RedactionEngine;
+  approvalDal?: ApprovalDal;
+  protocolDeps?: ProtocolDeps;
+  scope: WorkScope;
+  work_item_id: string;
+}) {
+  await assertItemMutable(params.db, params.scope, params.work_item_id);
+  const { childItemIds, attachedSignalIds } = await loadDeleteEffects({
+    db: params.db,
+    scope: params.scope,
+    workItemId: params.work_item_id,
+  });
+  await completePendingInterventionApprovals({
+    db: params.db,
+    scope: params.scope,
+    workItemId: params.work_item_id,
+    decision: "denied",
+    reason: "Work deleted by operator.",
+    approvalDal: params.approvalDal,
+    protocolDeps: params.protocolDeps,
+  });
+  await closePausedSubagents({
+    db: params.db,
+    scope: params.scope,
+    workItemId: params.work_item_id,
+    reason: "Deleted by operator.",
+    workboard: params.workboard,
+  });
+  await cancelPausedTasks({
+    db: params.db,
+    scope: params.scope,
+    workItemId: params.work_item_id,
+    detail: "Deleted by operator.",
+    workboard: params.workboard,
+  });
+  for (const signalId of attachedSignalIds) {
+    await params.workboard.updateSignal({
+      scope: params.scope,
+      signal_id: signalId,
+      patch: { status: "cancelled" },
+    });
+  }
+  const item = await params.workboard.deleteItem({
+    scope: params.scope,
+    work_item_id: params.work_item_id,
+  });
+  if (!item) {
+    return undefined;
+  }
+
+  await emitDeleteEffects({
+    db: params.db,
+    workboard: params.workboard,
+    scope: params.scope,
+    childItemIds,
+    attachedSignalIds,
+    redactionEngine: params.redactionEngine,
+    protocolDeps: params.protocolDeps,
+  });
+  await emitItemEvent({
+    db: params.db,
+    redactionEngine: params.redactionEngine,
+    protocolDeps: params.protocolDeps,
+    type: "work.item.deleted",
+    item,
+  });
+  return item;
+}

--- a/packages/gateway/src/modules/workboard/service-support.ts
+++ b/packages/gateway/src/modules/workboard/service-support.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { SubagentDescriptor, WorkItem, WorkScope, WsEventEnvelope } from "@tyrum/contracts";
+import type {
+  SubagentDescriptor,
+  WorkItem,
+  WorkScope,
+  WorkSignal,
+  WsEventEnvelope,
+} from "@tyrum/contracts";
 import type { PolicyService } from "@tyrum/runtime-policy";
 import type { SqlDb } from "../../statestore/types.js";
 import { broadcastWsEvent } from "../../ws/broadcast.js";
@@ -20,6 +26,8 @@ export type WorkItemEventType =
   | "work.item.failed"
   | "work.item.cancelled"
   | "work.item.deleted";
+
+export type WorkSignalEventType = "work.signal.updated";
 
 export type WorkTaskRow = {
   task_id: string;
@@ -269,6 +277,48 @@ export async function emitItemEvent(params: {
   );
 }
 
+export async function emitSignalEvent(params: {
+  db: SqlDb;
+  redactionEngine?: RedactionEngine;
+  protocolDeps?: ProtocolDeps;
+  type: WorkSignalEventType;
+  signal: WorkSignal;
+}): Promise<void> {
+  const message = {
+    event_id: randomUUID(),
+    type: params.type,
+    occurred_at: new Date().toISOString(),
+    scope: { kind: "agent", agent_id: params.signal.agent_id },
+    payload: { signal: params.signal },
+  } satisfies WsEventEnvelope;
+  if (params.protocolDeps) {
+    broadcastWsEvent(
+      params.signal.tenant_id,
+      message,
+      {
+        connectionManager: params.protocolDeps.connectionManager,
+        cluster: params.protocolDeps.cluster,
+        logger: params.protocolDeps.logger,
+        maxBufferedBytes: params.protocolDeps.maxBufferedBytes,
+      },
+      WORKBOARD_WS_AUDIENCE,
+    );
+    return;
+  }
+  const payload = {
+    message,
+    audience: WORKBOARD_WS_AUDIENCE,
+  };
+  const redactedPayload = params.redactionEngine
+    ? params.redactionEngine.redactUnknown(payload).redacted
+    : payload;
+  await params.db.run(
+    `INSERT INTO outbox (tenant_id, topic, target_edge_id, payload_json)
+     VALUES (?, ?, ?, ?)`,
+    [params.signal.tenant_id, "ws.broadcast", null, JSON.stringify(redactedPayload)],
+  );
+}
+
 export async function maybeEnqueueStateChangeNotification(params: {
   db: SqlDb;
   scope: WorkScope;
@@ -292,6 +342,83 @@ export async function maybeEnqueueStateChangeNotification(params: {
     policyService: params.policyService,
     protocolDeps: params.protocolDeps,
   }).catch(() => undefined);
+}
+
+export async function loadDeleteEffects(params: {
+  db: SqlDb;
+  scope: WorkScope;
+  workItemId: string;
+}): Promise<{ childItemIds: string[]; attachedSignalIds: string[] }> {
+  const [childRows, attachedSignalRows] = await Promise.all([
+    params.db.all<{ work_item_id: string }>(
+      `SELECT work_item_id
+       FROM work_items
+       WHERE tenant_id = ?
+         AND agent_id = ?
+         AND workspace_id = ?
+         AND parent_work_item_id = ?`,
+      [params.scope.tenant_id, params.scope.agent_id, params.scope.workspace_id, params.workItemId],
+    ),
+    params.db.all<{ signal_id: string }>(
+      `SELECT signal_id
+       FROM work_signals
+       WHERE tenant_id = ?
+         AND agent_id = ?
+         AND workspace_id = ?
+         AND work_item_id = ?
+         AND status IN ('active', 'paused')`,
+      [params.scope.tenant_id, params.scope.agent_id, params.scope.workspace_id, params.workItemId],
+    ),
+  ]);
+
+  return {
+    childItemIds: childRows.map((row) => row.work_item_id),
+    attachedSignalIds: attachedSignalRows.map((row) => row.signal_id),
+  };
+}
+
+export async function emitDeleteEffects(params: {
+  db: SqlDb;
+  workboard: WorkboardDal;
+  scope: WorkScope;
+  childItemIds: string[];
+  attachedSignalIds: string[];
+  redactionEngine?: RedactionEngine;
+  protocolDeps?: ProtocolDeps;
+}): Promise<void> {
+  for (const childItemId of params.childItemIds) {
+    const child = await params.workboard.getItem({
+      scope: params.scope,
+      work_item_id: childItemId,
+    });
+    if (!child) {
+      continue;
+    }
+    await emitItemEvent({
+      db: params.db,
+      redactionEngine: params.redactionEngine,
+      protocolDeps: params.protocolDeps,
+      type: "work.item.updated",
+      item: child,
+    });
+  }
+
+  for (const signalId of params.attachedSignalIds) {
+    const signal = await params.workboard.getSignal({
+      scope: params.scope,
+      signal_id: signalId,
+    });
+    if (!signal) {
+      continue;
+    }
+    await emitSignalEvent({
+      db: params.db,
+      redactionEngine: params.redactionEngine,
+      protocolDeps: params.protocolDeps,
+      type: "work.signal.updated",
+      signal,
+    });
+  }
 }
 
 export async function createCapturedWorkItem(params: {

--- a/packages/gateway/src/modules/workboard/service.ts
+++ b/packages/gateway/src/modules/workboard/service.ts
@@ -5,9 +5,9 @@ import type { ProtocolDeps } from "../../ws/protocol/types.js";
 import type { ApprovalDal } from "../approval/dal.js";
 import type { RedactionEngine } from "../redaction/engine.js";
 import { WorkboardDal } from "./dal.js";
+import { deleteWorkItem } from "./service-delete.js";
 import {
   assertItemMutable,
-  cancelPausedTasks,
   closePausedSubagents,
   completePendingInterventionApprovals,
   createCapturedWorkItem,
@@ -78,41 +78,15 @@ export class GatewayWorkboardService {
   }
 
   async deleteItem(params: Parameters<WorkboardDal["deleteItem"]>[0]) {
-    await assertItemMutable(this.opts.db, params.scope, params.work_item_id);
-    await completePendingInterventionApprovals({
+    return await deleteWorkItem({
       db: this.opts.db,
-      scope: params.scope,
-      workItemId: params.work_item_id,
-      decision: "denied",
-      reason: "Work deleted by operator.",
+      workboard: this.workboard,
+      redactionEngine: this.opts.redactionEngine,
       approvalDal: this.opts.approvalDal,
       protocolDeps: this.opts.protocolDeps,
-    });
-    await closePausedSubagents({
-      db: this.opts.db,
       scope: params.scope,
-      workItemId: params.work_item_id,
-      reason: "Deleted by operator.",
-      workboard: this.workboard,
+      work_item_id: params.work_item_id,
     });
-    await cancelPausedTasks({
-      db: this.opts.db,
-      scope: params.scope,
-      workItemId: params.work_item_id,
-      detail: "Deleted by operator.",
-      workboard: this.workboard,
-    });
-    const item = await this.workboard.deleteItem(params);
-    if (item) {
-      await emitItemEvent({
-        db: this.opts.db,
-        redactionEngine: this.opts.redactionEngine,
-        protocolDeps: this.opts.protocolDeps,
-        type: "work.item.deleted",
-        item,
-      });
-    }
-    return item;
   }
 
   async pauseItem(params: { scope: WorkScope; work_item_id: string; reason?: string }) {

--- a/packages/gateway/tests/unit/ws-workboard.delete-test-support.ts
+++ b/packages/gateway/tests/unit/ws-workboard.delete-test-support.ts
@@ -1,0 +1,300 @@
+import { expect, it } from "vitest";
+import { WorkboardDal } from "../../src/modules/workboard/dal.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+} from "../../src/modules/identity/scope.js";
+import { ConnectionManager } from "../../src/ws/connection-manager.js";
+import { handleClientMessage } from "../../src/ws/protocol.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import { makeClient, makeDeps } from "./ws-workboard.test-support.js";
+
+const DEFAULT_SCOPE = {
+  tenant_id: DEFAULT_TENANT_ID,
+  agent_id: DEFAULT_AGENT_ID,
+  workspace_id: DEFAULT_WORKSPACE_ID,
+} as const;
+
+export function registerWorkboardDeleteTests(): void {
+  it("handles work.delete and broadcasts work.item.deleted", async () => {
+    const cm = new ConnectionManager();
+    const { id, ws } = makeClient(cm);
+    const client = cm.getClient(id)!;
+
+    const db = openTestSqliteDb();
+    try {
+      const deps = makeDeps(cm, { db });
+
+      const createRes = await handleClientMessage(
+        client,
+        JSON.stringify({
+          request_id: "r-create",
+          type: "work.create",
+          payload: {
+            tenant_key: "default",
+            agent_key: "default",
+            workspace_key: "default",
+            item: { kind: "action", title: "Delete me" },
+          },
+        }),
+        deps,
+      );
+      expect((createRes as { ok: boolean }).ok).toBe(true);
+      const workItemId = (createRes as { result: { item: { work_item_id: string } } }).result.item
+        .work_item_id;
+      ws.send.mockClear();
+
+      const deleteRes = await handleClientMessage(
+        client,
+        JSON.stringify({
+          request_id: "r-delete",
+          type: "work.delete",
+          payload: {
+            tenant_key: "default",
+            agent_key: "default",
+            workspace_key: "default",
+            work_item_id: workItemId,
+          },
+        }),
+        deps,
+      );
+
+      expect((deleteRes as { ok: boolean }).ok).toBe(true);
+      expect((deleteRes as { type: string }).type).toBe("work.delete");
+      expect(
+        (deleteRes as { result: { item: { work_item_id: string } } }).result.item.work_item_id,
+      ).toBe(workItemId);
+
+      expect(ws.send).toHaveBeenCalledTimes(1);
+      const deletedEvt = JSON.parse(ws.send.mock.calls[0]?.[0] ?? "{}") as {
+        type?: string;
+        payload?: { item?: { work_item_id?: string } };
+      };
+      expect(deletedEvt.type).toBe("work.item.deleted");
+      expect(deletedEvt.payload?.item?.work_item_id).toBe(workItemId);
+
+      const listRes = await handleClientMessage(
+        client,
+        JSON.stringify({
+          request_id: "r-list",
+          type: "work.list",
+          payload: {
+            tenant_key: "default",
+            agent_key: "default",
+            workspace_key: "default",
+          },
+        }),
+        deps,
+      );
+
+      expect((listRes as { ok: boolean }).ok).toBe(true);
+      expect(
+        (listRes as { result: { items: Array<{ work_item_id: string }> } }).result.items,
+      ).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ work_item_id: workItemId })]),
+      );
+    } finally {
+      await db.close();
+    }
+  });
+
+  it("handles work.delete after cleaning up paused workboard state", async () => {
+    const cm = new ConnectionManager();
+    const { id, ws } = makeClient(cm);
+    const { ws: peerWs } = makeClient(cm);
+    const client = cm.getClient(id)!;
+
+    const db = openTestSqliteDb();
+    try {
+      const deps = makeDeps(cm, { db });
+
+      const createRes = await handleClientMessage(
+        client,
+        JSON.stringify({
+          request_id: "r-create-paused",
+          type: "work.create",
+          payload: {
+            tenant_key: "default",
+            agent_key: "default",
+            workspace_key: "default",
+            item: { kind: "action", title: "Delete paused work" },
+          },
+        }),
+        deps,
+      );
+      expect((createRes as { ok: boolean }).ok).toBe(true);
+      const workItemId = (
+        createRes as {
+          result: { item: { work_item_id: string } };
+        }
+      ).result.item.work_item_id;
+
+      const workboard = new WorkboardDal(db);
+      await workboard.createTask({
+        scope: DEFAULT_SCOPE,
+        task: {
+          work_item_id: workItemId,
+          status: "paused",
+          execution_profile: "executor",
+          side_effect_class: "workspace",
+          result_summary: "Waiting for operator",
+        },
+      });
+      const pausedSubagent = await workboard.createSubagent({
+        scope: DEFAULT_SCOPE,
+        subagent: {
+          work_item_id: workItemId,
+          execution_profile: "planner",
+          session_key: "subagent-delete-paused",
+          status: "paused",
+        },
+      });
+      await workboard.createClarification({
+        scope: DEFAULT_SCOPE,
+        clarification: {
+          work_item_id: workItemId,
+          question: "Need confirmation",
+          requested_for_session_key: "operator-session",
+        },
+      });
+      const child = await workboard.createItem({
+        scope: DEFAULT_SCOPE,
+        item: {
+          kind: "action",
+          title: "Child work",
+          parent_work_item_id: workItemId,
+          created_from_session_key: "operator-session",
+        },
+      });
+      const artifact = await workboard.createArtifact({
+        scope: DEFAULT_SCOPE,
+        artifact: {
+          work_item_id: workItemId,
+          kind: "note",
+          title: "Artifact",
+        },
+      });
+      const decision = await workboard.createDecision({
+        scope: DEFAULT_SCOPE,
+        decision: {
+          work_item_id: workItemId,
+          question: "Proceed?",
+          chosen: "yes",
+          rationale_md: "Looks good",
+        },
+      });
+      const signal = await workboard.createSignal({
+        scope: DEFAULT_SCOPE,
+        signal: {
+          work_item_id: workItemId,
+          trigger_kind: "manual",
+          trigger_spec_json: { source: "test" },
+        },
+      });
+      ws.send.mockClear();
+      peerWs.send.mockClear();
+
+      const deleteRes = await handleClientMessage(
+        client,
+        JSON.stringify({
+          request_id: "r-delete-paused",
+          type: "work.delete",
+          payload: {
+            tenant_key: "default",
+            agent_key: "default",
+            workspace_key: "default",
+            work_item_id: workItemId,
+          },
+        }),
+        deps,
+      );
+
+      expect((deleteRes as { ok: boolean }).ok).toBe(true);
+      expect(
+        (deleteRes as { result: { item: { work_item_id: string } } }).result.item.work_item_id,
+      ).toBe(workItemId);
+      const operatorEvents = ws.send.mock.calls.map((call) =>
+        JSON.parse(call[0] ?? "{}"),
+      ) as Array<{
+        type?: string;
+        payload?: Record<string, unknown>;
+      }>;
+      const peerEvents = peerWs.send.mock.calls.map((call) =>
+        JSON.parse(call[0] ?? "{}"),
+      ) as Array<{
+        type?: string;
+        payload?: Record<string, unknown>;
+      }>;
+      for (const events of [operatorEvents, peerEvents]) {
+        expect(events.map((event) => event.type)).toEqual([
+          "work.item.updated",
+          "work.signal.updated",
+          "work.item.deleted",
+        ]);
+        expect(events[0]?.payload?.item).toMatchObject({
+          work_item_id: child.work_item_id,
+        });
+        expect(
+          (events[0]?.payload?.item as { parent_work_item_id?: string | undefined } | undefined)
+            ?.parent_work_item_id,
+        ).toBeUndefined();
+        expect(events[1]?.payload?.signal).toMatchObject({
+          signal_id: signal.signal_id,
+          status: "cancelled",
+        });
+        expect(
+          (events[1]?.payload?.signal as { work_item_id?: string | undefined } | undefined)
+            ?.work_item_id,
+        ).toBeUndefined();
+        expect(events[2]?.payload?.item).toMatchObject({
+          work_item_id: workItemId,
+        });
+      }
+
+      expect(
+        await workboard.getSubagent({
+          scope: DEFAULT_SCOPE,
+          subagent_id: pausedSubagent.subagent_id,
+        }),
+      ).toMatchObject({
+        work_item_id: undefined,
+        work_item_task_id: undefined,
+      });
+      expect(
+        await workboard.listClarifications({
+          scope: DEFAULT_SCOPE,
+          work_item_id: workItemId,
+          statuses: ["open"],
+        }),
+      ).toEqual({ clarifications: [], next_cursor: undefined });
+      expect(
+        await workboard.getItem({ scope: DEFAULT_SCOPE, work_item_id: child.work_item_id }),
+      ).toMatchObject({
+        work_item_id: child.work_item_id,
+        parent_work_item_id: undefined,
+      });
+      expect(
+        await workboard.getArtifact({ scope: DEFAULT_SCOPE, artifact_id: artifact.artifact_id }),
+      ).toMatchObject({
+        artifact_id: artifact.artifact_id,
+        work_item_id: undefined,
+      });
+      expect(
+        await workboard.getDecision({ scope: DEFAULT_SCOPE, decision_id: decision.decision_id }),
+      ).toMatchObject({
+        decision_id: decision.decision_id,
+        work_item_id: undefined,
+      });
+      expect(
+        await workboard.getSignal({ scope: DEFAULT_SCOPE, signal_id: signal.signal_id }),
+      ).toMatchObject({
+        signal_id: signal.signal_id,
+        status: "cancelled",
+        work_item_id: undefined,
+      });
+    } finally {
+      await db.close();
+    }
+  });
+}

--- a/packages/gateway/tests/unit/ws-workboard.test.ts
+++ b/packages/gateway/tests/unit/ws-workboard.test.ts
@@ -1,5 +1,6 @@
 import { describe } from "vitest";
 import { registerWorkboardCrudTests } from "./ws-workboard.crud-test-support.js";
+import { registerWorkboardDeleteTests } from "./ws-workboard.delete-test-support.js";
 import { registerWorkboardTransitionTests } from "./ws-workboard.transitions-test-support.js";
 import { registerWorkboardTransitionErrorTests } from "./ws-workboard.transition-errors-test-support.js";
 import { registerWorkboardWipArtifactTests } from "./ws-workboard.wip-artifacts-test-support.js";
@@ -10,6 +11,7 @@ import { registerWorkboardScopeNonCreationTests } from "./ws-workboard.scope-non
 
 describe("handleClientMessage (work.*)", () => {
   registerWorkboardCrudTests();
+  registerWorkboardDeleteTests();
   registerWorkboardTransitionTests();
   registerWorkboardTransitionErrorTests();
   registerWorkboardWipArtifactTests();


### PR DESCRIPTION
## Summary
- fix workboard item deletion by clearing composite-FK optional references before deleting the item row
- retire attached signals and emit websocket updates for detached child items and cancelled signals
- split delete regression coverage into dedicated workboard delete tests, including the paused-state multi-client case

## Testing
- pnpm exec vitest run packages/gateway/tests/unit/ws-workboard.test.ts
- pnpm exec tsc --noEmit --project packages/gateway/tsconfig.json
- pre-push: pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test

Closes #1672

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletion now performs additional transactional cleanup and emits extra websocket events for related entities, which could affect data integrity and client state if any edge cases are missed. Changes are localized to workboard delete flow and covered by new multi-client paused-state tests.
> 
> **Overview**
> Improves `work.delete` reliability by making `WorkboardItemsDal.deleteItem` transactional and explicitly clearing optional composite-FK references (child `parent_work_item_id`, `subagents`, `work_artifacts`, `work_decisions`, `work_signals`) before deleting a work item to avoid unintended NULLing of key columns.
> 
> Refactors delete orchestration into a new `deleteWorkItem` service that also cancels attached active/paused signals, and emits websocket updates for *detached child items* and *cancelled signals* in addition to the final `work.item.deleted` event. Adds dedicated unit coverage for delete, including a paused-state scenario validating cleanup and event broadcasts to multiple connected clients.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92d5ef86165f5ea9a0b821d538177c0fb0ab7f14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->