### PR TITLE
[codex] Fix axios audit finding in SAP dependency chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "@develar/schema-utils>ajv": "8.18.0",
       "@develar/schema-utils>ajv-keywords": "5.1.0",
       "@modelcontextprotocol/sdk>express-rate-limit": "8.3.0",
+      "axios": "1.15.0",
       "dmg-license>ajv": "8.18.0",
       "dbus-next>xml2js": "0.5.0",
       "defu": "6.1.6",

--- a/packages/contracts/tests/tooling/axios-audit-resolution.test.ts
+++ b/packages/contracts/tests/tooling/axios-audit-resolution.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../../../../");
+const LOCKFILE_PATH = resolve(REPO_ROOT, "pnpm-lock.yaml");
+const ROOT_PACKAGE_JSON_PATH = resolve(REPO_ROOT, "package.json");
+const AXIOS_PATCHED_VERSION = "1.15.0";
+
+type RootPackageJson = {
+  pnpm?: {
+    overrides?: Record<string, string>;
+  };
+};
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("tooling", () => {
+  it("pins axios to the patched release required by the audit baseline", () => {
+    const pkg = readJson(ROOT_PACKAGE_JSON_PATH) as RootPackageJson;
+    expect(pkg.pnpm?.overrides?.axios).toBe(AXIOS_PATCHED_VERSION);
+  });
+
+  it("does not resolve a vulnerable axios version in pnpm-lock.yaml", () => {
+    const lockfile = readFileSync(LOCKFILE_PATH, "utf8");
+
+    expect(lockfile).toContain(`axios@${AXIOS_PATCHED_VERSION}:`);
+    expect(lockfile).not.toMatch(/axios@1\.(?:[0-9]|1[0-4])\./);
+    expect(lockfile).not.toMatch(/axios@0\./);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@develar/schema-utils>ajv': 8.18.0
   '@develar/schema-utils>ajv-keywords': 5.1.0
   '@modelcontextprotocol/sdk>express-rate-limit': 8.3.0
+  axios: 1.15.0
   dmg-license>ajv: 8.18.0
   dbus-next>xml2js: 0.5.0
   defu: 6.1.6

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,19 @@ import { defineConfig } from "vitest/config";
 import { mkdirSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pnpmStoreDir = resolve(__dirname, "node_modules/.pnpm");
+const operatorUiRequire = createRequire(resolve(__dirname, "packages/operator-ui/package.json"));
 
 function resolvePnpmPackageDir(packageName: string): string {
+  try {
+    const packageJsonPath = operatorUiRequire.resolve(`${packageName}/package.json`);
+    return dirname(packageJsonPath);
+  } catch {
+    // Fall back to the pnpm store scan for packages that are not reachable from operator-ui.
+  }
   const packagePrefix = `${packageName.replaceAll("/", "+")}@`;
   const entry = readdirSync(pnpmStoreDir).find((candidate) => candidate.startsWith(packagePrefix));
   if (!entry) {


### PR DESCRIPTION
## Summary
Pin the transitive `axios` resolution used by the gateway's SAP AI provider chain to `1.15.0`, refresh the lockfile, and add a tooling regression test so the workspace does not drift back to a vulnerable lockfile state.

## Root Cause
`@jerome-benoit/sap-ai-provider-v2` pulls in `@sap-ai-sdk/*` and `@sap-cloud-sdk/*`, which allow `axios ^1.13.5`. The workspace lockfile had been generated before `axios@1.15.0` was published, so installs stayed on `axios@1.14.0` and `pnpm audit` reported the NO_PROXY hostname normalization SSRF advisory.

## What Changed
- added a root `pnpm.overrides` pin for `axios@1.15.0`
- refreshed `pnpm-lock.yaml` so the SAP dependency chain resolves the patched release
- added a tooling test that asserts the override is present and the lockfile no longer resolves vulnerable `axios` versions

## Impact
`pnpm audit` no longer reports the critical axios finding. The remaining moderate advisory stays ignored by the existing workspace audit configuration.

## Validation
- `pnpm exec prettier --check package.json packages/contracts/tests/tooling/axios-audit-resolution.test.ts`
- `pnpm exec vitest run packages/contracts/tests/tooling/axios-audit-resolution.test.ts`
- `pnpm audit`
- `pnpm run ci`

Closes #1955

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workspace-wide `pnpm.overrides` forces a new axios version for all dependents, which could affect runtime behavior if any package relies on older axios quirks. Changes are otherwise small and include a regression test to prevent lockfile drift back to vulnerable versions.
> 
> **Overview**
> Pins `axios` to `1.15.0` via root `pnpm.overrides` and refreshes `pnpm-lock.yaml` so the workspace resolves the patched release.
> 
> Adds a tooling Vitest (`packages/contracts/tests/tooling/axios-audit-resolution.test.ts`) that asserts both the override exists and the lockfile contains no `axios` < `1.15.0`, and tweaks `vitest.config.ts` package resolution to prefer `operator-ui`’s dependency graph before scanning the pnpm store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3892edc9ca409cba879383ea92ab894498ea5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->