### PR TITLE
[P1] Add descriptions to chat queue mode options

### DIFF
--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -21,20 +21,13 @@ import {
 import { toast } from "sonner";
 import { AiSdkChatMessageList } from "./chat-page-ai-sdk-messages.js";
 import { getSessionDisplayTitle } from "./chat-page-ai-sdk-shared.js";
+import { ChatQueueModeControl } from "./chat-page-ai-sdk-queue-mode-control.js";
 import { Alert } from "../ui/alert.js";
 import { Button } from "../ui/button.js";
-import { Select } from "../ui/select.js";
 
 const DRAFT_MIN_ROWS = 2;
 const DRAFT_MAX_ROWS = 12;
 const DEFAULT_DRAFT_LINE_HEIGHT_PX = 20;
-const CHAT_QUEUE_MODE_OPTIONS: ReadonlyArray<{ label: string; value: QueueModeT }> = [
-  { value: "steer", label: "Steer" },
-  { value: "steer_backlog", label: "Steer + backlog" },
-  { value: "followup", label: "Follow-up" },
-  { value: "collect", label: "Collect" },
-  { value: "interrupt", label: "Interrupt" },
-];
 
 type ChatSessionWithQueueMode = TyrumAiSdkChatSession & {
   queue_mode?: QueueModeT;
@@ -399,32 +392,12 @@ export function AiSdkConversation({
 
       <div className="border-t border-border p-3">
         <div className="mb-2 flex flex-wrap items-center gap-2">
-          <div className="inline-flex items-center gap-2 rounded-md border border-border bg-bg-subtle/40 px-2 py-1">
-            <label htmlFor={queueModeId} className="text-xs font-medium text-fg-muted">
-              Queue
-            </label>
-            <Select
-              id={queueModeId}
-              bare
-              className="h-8 min-w-[10rem] border-0 bg-transparent px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
-              data-testid="ai-sdk-chat-queue-mode"
-              disabled={queueModeBusy}
-              value={queueMode}
-              onChange={(event) => {
-                const parsed = QueueMode.safeParse(event.currentTarget.value);
-                if (!parsed.success) {
-                  return;
-                }
-                void handleQueueModeChange(parsed.data);
-              }}
-            >
-              {CHAT_QUEUE_MODE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </Select>
-          </div>
+          <ChatQueueModeControl
+            id={queueModeId}
+            value={queueMode}
+            disabled={queueModeBusy}
+            onChange={(next) => void handleQueueModeChange(next)}
+          />
           <Button
             type="button"
             variant="secondary"

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-queue-mode-control.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-queue-mode-control.tsx
@@ -1,0 +1,101 @@
+import { QueueMode, type QueueMode as QueueModeT } from "@tyrum/contracts";
+import { Info } from "lucide-react";
+import { Select } from "../ui/select.js";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip.js";
+
+interface QueueModeOption {
+  readonly value: QueueModeT;
+  readonly label: string;
+  readonly description: string;
+}
+
+const QUEUE_MODE_OPTIONS: ReadonlyArray<QueueModeOption> = [
+  {
+    value: "steer",
+    label: "Steer",
+    description: "Inject message into the active run and cancel pending tool calls",
+  },
+  {
+    value: "steer_backlog",
+    label: "Steer + backlog",
+    description: "Steer the active run and keep the message queued for the next run",
+  },
+  {
+    value: "followup",
+    label: "Follow-up",
+    description: "Queue each message as a separate follow-up run after the current one finishes",
+  },
+  {
+    value: "collect",
+    label: "Collect",
+    description: "Batch messages during a debounce window and process them together",
+  },
+  {
+    value: "interrupt",
+    label: "Interrupt",
+    description:
+      "Abort the active run, discard other queued messages, and process only this message",
+  },
+];
+
+export interface ChatQueueModeControlProps {
+  id: string;
+  value: QueueModeT;
+  disabled: boolean;
+  onChange: (next: QueueModeT) => void;
+}
+
+export function ChatQueueModeControl({ id, value, disabled, onChange }: ChatQueueModeControlProps) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-md border border-border bg-bg-subtle/40 px-2 py-1">
+      <label
+        htmlFor={id}
+        className="inline-flex items-center gap-1 text-xs font-medium text-fg-muted"
+      >
+        Queue
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info
+                className="inline h-3 w-3 cursor-help text-fg-muted/70"
+                aria-label="Queue mode help"
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs space-y-1 text-xs">
+              <p className="font-medium">
+                How new messages are handled while the agent is running:
+              </p>
+              {QUEUE_MODE_OPTIONS.map((option) => (
+                <p key={option.value}>
+                  <span className="font-medium">{option.label}</span>
+                  {" \u2014 "}
+                  {option.description}
+                </p>
+              ))}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </label>
+      <Select
+        id={id}
+        bare
+        className="h-8 min-w-[10rem] border-0 bg-transparent px-2 py-1 text-xs focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-0"
+        data-testid="ai-sdk-chat-queue-mode"
+        disabled={disabled}
+        value={value}
+        onChange={(event) => {
+          const parsed = QueueMode.safeParse(event.currentTarget.value);
+          if (parsed.success) {
+            onChange(parsed.data);
+          }
+        }}
+      >
+        {QUEUE_MODE_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value} title={option.description}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1713
Part of #1700

## Summary
- Extracted `ChatQueueModeControl` component with built-in discoverability
- Added tooltip with descriptions of all 5 queue modes (info icon next to "Queue" label)
- Added `title` attributes on `<option>` elements for native browser tooltips
- Descriptions verified against gateway queue processing source code

## Queue mode descriptions
| Mode | Description |
|------|-------------|
| Steer | Inject message into the active run and cancel pending tool calls |
| Steer + backlog | Steer the active run and keep the message queued for the next run |
| Follow-up | Queue each message as a separate follow-up run after the current one finishes |
| Collect | Batch messages during a debounce window and process them together |
| Interrupt | Abort the active run, discard other queued messages, and process only this message |

## Changes
- New: `chat-page-ai-sdk-queue-mode-control.tsx` — extracted component with tooltip and descriptions
- `chat-page-ai-sdk-conversation.tsx` — uses the new component

## Test plan
- [ ] Hover info icon next to "Queue" label — see tooltip with all mode descriptions
- [ ] Hover individual options in dropdown — see native tooltip with description
- [ ] Queue mode selection still works correctly
- [ ] Existing queue mode tests pass
- [ ] Lint and typecheck pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only refactor that adds explanatory tooltips; selection behavior is preserved with the same `QueueMode` validation and change handler.
> 
> **Overview**
> Improves discoverability of AI SDK chat *queue mode* behavior by replacing the inline queue-mode `<Select>` with a new `ChatQueueModeControl` component.
> 
> `ChatQueueModeControl` adds an info-icon tooltip listing descriptions for all queue modes and sets per-option `title` attributes for native hover help, while keeping the same `QueueMode.safeParse`-validated change flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f531b2d21b263928e77ac68cf82fcfc0951d527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->