### PR TITLE
fix(ci): preserve desktop smoke reuse marker

### DIFF
--- a/apps/desktop/scripts/write-packaged-smoke-stamp.mjs
+++ b/apps/desktop/scripts/write-packaged-smoke-stamp.mjs
@@ -2,7 +2,7 @@ import { existsSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const PACKAGED_SMOKE_STAMP_FILENAME = ".packaged-smoke-ready";
+export const PACKAGED_SMOKE_STAMP_FILENAME = "packaged-smoke-ready.txt";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_RELEASE_DIR = resolve(__dirname, "../release");

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -29,7 +29,7 @@ const REPO_ROOT = resolve(__dirname, "../../../../");
 const DESKTOP_PRELOAD_ENTRY = resolve(REPO_ROOT, "apps/desktop/dist/preload/index.cjs");
 const DESKTOP_RENDERER_ENTRY = resolve(REPO_ROOT, "apps/desktop/dist/renderer/index.html");
 const DESKTOP_RELEASE_DIR = resolve(REPO_ROOT, "apps/desktop/release");
-const PACKAGED_SMOKE_STAMP = resolve(DESKTOP_RELEASE_DIR, ".packaged-smoke-ready");
+const PACKAGED_SMOKE_STAMP = resolve(DESKTOP_RELEASE_DIR, "packaged-smoke-ready.txt");
 const STAGED_GATEWAY_ENTRY = resolve(REPO_ROOT, "apps/desktop/dist/gateway/index.mjs");
 const PACKAGED_SMOKE_ENABLED = process.env["TYRUM_RUN_PACKAGED_SMOKE"] === "1";
 const DESKTOP_NODE_DIST_ENTRY = resolve(REPO_ROOT, "packages/desktop-node/dist/index.mjs");


### PR DESCRIPTION
Closes #1805.

## Summary

This changes the packaged desktop smoke reuse marker from a hidden filename to a visible one so the existing artifact upload/download flow preserves it without enabling `include-hidden-files` for the whole staged artifact tree.

That keeps the fix narrow and restores CI parity: the desktop cross-platform macOS test job can now reuse the packaged build artifact produced in the build job instead of silently rebuilding a different app variant in the test job.

## Why

The previous marker name, `.packaged-smoke-ready`, was dropped by `actions/upload-artifact` because hidden files are excluded by default. As a result, the macOS test job rebuilt the packaged app locally.

That rebuild path behaves differently on `pull_request` and `push`, which is why PRs were passing while pushes to `main` were failing.

## Testing

- `pnpm exec vitest run apps/desktop/tests/packaged-smoke-stamp.test.ts packages/gateway/tests/unit/ci-desktop-workflow.test.ts`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `git push` pre-push gate passed (`lint`, `typecheck`, desktop typecheck, full test suite)

## Risk / Follow-up

This change is expected to make PR macOS runs exercise the same signed packaged app path as push-to-main runs. If the signed packaged app still has a startup bug, this PR will surface it in PR CI instead of masking it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the marker file used to decide whether to reuse a prebuilt packaged desktop artifact in CI; if mismatched with workflow/artifacts, tests may unnecessarily rebuild or skip reuse and alter coverage.
> 
> **Overview**
> Switches the packaged desktop smoke “reuse stamp” from a hidden file to a visible `packaged-smoke-ready.txt` marker so CI artifact upload/download preserves it.
> 
> Updates both the stamp-writing script and the Electron packaged smoke integration test to read/write the new marker name when determining whether an existing `apps/desktop/release` bundle can be reused.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b88c52a21b12b75340662df494e2f43bdec2740. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->