### PR TITLE
Migrate execution engine core modules out of gateway and leave adapter wiring only (#1760)

### DIFF
--- a/packages/gateway/src/modules/execution/engine/attempt-runner-types.ts
+++ b/packages/gateway/src/modules/execution/engine/attempt-runner-types.ts
@@ -2,6 +2,7 @@ import type {
   ActionPrimitive as ActionPrimitiveT,
   ArtifactRef as ArtifactRefT,
 } from "@tyrum/contracts";
+import type { ExecuteAttemptOptions } from "@tyrum/runtime-execution";
 import type { SqlDb } from "../../../statestore/types.js";
 import type { Logger } from "../../observability/logger.js";
 import type { PolicyService } from "@tyrum/runtime-policy";
@@ -63,27 +64,7 @@ export interface ExecutionAttemptRunnerOptions {
   emitAttemptUpdatedTx: (tx: SqlDb, attemptId: string) => Promise<void>;
   emitStepUpdatedTx: (tx: SqlDb, stepId: string) => Promise<void>;
 }
-
-export interface ExecuteAttemptOptions {
-  planId: string;
-  stepIndex: number;
-  action: ActionPrimitiveT;
-  postconditionJson: string | null;
-  maxAttempts: number;
-  timeoutMs: number;
-  tenantId: string;
-  runId: string;
-  jobId: string;
-  agentId: string;
-  workspaceId: string;
-  key: string;
-  lane: string;
-  stepId: string;
-  attemptId: string;
-  attemptNum: number;
-  workerId: string;
-  executor: StepExecutor;
-}
+export type { ExecuteAttemptOptions } from "@tyrum/runtime-execution";
 
 export interface PreparedAttemptResult {
   result: StepResult;

--- a/packages/gateway/src/modules/execution/engine/clock.ts
+++ b/packages/gateway/src/modules/execution/engine/clock.ts
@@ -1,6 +1,0 @@
-import type { ExecutionClock } from "./types.js";
-
-export function defaultClock(): ExecutionClock {
-  const now = new Date();
-  return { nowMs: now.getTime(), nowIso: now.toISOString() };
-}

--- a/packages/gateway/src/modules/execution/engine/db.ts
+++ b/packages/gateway/src/modules/execution/engine/db.ts
@@ -1,23 +1,5 @@
+export { parsePlanIdFromTriggerJson } from "@tyrum/runtime-execution";
 import { DEFAULT_WORKSPACE_KEY, WorkspaceKey } from "@tyrum/contracts";
-
-export function parsePlanIdFromTriggerJson(triggerJson: string): string | undefined {
-  try {
-    const parsed = JSON.parse(triggerJson) as unknown;
-    if (parsed && typeof parsed === "object") {
-      const metadata = (parsed as Record<string, unknown>)["metadata"];
-      if (metadata && typeof metadata === "object") {
-        const planId = (metadata as Record<string, unknown>)["plan_id"];
-        if (typeof planId === "string" && planId.trim().length > 0) {
-          return planId;
-        }
-      }
-    }
-  } catch (err) {
-    // Intentional: caller treats invalid JSON as missing metadata.
-    void err;
-  }
-  return undefined;
-}
 
 export function normalizeWorkspaceKey(input: string | undefined): string {
   const trimmed = input?.trim();

--- a/packages/gateway/src/modules/execution/engine/execution-engine.ts
+++ b/packages/gateway/src/modules/execution/engine/execution-engine.ts
@@ -2,52 +2,88 @@ import type {
   ActionPrimitive as ActionPrimitiveT,
   ArtifactRef as ArtifactRefT,
 } from "@tyrum/contracts";
-import type { RedactionEngine } from "../../redaction/engine.js";
-import type { Logger } from "../../observability/logger.js";
+import { parseTyrumKey, WorkspaceKey } from "@tyrum/contracts";
+import {
+  defaultExecutionClock,
+  ExecutionEngine as RuntimeExecutionEngine,
+  type ClockFn,
+  type EnqueuePlanInput,
+  type EnqueuePlanResult,
+  type ExecutionConcurrencyLimits,
+  type StepExecutionContext,
+  type StepExecutor,
+  type StepResult,
+  type WorkerTickInput,
+} from "@tyrum/runtime-execution";
 import type { PolicyService } from "@tyrum/runtime-policy";
-import type { SecretProvider } from "../../secret/provider.js";
+import type { SqlDb } from "../../../statestore/types.js";
+import { IdentityScopeDal, requirePrimaryAgentId } from "../../identity/scope.js";
+import type { Logger } from "../../observability/logger.js";
+import type { RedactionEngine } from "../../redaction/engine.js";
 import { collectSecretHandleIds } from "../../secret/collect-secret-handle-ids.js";
 import { createSecretHandleResolver } from "../../secret/handle-resolver.js";
-import type { SqlDb } from "../../../statestore/types.js";
+import type { SecretProvider } from "../../secret/provider.js";
+import { ExecutionAttemptRunner } from "./attempt-runner.js";
 import { ExecutionEngineApprovalManager } from "./approval-manager.js";
-import { ExecutionAttemptRunner, type ExecuteAttemptOptions } from "./attempt-runner.js";
-import { defaultClock } from "./clock.js";
 import { ExecutionEngineArtifactRecorder } from "./artifact-recorder.js";
-import { executeWithTimeout as executeWithTimeoutFn } from "./concurrency-manager.js";
+import {
+  executeWithTimeout as executeWithTimeoutFn,
+  releaseConcurrencySlotsTx,
+} from "./concurrency-manager.js";
 import { ExecutionEngineEventEmitter } from "./event-emitter.js";
-import { parsePlanIdFromTriggerJson } from "./db.js";
-import type {
-  ClockFn,
-  EnqueuePlanInput,
-  EnqueuePlanResult,
-  ExecutionApprovalPort,
-  ExecutionArtifactPort,
-  ExecutionConcurrencyLimits,
-  ExecutionEventPort,
-  StepExecutionContext,
-  StepExecutor,
-  StepResult,
-  WorkerTickInput,
-} from "./types.js";
-import { listRunnableRunCandidates, tryAcquireRunLaneLease } from "./leasing.js";
-import { enqueuePlan, enqueuePlanInTx } from "./queueing.js";
-import { cancelRun, resumeRun } from "./run-control.js";
-import { claimStepExecution } from "./step-execution.js";
 import { maybePauseForToolIntentGuardrailTx } from "./execution-engine-intent-guardrail.js";
+import { listRunnableRunCandidates, tryAcquireRunLaneLease } from "./leasing.js";
+import { claimStepExecution } from "./step-execution.js";
+import { normalizeWorkspaceKey } from "./db.js";
 
-export class ExecutionEngine {
-  private readonly db: SqlDb;
-  private readonly clock: ClockFn;
-  private readonly redactionEngine?: RedactionEngine;
-  private readonly secretProviderForTenant?: (tenantId: string) => SecretProvider;
-  private readonly logger?: Logger;
-  private readonly policyService?: PolicyService;
-  private readonly eventsEnabled: boolean;
-  private readonly eventEmitter: ExecutionEventPort<SqlDb>;
-  private readonly artifactRecorder: ExecutionArtifactPort<SqlDb>;
-  private readonly approvalManager: ExecutionApprovalPort<SqlDb>;
-  private readonly attemptRunner: ExecutionAttemptRunner;
-  private readonly concurrencyLimits?: ExecutionConcurrencyLimits;
+async function resolveExecutionAgentId(tx: SqlDb, tenantId: string, key: string): Promise<string> {
+  const identityScopeDal = new IdentityScopeDal(tx);
+  try {
+    const parsedKey = parseTyrumKey(key as never);
+    if (parsedKey.kind === "agent") {
+      return await identityScopeDal.ensureAgentId(tenantId, parsedKey.agent_key);
+    }
+  } catch {
+    // Execution keys are broader than agent-scoped session keys; fall back to the
+    // existing primary agent for internal workflow lanes that do not encode an agent key.
+  }
+
+  return await requirePrimaryAgentId(identityScopeDal, tenantId);
+}
+
+async function resolveWorkspaceId(
+  tx: SqlDb,
+  tenantId: string,
+  input: EnqueuePlanInput,
+): Promise<string> {
+  const identityScopeDal = new IdentityScopeDal(tx);
+  const explicitWorkspaceKey = input.workspaceKey?.trim();
+  if (explicitWorkspaceKey) {
+    return await identityScopeDal.ensureWorkspaceId(tenantId, explicitWorkspaceKey);
+  }
+
+  const legacyWorkspace = input.workspaceId?.trim();
+  if (!legacyWorkspace) {
+    return await identityScopeDal.ensureWorkspaceId(tenantId, normalizeWorkspaceKey(undefined));
+  }
+
+  const existing = await tx.get<{ workspace_id: string }>(
+    "SELECT workspace_id FROM workspaces WHERE tenant_id = ? AND workspace_id = ? LIMIT 1",
+    [tenantId, legacyWorkspace],
+  );
+  if (existing?.workspace_id) {
+    return existing.workspace_id;
+  }
+
+  if (WorkspaceKey.safeParse(legacyWorkspace).success) {
+    return await identityScopeDal.ensureWorkspaceId(tenantId, legacyWorkspace);
+  }
+
+  return await identityScopeDal.ensureWorkspaceId(tenantId, normalizeWorkspaceKey(legacyWorkspace));
+}
+
+export class ExecutionEngine extends RuntimeExecutionEngine<SqlDb> {
+  private readonly eventEmitter: ExecutionEngineEventEmitter;
 
   constructor(opts: {
     db: SqlDb;
@@ -59,322 +95,197 @@ export class ExecutionEngine {
     eventsEnabled?: boolean;
     concurrencyLimits?: ExecutionConcurrencyLimits;
   }) {
-    this.db = opts.db;
-    this.clock = opts.clock ?? defaultClock;
-    this.redactionEngine = opts.redactionEngine;
-    this.secretProviderForTenant = opts.secretProviderForTenant;
-    this.logger = opts.logger;
-    this.policyService = opts.policyService;
-    this.eventsEnabled = opts.eventsEnabled ?? true;
-    this.concurrencyLimits = opts.concurrencyLimits;
-    this.eventEmitter = new ExecutionEngineEventEmitter({
-      clock: this.clock,
-      eventsEnabled: this.eventsEnabled,
+    const clock = opts.clock ?? defaultExecutionClock;
+    const redactUnknown = <T>(value: T): T =>
+      opts.redactionEngine ? (opts.redactionEngine.redactUnknown(value).redacted as T) : value;
+    const redactText = (text: string): string =>
+      opts.redactionEngine ? opts.redactionEngine.redactText(text).redacted : text;
+    const resolveSecretScopesFromArgs = async (
+      tenantId: string,
+      args: unknown,
+      context?: { runId?: string; stepId?: string; attemptId?: string },
+    ): Promise<string[]> => {
+      const handleIds = collectSecretHandleIds(args);
+      if (handleIds.length === 0) return [];
+
+      const secretProvider = opts.secretProviderForTenant?.(tenantId);
+      if (!secretProvider) {
+        return handleIds;
+      }
+
+      try {
+        return await createSecretHandleResolver(secretProvider).resolveScopes(handleIds);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        opts.logger?.warn("execution.secret_provider_list_failed", {
+          tenant_id: tenantId,
+          run_id: context?.runId,
+          step_id: context?.stepId,
+          attempt_id: context?.attemptId,
+          error: message,
+        });
+        return handleIds;
+      }
+    };
+    const eventEmitter = new ExecutionEngineEventEmitter({
+      clock,
+      eventsEnabled: opts.eventsEnabled ?? true,
     });
-    this.artifactRecorder = new ExecutionEngineArtifactRecorder({
-      eventEmitter: this.eventEmitter,
-      redactUnknown: (value) => this.redactUnknown(value),
+    const emitRunUpdatedTx = async (tx: SqlDb, runId: string) =>
+      await eventEmitter.emitRunUpdatedTx(tx, runId);
+    const emitStepUpdatedTx = async (tx: SqlDb, stepId: string) =>
+      await eventEmitter.emitStepUpdatedTx(tx, stepId);
+    const emitAttemptUpdatedTx = async (tx: SqlDb, attemptId: string) =>
+      await eventEmitter.emitAttemptUpdatedTx(tx, attemptId);
+    const emitRunIdEventTx = async (
+      tx: SqlDb,
+      type: "run.queued" | "run.started" | "run.resumed" | "run.completed" | "run.failed",
+      runId: string,
+    ) => await eventEmitter.emitRunIdEventTx(tx, type, runId);
+    const emitRunQueuedTx = async (tx: SqlDb, runId: string) =>
+      await emitRunIdEventTx(tx, "run.queued", runId);
+    const emitRunStartedTx = async (tx: SqlDb, runId: string) =>
+      await emitRunIdEventTx(tx, "run.started", runId);
+    const emitRunResumedTx = async (tx: SqlDb, runId: string) =>
+      await emitRunIdEventTx(tx, "run.resumed", runId);
+    const emitRunCompletedTx = async (tx: SqlDb, runId: string) =>
+      await emitRunIdEventTx(tx, "run.completed", runId);
+    const emitRunFailedTx = async (tx: SqlDb, runId: string) =>
+      await emitRunIdEventTx(tx, "run.failed", runId);
+    const emitRunCancelledTx = async (tx: SqlDb, cancelOpts: { runId: string; reason?: string }) =>
+      await eventEmitter.emitRunCancelledTx(tx, cancelOpts);
+    const artifactRecorder = new ExecutionEngineArtifactRecorder({
+      eventEmitter,
+      redactUnknown: (value) => redactUnknown(value),
     });
-    this.approvalManager = new ExecutionEngineApprovalManager({
-      clock: this.clock,
-      logger: this.logger,
-      policyService: this.policyService,
-      redactText: (value) => this.redactText(value),
-      redactUnknown: (value) => this.redactUnknown(value),
-      eventEmitter: this.eventEmitter,
+    const recordArtifactsTx = async (
+      tx: SqlDb,
+      scope: {
+        tenantId: string;
+        runId: string;
+        stepId: string;
+        attemptId: string;
+        workspaceId: string;
+        agentId: string | null;
+      },
+      artifacts: ArtifactRefT[],
+    ) => await artifactRecorder.recordArtifactsTx(tx, scope, artifacts);
+    const approvalManager = new ExecutionEngineApprovalManager({
+      clock,
+      logger: opts.logger,
+      policyService: opts.policyService,
+      redactText: (value) => redactText(value),
+      redactUnknown: (value) => redactUnknown(value),
+      eventEmitter,
     });
-    this.attemptRunner = new ExecutionAttemptRunner({
-      db: this.db,
-      clock: this.clock,
-      logger: this.logger,
-      policyService: this.policyService,
-      concurrencyLimits: this.concurrencyLimits,
-      redactText: (text) => this.redactText(text),
-      redactUnknown: (value) => this.redactUnknown(value),
+    const isApprovedPolicyGateTx = async (
+      tx: SqlDb,
+      tenantId: string,
+      approvalId: string | null,
+    ): Promise<boolean> => {
+      if (approvalId === null) return false;
+      const row = await tx.get<{ kind: string; status: string }>(
+        "SELECT kind, status FROM approvals WHERE tenant_id = ? AND approval_id = ? LIMIT 1",
+        [tenantId, approvalId],
+      );
+      if (!row) return false;
+      return row.kind === "policy" && row.status === "approved";
+    };
+    let attemptRunner!: ExecutionAttemptRunner;
+
+    super({
+      db: opts.db,
+      clock,
+      logger: opts.logger,
+      concurrencyLimits: opts.concurrencyLimits,
+      scopeResolver: {
+        resolveExecutionAgentId: async (tx, tenantId, key) =>
+          await resolveExecutionAgentId(tx, tenantId, key),
+        resolveWorkspaceId: async (tx, tenantId, input) =>
+          await resolveWorkspaceId(tx, tenantId, input),
+        ensureMembership: async (tx, tenantId, agentId, workspaceId) => {
+          const identityScopeDal = new IdentityScopeDal(tx);
+          await identityScopeDal.ensureMembership(tenantId, agentId, workspaceId);
+        },
+      },
+      releaseConcurrencySlotsTx: async (tx, tenantId, attemptId, nowIso, limits) =>
+        await releaseConcurrencySlotsTx(tx, tenantId, attemptId, nowIso, limits),
+      listRunnableRunCandidates: async (runId) => await listRunnableRunCandidates(opts.db, runId),
+      tryAcquireRunLaneLease: async (run, workerId, nowMs) =>
+        await tryAcquireRunLaneLease(opts.db, run, workerId, nowMs),
+      claimStepExecution: async (run, workerId, engineClock) =>
+        await claimStepExecution(
+          {
+            db: opts.db,
+            logger: opts.logger,
+            policyService: opts.policyService,
+            approvalManager,
+            concurrencyLimits: opts.concurrencyLimits,
+            redactText: (text) => redactText(text),
+            redactUnknown: (value) => redactUnknown(value),
+            emitRunUpdatedTx,
+            emitStepUpdatedTx,
+            emitAttemptUpdatedTx,
+            emitRunStartedTx,
+            emitRunCompletedTx,
+            emitRunFailedTx,
+            isApprovedPolicyGateTx,
+            resolveSecretScopesFromArgs,
+            maybePauseForToolIntentGuardrailTx: async (tx, guardrailOpts) =>
+              await maybePauseForToolIntentGuardrailTx(
+                { logger: opts.logger, approvalManager },
+                tx,
+                guardrailOpts,
+              ),
+          },
+          run,
+          workerId,
+          engineClock,
+        ),
+      executeAttempt: async (executeOpts) => await attemptRunner.executeAttempt(executeOpts),
+      emitRunUpdatedTx,
+      emitStepUpdatedTx,
+      emitAttemptUpdatedTx,
+      emitRunQueuedTx,
+      emitRunResumedTx,
+      emitRunCancelledTx,
+      redactText,
+    });
+
+    attemptRunner = new ExecutionAttemptRunner({
+      db: opts.db,
+      clock,
+      logger: opts.logger,
+      policyService: opts.policyService,
+      concurrencyLimits: opts.concurrencyLimits,
+      redactText: (text) => redactText(text),
+      redactUnknown: (value) => redactUnknown(value),
       executeWithTimeout: async (...args) => await this.executeWithTimeout(...args),
-      resolveSecretScopesFromArgs: async (tenantId, args, context) =>
-        await this.resolveSecretScopesFromArgs(tenantId, args, context),
+      resolveSecretScopesFromArgs,
       retryOrFailStep: async (retryOptions) =>
-        await this.approvalManager.maybeRetryOrFailStep(retryOptions),
+        await approvalManager.maybeRetryOrFailStep(retryOptions),
       pauseRunForApproval: async (tx, pauseOptions, input) =>
-        await this.approvalManager.pauseRunForApproval(tx, pauseOptions, input),
-      recordArtifactsTx: async (tx, scope, artifacts) =>
-        await this.recordArtifactsTx(tx, scope, artifacts),
-      emitAttemptUpdatedTx: async (tx, attemptId) => await this.emitAttemptUpdatedTx(tx, attemptId),
-      emitStepUpdatedTx: async (tx, stepId) => await this.emitStepUpdatedTx(tx, stepId),
+        await approvalManager.pauseRunForApproval(tx, pauseOptions, input),
+      recordArtifactsTx,
+      emitAttemptUpdatedTx,
+      emitStepUpdatedTx,
+    });
+
+    this.eventEmitter = eventEmitter;
+    Object.defineProperty(this, "approvalManager", {
+      value: approvalManager,
+      enumerable: false,
+      configurable: true,
+      writable: false,
     });
   }
 
-  private redactUnknown<T>(value: T): T {
-    return this.redactionEngine ? (this.redactionEngine.redactUnknown(value).redacted as T) : value;
-  }
-
-  private redactText(text: string): string {
-    return this.redactionEngine ? this.redactionEngine.redactText(text).redacted : text;
-  }
-
-  private async resolveSecretScopesFromArgs(
-    tenantId: string,
-    args: unknown,
-    context?: { runId?: string; stepId?: string; attemptId?: string },
-  ): Promise<string[]> {
-    const handleIds = collectSecretHandleIds(args);
-    if (handleIds.length === 0) return [];
-
-    const secretProvider = this.secretProviderForTenant?.(tenantId);
-    if (!secretProvider) {
-      return handleIds;
-    }
-
-    try {
-      return await createSecretHandleResolver(secretProvider).resolveScopes(handleIds);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger?.warn("execution.secret_provider_list_failed", {
-        tenant_id: tenantId,
-        run_id: context?.runId,
-        step_id: context?.stepId,
-        attempt_id: context?.attemptId,
-        error: message,
-      });
-      return handleIds;
-    }
-  }
-
-  private async isApprovedPolicyGateTx(
-    tx: SqlDb,
-    tenantId: string,
-    approvalId: string | null,
-  ): Promise<boolean> {
-    if (approvalId === null) return false;
-    const row = await tx.get<{ kind: string; status: string }>(
-      "SELECT kind, status FROM approvals WHERE tenant_id = ? AND approval_id = ? LIMIT 1",
-      [tenantId, approvalId],
-    );
-    if (!row) return false;
-    return row.kind === "policy" && row.status === "approved";
-  }
-
-  private async emitRunUpdatedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.eventEmitter.emitRunUpdatedTx(tx, runId);
-  }
-  private async emitStepUpdatedTx(tx: SqlDb, stepId: string): Promise<void> {
-    await this.eventEmitter.emitStepUpdatedTx(tx, stepId);
-  }
-  private async emitAttemptUpdatedTx(tx: SqlDb, attemptId: string): Promise<void> {
-    await this.eventEmitter.emitAttemptUpdatedTx(tx, attemptId);
-  }
-  private async emitRunIdEventTx(
+  protected async emitRunIdEventTx(
     tx: SqlDb,
     type: "run.queued" | "run.started" | "run.resumed" | "run.completed" | "run.failed",
     runId: string,
   ): Promise<void> {
     await this.eventEmitter.emitRunIdEventTx(tx, type, runId);
-  }
-  private async emitRunQueuedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.emitRunIdEventTx(tx, "run.queued", runId);
-  }
-  private async emitRunStartedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.emitRunIdEventTx(tx, "run.started", runId);
-  }
-  private async emitRunResumedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.emitRunIdEventTx(tx, "run.resumed", runId);
-  }
-  private async emitRunCompletedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.emitRunIdEventTx(tx, "run.completed", runId);
-  }
-  private async emitRunFailedTx(tx: SqlDb, runId: string): Promise<void> {
-    await this.emitRunIdEventTx(tx, "run.failed", runId);
-  }
-  private async emitRunCancelledTx(
-    tx: SqlDb,
-    opts: { runId: string; reason?: string },
-  ): Promise<void> {
-    await this.eventEmitter.emitRunCancelledTx(tx, opts);
-  }
-  private async recordArtifactsTx(
-    tx: SqlDb,
-    scope: {
-      tenantId: string;
-      runId: string;
-      stepId: string;
-      attemptId: string;
-      workspaceId: string;
-      agentId: string | null;
-    },
-    artifacts: ArtifactRefT[],
-  ): Promise<void> {
-    await this.artifactRecorder.recordArtifactsTx(tx, scope, artifacts);
-  }
-
-  async enqueuePlanInTx(tx: SqlDb, input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
-    return await enqueuePlanInTx(
-      {
-        db: this.db,
-        logger: this.logger,
-        emitRunUpdatedTx: async (innerTx, runId) => await this.emitRunUpdatedTx(innerTx, runId),
-        emitRunQueuedTx: async (innerTx, runId) => await this.emitRunQueuedTx(innerTx, runId),
-        emitStepUpdatedTx: async (innerTx, stepId) => await this.emitStepUpdatedTx(innerTx, stepId),
-        emitAttemptUpdatedTx: async (innerTx, attemptId) =>
-          await this.emitAttemptUpdatedTx(innerTx, attemptId),
-      },
-      tx,
-      input,
-    );
-  }
-
-  async enqueuePlan(input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
-    return await enqueuePlan(
-      {
-        db: this.db,
-        logger: this.logger,
-        emitRunUpdatedTx: async (tx, runId) => await this.emitRunUpdatedTx(tx, runId),
-        emitRunQueuedTx: async (tx, runId) => await this.emitRunQueuedTx(tx, runId),
-        emitStepUpdatedTx: async (tx, stepId) => await this.emitStepUpdatedTx(tx, stepId),
-        emitAttemptUpdatedTx: async (tx, attemptId) =>
-          await this.emitAttemptUpdatedTx(tx, attemptId),
-      },
-      input,
-    );
-  }
-
-  /**
-   * Resume a paused run using an opaque token.
-   *
-   * Returns the resumed run id on success, otherwise `undefined`.
-   */
-  async resumeRun(token: string): Promise<string | undefined> {
-    return await resumeRun(
-      {
-        db: this.db,
-        clock: this.clock,
-        redactText: (text) => this.redactText(text),
-        concurrencyLimits: this.concurrencyLimits,
-        emitRunUpdatedTx: async (tx, runId) => await this.emitRunUpdatedTx(tx, runId),
-        emitStepUpdatedTx: async (tx, stepId) => await this.emitStepUpdatedTx(tx, stepId),
-        emitAttemptUpdatedTx: async (tx, attemptId) =>
-          await this.emitAttemptUpdatedTx(tx, attemptId),
-        emitRunResumedTx: async (tx, runId) => await this.emitRunResumedTx(tx, runId),
-        emitRunCancelledTx: async (tx, opts) => await this.emitRunCancelledTx(tx, opts),
-      },
-      token,
-    );
-  }
-
-  async cancelRun(
-    runId: string,
-    reason?: string,
-  ): Promise<"cancelled" | "already_terminal" | "not_found"> {
-    return await cancelRun(
-      {
-        db: this.db,
-        clock: this.clock,
-        redactText: (text) => this.redactText(text),
-        concurrencyLimits: this.concurrencyLimits,
-        emitRunUpdatedTx: async (tx, runIdValue) => await this.emitRunUpdatedTx(tx, runIdValue),
-        emitStepUpdatedTx: async (tx, stepId) => await this.emitStepUpdatedTx(tx, stepId),
-        emitAttemptUpdatedTx: async (tx, attemptId) =>
-          await this.emitAttemptUpdatedTx(tx, attemptId),
-        emitRunResumedTx: async (tx, runIdValue) => await this.emitRunResumedTx(tx, runIdValue),
-        emitRunCancelledTx: async (tx, opts) => await this.emitRunCancelledTx(tx, opts),
-      },
-      runId,
-      reason,
-    );
-  }
-
-  async workerTick(input: WorkerTickInput): Promise<boolean> {
-    const { nowMs, nowIso } = this.clock();
-    const candidates = await listRunnableRunCandidates(this.db, input.runId);
-
-    for (const run of candidates) {
-      const leaseOk = await tryAcquireRunLaneLease(this.db, run, input.workerId, nowMs);
-      if (!leaseOk) continue;
-
-      try {
-        const outcome = await claimStepExecution(
-          {
-            db: this.db,
-            logger: this.logger,
-            policyService: this.policyService,
-            approvalManager: this.approvalManager,
-            concurrencyLimits: this.concurrencyLimits,
-            redactText: (text) => this.redactText(text),
-            redactUnknown: (value) => this.redactUnknown(value),
-            emitRunUpdatedTx: async (tx, runId) => await this.emitRunUpdatedTx(tx, runId),
-            emitStepUpdatedTx: async (tx, stepId) => await this.emitStepUpdatedTx(tx, stepId),
-            emitAttemptUpdatedTx: async (tx, attemptId) =>
-              await this.emitAttemptUpdatedTx(tx, attemptId),
-            emitRunStartedTx: async (tx, runId) => await this.emitRunStartedTx(tx, runId),
-            emitRunCompletedTx: async (tx, runId) => await this.emitRunCompletedTx(tx, runId),
-            emitRunFailedTx: async (tx, runId) => await this.emitRunFailedTx(tx, runId),
-            isApprovedPolicyGateTx: async (tx, tenantId, approvalId) =>
-              await this.isApprovedPolicyGateTx(tx, tenantId, approvalId),
-            resolveSecretScopesFromArgs: async (tenantId, args, context) =>
-              await this.resolveSecretScopesFromArgs(tenantId, args, context),
-            maybePauseForToolIntentGuardrailTx: async (tx, opts) =>
-              await maybePauseForToolIntentGuardrailTx(
-                { logger: this.logger, approvalManager: this.approvalManager },
-                tx,
-                opts,
-              ),
-          },
-          run,
-          input.workerId,
-          { nowMs, nowIso },
-        );
-        const didWork = await this.executeClaimedStep(outcome, input);
-        if (didWork) return true;
-      } finally {
-        // Lane leases are held across the whole run while it's active.
-        // The tick function releases on completion/failure. On transient
-        // errors we still keep the lease for a short TTL to reduce stampedes.
-      }
-    }
-
-    return false;
-  }
-
-  private async executeClaimedStep(
-    outcome: Awaited<ReturnType<typeof claimStepExecution>>,
-    input: WorkerTickInput,
-  ): Promise<boolean> {
-    if (outcome.kind === "noop") return false;
-    if (outcome.kind === "recovered") return true;
-    if (outcome.kind === "finalized") return true;
-    if (outcome.kind === "idempotent") return true;
-    if (outcome.kind === "cancelled") return true;
-    if (outcome.kind === "paused") return true;
-
-    const planId = parsePlanIdFromTriggerJson(outcome.triggerJson) ?? outcome.runId;
-
-    const action = JSON.parse(outcome.step.action_json) as ActionPrimitiveT;
-    const timeoutMs = Math.max(1, outcome.step.timeout_ms);
-
-    return await this.executeAttempt({
-      planId,
-      stepIndex: outcome.step.step_index,
-      action,
-      postconditionJson: outcome.step.postcondition_json,
-      maxAttempts: outcome.step.max_attempts,
-      timeoutMs,
-      tenantId: outcome.tenantId,
-      runId: outcome.runId,
-      jobId: outcome.jobId,
-      agentId: outcome.agentId,
-      workspaceId: outcome.workspaceId,
-      key: outcome.key,
-      lane: outcome.lane,
-      stepId: outcome.step.step_id,
-      attemptId: outcome.attempt.attemptId,
-      attemptNum: outcome.attempt.attemptNum,
-      workerId: input.workerId,
-      executor: input.executor,
-    });
-  }
-
-  private async executeAttempt(opts: ExecuteAttemptOptions): Promise<boolean> {
-    return await this.attemptRunner.executeAttempt(opts);
   }
 
   private async executeWithTimeout(
@@ -386,5 +297,30 @@ export class ExecutionEngine {
     context: StepExecutionContext,
   ): Promise<StepResult> {
     return await executeWithTimeoutFn(executor, action, planId, stepIndex, timeoutMs, context);
+  }
+
+  // Keep the gateway surface typed and explicit even though the runtime core now
+  // owns the orchestration methods.
+  override async enqueuePlanInTx(tx: SqlDb, input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
+    return await super.enqueuePlanInTx(tx, input);
+  }
+
+  override async enqueuePlan(input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
+    return await super.enqueuePlan(input);
+  }
+
+  override async resumeRun(token: string): Promise<string | undefined> {
+    return await super.resumeRun(token);
+  }
+
+  override async cancelRun(
+    runId: string,
+    reason?: string,
+  ): Promise<"cancelled" | "already_terminal" | "not_found"> {
+    return await super.cancelRun(runId, reason);
+  }
+
+  override async workerTick(input: WorkerTickInput): Promise<boolean> {
+    return await super.workerTick(input);
   }
 }

--- a/packages/gateway/src/modules/execution/engine/step-execution.ts
+++ b/packages/gateway/src/modules/execution/engine/step-execution.ts
@@ -1,4 +1,5 @@
 import type { ActionPrimitive as ActionPrimitiveT } from "@tyrum/contracts";
+import type { StepClaimOutcome } from "@tyrum/runtime-execution";
 import type { Logger } from "../../observability/logger.js";
 import type { PolicyService } from "@tyrum/runtime-policy";
 import type { SqlDb } from "../../../statestore/types.js";
@@ -11,29 +12,7 @@ import {
 import { type RunnableRunRow, type StepRow } from "./shared.js";
 import type { ExecutionApprovalPort, ExecutionClock, ExecutionConcurrencyLimits } from "./types.js";
 
-export type StepClaimOutcome =
-  | { kind: "noop" }
-  | { kind: "recovered" }
-  | { kind: "finalized" }
-  | { kind: "idempotent" }
-  | { kind: "cancelled" }
-  | { kind: "paused"; reason: "budget" | "policy" | "approval"; approvalId: string }
-  | {
-      kind: "claimed";
-      tenantId: string;
-      agentId: string;
-      runId: string;
-      jobId: string;
-      workspaceId: string;
-      key: string;
-      lane: string;
-      triggerJson: string;
-      step: StepRow;
-      attempt: {
-        attemptId: string;
-        attemptNum: number;
-      };
-    };
+export type { StepClaimOutcome } from "@tyrum/runtime-execution";
 
 export interface StepExecutionClaimDeps {
   db: SqlDb;

--- a/packages/gateway/tests/unit/execution-engine-core-extraction.test.ts
+++ b/packages/gateway/tests/unit/execution-engine-core-extraction.test.ts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("execution engine core extraction", () => {
+  it("sources the gateway execution engine wrapper from @tyrum/runtime-execution", async () => {
+    const runtimeWrapperPath = join(
+      __dirname,
+      "../../src/modules/execution/engine/execution-engine.ts",
+    );
+    const raw = await readFile(runtimeWrapperPath, "utf-8");
+
+    expect(raw).toContain('from "@tyrum/runtime-execution"');
+  });
+});

--- a/packages/gateway/tests/unit/ws-router-handler-extraction.test.ts
+++ b/packages/gateway/tests/unit/ws-router-handler-extraction.test.ts
@@ -113,7 +113,7 @@ describe("remaining WS handler extraction", () => {
     vi.restoreAllMocks();
   });
 
-  it("routes response envelopes through response-handlers", async () => {
+  it("routes response envelopes through response-handlers", { timeout: 10_000 }, async () => {
     const client = createAdminWsClient({ role: "node" });
     const deps = {};
     const raw = JSON.stringify({

--- a/packages/runtime-execution/src/engine/db.ts
+++ b/packages/runtime-execution/src/engine/db.ts
@@ -1,0 +1,18 @@
+export function parsePlanIdFromTriggerJson(triggerJson: string): string | undefined {
+  try {
+    const parsed = JSON.parse(triggerJson) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const metadata = (parsed as Record<string, unknown>)["metadata"];
+      if (metadata && typeof metadata === "object") {
+        const planId = (metadata as Record<string, unknown>)["plan_id"];
+        if (typeof planId === "string" && planId.trim().length > 0) {
+          return planId;
+        }
+      }
+    }
+  } catch (err) {
+    // Intentional: caller treats invalid JSON as missing metadata.
+    void err;
+  }
+  return undefined;
+}

--- a/packages/runtime-execution/src/engine/execution-engine.ts
+++ b/packages/runtime-execution/src/engine/execution-engine.ts
@@ -1,0 +1,196 @@
+import type { ActionPrimitive as ActionPrimitiveT } from "@tyrum/contracts";
+import { parsePlanIdFromTriggerJson } from "./db.js";
+import { enqueuePlan, enqueuePlanInTx } from "./queueing.js";
+import { cancelRun, resumeRun } from "./run-control.js";
+import type {
+  ClockFn,
+  EnqueuePlanInput,
+  EnqueuePlanResult,
+  ExecutionClock,
+  ExecutionConcurrencyLimits,
+  ExecutionDb,
+  ExecutionEngineLogger,
+  ExecutionRunEventPort,
+  ExecutionScopeResolver,
+  ExecuteAttemptOptions,
+  RunnableRunRow,
+  StepClaimOutcome,
+  WorkerTickInput,
+} from "./types.js";
+
+export function defaultExecutionClock(): ExecutionClock {
+  const now = new Date();
+  return { nowMs: now.getTime(), nowIso: now.toISOString() };
+}
+
+export interface ExecutionEngineOptions<
+  TDb extends ExecutionDb<TDb>,
+> extends ExecutionRunEventPort<TDb> {
+  db: TDb;
+  clock?: ClockFn;
+  logger?: ExecutionEngineLogger;
+  concurrencyLimits?: ExecutionConcurrencyLimits;
+  scopeResolver: ExecutionScopeResolver<TDb>;
+  releaseConcurrencySlotsTx(
+    tx: TDb,
+    tenantId: string,
+    attemptId: string,
+    nowIso: string,
+    concurrencyLimits?: ExecutionConcurrencyLimits,
+  ): Promise<void>;
+  listRunnableRunCandidates(runId?: string): Promise<RunnableRunRow[]>;
+  tryAcquireRunLaneLease(run: RunnableRunRow, workerId: string, nowMs: number): Promise<boolean>;
+  claimStepExecution(
+    run: RunnableRunRow,
+    workerId: string,
+    clock: ExecutionClock,
+  ): Promise<StepClaimOutcome>;
+  executeAttempt(opts: ExecuteAttemptOptions): Promise<boolean>;
+  emitRunQueuedTx(tx: TDb, runId: string): Promise<void>;
+  emitRunResumedTx(tx: TDb, runId: string): Promise<void>;
+  emitRunCancelledTx(tx: TDb, opts: { runId: string; reason?: string }): Promise<void>;
+  redactText?(text: string): string;
+}
+
+export class ExecutionEngine<TDb extends ExecutionDb<TDb>> {
+  private readonly clock: ClockFn;
+  private readonly redactText: (text: string) => string;
+
+  constructor(private readonly opts: ExecutionEngineOptions<TDb>) {
+    this.clock = opts.clock ?? defaultExecutionClock;
+    this.redactText = opts.redactText ?? ((text) => text);
+  }
+
+  async enqueuePlanInTx(tx: TDb, input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
+    return await enqueuePlanInTx(
+      {
+        db: this.opts.db,
+        logger: this.opts.logger,
+        scopeResolver: this.opts.scopeResolver,
+        emitRunUpdatedTx: async (innerTx, runId) =>
+          await this.opts.emitRunUpdatedTx(innerTx, runId),
+        emitRunQueuedTx: async (innerTx, runId) => await this.opts.emitRunQueuedTx(innerTx, runId),
+        emitStepUpdatedTx: async (innerTx, stepId) =>
+          await this.opts.emitStepUpdatedTx(innerTx, stepId),
+        emitAttemptUpdatedTx: async (innerTx, attemptId) =>
+          await this.opts.emitAttemptUpdatedTx(innerTx, attemptId),
+      },
+      tx,
+      input,
+    );
+  }
+
+  async enqueuePlan(input: EnqueuePlanInput): Promise<EnqueuePlanResult> {
+    return await enqueuePlan(
+      {
+        db: this.opts.db,
+        logger: this.opts.logger,
+        scopeResolver: this.opts.scopeResolver,
+        emitRunUpdatedTx: async (tx, runId) => await this.opts.emitRunUpdatedTx(tx, runId),
+        emitRunQueuedTx: async (tx, runId) => await this.opts.emitRunQueuedTx(tx, runId),
+        emitStepUpdatedTx: async (tx, stepId) => await this.opts.emitStepUpdatedTx(tx, stepId),
+        emitAttemptUpdatedTx: async (tx, attemptId) =>
+          await this.opts.emitAttemptUpdatedTx(tx, attemptId),
+      },
+      input,
+    );
+  }
+
+  async resumeRun(token: string): Promise<string | undefined> {
+    return await resumeRun(
+      {
+        db: this.opts.db,
+        clock: this.clock,
+        redactText: this.redactText,
+        concurrencyLimits: this.opts.concurrencyLimits,
+        emitRunUpdatedTx: async (tx, runId) => await this.opts.emitRunUpdatedTx(tx, runId),
+        emitStepUpdatedTx: async (tx, stepId) => await this.opts.emitStepUpdatedTx(tx, stepId),
+        emitAttemptUpdatedTx: async (tx, attemptId) =>
+          await this.opts.emitAttemptUpdatedTx(tx, attemptId),
+        emitRunResumedTx: async (tx, runId) => await this.opts.emitRunResumedTx(tx, runId),
+        emitRunCancelledTx: async (tx, opts) => await this.opts.emitRunCancelledTx(tx, opts),
+        releaseConcurrencySlotsTx: async (tx, tenantId, attemptId, nowIso, limits) =>
+          await this.opts.releaseConcurrencySlotsTx(tx, tenantId, attemptId, nowIso, limits),
+      },
+      token,
+    );
+  }
+
+  async cancelRun(
+    runId: string,
+    reason?: string,
+  ): Promise<"cancelled" | "already_terminal" | "not_found"> {
+    return await cancelRun(
+      {
+        db: this.opts.db,
+        clock: this.clock,
+        redactText: this.redactText,
+        concurrencyLimits: this.opts.concurrencyLimits,
+        emitRunUpdatedTx: async (tx, runIdValue) =>
+          await this.opts.emitRunUpdatedTx(tx, runIdValue),
+        emitStepUpdatedTx: async (tx, stepId) => await this.opts.emitStepUpdatedTx(tx, stepId),
+        emitAttemptUpdatedTx: async (tx, attemptId) =>
+          await this.opts.emitAttemptUpdatedTx(tx, attemptId),
+        emitRunResumedTx: async (tx, runIdValue) =>
+          await this.opts.emitRunResumedTx(tx, runIdValue),
+        emitRunCancelledTx: async (tx, opts) => await this.opts.emitRunCancelledTx(tx, opts),
+        releaseConcurrencySlotsTx: async (tx, tenantId, attemptId, nowIso, limits) =>
+          await this.opts.releaseConcurrencySlotsTx(tx, tenantId, attemptId, nowIso, limits),
+      },
+      runId,
+      reason,
+    );
+  }
+
+  async workerTick(input: WorkerTickInput): Promise<boolean> {
+    const { nowMs, nowIso } = this.clock();
+    const candidates = await this.opts.listRunnableRunCandidates(input.runId);
+
+    for (const run of candidates) {
+      const leaseOk = await this.opts.tryAcquireRunLaneLease(run, input.workerId, nowMs);
+      if (!leaseOk) continue;
+
+      const outcome = await this.opts.claimStepExecution(run, input.workerId, { nowMs, nowIso });
+      const didWork = await this.executeClaimedStep(outcome, input);
+      if (didWork) return true;
+    }
+
+    return false;
+  }
+
+  private async executeClaimedStep(
+    outcome: StepClaimOutcome,
+    input: WorkerTickInput,
+  ): Promise<boolean> {
+    if (outcome.kind === "noop") return false;
+    if (outcome.kind === "recovered") return true;
+    if (outcome.kind === "finalized") return true;
+    if (outcome.kind === "idempotent") return true;
+    if (outcome.kind === "cancelled") return true;
+    if (outcome.kind === "paused") return true;
+
+    const planId = parsePlanIdFromTriggerJson(outcome.triggerJson) ?? outcome.runId;
+    const action = JSON.parse(outcome.step.action_json) as ActionPrimitiveT;
+
+    return await this.opts.executeAttempt({
+      planId,
+      stepIndex: outcome.step.step_index,
+      action,
+      postconditionJson: outcome.step.postcondition_json,
+      maxAttempts: outcome.step.max_attempts,
+      timeoutMs: Math.max(1, outcome.step.timeout_ms),
+      tenantId: outcome.tenantId,
+      runId: outcome.runId,
+      jobId: outcome.jobId,
+      agentId: outcome.agentId,
+      workspaceId: outcome.workspaceId,
+      key: outcome.key,
+      lane: outcome.lane,
+      stepId: outcome.step.step_id,
+      attemptId: outcome.attempt.attemptId,
+      attemptNum: outcome.attempt.attemptNum,
+      workerId: input.workerId,
+      executor: input.executor,
+    });
+  }
+}

--- a/packages/runtime-execution/src/engine/queueing.ts
+++ b/packages/runtime-execution/src/engine/queueing.ts
@@ -1,28 +1,52 @@
 import { randomUUID } from "node:crypto";
 import type { ExecutionTrigger as ExecutionTriggerT } from "@tyrum/contracts";
-import { parseTyrumKey, WorkspaceKey } from "@tyrum/contracts";
-import { IdentityScopeDal, requirePrimaryAgentId } from "../../identity/scope.js";
-import type { SqlDb } from "../../../statestore/types.js";
-import { normalizeWorkspaceKey } from "./db.js";
-import type { EnqueuePlanInput, EnqueuePlanResult } from "./types.js";
-import type { QueueingDeps } from "./shared.js";
+import type {
+  EnqueuePlanInput,
+  EnqueuePlanResult,
+  ExecutionDb,
+  ExecutionEngineLogger,
+  ExecutionRunEventPort,
+  ExecutionScopeResolver,
+} from "./types.js";
 
-export async function enqueuePlanInTx(
-  deps: QueueingDeps,
-  tx: SqlDb,
+interface QueueingDeps<TDb extends ExecutionDb<TDb>> extends ExecutionRunEventPort<TDb> {
+  db: TDb;
+  logger?: ExecutionEngineLogger;
+  scopeResolver: ExecutionScopeResolver<TDb>;
+  emitRunQueuedTx(tx: TDb, runId: string): Promise<void>;
+}
+
+function normalizeTriggerKind(value: unknown): ExecutionTriggerT["kind"] {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (
+    normalized === "session" ||
+    normalized === "cron" ||
+    normalized === "heartbeat" ||
+    normalized === "hook" ||
+    normalized === "webhook" ||
+    normalized === "manual" ||
+    normalized === "api"
+  ) {
+    return normalized;
+  }
+  return "session";
+}
+
+export async function enqueuePlanInTx<TDb extends ExecutionDb<TDb>>(
+  deps: QueueingDeps<TDb>,
+  tx: TDb,
   input: EnqueuePlanInput,
 ): Promise<EnqueuePlanResult> {
-  const jobId = randomUUID();
-  const runId = randomUUID();
   const tenantId = input.tenantId.trim();
   if (!tenantId) {
     throw new Error("tenantId is required to enqueue execution plans");
   }
 
-  const identityScopeDal = new IdentityScopeDal(tx);
-  const agentId = await resolveExecutionAgentId(identityScopeDal, tenantId, input.key);
-  const workspaceId = await resolveWorkspaceId(identityScopeDal, tx, tenantId, input);
-  await identityScopeDal.ensureMembership(tenantId, agentId, workspaceId);
+  const jobId = randomUUID();
+  const runId = randomUUID();
+  const agentId = await deps.scopeResolver.resolveExecutionAgentId(tx, tenantId, input.key);
+  const workspaceId = await deps.scopeResolver.resolveWorkspaceId(tx, tenantId, input);
+  await deps.scopeResolver.ensureMembership(tx, tenantId, agentId, workspaceId);
 
   const baseMetadata = {
     plan_id: input.planId,
@@ -32,26 +56,10 @@ export async function enqueuePlanInTx(
     workspace_id: workspaceId,
   };
 
-  const normalizeTriggerKind = (value: unknown): ExecutionTriggerT["kind"] => {
-    const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
-    if (
-      normalized === "session" ||
-      normalized === "cron" ||
-      normalized === "heartbeat" ||
-      normalized === "hook" ||
-      normalized === "webhook" ||
-      normalized === "manual" ||
-      normalized === "api"
-    ) {
-      return normalized;
-    }
-    return "session";
-  };
-
   const trigger = (() => {
     if (!input.trigger) {
       return {
-        kind: "session",
+        kind: "session" as const,
         key: input.key,
         lane: input.lane,
         metadata: baseMetadata,
@@ -66,11 +74,9 @@ export async function enqueuePlanInTx(
         ? { ...(provided["metadata"] as Record<string, unknown>), ...baseMetadata }
         : baseMetadata;
 
-    const kind = normalizeTriggerKind(provided["kind"]);
-
     return {
       ...provided,
-      kind,
+      kind: normalizeTriggerKind(provided["kind"]),
       key: typeof provided["key"] === "string" ? provided["key"] : input.key,
       lane: typeof provided["lane"] === "string" ? provided["lane"] : input.lane,
       metadata,
@@ -176,15 +182,13 @@ export async function enqueuePlanInTx(
   return { jobId, runId };
 }
 
-export async function enqueuePlan(
-  deps: QueueingDeps,
+export async function enqueuePlan<TDb extends ExecutionDb<TDb>>(
+  deps: QueueingDeps<TDb>,
   input: EnqueuePlanInput,
 ): Promise<EnqueuePlanResult> {
-  const res = await deps.db.transaction(async (tx) => {
-    return await enqueuePlanInTx(deps, tx, input);
-  });
+  const res = await deps.db.transaction(async (tx) => await enqueuePlanInTx(deps, tx, input));
 
-  deps.logger?.info("execution.enqueue", {
+  deps.logger?.info?.("execution.enqueue", {
     tenant_id: input.tenantId,
     request_id: input.requestId,
     plan_id: input.planId,
@@ -195,53 +199,4 @@ export async function enqueuePlan(
     steps_count: input.steps.length,
   });
   return res;
-}
-
-async function resolveExecutionAgentId(
-  identityScopeDal: IdentityScopeDal,
-  tenantId: string,
-  key: string,
-): Promise<string> {
-  try {
-    const parsedKey = parseTyrumKey(key as never);
-    if (parsedKey.kind === "agent") {
-      return await identityScopeDal.ensureAgentId(tenantId, parsedKey.agent_key);
-    }
-  } catch {
-    // Execution keys are broader than agent-scoped session keys; fall back to the
-    // existing primary agent for internal workflow lanes that do not encode an agent key.
-  }
-
-  return await requirePrimaryAgentId(identityScopeDal, tenantId);
-}
-
-async function resolveWorkspaceId(
-  identityScopeDal: IdentityScopeDal,
-  tx: SqlDb,
-  tenantId: string,
-  input: EnqueuePlanInput,
-): Promise<string> {
-  const explicitWorkspaceKey = input.workspaceKey?.trim();
-  if (explicitWorkspaceKey) {
-    return await identityScopeDal.ensureWorkspaceId(tenantId, explicitWorkspaceKey);
-  }
-
-  const legacyWorkspace = input.workspaceId?.trim();
-  if (!legacyWorkspace) {
-    return await identityScopeDal.ensureWorkspaceId(tenantId, normalizeWorkspaceKey(undefined));
-  }
-
-  const existing = await tx.get<{ workspace_id: string }>(
-    "SELECT workspace_id FROM workspaces WHERE tenant_id = ? AND workspace_id = ? LIMIT 1",
-    [tenantId, legacyWorkspace],
-  );
-  if (existing?.workspace_id) {
-    return existing.workspace_id;
-  }
-
-  if (WorkspaceKey.safeParse(legacyWorkspace).success) {
-    return await identityScopeDal.ensureWorkspaceId(tenantId, legacyWorkspace);
-  }
-
-  return await identityScopeDal.ensureWorkspaceId(tenantId, normalizeWorkspaceKey(legacyWorkspace));
 }

--- a/packages/runtime-execution/src/engine/run-control.ts
+++ b/packages/runtime-execution/src/engine/run-control.ts
@@ -1,8 +1,38 @@
-import { releaseConcurrencySlotsTx } from "./concurrency-manager.js";
-import type { RunControlDeps } from "./shared.js";
-import type { ResumeTokenRow } from "./shared.js";
+import type {
+  ClockFn,
+  ExecutionConcurrencyLimits,
+  ExecutionDb,
+  ExecutionRunEventPort,
+} from "./types.js";
 
-export async function resumeRun(deps: RunControlDeps, token: string): Promise<string | undefined> {
+interface RunControlDeps<TDb extends ExecutionDb<TDb>> extends ExecutionRunEventPort<TDb> {
+  db: TDb;
+  clock: ClockFn;
+  redactText(text: string): string;
+  concurrencyLimits?: ExecutionConcurrencyLimits;
+  emitRunResumedTx(tx: TDb, runId: string): Promise<void>;
+  emitRunCancelledTx(tx: TDb, opts: { runId: string; reason?: string }): Promise<void>;
+  releaseConcurrencySlotsTx(
+    tx: TDb,
+    tenantId: string,
+    attemptId: string,
+    nowIso: string,
+    concurrencyLimits?: ExecutionConcurrencyLimits,
+  ): Promise<void>;
+}
+
+interface ResumeTokenRow {
+  tenant_id: string;
+  token: string;
+  run_id: string;
+  expires_at: string | Date | null;
+  revoked_at: string | Date | null;
+}
+
+export async function resumeRun<TDb extends ExecutionDb<TDb>>(
+  deps: RunControlDeps<TDb>,
+  token: string,
+): Promise<string | undefined> {
   const { nowIso } = deps.clock();
   return await deps.db.transaction(async (tx) => {
     const row = await tx.get<ResumeTokenRow>(
@@ -11,8 +41,7 @@ export async function resumeRun(deps: RunControlDeps, token: string): Promise<st
        WHERE token = ?`,
       [token],
     );
-    if (!row) return undefined;
-    if (row.revoked_at) return undefined;
+    if (!row || row.revoked_at) return undefined;
 
     if (row.expires_at) {
       const expiresAtMs =
@@ -80,8 +109,8 @@ export async function resumeRun(deps: RunControlDeps, token: string): Promise<st
   });
 }
 
-export async function cancelRun(
-  deps: RunControlDeps,
+export async function cancelRun<TDb extends ExecutionDb<TDb>>(
+  deps: RunControlDeps<TDb>,
   runId: string,
   reason?: string,
 ): Promise<"cancelled" | "already_terminal" | "not_found"> {
@@ -166,7 +195,7 @@ export async function cancelRun(
     );
 
     for (const attempt of runningAttempts) {
-      await releaseConcurrencySlotsTx(
+      await deps.releaseConcurrencySlotsTx(
         tx,
         row.tenant_id,
         attempt.attempt_id,

--- a/packages/runtime-execution/src/engine/types.ts
+++ b/packages/runtime-execution/src/engine/types.ts
@@ -26,6 +26,22 @@ export interface StepResult {
   };
 }
 
+export interface ExecutionRunResult {
+  changes: number;
+}
+
+export interface ExecutionDb<TTx = unknown> {
+  get<T>(sql: string, params?: readonly unknown[]): Promise<T | undefined>;
+  all<T>(sql: string, params?: readonly unknown[]): Promise<T[]>;
+  run(sql: string, params?: readonly unknown[]): Promise<ExecutionRunResult>;
+  transaction<T>(fn: (tx: TTx) => Promise<T>): Promise<T>;
+}
+
+export interface ExecutionEngineLogger {
+  info?(message: string, attributes?: Record<string, unknown>): void;
+  warn?(message: string, attributes?: Record<string, unknown>): void;
+}
+
 export interface StepExecutionContext {
   tenantId: string;
   runId: string;
@@ -79,6 +95,12 @@ export interface EnqueuePlanInput {
 export interface EnqueuePlanResult {
   jobId: string;
   runId: string;
+}
+
+export interface ExecutionScopeResolver<TTx> {
+  resolveExecutionAgentId(tx: TTx, tenantId: string, key: string): Promise<string>;
+  resolveWorkspaceId(tx: TTx, tenantId: string, input: EnqueuePlanInput): Promise<string>;
+  ensureMembership(tx: TTx, tenantId: string, agentId: string, workspaceId: string): Promise<void>;
 }
 
 export interface WorkerTickInput {
@@ -247,4 +269,49 @@ export interface StepRow {
   approval_id: string | null;
   max_attempts: number;
   timeout_ms: number;
+}
+
+export type StepClaimOutcome =
+  | { kind: "noop" }
+  | { kind: "recovered" }
+  | { kind: "finalized" }
+  | { kind: "idempotent" }
+  | { kind: "cancelled" }
+  | { kind: "paused"; reason: "budget" | "policy" | "approval"; approvalId: string }
+  | {
+      kind: "claimed";
+      tenantId: string;
+      agentId: string;
+      runId: string;
+      jobId: string;
+      workspaceId: string;
+      key: string;
+      lane: string;
+      triggerJson: string;
+      step: StepRow;
+      attempt: {
+        attemptId: string;
+        attemptNum: number;
+      };
+    };
+
+export interface ExecuteAttemptOptions {
+  planId: string;
+  stepIndex: number;
+  action: ActionPrimitiveT;
+  postconditionJson: string | null;
+  maxAttempts: number;
+  timeoutMs: number;
+  tenantId: string;
+  runId: string;
+  jobId: string;
+  agentId: string;
+  workspaceId: string;
+  key: string;
+  lane: string;
+  stepId: string;
+  attemptId: string;
+  attemptNum: number;
+  workerId: string;
+  executor: StepExecutor;
 }

--- a/packages/runtime-execution/src/index.ts
+++ b/packages/runtime-execution/src/index.ts
@@ -4,8 +4,12 @@ export type {
   StepExecutor,
   ExecutionClock,
   ClockFn,
+  ExecutionRunResult,
+  ExecutionDb,
+  ExecutionEngineLogger,
   EnqueuePlanInput,
   EnqueuePlanResult,
+  ExecutionScopeResolver,
   WorkerTickInput,
   ExecutionConcurrencyLimits,
   ExecutionPauseRunForApprovalOptions,
@@ -19,7 +23,12 @@ export type {
   ResumeTokenRow,
   RunnableRunRow,
   StepRow,
+  StepClaimOutcome,
+  ExecuteAttemptOptions,
 } from "./engine/types.js";
+export type { ExecutionEngineOptions } from "./engine/execution-engine.js";
+export { defaultExecutionClock, ExecutionEngine } from "./engine/execution-engine.js";
+export { parsePlanIdFromTriggerJson } from "./engine/db.js";
 export type { TaskResult } from "./task-result-registry.js";
 export { TaskResultRegistry } from "./task-result-registry.js";
 export type {

--- a/packages/runtime-execution/tests/entrypoints.test.ts
+++ b/packages/runtime-execution/tests/entrypoints.test.ts
@@ -16,6 +16,7 @@ describe("@tyrum/runtime-execution entrypoints", () => {
   it("re-exports execution engine adapter ports from the package root", async () => {
     const indexSource = await readFile(resolve(__dirname, "../src/index.ts"), "utf8");
 
+    expect(indexSource).toContain("ExecutionEngine");
     expect(indexSource).toContain("ExecutionApprovalPort");
     expect(indexSource).toContain("ExecutionArtifactPort");
     expect(indexSource).toContain("ExecutionEventPort");

--- a/packages/runtime-execution/tests/execution-engine.test.ts
+++ b/packages/runtime-execution/tests/execution-engine.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ExecuteAttemptOptions,
+  ExecutionDb,
+  RunnableRunRow,
+  StepClaimOutcome,
+  StepExecutor,
+} from "../src/index.js";
+import { ExecutionEngine } from "../src/index.js";
+
+function createDb(): ExecutionDb {
+  const db: ExecutionDb = {
+    get: vi.fn(async () => undefined),
+    all: vi.fn(async () => []),
+    run: vi.fn(async () => ({ changes: 0 })),
+    transaction: async (fn) => await fn(db),
+  };
+  return db;
+}
+
+function createExecutor(): StepExecutor {
+  return {
+    execute: vi.fn(async () => ({ success: true })),
+  };
+}
+
+function createRun(): RunnableRunRow {
+  return {
+    tenant_id: "tenant-1",
+    run_id: "run-1",
+    job_id: "job-1",
+    agent_id: "agent-1",
+    key: "agent:agent-1:telegram-1:group:thread-1",
+    lane: "main",
+    status: "queued",
+    trigger_json: JSON.stringify({ metadata: { plan_id: "plan-123" } }),
+    workspace_id: "workspace-1",
+    policy_snapshot_id: null,
+  };
+}
+
+function createClaimedOutcome(): StepClaimOutcome {
+  return {
+    kind: "claimed",
+    tenantId: "tenant-1",
+    agentId: "agent-1",
+    runId: "run-1",
+    jobId: "job-1",
+    workspaceId: "workspace-1",
+    key: "agent:agent-1:telegram-1:group:thread-1",
+    lane: "main",
+    triggerJson: JSON.stringify({ metadata: { plan_id: "plan-123" } }),
+    step: {
+      tenant_id: "tenant-1",
+      step_id: "step-1",
+      run_id: "run-1",
+      step_index: 2,
+      status: "queued",
+      action_json: JSON.stringify({ type: "Research", args: { query: "status" } }),
+      created_at: new Date().toISOString(),
+      idempotency_key: null,
+      postcondition_json: null,
+      approval_id: null,
+      max_attempts: 3,
+      timeout_ms: 45_000,
+    },
+    attempt: {
+      attemptId: "attempt-1",
+      attemptNum: 1,
+    },
+  };
+}
+
+describe("ExecutionEngine", () => {
+  it("routes claimed steps through the extracted execution core", async () => {
+    const executeAttempt = vi.fn(async (_opts: ExecuteAttemptOptions) => true);
+    const listRunnableRunCandidates = vi.fn(async () => [createRun()]);
+    const tryAcquireRunLaneLease = vi.fn(async () => true);
+    const claimStepExecution = vi.fn(async () => createClaimedOutcome());
+
+    const engine = new ExecutionEngine({
+      db: createDb(),
+      clock: () => ({ nowMs: 1000, nowIso: "2026-01-01T00:00:01.000Z" }),
+      scopeResolver: {
+        resolveExecutionAgentId: vi.fn(async () => "agent-1"),
+        resolveWorkspaceId: vi.fn(async () => "workspace-1"),
+        ensureMembership: vi.fn(async () => undefined),
+      },
+      releaseConcurrencySlotsTx: vi.fn(async () => undefined),
+      listRunnableRunCandidates,
+      tryAcquireRunLaneLease,
+      claimStepExecution,
+      executeAttempt,
+      emitRunUpdatedTx: vi.fn(async () => undefined),
+      emitStepUpdatedTx: vi.fn(async () => undefined),
+      emitAttemptUpdatedTx: vi.fn(async () => undefined),
+      emitRunQueuedTx: vi.fn(async () => undefined),
+      emitRunResumedTx: vi.fn(async () => undefined),
+      emitRunCancelledTx: vi.fn(async () => undefined),
+    });
+
+    const worked = await engine.workerTick({
+      workerId: "worker-1",
+      executor: createExecutor(),
+    });
+
+    expect(worked).toBe(true);
+    expect(listRunnableRunCandidates).toHaveBeenCalledWith(undefined);
+    expect(tryAcquireRunLaneLease).toHaveBeenCalledWith(createRun(), "worker-1", 1000);
+    expect(claimStepExecution).toHaveBeenCalledWith(
+      expect.objectContaining({ run_id: "run-1" }),
+      "worker-1",
+      expect.objectContaining({ nowMs: 1000 }),
+    );
+    expect(executeAttempt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planId: "plan-123",
+        runId: "run-1",
+        stepIndex: 2,
+        timeoutMs: 45_000,
+        attemptId: "attempt-1",
+        attemptNum: 1,
+      }),
+    );
+  });
+
+  it("skips noop claims without invoking the attempt executor", async () => {
+    const executeAttempt = vi.fn(async (_opts: ExecuteAttemptOptions) => true);
+
+    const engine = new ExecutionEngine({
+      db: createDb(),
+      clock: () => ({ nowMs: 50, nowIso: "2026-01-01T00:00:00.050Z" }),
+      scopeResolver: {
+        resolveExecutionAgentId: vi.fn(async () => "agent-1"),
+        resolveWorkspaceId: vi.fn(async () => "workspace-1"),
+        ensureMembership: vi.fn(async () => undefined),
+      },
+      releaseConcurrencySlotsTx: vi.fn(async () => undefined),
+      listRunnableRunCandidates: vi.fn(async () => [createRun()]),
+      tryAcquireRunLaneLease: vi.fn(async () => true),
+      claimStepExecution: vi.fn(async () => ({ kind: "noop" })),
+      executeAttempt,
+      emitRunUpdatedTx: vi.fn(async () => undefined),
+      emitStepUpdatedTx: vi.fn(async () => undefined),
+      emitAttemptUpdatedTx: vi.fn(async () => undefined),
+      emitRunQueuedTx: vi.fn(async () => undefined),
+      emitRunResumedTx: vi.fn(async () => undefined),
+      emitRunCancelledTx: vi.fn(async () => undefined),
+    });
+
+    const worked = await engine.workerTick({
+      workerId: "worker-2",
+      executor: createExecutor(),
+    });
+
+    expect(worked).toBe(false);
+    expect(executeAttempt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime-execution/tsconfig.json
+++ b/packages/runtime-execution/tsconfig.json
@@ -4,11 +4,6 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": [
-    "src/index.ts",
-    "src/worker-loop.ts",
-    "src/task-result-registry.ts",
-    "src/engine/types.ts"
-  ],
+  "include": ["src"],
   "references": [{ "path": "../contracts" }]
 }


### PR DESCRIPTION
Closes #1760

## Summary
- move execution engine queueing, run control, plan-id parsing, and the generic execution orchestration into `@tyrum/runtime-execution`
- keep the gateway `ExecutionEngine` as an adapter wrapper that wires gateway-specific collaborators into the extracted runtime core
- add runtime-execution coverage for the extracted engine and a gateway regression check for the wrapper/extraction boundary

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors core execution orchestration (`enqueuePlan`, `workerTick`, `resumeRun`, `cancelRun`) across package boundaries; regressions could affect run scheduling and lifecycle events despite largely preserving behavior.
> 
> **Overview**
> Moves the **execution engine orchestration core** (clock, plan-id parsing, queueing, run resume/cancel, and `workerTick` step dispatch) out of the gateway into `@tyrum/runtime-execution` via a new generic `ExecutionEngine` that operates against abstracted `ExecutionDb`/logger and a `ExecutionScopeResolver`.
> 
> Updates the gateway `ExecutionEngine` to become a thin adapter that extends the runtime engine and wires in gateway-specific concerns (identity/workspace resolution, leasing/claiming, concurrency slot release, approvals/guardrails, artifact recording, secret-scope resolution, and event emission), while re-exporting moved types like `ExecuteAttemptOptions` and `StepClaimOutcome` from the runtime package.
> 
> Adds tests to lock in the extraction boundary (gateway wrapper imports runtime core) and to validate the runtime engine’s `workerTick` routing behavior; also broadens `runtime-execution`’s `tsconfig` include and slightly relaxes a WS router unit test timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a21f00023c15220c8415f3fa59372fd91e22efd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->