### PR TITLE
fix(gateway): support telegram channel posts

### DIFF
--- a/packages/gateway/src/modules/channels/telegram-polling-monitor.ts
+++ b/packages/gateway/src/modules/channels/telegram-polling-monitor.ts
@@ -25,7 +25,7 @@ const DEFAULT_POLL_LIMIT = 25;
 const DEFAULT_LEASE_TTL_MS = 45_000;
 const DEFAULT_IDLE_DELAY_MS = 5_000;
 const DEFAULT_ERROR_BACKOFF_MS = 5_000;
-const ALLOWED_UPDATES = ["message", "edited_message"];
+const ALLOWED_UPDATES = ["message", "edited_message", "channel_post", "edited_channel_post"];
 
 class TelegramPollingWorkerConfigChangedError extends Error {
   constructor() {

--- a/packages/gateway/src/modules/ingress/telegram.ts
+++ b/packages/gateway/src/modules/ingress/telegram.ts
@@ -32,6 +32,8 @@ interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
   edited_message?: TelegramMessage;
+  channel_post?: TelegramMessage;
+  edited_channel_post?: TelegramMessage;
 }
 
 interface TelegramMessage {
@@ -164,10 +166,11 @@ function deserializeUpdate(payload: string | Uint8Array): TelegramUpdate {
 }
 
 function selectMessage(update: TelegramUpdate): TelegramMessage {
-  const message = update.edited_message ?? update.message;
+  const message =
+    update.edited_message ?? update.message ?? update.edited_channel_post ?? update.channel_post;
   if (message == null) {
     throw new TelegramNormalizationError(
-      "telegram update did not include a message or edited_message payload",
+      "telegram update did not include a supported message payload",
     );
   }
   return message;

--- a/packages/gateway/tests/unit/telegram-polling-monitor.test.ts
+++ b/packages/gateway/tests/unit/telegram-polling-monitor.test.ts
@@ -103,6 +103,11 @@ describe("TelegramPollingMonitor", () => {
     expect(enqueue).toHaveBeenCalledOnce();
     expect(bot.deleteWebhook).toHaveBeenCalledOnce();
     expect(bot.deleteWebhook).toHaveBeenCalledWith({ drop_pending_updates: false });
+    expect(bot.getUpdates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowed_updates: ["message", "edited_message", "channel_post", "edited_channel_post"],
+      }),
+    );
     expect(logger.info).toHaveBeenCalledWith(
       "channel.telegram.polling.webhook_deleted",
       expect.objectContaining({ account_key: "alerts", owner: "worker-a" }),

--- a/packages/gateway/tests/unit/telegram.test.ts
+++ b/packages/gateway/tests/unit/telegram.test.ts
@@ -183,6 +183,55 @@ describe("Telegram normalization", () => {
     expect(update.message.pii_fields).toContain("message_text");
   });
 
+  it("normalizes channel posts", () => {
+    const update = normalizeUpdate(
+      JSON.stringify({
+        update_id: 101,
+        channel_post: {
+          message_id: 77,
+          date: 1700000000,
+          chat: {
+            id: -1001234567890,
+            type: "channel",
+            title: "Ops Broadcasts",
+            username: "ops_broadcasts",
+          },
+          text: "Deploy completed",
+        },
+      }),
+    );
+
+    expect(update.thread).toEqual({
+      id: "-1001234567890",
+      kind: "channel",
+      title: "Ops Broadcasts",
+      username: "ops_broadcasts",
+      pii_fields: ["thread_title", "thread_username"],
+    });
+    expect(update.message.envelope).toEqual({
+      message_id: "77",
+      received_at: "2023-11-14T22:13:20.000Z",
+      delivery: {
+        channel: "telegram",
+        account: DEFAULT_CHANNEL_ACCOUNT_ID,
+      },
+      container: {
+        kind: "channel",
+        id: "-1001234567890",
+      },
+      sender: {
+        id: "chat:-1001234567890",
+      },
+      content: {
+        text: "Deploy completed",
+        attachments: [],
+      },
+      provenance: ["user"],
+    });
+    expect(update.message.sender).toBeUndefined();
+    expect(update.message.pii_fields).toEqual(["message_text"]);
+  });
+
   it("materializes media messages as artifact-backed attachments", async () => {
     const fetchFn = createTelegramMediaFetch(
       "photos/file-1.jpg",


### PR DESCRIPTION
## Summary
- support Telegram `channel_post` and `edited_channel_post` updates in gateway ingress normalization
- request channel post updates from the Telegram polling worker
- add regression coverage for normalization and polling configuration

## Testing
- pnpm vitest packages/gateway/tests/unit/telegram.test.ts packages/gateway/tests/unit/telegram-polling-monitor.test.ts packages/gateway/tests/integration/telegram-polling-e2e.test.ts
- pre-push hook: lint, typecheck, desktop typecheck, build/test preparation, and full vitest coverage run

Closes #1694.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Telegram ingestion/polling behavior and message selection logic, which could affect which updates are processed and how offsets advance.
> 
> **Overview**
> Adds support for Telegram `channel_post` and `edited_channel_post` updates end-to-end.
> 
> The ingress normalizer now recognizes these update types when selecting the message payload (and returns a clearer error when the update type is unsupported). The polling worker now requests these update types via `allowed_updates`, with unit tests updated/added to cover both the polling configuration and channel-post normalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59855f82c4cd07fc20819971bce68f8c9c23ae0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->