### PR TITLE
Move agent runtime lifecycle interfaces into @tyrum/runtime-agent (#1761)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/types.ts
+++ b/packages/gateway/src/modules/agent/runtime/types.ts
@@ -1,9 +1,17 @@
-import type { LanguageModel } from "ai";
 import type {
   AgentConfig as AgentConfigT,
   IdentityPack as IdentityPackT,
   McpServerSpec as McpServerSpecT,
 } from "@tyrum/contracts";
+import type {
+  AgentContextInjectedFileReport,
+  AgentContextPartReport,
+  AgentContextPreTurnToolReport,
+  AgentContextReport,
+  AgentContextToolCallReport,
+  AgentLoadedContext as RuntimeAgentLoadedContext,
+  AgentRuntimeAssemblyOptions,
+} from "@tyrum/runtime-agent";
 import type { GatewayContainer } from "../../../container.js";
 import type { McpManager } from "../mcp-manager.js";
 import type { SessionDal } from "../session-dal.js";
@@ -15,104 +23,29 @@ import type { PolicyService } from "@tyrum/runtime-policy";
 import type { SecretProvider } from "../../secret/provider.js";
 import type { ProtocolDeps } from "../../../ws/protocol.js";
 
-export interface AgentRuntimeOptions {
-  container: GatewayContainer;
-  /** Tenant identifier for DB scoping (default: default tenant). */
-  tenantId?: string;
-  home?: string;
-  sessionDal?: SessionDal;
-  fetchImpl?: typeof fetch;
-  /** Stable per-process instance owner identifier for OAuth leases and audit trails. */
-  instanceOwner?: string;
-  /** Stable agent identifier for routing/isolation (default: "default"). */
-  agentId?: string;
-  /** Workspace identifier for leases/audit (default: "default"). */
-  workspaceId?: string;
-  contextStore?: AgentContextStore;
-  /** Override the language model (useful for testing). */
-  languageModel?: LanguageModel;
-  mcpManager?: McpManager;
-  plugins?: PluginRegistry;
-  /** Optional per-agent policy service instance. */
-  policyService?: PolicyService;
-  /** Maximum tool/LLM steps per turn (AI SDK step budget). */
-  maxSteps?: number;
-  secretProvider?: SecretProvider;
-  approvalDal?: ApprovalDal;
-  /** Optional protocol deps for dedicated node-backed dispatch. */
-  protocolDeps?: ProtocolDeps;
-  /** How long to wait for a human approval before expiring it. */
-  approvalWaitMs?: number;
-  /** Poll interval while waiting for human approval. */
-  approvalPollMs?: number;
-  /** Maximum duration for a single turn to complete via the execution engine. */
-  turnEngineWaitMs?: number;
-}
+export type AgentRuntimeOptions = AgentRuntimeAssemblyOptions<
+  GatewayContainer,
+  AgentContextStore,
+  SessionDal,
+  McpManager,
+  PluginRegistry,
+  PolicyService,
+  SecretProvider,
+  ApprovalDal,
+  ProtocolDeps
+>;
 
-export interface AgentLoadedContext {
-  config: AgentConfigT;
-  identity: IdentityPackT;
-  skills: LoadedSkillManifest[];
-  mcpServers: McpServerSpecT[];
-}
+export type AgentLoadedContext = RuntimeAgentLoadedContext<
+  AgentConfigT,
+  IdentityPackT,
+  LoadedSkillManifest,
+  McpServerSpecT
+>;
 
-export interface AgentContextPartReport {
-  id: string;
-  chars: number;
-}
-
-export interface AgentContextToolCallReport {
-  tool_call_id: string;
-  tool_id: string;
-  injected_chars: number;
-}
-
-export interface AgentContextPreTurnToolReport {
-  tool_id: string;
-  status: "succeeded" | "failed" | "skipped";
-  injected_chars: number;
-  error?: string;
-}
-
-export interface AgentContextInjectedFileReport {
-  tool_call_id: string;
-  path: string;
-  offset?: number;
-  limit?: number;
-  raw_chars: number;
-  selected_chars: number;
-  injected_chars: number;
-  truncated: boolean;
-  truncation_marker?: string;
-}
-
-export interface AgentContextReport {
-  context_report_id: string;
-  generated_at: string;
-  session_id: string;
-  channel: string;
-  thread_id: string;
-  agent_id: string;
-  workspace_id: string;
-  execution_profile?: string;
-  execution_profile_source?: string;
-  system_prompt: {
-    chars: number;
-    sections: AgentContextPartReport[];
-  };
-  user_parts: AgentContextPartReport[];
-  selected_tools: string[];
-  tool_schema_top: AgentContextPartReport[];
-  tool_schema_total_chars: number;
-  enabled_skills: string[];
-  mcp_servers: string[];
-  memory: {
-    keyword_hits: number;
-    semantic_hits: number;
-    structured_hits?: number;
-    included_items?: number;
-  };
-  pre_turn_tools: AgentContextPreTurnToolReport[];
-  tool_calls: AgentContextToolCallReport[];
-  injected_files: AgentContextInjectedFileReport[];
-}
+export type {
+  AgentContextInjectedFileReport,
+  AgentContextPartReport,
+  AgentContextPreTurnToolReport,
+  AgentContextReport,
+  AgentContextToolCallReport,
+};

--- a/packages/gateway/tests/unit/agent-runtime-lifecycle-contracts-extraction.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-lifecycle-contracts-extraction.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("agent runtime lifecycle contract extraction", () => {
+  it("sources gateway runtime lifecycle contracts from @tyrum/runtime-agent", async () => {
+    const typesPath = join(__dirname, "../../src/modules/agent/runtime/types.ts");
+    const raw = await readFile(typesPath, "utf-8");
+
+    expect(raw).toContain('from "@tyrum/runtime-agent"');
+    expect(raw).not.toMatch(/\bexport interface AgentRuntimeOptions\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentLoadedContext\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentContextPartReport\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentContextToolCallReport\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentContextPreTurnToolReport\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentContextInjectedFileReport\b/);
+    expect(raw).not.toMatch(/\bexport interface AgentContextReport\b/);
+  });
+});

--- a/packages/runtime-agent/src/index.ts
+++ b/packages/runtime-agent/src/index.ts
@@ -10,3 +10,12 @@ export type {
 export { AgentRuntime } from "./agent-runtime.js";
 export type { ContextPruningConfig } from "./context-pruning.js";
 export { applyDeterministicContextCompactionAndToolPruning } from "./context-pruning.js";
+export type {
+  AgentContextInjectedFileReport,
+  AgentContextPartReport,
+  AgentContextPreTurnToolReport,
+  AgentContextReport,
+  AgentContextToolCallReport,
+  AgentLoadedContext,
+  AgentRuntimeAssemblyOptions,
+} from "./types.js";

--- a/packages/runtime-agent/src/types.ts
+++ b/packages/runtime-agent/src/types.ts
@@ -1,0 +1,59 @@
+import type { LanguageModel } from "ai";
+import type { ContextReport as ContextReportT } from "@tyrum/contracts";
+
+export type AgentContextReport = ContextReportT;
+export type AgentContextPartReport = ContextReportT["user_parts"][number];
+export type AgentContextToolCallReport = ContextReportT["tool_calls"][number];
+export type AgentContextPreTurnToolReport = ContextReportT["pre_turn_tools"][number];
+export type AgentContextInjectedFileReport = ContextReportT["injected_files"][number];
+
+export interface AgentLoadedContext<TConfig, TIdentity, TSkill, TMcpServer> {
+  config: TConfig;
+  identity: TIdentity;
+  skills: TSkill[];
+  mcpServers: TMcpServer[];
+}
+
+export interface AgentRuntimeAssemblyOptions<
+  TContainer,
+  TContextStore,
+  TSessionDal,
+  TMcpManager,
+  TPlugins,
+  TPolicyService,
+  TSecretProvider,
+  TApprovalDal,
+  TProtocolDeps,
+> {
+  container: TContainer;
+  /** Tenant identifier for DB scoping (default: default tenant). */
+  tenantId?: string;
+  home?: string;
+  sessionDal?: TSessionDal;
+  fetchImpl?: typeof fetch;
+  /** Stable per-process instance owner identifier for OAuth leases and audit trails. */
+  instanceOwner?: string;
+  /** Stable agent identifier for routing/isolation (default: "default"). */
+  agentId?: string;
+  /** Workspace identifier for leases/audit (default: "default"). */
+  workspaceId?: string;
+  contextStore?: TContextStore;
+  /** Override the language model (useful for testing). */
+  languageModel?: LanguageModel;
+  mcpManager?: TMcpManager;
+  plugins?: TPlugins;
+  /** Optional per-agent policy service instance. */
+  policyService?: TPolicyService;
+  /** Maximum tool/LLM steps per turn (AI SDK step budget). */
+  maxSteps?: number;
+  secretProvider?: TSecretProvider;
+  approvalDal?: TApprovalDal;
+  /** Optional protocol deps for dedicated node-backed dispatch. */
+  protocolDeps?: TProtocolDeps;
+  /** How long to wait for a human approval before expiring it. */
+  approvalWaitMs?: number;
+  /** Poll interval while waiting for human approval. */
+  approvalPollMs?: number;
+  /** Maximum duration for a single turn to complete via the execution engine. */
+  turnEngineWaitMs?: number;
+}

--- a/packages/runtime-agent/tests/entrypoints.test.ts
+++ b/packages/runtime-agent/tests/entrypoints.test.ts
@@ -1,15 +1,84 @@
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import type {
+  AgentConfig,
+  ContextInjectedFileReport,
+  ContextPartReport,
+  ContextReport,
+  IdentityPack,
+  McpServerSpec,
+} from "@tyrum/contracts";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  AgentContextInjectedFileReport,
+  AgentContextPartReport,
+  AgentContextPreTurnToolReport,
+  AgentContextReport,
+  AgentContextToolCallReport,
+  AgentLoadedContext,
+  AgentRuntimeAssemblyOptions,
+} from "../src/index.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+type LoadedSkillManifest = {
+  meta: {
+    id: string;
+  };
+};
+
 describe("@tyrum/runtime-agent entrypoints", () => {
-  it("re-exports the runtime orchestrator and context pruning helpers", async () => {
+  it("re-exports the runtime orchestrator, lifecycle contracts, and context pruning helpers", async () => {
     const indexSource = await readFile(resolve(__dirname, "../src/index.ts"), "utf8");
 
     expect(indexSource).toContain("AgentRuntime");
+    expect(indexSource).toContain("AgentRuntimeAssemblyOptions");
+    expect(indexSource).toContain("AgentLoadedContext");
+    expect(indexSource).toContain("AgentContextReport");
+    expect(indexSource).toContain("AgentContextPreTurnToolReport");
+    expect(indexSource).toContain("AgentContextToolCallReport");
     expect(indexSource).toContain("applyDeterministicContextCompactionAndToolPruning");
+  });
+
+  it("exposes package-owned lifecycle contract types", () => {
+    expectTypeOf<AgentContextReport>().toEqualTypeOf<ContextReport>();
+    expectTypeOf<AgentContextPartReport>().toEqualTypeOf<ContextPartReport>();
+    expectTypeOf<AgentContextToolCallReport>().toEqualTypeOf<ContextReport["tool_calls"][number]>();
+    expectTypeOf<AgentContextPreTurnToolReport>().toEqualTypeOf<
+      ContextReport["pre_turn_tools"][number]
+    >();
+    expectTypeOf<AgentContextInjectedFileReport>().toEqualTypeOf<ContextInjectedFileReport>();
+    expectTypeOf<
+      AgentLoadedContext<AgentConfig, IdentityPack, LoadedSkillManifest, McpServerSpec>
+    >().toEqualTypeOf<{
+      config: AgentConfig;
+      identity: IdentityPack;
+      skills: LoadedSkillManifest[];
+      mcpServers: McpServerSpec[];
+    }>();
+
+    const runtimeOptions: AgentRuntimeAssemblyOptions<
+      { name: string },
+      { scope: string },
+      { session: string },
+      { shutdown(): Promise<void> },
+      { id: string },
+      { policy: string },
+      { provider: string },
+      { approval: string },
+      { ws: string }
+    > = {
+      container: { name: "gateway" },
+      contextStore: { scope: "tenant:default" },
+      sessionDal: { session: "session-1" },
+      mcpManager: {
+        shutdown: async () => undefined,
+      },
+    };
+
+    expect(runtimeOptions.container.name).toBe("gateway");
+    expect(runtimeOptions.contextStore.scope).toBe("tenant:default");
+    expect(runtimeOptions.sessionDal.session).toBe("session-1");
   });
 });


### PR DESCRIPTION
## Summary
- add package-owned agent runtime lifecycle contract types to `@tyrum/runtime-agent`
- switch gateway agent runtime types to concrete aliases from `@tyrum/runtime-agent`
- add package and gateway regression tests to keep the contract ownership boundary in place

Closes #1761

## Testing
- `pnpm exec vitest run packages/runtime-agent/tests/entrypoints.test.ts packages/gateway/tests/unit/agent-runtime-lifecycle-contracts-extraction.test.ts packages/gateway/tests/unit/agent-runtime-context-identity.test.ts packages/gateway/tests/unit/turn-finalization.test.ts packages/gateway/tests/unit/turn-preparation-runtime.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a type-ownership refactor (moving interfaces to `@tyrum/runtime-agent`) with added compile-time/regression tests; runtime behavior should be unchanged, with main risk being downstream type incompatibilities if consumers relied on gateway-local definitions.
> 
> **Overview**
> Moves agent runtime lifecycle contract type definitions out of the gateway and into `@tyrum/runtime-agent`, with the gateway now exporting aliases (`AgentRuntimeOptions`, `AgentLoadedContext`, and context report-related types) sourced from the shared package.
> 
> Adds `@tyrum/runtime-agent` exports for these lifecycle contract types via a new `types.ts`, and introduces regression tests in both packages to ensure the gateway continues to import them from `@tyrum/runtime-agent` and that the exported types stay aligned with `@tyrum/contracts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab90d6bbb22c936cd72bc4effe710c4a0601dfb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->