### PR TITLE
[P1] Add aria-label to navigation landmarks and aria-expanded to toggle controls

### DIFF
--- a/packages/operator-ui/src/components/layout/mobile-nav.tsx
+++ b/packages/operator-ui/src/components/layout/mobile-nav.tsx
@@ -73,6 +73,7 @@ export function MobileNav({
 
   return (
     <nav
+      aria-label="Mobile navigation"
       className={cn(
         "fixed bottom-0 left-0 right-0 z-40 border-t border-border bg-bg-subtle pb-[env(safe-area-inset-bottom)]",
         className,

--- a/packages/operator-ui/src/components/layout/sidebar-footer.tsx
+++ b/packages/operator-ui/src/components/layout/sidebar-footer.tsx
@@ -157,7 +157,8 @@ function SidebarCollapseToggle({
     <button
       type="button"
       data-testid="sidebar-collapse-toggle"
-      title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+      aria-expanded={!collapsed}
       className={cn(
         "flex w-full items-center rounded-md text-sm transition-colors",
         collapsed

--- a/packages/operator-ui/src/components/layout/sidebar.tsx
+++ b/packages/operator-ui/src/components/layout/sidebar.tsx
@@ -177,6 +177,7 @@ function SidebarNav({
   return (
     <TooltipProvider>
       <nav
+        aria-label="Main navigation"
         data-testid="sidebar-nav"
         className={cn(
           "flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto py-2",
@@ -207,6 +208,7 @@ function SidebarNav({
             {secondaryCollapsible && !collapsed ? (
               <button
                 type="button"
+                aria-expanded={!secondaryCollapsed}
                 data-testid="sidebar-secondary-toggle"
                 className={cn(
                   "mt-1 rounded-md text-left transition-colors hover:text-fg",
@@ -294,6 +296,7 @@ export function Sidebar({
 
   return (
     <aside
+      aria-label="Sidebar"
       className={cn(
         "flex h-full shrink-0 flex-col border-r border-border bg-bg-subtle transition-[width] duration-200",
         collapsed ? "w-14" : "w-56",

--- a/packages/operator-ui/src/components/pages/chat-page-threads.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-threads.tsx
@@ -309,6 +309,7 @@ function ArchivedSection({
         className="flex w-full items-center gap-1.5 px-3 py-2 text-xs font-medium text-fg-muted hover:text-fg"
         onClick={handleToggle}
         data-testid="chat-archived-toggle"
+        aria-expanded={expanded}
       >
         <ChevronDown className={cn("h-3 w-3 transition-transform", !expanded && "-rotate-90")} />
         Archived


### PR DESCRIPTION
Closes #1707
Closes #1708
Part of #1700

## Summary
- Added `aria-label` to navigation landmarks (`<nav>`, `<aside>`) for screen reader distinction
- Added `aria-expanded` to expand/collapse toggle buttons for state communication
- Replaced `title` with `aria-label` on sidebar collapse toggle

## Changes
- `sidebar.tsx`: `aria-label` on `<nav>` and `<aside>`, `aria-expanded` on section toggle
- `sidebar-footer.tsx`: `title` → `aria-label`, added `aria-expanded` on collapse toggle
- `mobile-nav.tsx`: `aria-label` on `<nav>`
- `chat-page-threads.tsx`: `aria-expanded` on archived section toggle

## Test plan
- [ ] Screen reader landmark navigation shows distinct names
- [ ] Toggle buttons announce expanded/collapsed state
- [ ] Lint and typecheck pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds ARIA attributes and swaps a tooltip `title` for `aria-label` without changing navigation or state logic.
> 
> **Overview**
> Improves accessibility semantics across the operator UI by adding `aria-label` names to navigation landmarks (sidebar `<aside>`, main/sidebar `<nav>`, and mobile `<nav>`) so screen readers can distinguish them.
> 
> Adds `aria-expanded` to expand/collapse controls (sidebar secondary section toggle, sidebar collapse toggle, and chat archived threads toggle), and replaces the sidebar collapse toggle `title` with an `aria-label` for more reliable announcements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cf794e7db6bf221ae4ebe36e93ef11eea8fef5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->