### PR TITLE
fix(ci): reuse packaged desktop build artifacts in smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,9 @@ jobs:
       - name: Build desktop release files
         run: pnpm --filter tyrum-desktop dist
 
+      - name: Mark packaged desktop bundle ready for smoke reuse
+        run: node apps/desktop/scripts/write-packaged-smoke-stamp.mjs
+
       - name: Stage desktop Linux build artifact
         run: node scripts/ci/stage-build-artifact.mjs --group desktop-suite-builds --artifact-dir .ci-artifacts/desktop-suite-builds
 
@@ -693,6 +696,9 @@ jobs:
         env:
           CSC_FOR_PULL_REQUEST: ${{ matrix.os == 'macos-latest' && 'true' || 'false' }}
         run: pnpm --filter tyrum-desktop dist
+
+      - name: Mark packaged desktop bundle ready for smoke reuse
+        run: node apps/desktop/scripts/write-packaged-smoke-stamp.mjs
 
       - name: Stage desktop build artifact
         run: node scripts/ci/stage-build-artifact.mjs --group desktop-suite-builds --artifact-dir .ci-artifacts/desktop-suite-builds

--- a/apps/desktop/scripts/write-packaged-smoke-stamp.mjs
+++ b/apps/desktop/scripts/write-packaged-smoke-stamp.mjs
@@ -1,0 +1,31 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PACKAGED_SMOKE_STAMP_FILENAME = ".packaged-smoke-ready";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_RELEASE_DIR = resolve(__dirname, "../release");
+
+export function resolvePackagedSmokeStampPath(releaseDir = DEFAULT_RELEASE_DIR) {
+  return resolve(releaseDir, PACKAGED_SMOKE_STAMP_FILENAME);
+}
+
+export function writePackagedSmokeStamp(releaseDir = DEFAULT_RELEASE_DIR, now = new Date()) {
+  if (!existsSync(releaseDir)) {
+    throw new Error(`Desktop release directory not found: ${releaseDir}`);
+  }
+
+  const stampPath = resolvePackagedSmokeStampPath(releaseDir);
+  writeFileSync(stampPath, `${now.toISOString()}\n`);
+  return stampPath;
+}
+
+const isDirectInvocation =
+  typeof process.argv[1] === "string" &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectInvocation) {
+  const stampPath = writePackagedSmokeStamp();
+  console.log(`Wrote packaged smoke stamp: ${stampPath}`);
+}

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -151,9 +151,9 @@ function isPackagedReleaseCurrent(): boolean {
     return false;
   }
 
-  // CI may prebuild a release bundle via `pnpm dist`, but the packaged smoke
-  // test relies on a local `electron-builder --dir` artifact. Reuse only the
-  // directory build produced by this harness after all current inputs exist.
+  // CI prebuilds release bundles via `pnpm dist` and marks them with this
+  // stamp so the packaged smoke test can reuse the restored artifact instead
+  // of running a second local packaging pass in the test job.
   const releaseMtimeMs = statSync(PACKAGED_SMOKE_STAMP).mtimeMs;
   return [
     DESKTOP_NODE_DIST_ENTRY,

--- a/apps/desktop/tests/packaged-smoke-stamp.test.ts
+++ b/apps/desktop/tests/packaged-smoke-stamp.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PACKAGED_SMOKE_STAMP_FILENAME,
+  resolvePackagedSmokeStampPath,
+  writePackagedSmokeStamp,
+} from "../scripts/write-packaged-smoke-stamp.mjs";
+
+describe("writePackagedSmokeStamp", () => {
+  let tempRoot: string | undefined;
+
+  afterEach(() => {
+    if (!tempRoot) return;
+    rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  });
+
+  it("writes the packaged smoke reuse marker into the desktop release directory", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "tyrum-packaged-smoke-stamp-"));
+    const releaseDir = join(tempRoot, "release");
+    mkdirSync(releaseDir, { recursive: true });
+
+    const stampPath = writePackagedSmokeStamp(releaseDir);
+
+    expect(stampPath).toBe(resolvePackagedSmokeStampPath(releaseDir));
+    expect(stampPath).toBe(join(releaseDir, PACKAGED_SMOKE_STAMP_FILENAME));
+
+    const stampContents = readFileSync(stampPath, "utf8").trim();
+    expect(Number.isNaN(Date.parse(stampContents))).toBe(false);
+    expect(statSync(stampPath).isFile()).toBe(true);
+  });
+
+  it("fails when the desktop release directory does not exist", () => {
+    tempRoot = mkdtempSync(join(tmpdir(), "tyrum-packaged-smoke-stamp-"));
+    const missingReleaseDir = join(tempRoot, "missing-release");
+
+    expect(() => writePackagedSmokeStamp(missingReleaseDir)).toThrow(
+      `Desktop release directory not found: ${missingReleaseDir}`,
+    );
+  });
+});

