### PR TITLE
[P1] Replace ConfirmDangerDialog with standard dialog for non-destructive actions

### DIFF
--- a/packages/operator-ui/src/components/pages/admin-http-policy-config.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-policy-config.tsx
@@ -6,6 +6,7 @@ import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
 import { Card, CardContent, CardFooter, CardHeader } from "../ui/card.js";
 import { ConfirmDangerDialog } from "../ui/confirm-danger-dialog.js";
+import { ConfirmDialog } from "../ui/confirm-dialog.js";
 import { Input } from "../ui/input.js";
 import { Select } from "../ui/select.js";
 import { Separator } from "../ui/separator.js";
@@ -276,7 +277,7 @@ export function PolicyConfigSection(props: PolicyConfigSectionProps): React.Reac
           </Button>
           <ElevatedModeTooltip canMutate={props.canMutate} requestEnter={props.requestEnter}>
             <Button
-              variant="danger"
+              variant="primary"
               data-testid="policy-config-save"
               isLoading={props.saveBusy}
               disabled={props.configUnavailable || !dirty}
@@ -301,7 +302,7 @@ export function PolicyConfigSection(props: PolicyConfigSectionProps): React.Reac
         }}
       />
 
-      <ConfirmDangerDialog
+      <ConfirmDialog
         open={saveOpen}
         onOpenChange={setSaveOpen}
         title="Save deployment policy"
@@ -329,7 +330,7 @@ export function PolicyConfigSection(props: PolicyConfigSectionProps): React.Reac
             <span className="font-medium text-fg">Reason:</span> {saveReason.trim() || "None"}
           </div>
         </div>
-      </ConfirmDangerDialog>
+      </ConfirmDialog>
 
       <ConfirmDangerDialog
         open={revertTarget !== null}

--- a/packages/operator-ui/src/components/pages/admin-http-secrets.tsx
+++ b/packages/operator-ui/src/components/pages/admin-http-secrets.tsx
@@ -10,6 +10,7 @@ import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
 import { Card, CardContent, CardHeader } from "../ui/card.js";
 import { ConfirmDangerDialog } from "../ui/confirm-danger-dialog.js";
+import { ConfirmDialog } from "../ui/confirm-dialog.js";
 import { EmptyState } from "../ui/empty-state.js";
 import { Input } from "../ui/input.js";
 import { LoadingState } from "../ui/loading-state.js";
@@ -407,7 +408,7 @@ export function AdminHttpSecretsPanel({ core }: { core: OperatorCore }): React.R
         </CardContent>
       </Card>
 
-      <ConfirmDangerDialog
+      <ConfirmDialog
         open={storeOpen}
         onOpenChange={(open) => {
           setStoreOpen(open);
@@ -418,11 +419,15 @@ export function AdminHttpSecretsPanel({ core }: { core: OperatorCore }): React.R
         title="Store secret"
         description="Create a new write-only secret value. Existing secret keys must be rotated instead."
         confirmLabel="Store secret"
-        confirmationLabel="I understand the value is write-only and will not be shown again."
         confirmDisabled={!canStore}
         onConfirm={runStore}
       >
         <div className="grid gap-4">
+          <Alert
+            variant="info"
+            title="Write-only"
+            description="The secret value will not be shown again after submission."
+          />
           <Input
             label="Secret key"
             required
@@ -447,7 +452,7 @@ export function AdminHttpSecretsPanel({ core }: { core: OperatorCore }): React.R
             }}
           />
         </div>
-      </ConfirmDangerDialog>
+      </ConfirmDialog>
 
       <ConfirmDangerDialog
         open={rotateTarget !== null}

