### PR TITLE
[P0] Add keyboard accessibility to DataTable expandable rows

### DIFF
--- a/packages/operator-ui/src/components/ui/data-table.tsx
+++ b/packages/operator-ui/src/components/ui/data-table.tsx
@@ -184,13 +184,24 @@ export function DataTable<T>({
                 >
                   {isExpandable ? (
                     <td className="w-8 px-1 py-3 text-center">
-                      <ChevronRight
-                        aria-hidden
-                        className={cn(
-                          "mx-auto h-3.5 w-3.5 text-fg-muted/50 transition-transform",
-                          isExpanded && "rotate-90",
-                        )}
-                      />
+                      <button
+                        type="button"
+                        aria-expanded={isExpanded}
+                        aria-label={isExpanded ? "Collapse row" : "Expand row"}
+                        className="inline-flex items-center justify-center rounded p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleExpand(key);
+                        }}
+                      >
+                        <ChevronRight
+                          aria-hidden
+                          className={cn(
+                            "h-3.5 w-3.5 text-fg-muted/50 transition-transform",
+                            isExpanded && "rotate-90",
+                          )}
+                        />
+                      </button>
                     </td>
                   ) : null}
                   {columns.map((col) => (

--- a/packages/operator-ui/tests/ui/data-table.test.ts
+++ b/packages/operator-ui/tests/ui/data-table.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from "vitest";
-import React from "react";
+import React, { act } from "react";
 import { DataTable } from "../../src/components/ui/data-table.js";
 import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
 
@@ -122,5 +122,113 @@ describe("DataTable", () => {
     expect(allRows[1]?.textContent).toContain("Detail for Alpha");
 
     cleanupTestRoot({ container, root });
+  });
+
+  describe("expandable rows", () => {
+    function renderExpandableTable() {
+      return renderIntoDocument(
+        React.createElement(DataTable<Row>, {
+          columns: COLUMNS,
+          data: DATA,
+          rowKey: (row) => row.id,
+          renderExpandedRow: (row) =>
+            React.createElement(
+              "div",
+              { "data-testid": "expanded-content" },
+              `Details for ${row.name}`,
+            ),
+        }),
+      );
+    }
+
+    function getExpandButtons(container: HTMLElement): HTMLButtonElement[] {
+      return Array.from(
+        container.querySelectorAll<HTMLButtonElement>("tbody button[aria-expanded]"),
+      );
+    }
+
+    it("renders expand buttons with aria-expanded='false' by default", () => {
+      const { container, root } = renderExpandableTable();
+
+      const buttons = getExpandButtons(container);
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]?.getAttribute("aria-expanded")).toBe("false");
+      expect(buttons[1]?.getAttribute("aria-expanded")).toBe("false");
+      expect(buttons[0]?.getAttribute("aria-label")).toBe("Expand row");
+
+      cleanupTestRoot({ container, root });
+    });
+
+    it("expands a row on button click and updates aria-expanded", () => {
+      const { container, root } = renderExpandableTable();
+
+      const buttons = getExpandButtons(container);
+      act(() => {
+        buttons[0]!.click();
+      });
+
+      const updatedButtons = getExpandButtons(container);
+      expect(updatedButtons[0]?.getAttribute("aria-expanded")).toBe("true");
+      expect(updatedButtons[0]?.getAttribute("aria-label")).toBe("Collapse row");
+      expect(container.querySelector("[data-testid='expanded-content']")?.textContent).toBe(
+        "Details for Alpha",
+      );
+
+      cleanupTestRoot({ container, root });
+    });
+
+    it("toggles expansion on Enter key", () => {
+      const { container, root } = renderExpandableTable();
+
+      const btn = getExpandButtons(container)[0]!;
+
+      // Browsers fire click on Enter for native buttons; simulate the sequence
+      act(() => {
+        btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+        btn.click();
+      });
+
+      expect(getExpandButtons(container)[0]?.getAttribute("aria-expanded")).toBe("true");
+      expect(container.querySelector("[data-testid='expanded-content']")).not.toBeNull();
+
+      // Toggle back
+      act(() => {
+        const updated = getExpandButtons(container)[0]!;
+        updated.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+        updated.click();
+      });
+
+      expect(getExpandButtons(container)[0]?.getAttribute("aria-expanded")).toBe("false");
+      expect(container.querySelector("[data-testid='expanded-content']")).toBeNull();
+
+      cleanupTestRoot({ container, root });
+    });
+
+    it("toggles expansion on Space key", () => {
+      const { container, root } = renderExpandableTable();
+
+      const btn = getExpandButtons(container)[0]!;
+
+      // Browsers fire click on Space for native buttons; simulate the sequence
+      act(() => {
+        btn.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+        btn.click();
+      });
+
+      expect(getExpandButtons(container)[0]?.getAttribute("aria-expanded")).toBe("true");
+      expect(container.querySelector("[data-testid='expanded-content']")).not.toBeNull();
+
+      // Toggle back
+      act(() => {
+        const updated = getExpandButtons(container)[0]!;
+        updated.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+        updated.click();
+      });
+
+      expect(getExpandButtons(container)[0]?.getAttribute("aria-expanded")).toBe("false");
+      expect(container.querySelector("[data-testid='expanded-content']")).toBeNull();
+
+      cleanupTestRoot({ container, root });
+    });
   });
 });


### PR DESCRIPTION
Closes #1702
Part of #1700

## Summary
- Added accessible expand/collapse button in each expandable DataTable row
- Button has `aria-expanded`, `aria-label`, visible focus ring, and keyboard support
- Added tests for keyboard expansion behavior

## Changes
- `data-table.tsx`: Wrapped ChevronRight icon in `<button>` with aria attributes and focus ring
- `data-table.test.ts`: Added expandable rows test suite (aria-expanded, click, Enter, Space)

## Test plan
- [ ] Tab to expand button in DataTable rows — verify focus ring
- [ ] Enter/Space toggles expansion
- [ ] aria-expanded reflects state
- [ ] Existing click-to-expand on row still works
- [ ] Memory and Pairing pages work correctly
- [ ] DataTable unit tests pass
- [ ] Lint and typecheck pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI behavior change limited to expandable `DataTable` rows plus new unit tests; main risk is minor regressions in row expansion click handling.
> 
> **Overview**
> Makes `DataTable` expandable rows keyboard accessible by replacing the decorative chevron with an explicit expand/collapse `button` that includes `aria-expanded`/`aria-label`, focus-ring styling, and stops event propagation so row clicks still behave as before.
> 
> Adds a dedicated test suite covering default ARIA state, mouse click expansion, and Enter/Space key toggling behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa0f213f9f41af00c0ea5b9a5727b6b21a7678ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->