### PR TITLE
Remove execution tables from snapshot import/export (#1889)

### DIFF
--- a/packages/gateway/src/routes/snapshot.ts
+++ b/packages/gateway/src/routes/snapshot.ts
@@ -48,14 +48,13 @@ const DEFAULT_TABLES = [
   "approvals",
   // Canvas
   "canvas_artifacts",
-  // Execution engine
+  // Turn + workflow durability
   "turn_jobs",
   "turns",
   "turn_items",
   "workflow_runs",
   "workflow_run_steps",
-  "execution_steps",
-  "execution_attempts",
+  "dispatch_records",
   "artifacts",
   "artifact_access",
   "artifact_links",
@@ -112,8 +111,7 @@ const IMPORT_ORDER = [
   "turn_items",
   "workflow_runs",
   "workflow_run_steps",
-  "execution_steps",
-  "execution_attempts",
+  "dispatch_records",
   "artifacts",
   "artifact_access",
   "artifact_links",
@@ -125,9 +123,8 @@ const DEFERRED_APPROVAL_SCOPE_REF_COLUMNS = [
   "turn_id",
   "turn_item_id",
   "workflow_run_step_id",
-  "step_id",
-  "attempt_id",
 ] as const;
+const LEGACY_APPROVAL_SCOPE_REF_COLUMNS = ["step_id", "attempt_id"] as const;
 const CONVERSATION_PENDING_JSON_DEFAULT =
   '{"compacted_through_message_id":null,"recent_message_ids":[],"pending_approvals":[],"pending_tool_state":[]}';
 
@@ -137,8 +134,6 @@ interface DeferredApprovalScopeRefPatch {
   turnId: unknown;
   turnItemId: unknown;
   workflowRunStepId: unknown;
-  stepId: unknown;
-  attemptId: unknown;
 }
 
 function quoteIdent(name: string): string {
@@ -331,9 +326,13 @@ function prepareApprovalImportWithDeferredScopeRefs(data: SnapshotTableT): {
   const deferredColumns = DEFERRED_APPROVAL_SCOPE_REF_COLUMNS.filter((column) =>
     data.columns.includes(column),
   );
-  if (deferredColumns.length === 0) {
+  const legacyColumns = LEGACY_APPROVAL_SCOPE_REF_COLUMNS.filter((column) =>
+    data.columns.includes(column),
+  );
+  if (deferredColumns.length === 0 && legacyColumns.length === 0) {
     return { data, deferredPatches: [] };
   }
+  const sanitizedColumns = [...deferredColumns, ...legacyColumns];
 
   if (!data.columns.includes("tenant_id") || !data.columns.includes("approval_id")) {
     throw new Error("snapshot import: approvals rows require tenant_id and approval_id");
@@ -344,7 +343,7 @@ function prepareApprovalImportWithDeferredScopeRefs(data: SnapshotTableT): {
       columns: data.columns,
       rows: data.rows.map((row: Record<string, unknown>) => {
         const sanitizedRow: Record<string, unknown> = { ...row };
-        for (const column of deferredColumns) {
+        for (const column of sanitizedColumns) {
           sanitizedRow[column] = null;
         }
         return sanitizedRow;
@@ -357,14 +356,8 @@ function prepareApprovalImportWithDeferredScopeRefs(data: SnapshotTableT): {
         turnId: rowValue(row, "turn_id"),
         turnItemId: rowValue(row, "turn_item_id"),
         workflowRunStepId: rowValue(row, "workflow_run_step_id"),
-        stepId: rowValue(row, "step_id"),
-        attemptId: rowValue(row, "attempt_id"),
       };
-      return patch.turnId === null &&
-        patch.turnItemId === null &&
-        patch.workflowRunStepId === null &&
-        patch.stepId === null &&
-        patch.attemptId === null
+      return patch.turnId === null && patch.turnItemId === null && patch.workflowRunStepId === null
         ? []
         : [patch];
     }),
@@ -382,19 +375,9 @@ async function applyDeferredApprovalScopeRefPatches(
       `UPDATE approvals
        SET turn_id = ?,
            turn_item_id = ?,
-           workflow_run_step_id = ?,
-           step_id = ?,
-           attempt_id = ?
+           workflow_run_step_id = ?
        WHERE tenant_id = ? AND approval_id = ?`,
-      [
-        patch.turnId,
-        patch.turnItemId,
-        patch.workflowRunStepId,
-        patch.stepId,
-        patch.attemptId,
-        patch.tenantId,
-        patch.approvalId,
-      ],
+      [patch.turnId, patch.turnItemId, patch.workflowRunStepId, patch.tenantId, patch.approvalId],
     );
     if (res.changes !== 1) {
       throw new Error(

--- a/packages/gateway/tests/integration/snapshot.approval-scope.test.ts
+++ b/packages/gateway/tests/integration/snapshot.approval-scope.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createTestApp } from "./helpers.js";
 import { seedPausedExecutionRun } from "../helpers/execution-fixtures.js";
 import { seedSnapshotApprovalScopeFixtures } from "../helpers/snapshot-fixtures.js";
+import { DispatchRecordDal } from "../../src/modules/node/dispatch-record-dal.js";
 import {
   DEFAULT_AGENT_ID,
   DEFAULT_TENANT_ID,
@@ -9,17 +10,18 @@ import {
 } from "../../src/modules/identity/scope.js";
 
 describe("snapshot routes approval scope import", () => {
-  it("imports approvals that reference execution, turn-item, and workflow scope rows", async () => {
+  it("round-trips replacement scope records and drops legacy execution refs", async () => {
     const { app, container } = await createTestApp({
       deploymentConfig: { snapshots: { importEnabled: true } },
     });
 
-    const turnId = "turn-snapshot-linked";
-    const turnItemId = "turn-item-snapshot-linked";
-    const stepId = "step-snapshot-linked";
-    const attemptId = "attempt-snapshot-linked";
-    const workflowRunId = "workflow-run-snapshot-linked";
-    const workflowRunStepId = "workflow-step-snapshot-linked";
+    const turnId = "550e8400-e29b-41d4-a716-446655440200";
+    const turnItemId = "550e8400-e29b-41d4-a716-446655440201";
+    const stepId = "550e8400-e29b-41d4-a716-446655440202";
+    const attemptId = "550e8400-e29b-41d4-a716-446655440203";
+    const workflowRunId = "550e8400-e29b-41d4-a716-446655440204";
+    const workflowRunStepId = "550e8400-e29b-41d4-a716-446655440205";
+    const dispatchId = "550e8400-e29b-41d4-a716-446655440206";
     await seedPausedExecutionRun({ db: container.db, jobId: "job-snapshot-linked", turnId });
     await seedSnapshotApprovalScopeFixtures({
       db: container.db,
@@ -80,10 +82,33 @@ describe("snapshot routes approval scope import", () => {
        WHERE tenant_id = ? AND step_id = ?`,
       [approval.approval_id, DEFAULT_TENANT_ID, stepId],
     );
+    await new DispatchRecordDal(container.db).create({
+      tenantId: DEFAULT_TENANT_ID,
+      dispatchId,
+      capability: "tyrum.desktop.snapshot",
+      action: {
+        type: "Desktop",
+        args: { op: "snapshot", include_tree: true },
+      },
+      taskId: "task-snapshot-linked",
+      turnId,
+      turnItemId,
+      workflowRunStepId,
+      selectedNodeId: "node-snapshot-linked",
+      connectionId: "conn-snapshot-linked",
+    });
 
     const exportRes = await app.request("/snapshot/export");
     expect(exportRes.status).toBe(200);
     const bundle = (await exportRes.json()) as Record<string, unknown>;
+    const tables = bundle["tables"] as Record<string, unknown> | undefined;
+    expect(tables).toBeDefined();
+    expect(tables).toHaveProperty("turn_items");
+    expect(tables).toHaveProperty("workflow_runs");
+    expect(tables).toHaveProperty("workflow_run_steps");
+    expect(tables).toHaveProperty("dispatch_records");
+    expect(tables).not.toHaveProperty("execution_steps");
+    expect(tables).not.toHaveProperty("execution_attempts");
 
     const { app: app2, container: container2 } = await createTestApp({
       deploymentConfig: { snapshots: { importEnabled: true } },
@@ -113,8 +138,8 @@ describe("snapshot routes approval scope import", () => {
       turn_id: turnId,
       turn_item_id: turnItemId,
       workflow_run_step_id: workflowRunStepId,
-      step_id: stepId,
-      attempt_id: attemptId,
+      step_id: null,
+      attempt_id: null,
     });
 
     const importedTurnItem = await container2.db.get<{ turn_item_id: string }>(
@@ -133,13 +158,26 @@ describe("snapshot routes approval scope import", () => {
     );
     expect(importedWorkflowStep).toEqual({ workflow_run_step_id: workflowRunStepId });
 
-    const importedStep = await container2.db.get<{ approval_id: string | null }>(
-      `SELECT approval_id
-       FROM execution_steps
-       WHERE tenant_id = ? AND step_id = ?`,
-      [DEFAULT_TENANT_ID, stepId],
-    );
-    expect(importedStep).toEqual({ approval_id: approval.approval_id });
+    await expect(
+      new DispatchRecordDal(container2.db).getByDispatchId({
+        tenantId: DEFAULT_TENANT_ID,
+        dispatchId,
+      }),
+    ).resolves.toMatchObject({
+      dispatch_id: dispatchId,
+      turn_id: turnId,
+      turn_item_id: turnItemId,
+      workflow_run_step_id: workflowRunStepId,
+      capability: "tyrum.desktop.snapshot",
+      status: "dispatched",
+      task_id: "task-snapshot-linked",
+      selected_node_id: "node-snapshot-linked",
+      connection_id: "conn-snapshot-linked",
+      action: {
+        type: "Desktop",
+        args: { op: "snapshot", include_tree: true },
+      },
+    });
 
     await container.db.close();
     await container2.db.close();


### PR DESCRIPTION
Closes #1889

## Summary
- remove `execution_steps` and `execution_attempts` from default snapshot export/import tables
- add `dispatch_records` to the snapshot round-trip alongside `turn_items` and workflow records
- sanitize legacy approval `step_id` and `attempt_id` values during snapshot import while preserving turn/workflow scope ids

## Validation
- `pnpm format:check`
- `pnpm exec vitest run packages/gateway/tests/integration/snapshot.test.ts packages/gateway/tests/integration/snapshot.approval-scope.test.ts packages/gateway/tests/integration/snapshot.postgres-import.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- pre-push `pnpm ci:local`

## Playwright
- not used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the set of tables exported/imported and modifies approval scope restoration logic, which could affect snapshot round-trips and data integrity if mismatched with existing bundles.
> 
> **Overview**
> Snapshot export/import now **excludes legacy execution durability tables** (`execution_steps`, `execution_attempts`) and instead **includes `dispatch_records`** alongside turn/workflow records.
> 
> During snapshot import of `approvals`, the importer now sanitizes both current scope refs (`turn_id`, `turn_item_id`, `workflow_run_step_id`) and legacy refs (`step_id`, `attempt_id`), but only restores the turn/workflow scope ids afterward (leaving `step_id`/`attempt_id` as `NULL`). Integration tests were updated to assert the new bundle contents and verify `dispatch_records` round-trips while legacy execution refs are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd3de72754b8e1e421789c3207451d68d95e8aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->