### PR TITLE
[codex] Pin defu to 6.1.6 for the prototype pollution alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
       "@modelcontextprotocol/sdk>express-rate-limit": "8.3.0",
       "dmg-license>ajv": "8.18.0",
       "dbus-next>xml2js": "0.5.0",
+      "defu": "6.1.6",
       "fast-xml-parser": "5.5.7",
       "file-loader>schema-utils": "4.3.3",
       "brace-expansion": "5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   '@modelcontextprotocol/sdk>express-rate-limit': 8.3.0
   dmg-license>ajv: 8.18.0
   dbus-next>xml2js: 0.5.0
+  defu: 6.1.6
   fast-xml-parser: 5.5.7
   file-loader>schema-utils: 4.3.3
   brace-expansion: 5.0.5
@@ -6838,8 +6839,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.6:
+    resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -19937,7 +19938,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.6: {}
 
   delaunator@5.0.1:
     dependencies:
@@ -25170,7 +25171,7 @@ snapshots:
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
-      defu: 6.1.4
+      defu: 6.1.6
       empathic: 2.0.0
       hookable: 6.1.0
       import-without-cache: 0.2.5


### PR DESCRIPTION
Closes #1923.

## What changed
- added a root `pnpm.overrides` pin for `defu: 6.1.6`
- regenerated `pnpm-lock.yaml` so the `tsdown` dependency path resolves `defu@6.1.6`

## Why
Dependabot alert #64 reported prototype pollution in `defu<=6.1.4`. The vulnerable package is only present transitively through the root devDependency `tsdown@0.21.7`.

## Root cause
The workspace lockfile was still resolving `defu@6.1.4`, and there was no repo-level override to enforce a patched minimum for that transitive dependency. A plain lockfile refresh was not sufficient to move the subdependency reliably, so the vulnerable resolution persisted.

## Impact
- removes the vulnerable `defu@6.1.4` resolution from this workspace
- keeps the fix narrow to dependency policy and lockfile state
- follows the repo's existing pattern of using `pnpm.overrides` for targeted dependency security fixes

## Validation
- `pnpm why defu` -> `tsdown 0.21.7 -> defu 6.1.6`
- `pnpm audit --prod --dev --json` no longer reports `defu`; remaining audit output is an unrelated `file-type` review item
- `pnpm run ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-policy change that forces a patched transitive version of `defu` to address a prototype pollution advisory. Main risk is unexpected incompatibility if any dependency relied on `defu@6.1.4` behavior.
> 
> **Overview**
> Pins the transitive dependency `defu` to `6.1.6` via a root `pnpm.overrides` entry to remediate a prototype pollution alert.
> 
> Regenerates `pnpm-lock.yaml` so the workspace no longer resolves `defu@6.1.4` (including under `tsdown`) and consistently pulls `defu@6.1.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bccee288083e2264ab05a13681f747bb27f1694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->