### PR TITLE
[P2] Add accessible name to pairing search input

### DIFF
--- a/packages/operator-ui/src/components/pages/pairing-page.tsx
+++ b/packages/operator-ui/src/components/pages/pairing-page.tsx
@@ -401,6 +401,7 @@ export function PairingPage({ core }: { core: OperatorCore }) {
 
         <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem]">
           <Input
+            aria-label="Filter nodes"
             data-testid="pairing-search"
             value={searchQuery}
             placeholder="Filter by identifier or mode"


### PR DESCRIPTION
Closes #1715
Part of #1700

## Summary
Added `aria-label="Filter nodes"` to the pairing page search input which only had a placeholder as its labeling mechanism.

## Changes
- `pairing-page.tsx`: Added `aria-label="Filter nodes"` to the filter Input

## Test plan
- [ ] Screen reader announces "Filter nodes" when input is focused
- [ ] Lint and typecheck pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI accessibility tweak that only adds an `aria-label` to an existing input, with no logic or data-flow changes.
> 
> **Overview**
> Improves accessibility on the pairing page by giving the nodes search input an explicit accessible name via `aria-label="Filter nodes"`, rather than relying solely on the placeholder text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a15d6d09075620a106c5fdb57e70e57a19857a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->