### PR TITLE
Add `turn_items` schema and contracts for conversation turn traces (#1864)

### DIFF
--- a/docs/architecture/scaling-ha/data-model-map.md
+++ b/docs/architecture/scaling-ha/data-model-map.md
@@ -79,12 +79,12 @@ Purpose: durable policy bundles/overrides plus approval, review, and plan/audit 
 
 Tables:
 
-- `turns`, `turn_pauses`, `turn_artifacts`
+- `turns`, `turn_items`, `turn_pauses`, `turn_artifacts`
 - `resume_tokens`
 - `conversation_leases`, `workspace_leases`
 - `idempotency_records`, `concurrency_slots`
 
-Purpose: durable turn orchestration state, pause/resume metadata, evidence linkage, and the leases/idempotency primitives that keep conversation progress safe under retries or restarts.
+Purpose: durable turn orchestration state, immutable per-turn trace items, pause/resume metadata, evidence linkage, and the leases/idempotency primitives that keep conversation progress safe under retries or restarts.
 
 ### Automation (watchers)
 

--- a/packages/contracts/src/execution.ts
+++ b/packages/contracts/src/execution.ts
@@ -6,12 +6,16 @@ import { ArtifactRef } from "./artifact.js";
 import { PostconditionReport } from "./postcondition.js";
 import { PolicyDecision } from "./policy.js";
 import { PolicyOverrideId, PolicySnapshotId } from "./policy-bundle.js";
+import { TyrumUIMessage } from "./ui-message.js";
 
 export const TurnJobId = UuidSchema;
 export type TurnJobId = z.infer<typeof TurnJobId>;
 
 export const TurnId = UuidSchema;
 export type TurnId = z.infer<typeof TurnId>;
+
+export const TurnItemId = UuidSchema;
+export type TurnItemId = z.infer<typeof TurnItemId>;
 
 export const ExecutionStepId = UuidSchema;
 export type ExecutionStepId = z.infer<typeof ExecutionStepId>;
@@ -204,6 +208,32 @@ export const Turn = z
   })
   .strict();
 export type Turn = z.infer<typeof Turn>;
