### PR TITLE
[P0] Restore focus ring on chat select controls

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -396,7 +396,7 @@ export function AiSdkConversation({
             <Select
               id={queueModeId}
               bare
-              className="h-8 min-w-[10rem] border-0 bg-transparent px-2 py-1 text-xs focus-visible:ring-0"
+              className="h-8 min-w-[10rem] border-0 bg-transparent px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
               data-testid="ai-sdk-chat-queue-mode"
               disabled={queueModeBusy}
               value={queueMode}

--- a/packages/operator-ui/src/components/pages/chat-page-threads.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-threads.tsx
@@ -92,7 +92,7 @@ export function ChatThreadsPanel({
           value={agentId}
           disabled={!connected || agentsLoading}
           onChange={(event) => onAgentChange(event.currentTarget.value)}
-          className="h-7 max-w-[140px] truncate rounded-md border-none bg-transparent px-1 py-0 text-sm font-medium text-fg focus-visible:outline-none focus-visible:ring-0"
+          className="h-7 max-w-[140px] truncate rounded-md border-none bg-transparent px-1 py-0 text-sm font-medium text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
         >
           {agents.length === 0 ? (
             <option value={agentId}>{agentId}</option>


### PR DESCRIPTION
Closes #1703
Part of #1700

## Summary
- Restored visible keyboard focus ring on two chat page select controls that had `focus-visible:ring-0` suppressing focus indicators
- Applied the standard form-control focus ring pattern (`ring-2 ring-focus-ring ring-offset-0`) matching the shared `Select` component

## Changes
- `chat-page-threads.tsx`: agent-picker `<select>` — replaced `focus-visible:ring-0` with standard focus ring
- `chat-page-ai-sdk-conversation.tsx`: queue-mode `<Select>` — replaced `focus-visible:ring-0` with standard focus ring

## Why
WCAG 2.4.7 (Focus Visible) requires keyboard focus to be visually apparent. These two controls were invisible to keyboard navigation.

## Test plan
- [ ] Tab to agent picker select in chat threads — verify visible focus ring
- [ ] Tab to queue mode select in chat input — verify visible focus ring
- [ ] Verify focus ring matches other Select components in the app
- [ ] Verify no visual change on mouse/touch interaction (focus-visible only activates on keyboard)
- [ ] Lint and typecheck pass