--- a/packages/operator-ui/src/components/ui/confirm-dialog.tsx
+++ b/packages/operator-ui/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { toast } from "sonner";
+import { formatErrorMessage } from "../../utils/format-error-message.js";
+import { Button } from "./button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog.js";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  confirmLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+  onConfirm: () => void | false | Promise<void | false>;
+  isLoading?: boolean;
+  confirmDisabled?: boolean;
+  children?: React.ReactNode;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  isLoading = false,
+  confirmDisabled = false,
+  children,
+}: ConfirmDialogProps): React.ReactElement {
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) return;
+    setSubmitting(false);
+  }, [open]);
+
+  const busy = isLoading || submitting;
+
+  const close = (): void => {
+    if (busy) return;
+    onOpenChange(false);
+  };
+
+  const submit = async (): Promise<void> => {
+    if (busy || confirmDisabled) return;
+    setSubmitting(true);
+    try {
+      const result = await onConfirm();
+      if (result !== false) onOpenChange(false);
+    } catch (error) {
+      toast.error("Action failed", { description: formatErrorMessage(error) });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          onOpenChange(true);
+          return;
+        }
+        close();
+      }}
+    >
+      <DialogContent
+        data-testid="confirm-dialog"
+        aria-modal="true"
+        onEscapeKeyDown={(event) => {
+          if (busy) event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          if (busy) event.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+
+        {children ? <div className="mt-4 grid gap-4">{children}</div> : null}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            data-testid="confirm-dialog-cancel"
+            variant="secondary"
+            disabled={busy}
+            onClick={() => {
+              close();
+            }}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            data-testid="confirm-dialog-confirm"
+            variant="primary"
+            isLoading={submitting}
+            disabled={busy || confirmDisabled}
+            onClick={() => {
+              void submit();
+            }}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/operator-ui/tests/pages/admin-page.http.policy-config-save-sync.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.policy-config-save-sync.test.ts
@@ -157,8 +157,7 @@ describe("PolicyConfigSection save sync", () => {
       );
     });
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     randomSpy.mockClear();

--- a/packages/operator-ui/tests/pages/admin-page.http.policy-config.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.policy-config.test.ts
@@ -88,8 +88,7 @@ describe("PolicyConfigSection", () => {
     });
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(onSave).toHaveBeenCalledWith(
@@ -145,8 +144,7 @@ describe("PolicyConfigSection", () => {
     );
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(onSave).toHaveBeenCalledWith(
@@ -232,8 +230,7 @@ describe("PolicyConfigSection", () => {
     );
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(onSave).toHaveBeenCalledTimes(1);
@@ -315,8 +312,7 @@ describe("PolicyConfigSection", () => {
     });
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(onSave).toHaveBeenCalledTimes(1);
@@ -400,8 +396,7 @@ describe("PolicyConfigSection", () => {
     });
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(onSave).toHaveBeenCalledWith(

--- a/packages/operator-ui/tests/pages/admin-page.http.policy-deployment-bundle.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.policy-deployment-bundle.test.ts
@@ -151,8 +151,7 @@ describe("ConfigurePage (HTTP) policy deployment bundle", () => {
     });
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
     await flush();
 

--- a/packages/operator-ui/tests/pages/admin-page.http.policy.elevated-mode.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.policy.elevated-mode.test.ts
@@ -197,8 +197,7 @@ describe("ConfigurePage (HTTP) policy elevated mode prompts", () => {
     });
     await flush();
 
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
 
     expect(

--- a/packages/operator-ui/tests/pages/admin-page.http.policy.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.policy.test.ts
@@ -434,8 +434,7 @@ describe("ConfigurePage (HTTP) policy + config", () => {
     });
 
     click(getByTestId<HTMLButtonElement>(page.container, "policy-config-save"));
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
-    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm"));
+    await clickAndFlush(getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm"));
     await flush();
     await flush();
 

--- a/packages/operator-ui/tests/pages/admin-page.http.secrets.test.ts
+++ b/packages/operator-ui/tests/pages/admin-page.http.secrets.test.ts
@@ -133,7 +133,7 @@ describe("ConfigurePage (HTTP) secrets", () => {
 
     click(getByTestId<HTMLButtonElement>(page.container, "admin-http-secrets-store-open"));
 
-    const confirmButton = getByTestId<HTMLButtonElement>(document.body, "confirm-danger-confirm");
+    const confirmButton = getByTestId<HTMLButtonElement>(document.body, "confirm-dialog-confirm");
     expect(confirmButton.disabled).toBe(true);
 
     act(() => {
@@ -142,8 +142,6 @@ describe("ConfigurePage (HTTP) secrets", () => {
     });
     await flush();
 
-    expect(confirmButton.disabled).toBe(true);
-    click(getByTestId<HTMLElement>(document.body, "confirm-danger-checkbox"));
     expect(confirmButton.disabled).toBe(false);
 
     await clickAndFlush(confirmButton);


### PR DESCRIPTION
Closes #1711
Part of #1700

## Summary
- Created `ConfirmDialog` component for important-but-not-destructive confirmations (primary button, no mandatory checkbox)
- Replaced `ConfirmDangerDialog` with `ConfirmDialog` for "Store secret" and "Save deployment policy"
- Preserved `ConfirmDangerDialog` for all actual destructive actions (rotate, revoke, revert, delete)

## Changes
- New: `confirm-dialog.tsx` — standard confirmation dialog with primary button
- `admin-http-secrets.tsx` — "Store secret" now uses `ConfirmDialog` + info Alert for write-only warning
- `admin-http-policy-config.tsx` — "Save policy" now uses `ConfirmDialog` + primary button
- 6 test files updated to match new test IDs and remove checkbox steps

## Why
Using `ConfirmDangerDialog` for routine create/update operations causes alarm fatigue — users learn to click through danger confirmations without reading, reducing effectiveness when it actually matters.

## Test plan
- [ ] "Store secret" shows primary-styled dialog without checkbox
- [ ] Write-only warning text still visible in store dialog
- [ ] "Save deployment policy" shows primary-styled dialog
- [ ] "Rotate secret" still shows danger dialog with checkbox
- [ ] "Revoke secret" still shows danger dialog with checkbox
- [ ] All existing tests pass (5146 tests)
- [ ] Lint and typecheck pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that mainly affects confirmation dialog behavior and associated tests; no backend/API or auth logic is modified.
> 
> **Overview**
> Adds a new `ConfirmDialog` component that provides a standard confirmation modal (primary confirm button, cancel button, built-in async submit/error toast) without the “danger” checkbox.
> 
> Updates the admin HTTP UI to use `ConfirmDialog` for **saving deployment policy** and **storing secrets** (including a new inline info alert for the write-only warning), while keeping `ConfirmDangerDialog` for genuinely destructive actions. Related tests were updated to target the new dialog test IDs and remove checkbox-confirm steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04c7053fb72934e3169495834dd5fd2b12a03d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->