### PR TITLE
[codex] Harden supply-chain controls in CI and dependency intake

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/.github/workflows/** @rhernaus
+/package.json @rhernaus
+/pnpm-lock.yaml @rhernaus
+/pnpm-workspace.yaml @rhernaus
+/patches/** @rhernaus
+/.github/dependabot.yml @rhernaus
+/scripts/install.sh @rhernaus

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,6 +15,7 @@ branches:
       required_status_checks:
         strict: true
         contexts:
+          - ci / Dependency Review
           - ci / Packages
           - ci / Web
           - security-baseline / Security baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       desktop_ci: ${{ steps.filter.outputs.desktop_ci }}
       deployment_smoke: ${{ steps.filter.outputs.deployment_smoke }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -134,8 +134,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker://rhysd/actionlint:1.7.11
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: docker://rhysd/actionlint:1.7.11@sha256:6f03470d0152251d7f07f7c4dc019dbe7024c72cd952f839544c7798843efa8f
 
   shell-lint:
     name: Shell Lint
@@ -143,7 +143,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.scripts == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Ensure shellcheck is available
         run: |
           if ! command -v shellcheck >/dev/null 2>&1; then
@@ -159,11 +159,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_gate == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check docs for internal-only content
         run: bash scripts/check-public-docs.sh
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -181,8 +181,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          fail-on-scopes: runtime,unknown
 
   pr-overwrite-analyzer:
     name: PR Overwrite Analyzer
@@ -194,7 +197,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -231,7 +234,7 @@ jobs:
 
       - name: Sync PR analyzer comment
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ github.token }}
           script: |
@@ -310,7 +313,7 @@ jobs:
 
       - name: Upload analyzer artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: pr-overwrite-analysis
           path: pr-overwrite-analysis.json
@@ -323,11 +326,11 @@ jobs:
     if: needs.changes.outputs.ci == 'true' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -367,7 +370,7 @@ jobs:
       - name: Stage Linux workspace build artifact
         run: node scripts/ci/stage-build-artifact.mjs --group linux-workspace-builds --artifact-dir .ci-artifacts/linux-workspace-builds
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: linux-workspace-builds
           path: .ci-artifacts/linux-workspace-builds
@@ -384,17 +387,17 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: linux-workspace-builds
           path: .ci-artifacts/linux-workspace-builds
@@ -426,7 +429,7 @@ jobs:
 
       - name: Upload vitest blob report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: vitest-blob-${{ matrix.shard }}
           path: vitest-reports/blob-${{ matrix.shard }}.json
@@ -439,23 +442,23 @@ jobs:
     if: needs.linux-foundation.result == 'success' && (needs.changes.outputs.ci == 'true' || needs.changes.outputs.deps == 'true')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Cache Playwright browsers (Chromium)
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: linux-workspace-builds
           path: .ci-artifacts/linux-workspace-builds
@@ -491,7 +494,7 @@ jobs:
 
       - name: Upload vitest blob report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: vitest-blob-linux-browser
           path: vitest-reports/blob-linux-browser.json
@@ -504,17 +507,17 @@ jobs:
     if: needs.linux-foundation.result == 'success' && needs.changes.outputs.desktop_ci == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: linux-workspace-builds
           path: .ci-artifacts/linux-workspace-builds
@@ -536,7 +539,7 @@ jobs:
       - name: Stage desktop Linux build artifact
         run: node scripts/ci/stage-build-artifact.mjs --group desktop-suite-builds --artifact-dir .ci-artifacts/desktop-suite-builds
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: desktop-suite-build-linux
           path: .ci-artifacts/desktop-suite-builds
@@ -549,23 +552,23 @@ jobs:
     if: needs.linux-foundation.result == 'success' && needs.desktop-linux-build.result == 'success' && needs.changes.outputs.desktop_ci == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Cache Playwright browsers (Chromium)
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: desktop-suite-build-linux
           path: .ci-artifacts/desktop-suite-builds
@@ -599,7 +602,7 @@ jobs:
 
       - name: Upload vitest blob report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: vitest-blob-desktop-linux
           path: vitest-reports/blob-desktop-linux.json
@@ -612,11 +615,11 @@ jobs:
     if: needs.linux-foundation.result == 'success' && needs.test-shards.result == 'success' && needs.linux-browser-suite.result == 'success' && (needs.changes.outputs.desktop_ci != 'true' || needs.desktop-linux-test.result == 'success') && (needs.changes.outputs.ci == 'true' || needs.changes.outputs.deps == 'true')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -625,7 +628,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Download shard reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: vitest-blob-*
           path: artifacts
@@ -661,7 +664,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: coverage-report-ubuntu
           path: coverage/
@@ -678,11 +681,11 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -712,7 +715,7 @@ jobs:
       - name: Stage desktop build artifact
         run: node scripts/ci/stage-build-artifact.mjs --group desktop-suite-builds --artifact-dir .ci-artifacts/desktop-suite-builds
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: desktop-suite-build-${{ matrix.os }}
           path: .ci-artifacts/desktop-suite-builds
@@ -729,11 +732,11 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -747,7 +750,7 @@ jobs:
           node_prefix="$(dirname "$(dirname "$(command -v node)")")"
           echo "npm_config_nodedir=$node_prefix" >> "$GITHUB_ENV"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: desktop-suite-build-${{ matrix.os }}
           path: .ci-artifacts/desktop-suite-builds
@@ -783,11 +786,11 @@ jobs:
     if: needs.linux-foundation.result == 'success' && (needs.changes.outputs.ci == 'true' || needs.changes.outputs.deps == 'true')
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -822,22 +825,22 @@ jobs:
     if: needs.linux-foundation.result == 'success' && (needs.changes.outputs.ci == 'true' || needs.changes.outputs.deps == 'true')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "21"
 
-      - uses: android-actions/setup-android@v4
+      - uses: android-actions/setup-android@651bceb6f9ca583f16b8d75b62c36ded2ae6fc9c # v4
 
       - name: Install Android SDK packages
         shell: bash
@@ -865,7 +868,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Smoke (single-host, SQLite)
         shell: bash

--- a/.github/workflows/desktop-sandbox-image.yml
+++ b/.github/workflows/desktop-sandbox-image.yml
@@ -37,10 +37,10 @@ jobs:
     name: Build Desktop Sandbox Image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - id: vars
         name: Resolve publish tags
@@ -87,7 +87,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.vars.outputs.push_image == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -95,7 +95,7 @@ jobs:
 
       - id: meta
         name: Compute image metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.vars.outputs.tags }}
@@ -104,7 +104,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and optionally publish image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           file: docker/desktop-sandbox/Dockerfile

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -20,14 +20,14 @@ jobs:
     name: Deploy Docs to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check docs for internal-only content
         run: bash scripts/check-public-docs.sh
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -39,7 +39,7 @@ jobs:
         run: pnpm --filter @tyrum/docs build
 
       - name: Create Pages project (idempotent)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         continue-on-error: true
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
           workingDirectory: apps/docs
           command: pages project create tyrum-docs --production-branch=main
       - name: Publish docs site
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -35,9 +35,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
 
@@ -108,7 +108,7 @@ jobs:
     name: Windows npm Install
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,11 @@ jobs:
       npm_tag: ${{ steps.version.outputs.npm_tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -187,7 +187,7 @@ jobs:
           (cd packages/gateway && pnpm pack --pack-destination ../../artifacts/npm)
           ls -lah artifacts/npm
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: npm-packages
           path: artifacts/npm/*.tgz
@@ -203,11 +203,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -426,7 +426,7 @@ jobs:
 
           ls -lah artifacts/desktop
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: desktop-${{ matrix.os }}
           path: artifacts/desktop/*
@@ -440,14 +440,14 @@ jobs:
     env:
       HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: npm-packages
           path: release-assets
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: desktop-*
           path: release-assets
@@ -465,7 +465,7 @@ jobs:
             | xargs -0 sha256sum > SHA256SUMS
           cat SHA256SUMS
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         if: ${{ env.HAS_NPM_TOKEN == 'true' }}
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -479,6 +479,8 @@ jobs:
           RELEASE_VERSION: ${{ needs.package-bundles.outputs.version }}
         run: |
           set -euo pipefail
+
+          echo "Publishing with NPM_TOKEN. Switch back to trusted publishing once the packages exist on npm."
 
           declare -A packages=(
             ["@tyrum/contracts"]="release-assets/tyrum-contracts-${RELEASE_VERSION}.tgz"
@@ -507,7 +509,7 @@ jobs:
         if: ${{ env.HAS_NPM_TOKEN != 'true' }}
         run: echo "NPM_TOKEN is not set; skipping npm publish."
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ needs.package-bundles.outputs.tag }}
           name: tyrum ${{ needs.package-bundles.outputs.version }}

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -30,9 +30,9 @@ jobs:
       security-events: write
       actions: read
     container:
-      image: semgrep/semgrep:1.152.0
+      image: semgrep/semgrep:1.152.0@sha256:e04d2cb132288d90035db8791d64f610cb255b21e727b94db046243b30c01ae9
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Semgrep (SARIF)
         continue-on-error: true
@@ -42,6 +42,6 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -37,12 +37,12 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
           cache: pnpm
@@ -58,7 +58,7 @@ jobs:
 
       - name: Report failure for triage
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ github.token }}
           script: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ The repo-local hooks are:
 - `pre-commit`: runs `pnpm format:check-staged` and `pnpm lint` for fast checks on commit.
 - `pre-push`: runs `pnpm lint`, `pnpm typecheck`, `pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json`, and `pnpm test` for stronger validation before pushing.
 
+### Dependency intake
+
+Dependency additions are treated as supply-chain changes, not routine cleanup.
+
+- Keep installs on the frozen lockfile path: `pnpm install --frozen-lockfile`.
+- If a new dependency needs `preinstall` / `install` / `postinstall`, review it explicitly and update the root `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml` in the same PR.
+- Use `pnpm approve-builds` only as a review aid; the PR description should name the package, why the build script is required, and what was reviewed before allowing it.
+
 ## 5. Test Conventions
 
 Use the smallest test scope that proves the behavior you changed:
@@ -144,9 +152,13 @@ pnpm lint:oxlint:report
 
 Pull requests must reference their GitHub Issue and pass all required checks:
 
-- `ci-web`
-- `security-baseline`
+- `ci / Dependency Review`
+- `ci / Packages`
+- `ci / Web`
+- `security-baseline / Security baseline`
 - At least one approving review
+
+Changes under `.github/workflows/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `patches/**`, `.github/dependabot.yml`, or `scripts/install.sh` also require code-owner review.
 
 Follow the 72-character imperative commit style (e.g. `Add policy gate scaffold`).
 

--- a/package.json
+++ b/package.json
@@ -79,18 +79,7 @@
       "ignoreCves": [
         "CVE-2026-31808"
       ]
-    },
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "core-js",
-      "core-js-pure",
-      "electron",
-      "electron-winstaller",
-      "esbuild",
-      "protobufjs",
-      "tesseract.js",
-      "usocket"
-    ]
+    }
   },
   "devDependencies": {
     "astral-regex": "^2.0.0",

--- a/packages/gateway/tests/unit/rebased-pr-overwrites-script.test.ts
+++ b/packages/gateway/tests/unit/rebased-pr-overwrites-script.test.ts
@@ -91,8 +91,8 @@ describe("rebased PR overwrite analyzer", () => {
     expect(workflow).toContain("node scripts/report-rebased-pr-overwrites.mjs");
     expect(workflow).toContain('--pr "${{ github.event.pull_request.number }}"');
     expect(workflow).toContain("pr-overwrite-analysis.json");
-    expect(workflow).toContain("actions/github-script@v8");
+    expect(workflow).toMatch(/actions\/github-script@[0-9a-f]{40} # v8/u);
     expect(workflow).toContain("<!-- pr-overwrite-analyzer -->");
-    expect(workflow).toContain("actions/upload-artifact@v7");
+    expect(workflow).toMatch(/actions\/upload-artifact@[0-9a-f]{40} # v7/u);
   });
 });

--- a/packages/gateway/tests/unit/sast-workflow.test.ts
+++ b/packages/gateway/tests/unit/sast-workflow.test.ts
@@ -16,6 +16,7 @@ test("SAST workflow exists and scopes to packages/apps", () => {
   expect(workflow).toContain("paths:");
   expect(workflow).toContain("packages/**");
   expect(workflow).toContain("apps/**");
-  expect(workflow).toContain("uses: github/codeql-action/upload-sarif@v4");
+  expect(workflow).toContain("semgrep/semgrep:1.152.0@sha256:");
+  expect(workflow).toMatch(/uses: github\/codeql-action\/upload-sarif@[0-9a-f]{40} # v4/u);
   expect(workflow).not.toMatch(/dorny\/paths-filter@v\d+/);
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,17 @@ packages:
   - "packages/*"
   - "apps/*"
 
+minimumReleaseAge: 1440
+blockExoticSubdeps: true
+strictDepBuilds: true
+
 onlyBuiltDependencies:
-  - esbuild
   - better-sqlite3
+  - core-js
+  - core-js-pure
+  - electron
+  - electron-winstaller
+  - esbuild
+  - protobufjs
+  - tesseract.js
+  - usocket


### PR DESCRIPTION
Closes #1905.

## What changed

This PR implements the shortest high-impact phase-1 supply-chain hardening for the repo and CI workflows.

- hardens dependency intake with `minimumReleaseAge`, `blockExoticSubdeps`, and `strictDepBuilds`
- moves the effective `onlyBuiltDependencies` allowlist into `pnpm-workspace.yaml`
- adds `CODEOWNERS` coverage for supply-chain-sensitive files
- tightens dependency review and wires it into required status checks
- pins all GitHub Actions to immutable commit SHAs
- pins the `actionlint` and `semgrep` workflow container images by digest
- documents contributor expectations for dependency build-script review
- preserves token-based npm publish for the first release while keeping `--provenance`

## Why

The repo already had some useful controls, but phase 1 focused on the shortest path to reduce supply-chain risk in three areas:

- dependency intake
- mutable CI/workflow dependencies
- review protection for sensitive files

The npm trusted-publishing cutover was intentionally deferred because these packages have not been published yet, so npm trusted publishers cannot be configured until after the first publish.

## Impact

- dependency PRs with high-severity runtime or unknown-scope risk now fail dependency review
- workflow and release-sensitive files now require code-owner review
- CI workflow dependencies are pinned immutably
- installs remain compatible with the current first-publish token flow

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/gateway/tests/unit/sast-workflow.test.ts packages/gateway/tests/unit/rebased-pr-overwrites-script.test.ts`
- `pnpm lint`
- `docker run --rm -v "$PWD":/repo:Z -w /repo rhysd/actionlint:1.7.11@sha256:6f03470d0152251d7f07f7c4dc019dbe7024c72cd952f839544c7798843efa8f -color`
- pre-push hook: `pnpm lint && pnpm typecheck && pnpm exec tsc --noEmit --project apps/desktop/tsconfig.json && pnpm test`

## Follow-up

After the packages exist on npm, configure npm trusted publishers for the four published packages, then remove the `NPM_TOKEN` fallback in a follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten dependency intake rules and CI enforcement (dependency review gating, pnpm build-script allowlisting), which can break installs or PR merges if misconfigured. Workflow action pinning is low functional risk but touches critical CI/release pipelines.
> 
> **Overview**
> Introduces *supply-chain hardening* across dependency management and CI: pnpm workspace now enforces `minimumReleaseAge`, `blockExoticSubdeps`, `strictDepBuilds`, and centralizes the `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml` (removed from `package.json`).
> 
> CI and repo protections are tightened by adding a `Dependency Review` job that fails on high-severity runtime/unknown-scope changes and making it a required status check, plus adding `CODEOWNERS` coverage for workflow/dependency/release-sensitive paths. All GitHub Actions and key container images used in workflows are pinned to immutable SHAs/digests, and contributor docs are updated with explicit dependency/build-script review expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5a0ddabe64c775293b8863fee4e09c4741e47c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->