### PR TITLE
Introduce `TurnRunner` claim/resume helpers backed by `turns` (#1866)

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/turn-runner.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-runner.ts
@@ -14,7 +14,7 @@ import { normalizeDbDateTime } from "../../../utils/db-time.js";
 import { safeJsonParse } from "../../../utils/json.js";
 import {
   releaseConversationLeaseTx,
-  tryAcquireConversationLease,
+  tryAcquireConversationLeaseTx,
 } from "../../execution/engine/concurrency-manager.js";
 
 type RawTurnRunnerRow = {
@@ -345,7 +345,7 @@ export class TurnRunner {
     turn: TurnRunnerTurn,
     input: { tenantId: string; turnId: string; owner: string; nowMs: number; leaseTtlMs: number },
   ): Promise<boolean> {
-    const claimed = await tryAcquireConversationLease(tx, {
+    const claimed = await tryAcquireConversationLeaseTx(tx, {
       tenantId: input.tenantId,
       key: turn.conversation_key,
       owner: input.owner,

--- a/packages/gateway/src/modules/execution/engine/concurrency-manager.ts
+++ b/packages/gateway/src/modules/execution/engine/concurrency-manager.ts
@@ -210,6 +210,40 @@ export async function tryAcquireConcurrencyForAttemptTx(
   return true;
 }
 
+export async function tryAcquireConversationLeaseTx(
+  tx: SqlDb,
+  opts: {
+    tenantId: string;
+    key: string;
+    owner: string;
+    nowMs: number;
+    ttlMs: number;
+  },
+): Promise<boolean> {
+  const expiresAt = opts.nowMs + Math.max(1, opts.ttlMs);
+  const inserted = await tx.run(
+    `INSERT INTO conversation_leases (
+       tenant_id,
+       conversation_key,
+       lease_owner,
+       lease_expires_at_ms
+     )
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (tenant_id, conversation_key) DO NOTHING`,
+    [opts.tenantId, opts.key, opts.owner, expiresAt],
+  );
+  if (inserted.changes === 1) return true;
+
+  const updated = await tx.run(
+    `UPDATE conversation_leases
+     SET lease_owner = ?, lease_expires_at_ms = ?
+     WHERE tenant_id = ? AND conversation_key = ?
+       AND (lease_expires_at_ms <= ? OR lease_owner = ?)`,
+    [opts.owner, expiresAt, opts.tenantId, opts.key, opts.nowMs, opts.owner],
+  );
+  return updated.changes === 1;
+}
+
 export async function tryAcquireConversationLease(
   db: SqlDb,
   opts: {
@@ -220,30 +254,7 @@ export async function tryAcquireConversationLease(
     ttlMs: number;
   },
 ): Promise<boolean> {
-  const expiresAt = opts.nowMs + Math.max(1, opts.ttlMs);
-  return await db.transaction(async (tx) => {
-    const inserted = await tx.run(
-      `INSERT INTO conversation_leases (
-         tenant_id,
-         conversation_key,
-         lease_owner,
-         lease_expires_at_ms
-       )
-       VALUES (?, ?, ?, ?)
-       ON CONFLICT (tenant_id, conversation_key) DO NOTHING`,
-      [opts.tenantId, opts.key, opts.owner, expiresAt],
-    );
-    if (inserted.changes === 1) return true;
-
-    const updated = await tx.run(
-      `UPDATE conversation_leases
-       SET lease_owner = ?, lease_expires_at_ms = ?
-       WHERE tenant_id = ? AND conversation_key = ?
-         AND (lease_expires_at_ms <= ? OR lease_owner = ?)`,
-      [opts.owner, expiresAt, opts.tenantId, opts.key, opts.nowMs, opts.owner],
-    );
-    return updated.changes === 1;
-  });
+  return await db.transaction(async (tx) => await tryAcquireConversationLeaseTx(tx, opts));
 }
 
 export async function releaseConversationLeaseTx(

--- a/packages/gateway/tests/unit/turn-runner.test.ts
+++ b/packages/gateway/tests/unit/turn-runner.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_TENANT_ID,
   DEFAULT_WORKSPACE_ID,
 } from "../../src/modules/identity/scope.js";
+import type { SqlDb } from "../../src/statestore/types.js";
 import type { SqliteDb } from "../../src/statestore/sqlite.js";
 import { openTestSqliteDb } from "../helpers/sqlite-db.js";
 
@@ -107,6 +108,32 @@ describe("TurnRunner", () => {
     );
   }
 
+  function guardNestedTransactions(base: SqliteDb): SqlDb {
+    return {
+      kind: base.kind,
+      get: async (sql, params) => await base.get(sql, params),
+      all: async (sql, params) => await base.all(sql, params),
+      run: async (sql, params) => await base.run(sql, params),
+      exec: async (sql) => await base.exec(sql),
+      transaction: async (fn) =>
+        await base.transaction(
+          async (tx) =>
+            await fn({
+              kind: tx.kind,
+              get: async (sql, params) => await tx.get(sql, params),
+              all: async (sql, params) => await tx.all(sql, params),
+              run: async (sql, params) => await tx.run(sql, params),
+              exec: async (sql) => await tx.exec(sql),
+              transaction: async () => {
+                throw new Error("nested transaction should not be opened");
+              },
+              close: async () => {},
+            }),
+        ),
+      close: async () => await base.close(),
+    };
+  }
+
   it("claims queued conversation turns and leaves execution steps untouched", async () => {
     db = openTestSqliteDb();
     await seedTurn(db);
@@ -137,6 +164,25 @@ describe("TurnRunner", () => {
       [TENANT_ID, STEP_ID],
     );
     expect(step?.status).toBe("queued");
+  });
+
+  it("claims turns inside the existing transaction without opening a nested lease transaction", async () => {
+    db = openTestSqliteDb();
+    await seedTurn(db);
+
+    const runner = new TurnRunner(guardNestedTransactions(db));
+    await expect(
+      runner.claim({
+        tenantId: TENANT_ID,
+        turnId: TURN_ID,
+        owner: "worker-1",
+        nowMs: 5_000,
+        nowIso: "2026-03-31T14:00:05.000Z",
+        leaseTtlMs: 60_000,
+      }),
+    ).resolves.toMatchObject({
+      kind: "claimed",
+    });
   });
 
   it("resumes paused conversation turns without touching execution steps", async () => {


### PR DESCRIPTION
Closes #1866

## Summary
- add a storage-backed `TurnRunner` helper for conversation turns using the `turns` table and conversation leases
- support claim, resume, heartbeat, complete, and fail flows without duplicating execution-step state
- add unit coverage for claim/resume, heartbeat, terminal rejections, and lease release on completion/failure

## Verification
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new transaction-scoped turn lifecycle mutations (claim/resume/heartbeat/finish) and refactors conversation lease acquisition to be TX-aware, which could affect turn scheduling/locking behavior if edge cases are missed.
> 
> **Overview**
> Adds a new storage-backed `TurnRunner` that manages conversation-triggered turns directly in `turns`/`turn_jobs`: **claim** (move to `running` + set `started_at`), **resume** (unblock + optional budget override), **heartbeat** (refresh lease + optional checkpoint/progress), and **complete/fail** (set terminal status, clear turn lease, and release the conversation lease), while explicitly *not* mutating `execution_steps`.
> 
> Refactors conversation lease acquisition by extracting `tryAcquireConversationLeaseTx` so callers can acquire/refresh leases inside an existing DB transaction (avoiding nested transactions), and adds unit tests covering these flows and lease release behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3188c0f10fe6897b88e44c51a6113defc1c457ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->