+
+export const TurnItemKind = z.enum(["message"]);
+export type TurnItemKind = z.infer<typeof TurnItemKind>;
+
+const TurnItemBase = z
+  .object({
+    turn_item_id: TurnItemId,
+    turn_id: TurnId,
+    item_index: z.number().int().nonnegative(),
+    item_key: z.string().trim().min(1),
+    created_at: DateTimeSchema,
+  })
+  .strict();
+
+export const TurnMessageItem = TurnItemBase.extend({
+  kind: z.literal(TurnItemKind.enum.message),
+  payload: z
+    .object({
+      message: TyrumUIMessage,
+    })
+    .strict(),
+}).strict();
+export type TurnMessageItem = z.infer<typeof TurnMessageItem>;
+
+export const TurnItem = z.discriminatedUnion("kind", [TurnMessageItem]);
+export type TurnItem = z.infer<typeof TurnItem>;
 
 export const ExecutionStep = z
   .object({

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -134,7 +134,7 @@ export { ArtifactId, ArtifactKind, ArtifactMediaClass, Sha256Hex, ArtifactUri, A
 // prettier-ignore
 export { ApprovalStatus, ApprovalKind, ApprovalScope, ApprovalDecision, Approval, ApprovalListRequest, ApprovalListResponse, ApprovalResolveRequest, ApprovalResolveResponse } from "./approval.js";
 // prettier-ignore
-export { TurnJobId, TurnId, ExecutionStepId, ExecutionAttemptId, TurnStatus, ExecutionStepStatus, ExecutionAttemptStatus, TurnJobStatus, TurnTriggerKind, TurnTrigger, TurnJob, TurnBlockReason, TurnBlockedPayload, Turn, ExecutionStep, ExecutionAttempt, AttemptCost, ExecutionBudgets } from "./execution.js";
+export { TurnJobId, TurnId, TurnItemId, ExecutionStepId, ExecutionAttemptId, TurnStatus, TurnItemKind, ExecutionStepStatus, ExecutionAttemptStatus, TurnJobStatus, TurnTriggerKind, TurnTrigger, TurnJob, TurnBlockReason, TurnBlockedPayload, Turn, TurnMessageItem, TurnItem, ExecutionStep, ExecutionAttempt, AttemptCost, ExecutionBudgets } from "./execution.js";
 // prettier-ignore
 export { WorkScope, WorkItemId, WorkItemKind, WorkItemState, WorkItemFingerprint, WorkItem, WorkItemTaskId, WorkItemTaskState, WorkItemTask, WorkItemLinkKind, WorkItemLink } from "./workboard.js";
 // prettier-ignore

--- a/packages/contracts/tests/execution.test.ts
+++ b/packages/contracts/tests/execution.test.ts
@@ -6,6 +6,7 @@ import {
   ExecutionStepStatus,
   AttemptCost,
   Turn,
+  TurnItem,
   TurnBlockedPayload,
   TurnJob,
   TurnJobStatus,
@@ -77,6 +78,23 @@ describe("Execution engine contracts", () => {
     provider: "openai",
   } as const;
 
+  const baseTurnItem = {
+    turn_item_id: "11111111-2222-4333-8444-555555555555",
+    turn_id: baseTurn.turn_id,
+    item_index: 0,
+    item_key: "message:user-msg-1",
+    kind: "message",
+    created_at: "2026-02-19T12:00:00Z",
+    payload: {
+      message: {
+        id: "user-msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+        metadata: { turn_id: baseTurn.turn_id },
+      },
+    },
+  } as const;
+
   it("parses a job record", () => {
     const job = TurnJob.parse(baseJob);
     expect(job.status).toBe("queued");
@@ -120,6 +138,25 @@ describe("Execution engine contracts", () => {
 
   it("rejects a step record with wrong step_index type", () => {
     expectRejects(ExecutionStep, { ...baseStep, step_index: "0" });
+  });
+
+  it("parses a turn item record", () => {
+    const item = TurnItem.parse(baseTurnItem);
+    expect(item.kind).toBe("message");
+    expect(item.payload.message.id).toBe("user-msg-1");
+  });
+
+  it("rejects a turn item record with invalid payload", () => {
+    expectRejects(TurnItem, {
+      ...baseTurnItem,
+      payload: {
+        message: {
+          id: "",
+          role: "user",
+          parts: [],
+        },
+      },
+    });
   });
 
   it("parses an attempt record with artifacts", () => {

--- a/packages/gateway/migrations/postgres/156_turn_items.sql
+++ b/packages/gateway/migrations/postgres/156_turn_items.sql
@@ -1,0 +1,18 @@
+CREATE TABLE turn_items (
+  tenant_id      UUID NOT NULL,
+  turn_item_id   UUID NOT NULL,
+  turn_id        UUID NOT NULL,
+  item_index     INTEGER NOT NULL CHECK (item_index >= 0),
+  item_key       TEXT NOT NULL,
+  kind           TEXT NOT NULL CHECK (kind IN ('message')),
+  payload_json   TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, turn_item_id),
+  UNIQUE (tenant_id, turn_id, item_index),
+  UNIQUE (tenant_id, turn_id, item_key),
+  CONSTRAINT turn_items_turn_fk
+    FOREIGN KEY (tenant_id, turn_id) REFERENCES turns(tenant_id, turn_id) ON DELETE CASCADE
+);
+
+CREATE INDEX turn_items_turn_order_idx
+  ON turn_items (tenant_id, turn_id, created_at ASC, item_index ASC);

--- a/packages/gateway/migrations/sqlite/156_turn_items.sql
+++ b/packages/gateway/migrations/sqlite/156_turn_items.sql
@@ -1,0 +1,18 @@
+CREATE TABLE turn_items (
+  tenant_id      TEXT NOT NULL,
+  turn_item_id   TEXT NOT NULL,
+  turn_id        TEXT NOT NULL,
+  item_index     INTEGER NOT NULL CHECK (item_index >= 0),
+  item_key       TEXT NOT NULL,
+  kind           TEXT NOT NULL CHECK (kind IN ('message')),
+  payload_json   TEXT NOT NULL,
+  created_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, turn_item_id),
+  UNIQUE (tenant_id, turn_id, item_index),
+  UNIQUE (tenant_id, turn_id, item_key),
+  FOREIGN KEY (tenant_id, turn_id)
+    REFERENCES turns(tenant_id, turn_id) ON DELETE CASCADE
+);
+
+CREATE INDEX turn_items_turn_order_idx
+  ON turn_items (tenant_id, turn_id, created_at ASC, item_index ASC);

--- a/packages/gateway/src/app/modules/agent/turn-item-dal.ts
+++ b/packages/gateway/src/app/modules/agent/turn-item-dal.ts
@@ -1,0 +1,1 @@
+export * from "../../../modules/agent/turn-item-dal.js";

--- a/packages/gateway/src/modules/agent/turn-item-dal.ts
+++ b/packages/gateway/src/modules/agent/turn-item-dal.ts
@@ -1,0 +1,126 @@
+import { TurnItem } from "@tyrum/contracts";
+import type { TurnItem as TurnItemRecord } from "@tyrum/contracts";
+import type { SqlDb } from "../../statestore/types.js";
+import { buildSqlPlaceholders } from "../../utils/sql.js";
+
+type RawTurnItemRow = {
+  turn_item_id: string;
+  turn_id: string;
+  item_index: number;
+  item_key: string;
+  kind: string;
+  payload_json: string;
+  created_at: string | Date;
+};
+
+export type EnsureTurnItemInput = {
+  tenantId: string;
+  turnItemId: string;
+  turnId: string;
+  itemIndex: number;
+  itemKey: string;
+  kind: TurnItemRecord["kind"];
+  payload: TurnItemRecord["payload"];
+  createdAt: string;
+};
+
+function normalizeTime(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function parsePayload(raw: string): unknown {
+  return JSON.parse(raw) as unknown;
+}
+
+function toTurnItem(row: RawTurnItemRow): TurnItemRecord {
+  return TurnItem.parse({
+    turn_item_id: row.turn_item_id,
+    turn_id: row.turn_id,
+    item_index: row.item_index,
+    item_key: row.item_key,
+    kind: row.kind,
+    payload: parsePayload(row.payload_json),
+    created_at: normalizeTime(row.created_at),
+  });
+}
+
+export class TurnItemDal {
+  constructor(private readonly db: SqlDb) {}
+
+  async ensureItem(input: EnsureTurnItemInput): Promise<TurnItemRecord> {
+    const inserted = await this.db.get<RawTurnItemRow>(
+      `INSERT INTO turn_items (
+         tenant_id,
+         turn_item_id,
+         turn_id,
+         item_index,
+         item_key,
+         kind,
+         payload_json,
+         created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (tenant_id, turn_id, item_key) DO NOTHING
+       RETURNING turn_item_id, turn_id, item_index, item_key, kind, payload_json, created_at`,
+      [
+        input.tenantId,
+        input.turnItemId,
+        input.turnId,
+        input.itemIndex,
+        input.itemKey,
+        input.kind,
+        JSON.stringify(input.payload),
+        input.createdAt,
+      ],
+    );
+    if (inserted) {
+      return toTurnItem(inserted);
+    }
+
+    const existing = await this.db.get<RawTurnItemRow>(
+      `SELECT turn_item_id, turn_id, item_index, item_key, kind, payload_json, created_at
+       FROM turn_items
+       WHERE tenant_id = ? AND turn_id = ? AND item_key = ?`,
+      [input.tenantId, input.turnId, input.itemKey],
+    );
+    if (!existing) {
+      throw new Error(`turn item '${input.itemKey}' was not persisted`);
+    }
+    return toTurnItem(existing);
+  }
+
+  async listByTurnId(input: { tenantId: string; turnId: string }): Promise<TurnItemRecord[]> {
+    const itemsByTurn = await this.listByTurnIds({
+      tenantId: input.tenantId,
+      turnIds: [input.turnId],
+    });
+    return itemsByTurn.get(input.turnId) ?? [];
+  }
+
+  async listByTurnIds(input: {
+    tenantId: string;
+    turnIds: readonly string[];
+  }): Promise<Map<string, TurnItemRecord[]>> {
+    const itemsByTurn = new Map<string, TurnItemRecord[]>();
+    if (input.turnIds.length === 0) {
+      return itemsByTurn;
+    }
+
+    const rows = await this.db.all<RawTurnItemRow>(
+      `SELECT turn_item_id, turn_id, item_index, item_key, kind, payload_json, created_at
+       FROM turn_items
+       WHERE tenant_id = ?
+         AND turn_id IN (${buildSqlPlaceholders(input.turnIds.length)})
+       ORDER BY turn_id ASC, item_index ASC`,
+      [input.tenantId, ...input.turnIds],
+    );
+
+    for (const row of rows) {
+      const turnItem = toTurnItem(row);
+      const items = itemsByTurn.get(turnItem.turn_id) ?? [];
+      items.push(turnItem);
+      itemsByTurn.set(turnItem.turn_id, items);
+    }
+
+    return itemsByTurn;
+  }
+}

--- a/packages/gateway/src/statestore/json-columns.json
+++ b/packages/gateway/src/statestore/json-columns.json
@@ -350,6 +350,13 @@
     "default": null
   },
   {
+    "table": "turn_items",
+    "column": "payload_json",
+    "shape": "object",
+    "nullable": false,
+    "default": null
+  },
+  {
     "table": "execution_steps",
     "column": "action_json",
     "shape": "object",

--- a/packages/gateway/tests/contract/schema-contract.test.ts
+++ b/packages/gateway/tests/contract/schema-contract.test.ts
@@ -66,6 +66,7 @@ describe("StateStore schema contract (sqlite vs postgres)", () => {
         "secret_resolutions",
         "turn_jobs",
         "turns",
+        "turn_items",
         "execution_steps",
         "execution_attempts",
         "artifacts",

--- a/packages/gateway/tests/unit/turn-item-dal.test.ts
+++ b/packages/gateway/tests/unit/turn-item-dal.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { TurnItemDal } from "../../src/modules/agent/turn-item-dal.js";
+import {
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+} from "../../src/modules/identity/scope.js";
+import { openTestSqliteDb } from "../helpers/sqlite-db.js";
+import type { SqliteDb } from "../../src/statestore/sqlite.js";
+
+const TENANT_ID = DEFAULT_TENANT_ID;
+const JOB_ID = "10000000-0000-4000-8000-000000000000";
+const TURN_ID = "20000000-0000-4000-8000-000000000000";
+
+describe("TurnItemDal", () => {
+  let db: SqliteDb | undefined;
+
+  afterEach(async () => {
+    await db?.close();
+    db = undefined;
+  });
+
+  it("stores ordered message-backed turn items and deduplicates by item_key", async () => {
+    db = openTestSqliteDb();
+    const dal = new TurnItemDal(db);
+
+    await db.run(
+      `INSERT INTO turn_jobs (
+         tenant_id,
+         job_id,
+         agent_id,
+         workspace_id,
+         conversation_key,
+         status,
+         trigger_json,
+         input_json,
+         created_at
+       ) VALUES (?, ?, ?, ?, ?, 'completed', ?, NULL, ?)`,
+      [
+        TENANT_ID,
+        JOB_ID,
+        DEFAULT_AGENT_ID,
+        DEFAULT_WORKSPACE_ID,
+        "agent:default:main",
+        JSON.stringify({ kind: "manual" }),
+        "2026-02-19T12:00:00.000Z",
+      ],
+    );
+    await db.run(
+      `INSERT INTO turns (
+         tenant_id,
+         turn_id,
+         job_id,
+         conversation_key,
+         status,
+         attempt,
+         created_at,
+         started_at,
+         finished_at
+       ) VALUES (?, ?, ?, ?, 'succeeded', 1, ?, ?, ?)`,
+      [
+        TENANT_ID,
+        TURN_ID,
+        JOB_ID,
+        "agent:default:main",
+        "2026-02-19T12:00:00.000Z",
+        "2026-02-19T12:00:01.000Z",
+        "2026-02-19T12:00:02.000Z",
+      ],
+    );
+
+    const inserted = await dal.ensureItem({
+      tenantId: TENANT_ID,
+      turnItemId: "30000000-0000-4000-8000-000000000000",
+      turnId: TURN_ID,
+      itemIndex: 0,
+      itemKey: "message:user-1",
+      kind: "message",
+      createdAt: "2026-02-19T12:00:03.000Z",
+      payload: {
+        message: {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Hello" }],
+          metadata: { turn_id: TURN_ID },
+        },
+      },
+    });
+
+    const duplicate = await dal.ensureItem({
+      tenantId: TENANT_ID,
+      turnItemId: "40000000-0000-4000-8000-000000000000",
+      turnId: TURN_ID,
+      itemIndex: 0,
+      itemKey: "message:user-1",
+      kind: "message",
+      createdAt: "2026-02-19T12:00:04.000Z",
+      payload: {
+        message: {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Hello again" }],
+          metadata: { turn_id: TURN_ID },
+        },
+      },
+    });
+
+    await dal.ensureItem({
+      tenantId: TENANT_ID,
+      turnItemId: "50000000-0000-4000-8000-000000000000",
+      turnId: TURN_ID,
+      itemIndex: 1,
+      itemKey: "message:assistant-1",
+      kind: "message",
+      createdAt: "2026-02-19T12:00:05.000Z",
+      payload: {
+        message: {
+          id: "assistant-1",
+          role: "assistant",
+          parts: [{ type: "text", text: "Hi there" }],
+          metadata: { turn_id: TURN_ID },
+        },
+      },
+    });
+
+    expect(duplicate).toEqual(inserted);
+
+    const items = await dal.listByTurnId({ tenantId: TENANT_ID, turnId: TURN_ID });
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.item_key)).toEqual(["message:user-1", "message:assistant-1"]);
+    expect(items[0]?.payload.message.role).toBe("user");
+    expect(items[1]?.payload.message.role).toBe("assistant");
+  });
+
+  it("groups items by turn id for transcript follow-up reads", async () => {
+    db = openTestSqliteDb();
+    const dal = new TurnItemDal(db);
+
+    const secondJobId = "60000000-0000-4000-8000-000000000000";
+    const secondTurnId = "70000000-0000-4000-8000-000000000000";
+    for (const [jobId, turnId, conversationKey] of [
+      [JOB_ID, TURN_ID, "agent:default:main"],
+      [secondJobId, secondTurnId, "agent:default:secondary"],
+    ] as const) {
+      await db.run(
+        `INSERT INTO turn_jobs (
+           tenant_id,
+           job_id,
+           agent_id,
+           workspace_id,
+           conversation_key,
+           status,
+           trigger_json,
+           input_json,
+           created_at
+         ) VALUES (?, ?, ?, ?, ?, 'completed', ?, NULL, ?)`,
+        [
+          TENANT_ID,
+          jobId,
+          DEFAULT_AGENT_ID,
+          DEFAULT_WORKSPACE_ID,
+          conversationKey,
+          JSON.stringify({ kind: "manual" }),
+          "2026-02-19T12:00:00.000Z",
+        ],
+      );
+      await db.run(
+        `INSERT INTO turns (
+           tenant_id,
+           turn_id,
+           job_id,
+           conversation_key,
+           status,
+           attempt,
+           created_at,
+           started_at,
+           finished_at
+         ) VALUES (?, ?, ?, ?, 'succeeded', 1, ?, ?, ?)`,
+        [
+          TENANT_ID,
+          turnId,
+          jobId,
+          conversationKey,
+          "2026-02-19T12:00:00.000Z",
+          "2026-02-19T12:00:01.000Z",
+          "2026-02-19T12:00:02.000Z",
+        ],
+      );
+    }
+
+    await dal.ensureItem({
+      tenantId: TENANT_ID,
+      turnItemId: "80000000-0000-4000-8000-000000000000",
+      turnId: TURN_ID,
+      itemIndex: 0,
+      itemKey: "message:user-1",
+      kind: "message",
+      createdAt: "2026-02-19T12:00:03.000Z",
+      payload: {
+        message: {
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "One" }],
+          metadata: { turn_id: TURN_ID },
+        },
+      },
+    });
+    await dal.ensureItem({
+      tenantId: TENANT_ID,
+      turnItemId: "90000000-0000-4000-8000-000000000000",
+      turnId: secondTurnId,
+      itemIndex: 0,
+      itemKey: "message:user-2",
+      kind: "message",
+      createdAt: "2026-02-19T12:00:03.000Z",
+      payload: {
+        message: {
+          id: "user-2",
+          role: "user",
+          parts: [{ type: "text", text: "Two" }],
+          metadata: { turn_id: secondTurnId },
+        },
+      },
+    });
+
+    const itemsByTurn = await dal.listByTurnIds({
+      tenantId: TENANT_ID,
+      turnIds: [TURN_ID, secondTurnId],
+    });
+
+    expect(itemsByTurn.get(TURN_ID)?.map((item) => item.payload.message.id)).toEqual(["user-1"]);
+    expect(itemsByTurn.get(secondTurnId)?.map((item) => item.payload.message.id)).toEqual([
+      "user-2",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add durable `turn_items` migrations for SQLite and Postgres with ordering and idempotency keys
- export a validated `TurnItem` contract for immutable message-backed turn traces
- add a minimal `TurnItemDal` plus schema/contract/DAL coverage and update the schema map doc

## Why
Issue #1864 introduces the replacement persistence surface needed before conversational runtime and transcript callsites can move off execution step/attempt records.

## Root Cause
The repo still lacked a turn-scoped persistence contract and table for conversational traces, so follow-up work had no durable target to write or read.

## Impact
Follow-up issues can now persist ordered message-backed turn items idempotently and read them back by turn without changing runtime callsites yet.

## Validation
- `pnpm exec vitest run packages/contracts/tests/execution.test.ts`
- `pnpm exec vitest run packages/gateway/tests/contract/schema-contract.test.ts packages/gateway/tests/unit/turn-item-dal.test.ts packages/gateway/tests/contract/json-column-specs.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`
- `pnpm format:check`

Closes #1864

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive but touches database schema (new table + indexes) and introduces new persistence/read paths; incorrect constraints or ordering/dedupe assumptions could affect transcript/turn trace consistency.
> 
> **Overview**
> Adds a new durable persistence surface for per-turn trace items by introducing the `turn_items` table (SQLite/Postgres) with ordering (`item_index`), dedupe keys (`item_key`), and a FK back to `turns`.
> 
> Extends the contracts package with `TurnItem`/`TurnMessageItem` (validated `TyrumUIMessage` payloads) and exports these new types, then adds a minimal `TurnItemDal` to idempotently insert (conflict on `item_key`) and list items by one or many turn IDs. Updates schema/JSON-column specs and tests to cover the new table, contract parsing, and DAL behavior, plus documents `turn_items` in the data-model map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfdfc49a3a0bbbd986ae01952b2d992e9bef0665. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->