### PR TITLE
[codex] Bound Discord heartbeat intervals

### DIFF
--- a/packages/gateway/src/modules/channels/discord-monitor.ts
+++ b/packages/gateway/src/modules/channels/discord-monitor.ts
@@ -7,6 +7,9 @@ import { ChannelConfigDal, type StoredDiscordChannelConfig } from "./channel-con
 
 const DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
 const DISCORD_GATEWAY_INTENTS = 1 + 512 + 4096 + 32768;
+const DEFAULT_DISCORD_HEARTBEAT_INTERVAL_MS = 45_000;
+const MIN_DISCORD_HEARTBEAT_INTERVAL_MS = 5_000;
+const MAX_DISCORD_HEARTBEAT_INTERVAL_MS = 120_000;
 const DEFAULT_RECONCILE_INTERVAL_MS = 30_000;
 const DEFAULT_RECONNECT_DELAY_MS = 5_000;
 const DISCORD_MESSAGE_LIMIT = 2_000;
@@ -79,6 +82,20 @@ function splitDiscordMessage(text: string): string[] {
     chunks.push(remaining);
   }
   return chunks;
+}
+
+function resolveDiscordHeartbeatIntervalMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_DISCORD_HEARTBEAT_INTERVAL_MS;
+  }
+  const normalized = Math.floor(value);
+  if (
+    normalized < MIN_DISCORD_HEARTBEAT_INTERVAL_MS ||
+    normalized > MAX_DISCORD_HEARTBEAT_INTERVAL_MS
+  ) {
+    return DEFAULT_DISCORD_HEARTBEAT_INTERVAL_MS;
+  }
+  return normalized;
 }
 
 function isDiscordMessageAllowed(
@@ -336,10 +353,7 @@ class DiscordGatewayConnection {
         return;
       case 10: {
         const data = payload.d as { heartbeat_interval?: number } | undefined;
-        const heartbeatIntervalMs =
-          typeof data?.heartbeat_interval === "number" && data.heartbeat_interval > 0
-            ? data.heartbeat_interval
-            : 45_000;
+        const heartbeatIntervalMs = resolveDiscordHeartbeatIntervalMs(data?.heartbeat_interval);
         this.startHeartbeat(heartbeatIntervalMs);
         this.identify();
         return;

--- a/packages/gateway/tests/unit/discord-monitor.test.ts
+++ b/packages/gateway/tests/unit/discord-monitor.test.ts
@@ -1,7 +1,61 @@
-import { describe, expect, it, vi } from "vitest";
-import { handleDiscordMessageCreate } from "../../src/modules/channels/discord-monitor.js";
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import type { StoredDiscordChannelConfig } from "../../src/modules/channels/channel-config-dal.js";
+import {
+  DiscordChannelMonitor,
+  handleDiscordMessageCreate,
+} from "../../src/modules/channels/discord-monitor.js";
+
+const DISCORD_MONITOR_CONFIG: StoredDiscordChannelConfig = {
+  channel: "discord",
+  account_key: "community",
+  agent_key: "agent-b",
+  bot_token: "discord-bot-token",
+  allowed_user_ids: [],
+  allowed_channels: [],
+};
+
+class FakeGatewaySocket extends EventEmitter {
+  readyState = WebSocket.OPEN;
+  readonly sentPayloads: unknown[] = [];
+
+  send(data: string): void {
+    this.sentPayloads.push(JSON.parse(data) as Record<string, unknown>);
+  }
+
+  close(code = 1000): void {
+    this.readyState = WebSocket.CLOSED;
+    this.emit("close", code);
+  }
+}
+
+async function startDiscordMonitorWithSocket(
+  socket: FakeGatewaySocket,
+): Promise<DiscordChannelMonitor> {
+  const monitor = new DiscordChannelMonitor({
+    channelConfigDal: {
+      list: async () => [DISCORD_MONITOR_CONFIG],
+    } as never,
+    agents: {
+      getRuntime: vi.fn(),
+    } as never,
+    createWebSocket: () => socket as unknown as WebSocket,
+    reconcileIntervalMs: 60_000,
+  });
+
+  monitor.start();
+  await vi.advanceTimersByTimeAsync(0);
+
+  return monitor;
+}
 
 describe("discord monitor", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
   it("routes DM messages to the configured agent and sends a reply", async () => {
     const fetchMock = vi.fn(
       async () => new Response(JSON.stringify({ id: "message-1" }), { status: 200 }),
@@ -154,5 +208,45 @@ describe("discord monitor", () => {
 
     expect(turnCalled).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default heartbeat interval when the gateway interval is too large", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeGatewaySocket();
+    const monitor = await startDiscordMonitorWithSocket(socket);
+
+    socket.emit("message", JSON.stringify({ op: 10, d: { heartbeat_interval: 600_000 } }));
+
+    expect(socket.sentPayloads).toHaveLength(1);
+    expect(socket.sentPayloads[0]).toMatchObject({ op: 2 });
+
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(socket.sentPayloads).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(socket.sentPayloads).toHaveLength(2);
+    expect(socket.sentPayloads[1]).toMatchObject({ op: 1 });
+
+    monitor.stop();
+  });
+
+  it("falls back to the default heartbeat interval when the gateway interval is too small", async () => {
+    vi.useFakeTimers();
+    const socket = new FakeGatewaySocket();
+    const monitor = await startDiscordMonitorWithSocket(socket);
+
+    socket.emit("message", JSON.stringify({ op: 10, d: { heartbeat_interval: 1 } }));
+
+    expect(socket.sentPayloads).toHaveLength(1);
+    expect(socket.sentPayloads[0]).toMatchObject({ op: 2 });
+
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(socket.sentPayloads).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(socket.sentPayloads).toHaveLength(2);
+    expect(socket.sentPayloads[1]).toMatchObject({ op: 1 });
+
+    monitor.stop();
   });
 });


### PR DESCRIPTION
## Summary
- validate Discord gateway `HELLO` heartbeat intervals before they reach `setInterval`
- fall back to the existing 45s default when the gateway sends a non-finite, too-small, or too-large interval
- add regression tests that prove out-of-range values no longer control the heartbeat timer lifecycle

## Root cause
`DiscordGatewayConnection.handleGatewayMessage()` accepted any positive `heartbeat_interval` value from the Discord gateway payload and passed it straight into `setInterval`. That payload is network input, so it must be treated as untrusted even though the endpoint is expected to be Discord. Without explicit bounds, malformed input could force extremely short or long-lived timers and trip CodeQL's resource exhaustion rule.

## Impact
This keeps valid Discord heartbeat behavior intact while preventing unbounded external timer control. Invalid gateway intervals now degrade safely to the existing default behavior.

## Validation
- `pnpm exec vitest run packages/gateway/tests/unit/discord-monitor.test.ts`
- pre-push `pnpm run ci` via git hook

Closes #1922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Discord gateway `HELLO` heartbeat intervals are interpreted, which could affect connection stability if bounds are incorrect; mitigated by targeted unit tests covering out-of-range values.
> 
> **Overview**
> Adds validation/bounds for the Discord gateway `HELLO` `heartbeat_interval` before starting the heartbeat timer, clamping behavior by falling back to the existing 45s default when the value is non-finite, too small (<5s), or too large (>120s).
> 
> Extends `discord-monitor` unit tests with a fake WebSocket to assert that out-of-range intervals no longer control heartbeat scheduling and that the monitor still identifies and sends heartbeats on the default cadence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3cd1c99d43870434ef162287a498260713876e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->