### PR TITLE
[P0] Replace hardcoded amber colors with semantic tokens in chat

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
@@ -17,7 +17,7 @@ function messageContainerClassName(role: UIMessage["role"]): string {
     return "border border-border bg-bg";
   }
   if (role === "system") {
-    return "border border-amber-200/70 bg-amber-50/70";
+    return "border border-warning/30 bg-warning/10";
   }
   return "border border-border bg-bg-subtle/70";
 }


### PR DESCRIPTION
Closes #1704
Part of #1700

## Summary
- Replaced hardcoded `amber-50/amber-200` Tailwind palette colors with semantic `warning` tokens for system-role chat messages
- Fixes dark mode where system messages appeared as near-white cards on dark backgrounds

## Changes
- `chat-page-ai-sdk-message-card.tsx`: system role `border border-amber-200/70 bg-amber-50/70` → `border border-warning/30 bg-warning/10`

## Test plan
- [ ] System-role messages render correctly in all dark themes
- [ ] System-role messages render correctly in all light themes
- [ ] System messages remain visually distinct from user/assistant messages
- [ ] No hardcoded amber colors remain
- [ ] Lint and typecheck pass