--- a/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
+++ b/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+test("desktop CI build jobs mark packaged bundles for smoke reuse", () => {
+  const workflowPath = fileURLToPath(
+    new URL("../../../../.github/workflows/ci.yml", import.meta.url),
+  );
+  const workflow = readFileSync(workflowPath, "utf8");
+
+  expect(workflow.match(/Mark packaged desktop bundle ready for smoke reuse/gu)?.length ?? 0).toBe(
+    2,
+  );
+  expect(
+    workflow.match(/node apps\/desktop\/scripts\/write-packaged-smoke-stamp\.mjs/gu)?.length ?? 0,
+  ).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add a small desktop helper that writes the packaged smoke reuse marker into `apps/desktop/release`
- call that helper in the CI desktop Linux and cross-platform build jobs after `pnpm --filter tyrum-desktop dist`
- add regression tests for the stamp helper and CI workflow wiring, and update the packaged smoke comment to reflect the CI artifact path

## Root Cause
The desktop packaged smoke harness only reuses `apps/desktop/release` when `.packaged-smoke-ready` exists. After `ac31b445` started restoring desktop build artifacts across CI jobs, the build jobs uploaded `apps/desktop/release` without that marker. The downstream desktop test jobs therefore threw away the downloaded release bundle and ran a second local `electron-builder --dir` pass inside the test phase. That extra packaging step is what made the packaged app smoke flaky on `push` to `main`, showing up as `Gateway did not become healthy within 30000ms` in jobs like:
- https://github.com/tyrumai/tyrum/actions/runs/23506732242/job/68418947289
- https://github.com/tyrumai/tyrum/actions/runs/23479191907/job/68320456531

## Verification
- `pnpm exec vitest run apps/desktop/tests/packaged-smoke-stamp.test.ts packages/gateway/tests/unit/ci-desktop-workflow.test.ts`
- `pnpm exec vitest run apps/web/tests/ci-build-artifacts.test.ts`
- repo pre-push gate passed: lint, typecheck, desktop tsconfig check, and full `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI workflow wiring and the desktop packaged smoke reuse gate; if the stamp is written in the wrong place/time, desktop smoke jobs may incorrectly reuse or rebuild artifacts and fail intermittently.
> 
> **Overview**
> **Re-enables reuse of prebuilt desktop release bundles in packaged smoke tests.** CI desktop build jobs now write a `.packaged-smoke-ready` stamp into `apps/desktop/release` immediately after `pnpm --filter tyrum-desktop dist`, so downstream smoke tests can trust and reuse the restored packaged artifact instead of repackaging.
> 
> Adds `apps/desktop/scripts/write-packaged-smoke-stamp.mjs` (with vitest coverage) and a regression test in `packages/gateway` that asserts the workflow includes the new stamping step; updates the packaged-smoke test comment to reflect the CI-driven reuse path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9408d3f81eb16d8e85ec71d8b3fe8fc5989dcd29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->