### PR TITLE
[P3] Polish — touch targets, progressive disclosure, tablet layout, selection token

### DIFF
--- a/packages/operator-ui/src/components/pages/agents-page-editor-sections.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-editor-sections.tsx
@@ -1,5 +1,6 @@
 import type { AgentCapabilitiesResponse, ManagedExtensionDetail } from "@tyrum/contracts";
 import { PERSONA_TONES } from "@tyrum/contracts";
+import { ChevronRight } from "lucide-react";
 import type { AgentEditorFormState, AgentEditorSetField } from "./agents-page-editor-form.js";
 import { AccessTransferField } from "./agents-page-editor-access-transfer.js";
 import type { ModelPreset } from "./admin-http-models.shared.js";
@@ -289,62 +290,72 @@ export function AgentEditorSections({
             onChange={(event) => setField("pruningToolKeep", event.currentTarget.value)}
           />
         </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <div className="grid gap-3 rounded-lg border border-border/70 p-3">
-            <ToggleField
-              label="Enable within-turn loop detection"
-              checked={form.withinTurnEnabled}
-              onCheckedChange={(checked) => setField("withinTurnEnabled", checked)}
-            />
-            <div className="grid gap-3 sm:grid-cols-2">
-              <Input
-                label="Consecutive repeat limit"
-                value={form.withinTurnConsecutiveLimit}
-                onChange={(event) =>
-                  setField("withinTurnConsecutiveLimit", event.currentTarget.value)
-                }
+        <details className="group/loop-details">
+          <summary className="cursor-pointer list-none text-sm font-medium text-fg-muted hover:text-fg [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex items-center gap-1.5">
+              <ChevronRight className="h-3.5 w-3.5 transition-transform group-open/loop-details:rotate-90" />
+              Loop detection parameters
+            </span>
+          </summary>
+          <div className="mt-3 grid gap-4 lg:grid-cols-2">
+            <div className="grid gap-3 rounded-lg border border-border/70 p-3">
+              <ToggleField
+                label="Enable within-turn loop detection"
+                checked={form.withinTurnEnabled}
+                onCheckedChange={(checked) => setField("withinTurnEnabled", checked)}
               />
-              <Input
-                label="Cycle repeat limit"
-                value={form.withinTurnCycleLimit}
-                onChange={(event) => setField("withinTurnCycleLimit", event.currentTarget.value)}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Input
+                  label="Consecutive repeat limit"
+                  value={form.withinTurnConsecutiveLimit}
+                  onChange={(event) =>
+                    setField("withinTurnConsecutiveLimit", event.currentTarget.value)
+                  }
+                />
+                <Input
+                  label="Cycle repeat limit"
+                  value={form.withinTurnCycleLimit}
+                  onChange={(event) => setField("withinTurnCycleLimit", event.currentTarget.value)}
+                />
+              </div>
+            </div>
+            <div className="grid gap-3 rounded-lg border border-border/70 p-3">
+              <ToggleField
+                label="Enable cross-turn loop detection"
+                checked={form.crossTurnEnabled}
+                onCheckedChange={(checked) => setField("crossTurnEnabled", checked)}
               />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Input
+                  label="Window assistant messages"
+                  value={form.crossTurnWindowMessages}
+                  onChange={(event) =>
+                    setField("crossTurnWindowMessages", event.currentTarget.value)
+                  }
+                />
+                <Input
+                  label="Similarity threshold"
+                  value={form.crossTurnSimilarityThreshold}
+                  onChange={(event) =>
+                    setField("crossTurnSimilarityThreshold", event.currentTarget.value)
+                  }
+                />
+                <Input
+                  label="Minimum chars"
+                  value={form.crossTurnMinChars}
+                  onChange={(event) => setField("crossTurnMinChars", event.currentTarget.value)}
+                />
+                <Input
+                  label="Cooldown assistant messages"
+                  value={form.crossTurnCooldownMessages}
+                  onChange={(event) =>
+                    setField("crossTurnCooldownMessages", event.currentTarget.value)
+                  }
+                />
+              </div>
             </div>
           </div>
-          <div className="grid gap-3 rounded-lg border border-border/70 p-3">
-            <ToggleField
-              label="Enable cross-turn loop detection"
-              checked={form.crossTurnEnabled}
-              onCheckedChange={(checked) => setField("crossTurnEnabled", checked)}
-            />
-            <div className="grid gap-3 sm:grid-cols-2">
-              <Input
-                label="Window assistant messages"
-                value={form.crossTurnWindowMessages}
-                onChange={(event) => setField("crossTurnWindowMessages", event.currentTarget.value)}
-              />
-              <Input
-                label="Similarity threshold"
-                value={form.crossTurnSimilarityThreshold}
-                onChange={(event) =>
-                  setField("crossTurnSimilarityThreshold", event.currentTarget.value)
-                }
-              />
-              <Input
-                label="Minimum chars"
-                value={form.crossTurnMinChars}
-                onChange={(event) => setField("crossTurnMinChars", event.currentTarget.value)}
-              />
-              <Input
-                label="Cooldown assistant messages"
-                value={form.crossTurnCooldownMessages}
-                onChange={(event) =>
-                  setField("crossTurnCooldownMessages", event.currentTarget.value)
-                }
-              />
-            </div>
-          </div>
-        </div>
+        </details>
       </FieldGroup>
 
       <FieldGroup title="Memory" description="Memory retrieval and budget controls.">

--- a/packages/operator-ui/src/components/pages/agents-page.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page.tsx
@@ -390,7 +390,7 @@ export function AgentsPage({ core }: { core: OperatorCore }) {
       {stopAction.error ? <StopSubagentErrorBanner error={stopAction.error} /> : null}
 
       <div
-        className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[320px_minmax(0,1fr)_320px]"
+        className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[280px_minmax(0,1fr)] lg:grid-cols-[320px_minmax(0,1fr)_320px]"
         data-testid="agents-content-layout"
       >
         <AgentsPageSidebar

--- a/packages/operator-ui/src/components/pages/chat-page-threads.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-threads.tsx
@@ -239,12 +239,12 @@ function ThreadItem({
           </div>
         </div>
         <div className="flex shrink-0 items-center">
-          <span className="text-[10px] opacity-60 group-hover:hidden">
+          <span className="text-[10px] opacity-60 md:group-hover:hidden">
             {formatRelativeTime(session.updated_at)}
           </span>
           <button
             type="button"
-            className="hidden h-5 w-5 items-center justify-center rounded text-fg-muted hover:text-fg group-hover:flex"
+            className="flex h-8 w-8 items-center justify-center rounded text-fg-muted hover:text-fg md:hidden md:group-hover:flex"
             title={actionIcon === "archive" ? "Archive" : "Restore"}
             onClick={(e) => {
               e.stopPropagation();
@@ -252,9 +252,9 @@ function ThreadItem({
             }}
           >
             {actionIcon === "archive" ? (
-              <Archive className="h-3 w-3" />
+              <Archive className="h-3.5 w-3.5" />
             ) : (
-              <ArchiveRestore className="h-3 w-3" />
+              <ArchiveRestore className="h-3.5 w-3.5" />
             )}
           </button>
         </div>

--- a/packages/operator-ui/src/globals.css
+++ b/packages/operator-ui/src/globals.css
@@ -58,6 +58,10 @@
     animation: tyrum-fade-in 200ms ease-out both;
   }
 
+  ::selection {
+    background: var(--color-selection);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     *,
     *::before,


### PR DESCRIPTION
Closes #1739
Closes #1740
Closes #1743
Closes #1745
Refs #1732 — deferred, requires backend historical metrics
Part of #1700

## Summary
Four P3 fixes plus one deferred:
- **#1739**: Chat thread archive button enlarged to 32px touch target, always visible on mobile
- **#1740**: Agent editor Sessions section — loop detection params collapsed under `<details>` by default
- **#1743**: Agents page adds `md` 2-column layout for tablets (sidebar + timeline)
- **#1745**: Applied the unused `--color-selection` token to `::selection` in globals.css
- **#1732**: Deferred — KPI trend indicators require backend historical data that doesn't exist yet

## Changes
- `chat-page-threads.tsx`: Archive button h-5→h-8, always visible below md
- `agents-page-editor-sections.tsx`: Loop detection params in collapsible `<details>`
- `agents-page.tsx`: Added `md:grid-cols-[280px_minmax(0,1fr)]` breakpoint
- `globals.css`: `::selection { background: var(--color-selection); }`

## Test plan
- [ ] Chat thread archive button visible on narrow viewports without hover
- [ ] Agent editor Sessions section shows basic fields, advanced collapsed
- [ ] Agents page on tablet shows 2-column layout
- [ ] Text selection uses themed highlight color
- [ ] All tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only tweaks to layout and styling; main risk is minor responsive/regression in visibility of controls across breakpoints.
> 
> **Overview**
> Polishes operator UI ergonomics and responsiveness.
> 
> Agent editor **hides advanced loop detection settings** behind a collapsible `details` disclosure (with a chevron indicator) in the Sessions section. The Agents page gains a **tablet `md` two-column grid layout** before switching to the existing 3-column `lg` layout.
> 
> Chat thread items **increase the archive/restore button touch target** and make the action visible on mobile (no hover required), while `globals.css` now applies the `--color-selection` token via `::selection`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2afae7496ab6685c329121739c9f9c50f1e897c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->