### PR TITLE
Fix Add model dialog autofocus and field order

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-models-preset-dialog.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-models-preset-dialog.tsx
@@ -49,6 +49,7 @@ export function ModelPresetDialog({
   const [state, setState] = React.useState<ModelDialogState>(emptyDialogState());
   const [modelFilter, setModelFilter] = React.useState("");
   const [saving, setSaving] = React.useState(false);
+  const modelFilterInputRef = React.useRef<HTMLInputElement>(null);
   const selectedModel = availableModels.find((model) => modelRefFor(model) === state.modelRef);
   const filteredAvailableModels = React.useMemo(
     () => filterAvailableModels(availableModels, modelFilter),
@@ -135,7 +136,16 @@ export function ModelPresetDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent data-testid="models-preset-dialog">
+      <DialogContent
+        data-testid="models-preset-dialog"
+        onOpenAutoFocus={(event) => {
+          if (preset) {
+            return;
+          }
+          event.preventDefault();
+          modelFilterInputRef.current?.focus();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{preset ? "Edit model preset" : "Add model"}</DialogTitle>
           <DialogDescription>
@@ -146,33 +156,48 @@ export function ModelPresetDialog({
         </DialogHeader>
 
         <div className="grid gap-4">
-          <Input
-            label="Display name"
-            required
-            value={state.displayName}
-            onChange={(event) => {
-              setState((current) => ({
-                ...current,
-                displayName: event.currentTarget.value,
-              }));
-            }}
-          />
-
           {preset ? (
-            <Input
-              label="Model"
-              readOnly
-              value={`${preset.provider_key}/${preset.model_id}`}
-              helperText="The underlying model is fixed after creation."
-            />
+            <>
+              <Input
+                label="Display name"
+                required
+                value={state.displayName}
+                onChange={(event) => {
+                  setState((current) => ({
+                    ...current,
+                    displayName: event.currentTarget.value,
+                  }));
+                }}
+              />
+              <Input
+                label="Model"
+                readOnly
+                value={`${preset.provider_key}/${preset.model_id}`}
+                helperText="The underlying model is fixed after creation."
+              />
+            </>
           ) : (
-            <ModelPickerField
-              filteredModels={filteredAvailableModels}
-              modelFilter={modelFilter}
-              onModelFilterChange={setModelFilter}
-              onSelectModel={applyModelSelection}
-              selectedModelRef={state.modelRef}
-            />
+            <>
+              <ModelPickerField
+                filteredModels={filteredAvailableModels}
+                filterInputRef={modelFilterInputRef}
+                modelFilter={modelFilter}
+                onModelFilterChange={setModelFilter}
+                onSelectModel={applyModelSelection}
+                selectedModelRef={state.modelRef}
+              />
+              <Input
+                label="Display name"
+                required
+                value={state.displayName}
+                onChange={(event) => {
+                  setState((current) => ({
+                    ...current,
+                    displayName: event.currentTarget.value,
+                  }));
+                }}
+              />
+            </>
           )}
 
           <Select

--- a/packages/operator-ui/src/components/pages/model-picker-field.tsx
+++ b/packages/operator-ui/src/components/pages/model-picker-field.tsx
@@ -14,12 +14,14 @@ function modelOptionTestId(model: AvailableModel): string {
 
 export function ModelPickerField({
   filteredModels,
+  filterInputRef,
   modelFilter,
   onModelFilterChange,
   onSelectModel,
   selectedModelRef,
 }: {
   filteredModels: readonly AvailableModel[];
+  filterInputRef?: React.Ref<HTMLInputElement>;
   modelFilter: string;
   onModelFilterChange: (value: string) => void;
   onSelectModel: (modelRef: string) => void;
@@ -37,6 +39,7 @@ export function ModelPickerField({
       <div className="overflow-hidden rounded-lg border border-border bg-bg-card/40">
         <div className="border-b border-border/70 p-2">
           <input
+            ref={filterInputRef}
             id={modelFilterId}
             type="text"
             value={modelFilter}

--- a/packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts
@@ -74,6 +74,10 @@ function getModelPickerOption(dialog: HTMLElement, modelRef: string): HTMLButton
   return getByTestId<HTMLButtonElement>(dialog, `models-model-option-${modelRef}`);
 }
 
+function expectDocumentOrder(before: Node, after: Node): void {
+  expect(before.compareDocumentPosition(after) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+}
+
 describe("ConfigurePage (HTTP) models", () => {
   it("disables model creation when no provider models are available", async () => {
     const { core } = createAdminHttpTestCore();
@@ -134,9 +138,17 @@ describe("ConfigurePage (HTTP) models", () => {
     await openModelsTab(page.container);
 
     click(getByTestId<HTMLButtonElement>(page.container, "models-add-open"));
+    await flush();
+
     const dialog = getByTestId<HTMLElement>(document.body, "models-preset-dialog");
+    const filterInput = getModelFilterInput(dialog);
     const displayNameInput = getDialogInput(dialog, "Display name");
     const reasoningEffortSelect = getDialogSelect(dialog, "Reasoning effort");
+
+    expect(document.activeElement).toBe(filterInput);
+    expectDocumentOrder(filterInput, displayNameInput);
+    expectDocumentOrder(displayNameInput, reasoningEffortSelect);
+
     expect(getDialogSelect(dialog, "Reasoning display").value).toBe("");
     click(getModelPickerOption(dialog, "openai/gpt-4.1-mini"));
     expect(displayNameInput.value).toBe("GPT-4.1 Mini");


### PR DESCRIPTION
## Summary
- focus the Add model search input when the dialog opens
- move the model picker ahead of Display name in create mode
- add coverage for the new focus and field order behavior

## Testing
- pnpm exec vitest run packages/operator-ui/tests/pages/admin-page.http.models-flow.test.ts
- pnpm lint
- pnpm typecheck
- pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json
- pre-push hook: pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test

Closes #1682

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX adjustment limited to dialog focus/field ordering plus a small ref-forwarding change and updated tests; no data/auth logic changed.
> 
> **Overview**
> Fixes the **Add model** dialog to autofocus the model filter input on open (while preserving existing behavior for editing presets) and reorders the create flow so the model picker appears before the display name field.
> 
> Updates `ModelPickerField` to accept a forwarded `filterInputRef`, and extends the HTTP models flow test to assert initial focus and DOM order for the key fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e139982c1ef63fa9a9a9cd6491bee8a4401a3126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->