### PR TITLE
Reduce gateway agent runtime to adapters/composition and preserve parity tests (#1762)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime.ts
@@ -1,6 +1,5 @@
 import type { streamText } from "ai";
 import type {
-  AgentStatusResponse as AgentStatusResponseT,
   AgentTurnRequest as AgentTurnRequestT,
   AgentTurnResponse as AgentTurnResponseT,
 } from "@tyrum/contracts";
@@ -31,23 +30,21 @@ import { type SessionCompactionResult } from "./session-compaction-service.js";
 import type { ToolDescriptor } from "../tools.js";
 import type { GuardianReviewDecision } from "../../review/guardian-review-mode.js";
 
-export class AgentRuntime {
+export class AgentRuntime extends RuntimeAgent<
+  GatewayAgentRuntimeDeps,
+  PluginRegistry,
+  ExecutionEngine,
+  AgentContextReport,
+  ToolDescriptor,
+  GuardianReviewDecision,
+  GuardianReviewDecisionCollectorResult,
+  SessionCompactionResult,
+  ReturnType<typeof streamText>
+> {
   public readonly executionEngine: ExecutionEngine;
   public readonly opts: AgentRuntimeOptions;
-  private readonly runtime: RuntimeAgent<
-    GatewayAgentRuntimeDeps,
-    PluginRegistry,
-    ExecutionEngine,
-    AgentContextReport,
-    ToolDescriptor,
-    GuardianReviewDecision,
-    GuardianReviewDecisionCollectorResult,
-    SessionCompactionResult,
-    ReturnType<typeof streamText>
-  >;
 
   constructor(opts: AgentRuntimeOptions) {
-    this.opts = opts;
     const agentIdCandidate = opts.agentId?.trim() || resolveAgentId();
     const home = opts.home ?? resolveAgentHome(resolveTyrumHome(), agentIdCandidate);
     const contextStore =
@@ -67,8 +64,7 @@ export class AgentRuntime {
       logger: opts.container.logger,
     });
 
-    this.executionEngine = executionEngine;
-    this.runtime = new RuntimeAgent({
+    super({
       deps: {
         opts,
         contextStore,
@@ -99,163 +95,47 @@ export class AgentRuntime {
       approvalPollMs: opts.approvalPollMs,
       turnEngineWaitMs: opts.turnEngineWaitMs,
     });
-  }
 
-  setPlugins(plugins: PluginRegistry): void {
-    this.runtime.setPlugins(plugins);
-  }
-
-  async shutdown(): Promise<void> {
-    await this.runtime.shutdown();
-  }
-
-  async status(enabled: boolean): Promise<AgentStatusResponseT> {
-    return await this.runtime.status(enabled);
-  }
-
-  async listRegisteredTools(): Promise<{
-    allowlist: string[];
-    tools: ToolDescriptor[];
-    mcpServers: string[];
-  }> {
-    return await this.runtime.listRegisteredTools();
-  }
-
-  getLastContextReport(): AgentContextReport | undefined {
-    return this.runtime.getLastContextReport();
-  }
-
-  get instanceOwner(): string {
-    return this.runtime.instanceOwner;
-  }
-
-  get home(): string {
-    return this.runtime.getContext().home;
+    this.executionEngine = executionEngine;
+    this.opts = opts;
   }
 
   get contextStore(): AgentContextStore {
-    return this.runtime.getContext().deps.contextStore;
+    return this.deps.contextStore;
   }
 
   get sessionDal(): SessionDal {
-    return this.runtime.getContext().deps.sessionDal;
+    return this.deps.sessionDal;
   }
 
   get fetchImpl(): typeof fetch {
-    return this.runtime.getContext().deps.fetchImpl;
-  }
-
-  get tenantId(): string {
-    return this.runtime.getContext().tenantId;
-  }
-
-  get agentId(): string {
-    return this.runtime.getContext().agentId;
-  }
-
-  get workspaceId(): string {
-    return this.runtime.getContext().workspaceId;
-  }
-
-  get languageModelOverride() {
-    return this.runtime.getContext().languageModelOverride;
+    return this.deps.fetchImpl;
   }
 
   get mcpManager(): McpManager {
-    return this.runtime.getContext().deps.mcpManager;
-  }
-
-  get plugins(): PluginRegistry | undefined {
-    return this.runtime.getContext().plugins;
+    return this.deps.mcpManager;
   }
 
   get policyService(): PolicyService {
-    return this.runtime.getContext().deps.policyService;
+    return this.deps.policyService;
   }
 
   get approvalDal(): ApprovalDal {
-    return this.runtime.getContext().deps.approvalDal;
-  }
-
-  get approvalWaitMs(): number {
-    return this.runtime.getContext().approvalWaitMs;
-  }
-
-  get approvalPollMs(): number {
-    return this.runtime.getContext().approvalPollMs;
-  }
-
-  get maxSteps(): number {
-    return this.runtime.getContext().maxSteps;
-  }
-
-  get executionWorkerId(): string {
-    return this.runtime.getContext().executionWorkerId;
-  }
-
-  get turnEngineWaitMs(): number {
-    return this.runtime.getContext().turnEngineWaitMs;
-  }
-
-  get cleanupAtMs(): number {
-    return this.runtime.getContext().cleanupAtMs;
-  }
-
-  set cleanupAtMs(value: number) {
-    this.runtime.getContext().cleanupAtMs = value;
-  }
-
-  get defaultHeartbeatSeededScopes(): Set<string> {
-    return this.runtime.getContext().defaultHeartbeatSeededScopes;
+    return this.deps.approvalDal;
   }
 
   get prepareTurnDeps(): PrepareTurnDeps {
-    return buildPrepareTurnDeps(this.runtime.getContext());
+    return buildPrepareTurnDeps(this.getContext());
   }
 
   get turnDirectDeps(): TurnDirectDeps {
-    return buildTurnDirectDeps(this.runtime.getContext());
-  }
-
-  async turnStream(input: AgentTurnRequestT): Promise<{
-    streamResult: ReturnType<typeof streamText>;
-    sessionId: string;
-    guardianReviewDecisionCollector?: GuardianReviewDecisionCollectorResult;
-    finalize: () => Promise<AgentTurnResponseT>;
-  }> {
-    return await this.runtime.turnStream(input);
-  }
-
-  async turn(input: AgentTurnRequestT): Promise<AgentTurnResponseT> {
-    return await this.runtime.turn(input);
-  }
-
-  async compactSession(input: {
-    sessionId: string;
-    keepLastMessages?: number;
-    abortSignal?: AbortSignal;
-    timeoutMs?: number;
-  }): Promise<SessionCompactionResult> {
-    return await this.runtime.compactSession(input);
+    return buildTurnDirectDeps(this.getContext());
   }
 
   async executeDecideAction(
     input: AgentTurnRequestT,
     opts?: { abortSignal?: AbortSignal; timeoutMs?: number; execution?: TurnExecutionContext },
   ): Promise<AgentTurnResponseT> {
-    return await this.runtime.executeDecideAction(input, opts);
-  }
-
-  async executeGuardianReview(
-    input: AgentTurnRequestT,
-    opts?: { abortSignal?: AbortSignal; timeoutMs?: number },
-  ): Promise<{
-    response: AgentTurnResponseT;
-    decision?: GuardianReviewDecision;
-    calls: number;
-    invalidCalls: number;
-    error?: string;
-  }> {
-    return await this.runtime.executeGuardianReview(input, opts);
+    return await super.executeDecideAction(input, opts);
   }
 }

--- a/packages/gateway/src/modules/review/guardian-review-processor.ts
+++ b/packages/gateway/src/modules/review/guardian-review-processor.ts
@@ -438,7 +438,7 @@ export class GuardianReviewProcessor {
       tenantId: approval.tenant_id,
       secretProviderForTenant: this.opts.secretProviderForTenant,
     });
-    const runtimeAgentKey = runtime.opts.agentId;
+    const runtimeAgentKey = runtime.agentId;
     if (!runtimeAgentKey) {
       throw new Error("guardian reviewer runtime agent id is missing");
     }
@@ -476,7 +476,7 @@ export class GuardianReviewProcessor {
       tenantId: this.tenantId,
       secretProviderForTenant: this.opts.secretProviderForTenant,
     });
-    const runtimeAgentKey = runtime.opts.agentId;
+    const runtimeAgentKey = runtime.agentId;
     if (!runtimeAgentKey) {
       throw new Error("guardian reviewer runtime agent id is missing");
     }

--- a/packages/gateway/tests/unit/agent-runtime-lifecycle-contracts-extraction.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-lifecycle-contracts-extraction.test.ts
@@ -19,4 +19,12 @@ describe("agent runtime lifecycle contract extraction", () => {
     expect(raw).not.toMatch(/\bexport interface AgentContextInjectedFileReport\b/);
     expect(raw).not.toMatch(/\bexport interface AgentContextReport\b/);
   });
+
+  it("keeps gateway agent runtime focused on composition over reusable shell logic", async () => {
+    const runtimePath = join(__dirname, "../../src/modules/agent/runtime/agent-runtime.ts");
+    const raw = await readFile(runtimePath, "utf-8");
+
+    expect(raw).toContain("extends RuntimeAgent<");
+    expect(raw).not.toContain("private readonly runtime:");
+  });
 });

--- a/packages/runtime-agent/src/agent-runtime.ts
+++ b/packages/runtime-agent/src/agent-runtime.ts
@@ -180,7 +180,7 @@ export class AgentRuntime<
   private readonly context: AgentRuntimeContext<TDeps, TPlugins, TExecutionPort, TContextReport>;
 
   constructor(
-    private readonly opts: AgentRuntimeOptions<
+    private readonly runtimeOptions: AgentRuntimeOptions<
       TDeps,
       TPlugins,
       TExecutionPort,
@@ -192,6 +192,7 @@ export class AgentRuntime<
       TStreamResult
     >,
   ) {
+    const opts = this.runtimeOptions;
     const agentIdCandidate = opts.agentId?.trim() || opts.resolveDefaultAgentId();
     const parsedAgentId = AgentKey.safeParse(agentIdCandidate);
     if (!parsedAgentId.success) {
@@ -235,15 +236,35 @@ export class AgentRuntime<
   }
 
   async shutdown(): Promise<void> {
-    await this.opts.onShutdown(this.context);
+    await this.runtimeOptions.onShutdown(this.context);
   }
 
   async status(enabled: boolean): Promise<AgentStatusResponseT> {
-    return await this.opts.lifecycle.status(this.context, enabled);
+    return await this.runtimeOptions.lifecycle.status(this.context, enabled);
   }
 
   async listRegisteredTools(): Promise<AgentRuntimeToolCatalog<TToolDescriptor>> {
-    return await this.opts.lifecycle.listRegisteredTools(this.context);
+    return await this.runtimeOptions.lifecycle.listRegisteredTools(this.context);
+  }
+
+  get deps(): TDeps {
+    return this.context.deps;
+  }
+
+  get home(): string {
+    return this.context.home;
+  }
+
+  get tenantId(): string {
+    return this.context.tenantId;
+  }
+
+  get agentId(): string {
+    return this.context.agentId;
+  }
+
+  get workspaceId(): string {
+    return this.context.workspaceId;
   }
 
   getLastContextReport(): TContextReport | undefined {
@@ -252,6 +273,50 @@ export class AgentRuntime<
 
   get instanceOwner(): string {
     return this.context.instanceOwner;
+  }
+
+  get languageModelOverride(): LanguageModel | undefined {
+    return this.context.languageModelOverride;
+  }
+
+  get maxSteps(): number {
+    return this.context.maxSteps;
+  }
+
+  get approvalWaitMs(): number {
+    return this.context.approvalWaitMs;
+  }
+
+  get approvalPollMs(): number {
+    return this.context.approvalPollMs;
+  }
+
+  get executionPort(): TExecutionPort {
+    return this.context.executionPort;
+  }
+
+  get executionWorkerId(): string {
+    return this.context.executionWorkerId;
+  }
+
+  get turnEngineWaitMs(): number {
+    return this.context.turnEngineWaitMs;
+  }
+
+  get defaultHeartbeatSeededScopes(): Set<string> {
+    return this.context.defaultHeartbeatSeededScopes;
+  }
+
+  get plugins(): TPlugins | undefined {
+    return this.context.plugins;
+  }
+
+  get cleanupAtMs(): number {
+    return this.context.cleanupAtMs;
+  }
+
+  set cleanupAtMs(value: number) {
+    this.context.cleanupAtMs = value;
   }
 
   getContext(): AgentRuntimeContext<TDeps, TPlugins, TExecutionPort, TContextReport> {
@@ -264,7 +329,7 @@ export class AgentRuntime<
     guardianReviewDecisionCollector?: TGuardianReviewDecisionCollector;
     finalize: () => Promise<AgentTurnResponseT>;
   }> {
-    const result = await this.opts.lifecycle.turnStream(this.context, input);
+    const result = await this.runtimeOptions.lifecycle.turnStream(this.context, input);
     if (result.contextReport !== undefined) {
       this.context.lastContextReport = result.contextReport;
     }
@@ -283,7 +348,7 @@ export class AgentRuntime<
   }
 
   async turn(input: AgentTurnRequestT): Promise<AgentTurnResponseT> {
-    const result = await this.opts.lifecycle.turn(this.context, input);
+    const result = await this.runtimeOptions.lifecycle.turn(this.context, input);
     return await this.finalizeTurnLifecycle({
       turnInput: input,
       response: result.response,
@@ -297,14 +362,18 @@ export class AgentRuntime<
     abortSignal?: AbortSignal;
     timeoutMs?: number;
   }): Promise<TSessionCompactionResult> {
-    return await this.opts.lifecycle.compactSession(this.context, input);
+    return await this.runtimeOptions.lifecycle.compactSession(this.context, input);
   }
 
   async executeDecideAction(
     input: AgentTurnRequestT,
     opts?: { abortSignal?: AbortSignal; timeoutMs?: number; execution?: unknown },
   ): Promise<AgentTurnResponseT> {
-    const result = await this.opts.lifecycle.executeDecideAction(this.context, input, opts);
+    const result = await this.runtimeOptions.lifecycle.executeDecideAction(
+      this.context,
+      input,
+      opts,
+    );
     return await this.finalizeTurnLifecycle({
       turnInput: input,
       response: result.response,
@@ -322,7 +391,11 @@ export class AgentRuntime<
     invalidCalls: number;
     error?: string;
   }> {
-    const result = await this.opts.lifecycle.executeGuardianReview(this.context, input, opts);
+    const result = await this.runtimeOptions.lifecycle.executeGuardianReview(
+      this.context,
+      input,
+      opts,
+    );
     return {
       response: await this.finalizeTurnLifecycle({
         turnInput: input,
@@ -344,6 +417,6 @@ export class AgentRuntime<
     if (input.contextReport !== undefined) {
       this.context.lastContextReport = input.contextReport;
     }
-    return await this.opts.lifecycle.finalizeTurnLifecycle(this.context, input);
+    return await this.runtimeOptions.lifecycle.finalizeTurnLifecycle(this.context, input);
   }
 }

--- a/packages/runtime-agent/tests/agent-runtime.test.ts
+++ b/packages/runtime-agent/tests/agent-runtime.test.ts
@@ -242,6 +242,40 @@ describe("@tyrum/runtime-agent AgentRuntime", () => {
     expect(lifecycle.listRegisteredTools).toHaveBeenCalledWith(runtime.getContext());
   });
 
+  it("exposes normalized runtime context through package-owned accessors", () => {
+    const plugins = { name: "plugin-a" } satisfies Plugins;
+    const { runtime, executionPort } = createRuntime({
+      options: {
+        agentId: " agent-1 ",
+        workspaceId: " workspace-1 ",
+        tenantId: " tenant-1 ",
+        home: "/tmp/custom-home",
+        plugins,
+        maxSteps: 9,
+        approvalWaitMs: 2_000,
+        approvalPollMs: 250,
+        turnEngineWaitMs: 9_000,
+      },
+    });
+
+    runtime.cleanupAtMs = 42;
+
+    expect(runtime.deps.shutdown).toBeTypeOf("function");
+    expect(runtime.executionPort).toBe(executionPort);
+    expect(runtime.home).toBe("/tmp/custom-home");
+    expect(runtime.tenantId).toBe("tenant-1");
+    expect(runtime.agentId).toBe("agent-1");
+    expect(runtime.workspaceId).toBe("workspace-1");
+    expect(runtime.plugins).toBe(plugins);
+    expect(runtime.maxSteps).toBe(9);
+    expect(runtime.approvalWaitMs).toBe(2_000);
+    expect(runtime.approvalPollMs).toBe(250);
+    expect(runtime.turnEngineWaitMs).toBe(9_000);
+    expect(runtime.executionWorkerId).toMatch(/^agent-runtime-agent-1-/);
+    expect(runtime.cleanupAtMs).toBe(42);
+    expect(runtime.defaultHeartbeatSeededScopes.size).toBe(0);
+  });
+
   it("delegates compactSession inputs unchanged", async () => {
     const { runtime, lifecycle } = createRuntime();
     const abortController = new AbortController();


### PR DESCRIPTION
Closes #1762

## Summary
- move reusable runtime context accessors into `@tyrum/runtime-agent` so the package owns more of the orchestration shell
- reduce gateway `AgentRuntime` to subclass-based composition plus gateway-only adapters and dependency accessors
- add parity coverage that locks in the extraction and update guardian review code to use the package-owned runtime agent id accessor

## Testing
- `pnpm format:check`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test --coverage.enabled --coverage.reporter=text-summary` (pre-push hook; coverage summary: lines 80.95%, statements 79.05%, functions 82.14%, branches 67.69%)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors the `AgentRuntime` wrapper/inheritance boundary used across gateway turn execution and guardian review flows; behavior should be equivalent but subtle context/accessor differences could impact runtime identity or lifecycle delegation.
> 
> **Overview**
> Gateway `AgentRuntime` is rewritten from a delegating wrapper around `@tyrum/runtime-agent` into a subclass, removing most pass-through methods and relying on the base class for lifecycle orchestration while keeping gateway-specific dependency wiring and adapters.
> 
> `@tyrum/runtime-agent` now exposes package-owned accessors (e.g., `deps`, `agentId`, `workspaceId`, `tenantId`, timing settings, `cleanupAtMs`) and uses `runtimeOptions` internally, and guardian review code switches to `runtime.agentId` instead of reaching into `runtime.opts`.
> 
> Adds tests to lock in the extraction: a gateway unit test asserting subclass-based composition, and a runtime-agent unit test covering the new accessors and normalized context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b1d6d7faaaca5cbf1ae145f3b18ba961c38e184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->