### PR TITLE
[#1968] Add canonical tool bundle/tier config contract

### DIFF
--- a/packages/contracts/src/agent-access.ts
+++ b/packages/contracts/src/agent-access.ts
@@ -19,6 +19,7 @@ function normalizeLegacySkillConfig(value: unknown): unknown {
     !("deny" in parsed)
   ) {
     return {
+      ...parsed,
       default_mode: "deny",
       allow: parsed["enabled"],
       deny: [],
@@ -40,6 +41,7 @@ function normalizeLegacyMcpConfig(value: unknown): unknown {
     !("deny" in parsed)
   ) {
     return {
+      ...parsed,
       default_mode: "deny",
       allow: parsed["enabled"],
       deny: [],
@@ -59,6 +61,7 @@ function normalizeLegacyToolConfig(value: unknown): unknown {
       rawAllow.filter((entry): entry is string => typeof entry === "string"),
     ).includes("*");
     return {
+      ...parsed,
       default_mode: allowAll ? "allow" : "deny",
       allow: allowAll ? [] : parsed["allow"],
       deny: [],
@@ -70,6 +73,12 @@ function normalizeLegacyToolConfig(value: unknown): unknown {
 
 export const AgentAccessDefaultMode = z.enum(["allow", "deny"]);
 export type AgentAccessDefaultMode = z.infer<typeof AgentAccessDefaultMode>;
+
+export const AgentToolExposureBundle = z.string().trim().min(1);
+export type AgentToolExposureBundle = z.infer<typeof AgentToolExposureBundle>;
+
+export const AgentToolExposureTier = z.enum(["default", "advanced"]);
+export type AgentToolExposureTier = z.infer<typeof AgentToolExposureTier>;
 
 function uniqueStringList(values: readonly string[]): string[] {
   const result: string[] = [];
@@ -118,6 +127,8 @@ export const AgentMcpConfig = z.preprocess(
   normalizeLegacyMcpConfig,
   z
     .object({
+      bundle: AgentToolExposureBundle.optional(),
+      tier: AgentToolExposureTier.optional(),
       default_mode: AgentAccessDefaultMode.default("allow"),
       allow: z.array(z.string().trim().min(1)).default([]).overwrite(uniqueStringList),
       deny: z.array(z.string().trim().min(1)).default([]).overwrite(uniqueStringList),
@@ -137,6 +148,8 @@ export const AgentToolConfig = z.preprocess(
   normalizeLegacyToolConfig,
   z
     .object({
+      bundle: AgentToolExposureBundle.optional(),
+      tier: AgentToolExposureTier.optional(),
       default_mode: AgentAccessDefaultMode.default("allow"),
       allow: z.array(z.string().trim().min(1)).default([]).overwrite(canonicalizeToolIdList),
       deny: z.array(z.string().trim().min(1)).default([]).overwrite(canonicalizeToolIdList),

--- a/packages/contracts/tests/agent-access.test.ts
+++ b/packages/contracts/tests/agent-access.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "vitest";
 import { AgentMcpConfig, AgentSkillConfig, AgentToolConfig } from "../src/agent-access.js";
 
 describe("agent access config normalization", () => {
+  it("accepts canonical MCP bundle/tier selectors", () => {
+    const parsed = AgentMcpConfig.parse({
+      bundle: " workspace-default ",
+      tier: "advanced",
+      pre_turn_tools: ["mcp.memory.seed"],
+    });
+
+    expect(parsed).toEqual({
+      bundle: "workspace-default",
+      tier: "advanced",
+      default_mode: "allow",
+      allow: [],
+      deny: [],
+      pre_turn_tools: ["mcp.memory.seed"],
+      server_settings: {},
+    });
+  });
+
   it("normalizes legacy skill enabled lists into deny-by-default access config", () => {
     const parsed = AgentSkillConfig.parse({
       enabled: [" authoring ", "authoring"],
@@ -38,6 +56,22 @@ describe("agent access config normalization", () => {
     expect(parsed).toEqual({
       default_mode: "deny",
       allow: ["read", "write", "edit", "apply_patch", "glob", "grep", "bash"],
+      deny: [],
+    });
+  });
+
+  it("preserves canonical tool bundle/tier selectors alongside legacy allowlists", () => {
+    const parsed = AgentToolConfig.parse({
+      bundle: " authoring-core ",
+      tier: "default",
+      allow: [" tool.exec "],
+    });
+
+    expect(parsed).toEqual({
+      bundle: "authoring-core",
+      tier: "default",
+      default_mode: "deny",
+      allow: ["bash"],
       deny: [],
     });
   });

--- a/packages/contracts/tests/agent.test.ts
+++ b/packages/contracts/tests/agent.test.ts
@@ -29,11 +29,15 @@ describe("AgentConfig", () => {
     expect(parsed.mcp.default_mode).toBe("allow");
     expect(parsed.mcp.allow).toEqual([]);
     expect(parsed.mcp.deny).toEqual([]);
+    expect(parsed.mcp.bundle).toBeUndefined();
+    expect(parsed.mcp.tier).toBeUndefined();
     expect(parsed.mcp.pre_turn_tools).toEqual([]);
     expect(parsed.mcp.server_settings).toEqual({});
     expect(parsed.tools.default_mode).toBe("allow");
     expect(parsed.tools.allow).toEqual([]);
     expect(parsed.tools.deny).toEqual([]);
+    expect(parsed.tools.bundle).toBeUndefined();
+    expect(parsed.tools.tier).toBeUndefined();
     expect(parsed.conversations.ttl_days).toBe(365);
     expect(parsed.conversations.max_turns).toBe(0);
     expect(parsed.conversations.compaction.auto).toBe(true);
@@ -142,6 +146,25 @@ describe("AgentConfig", () => {
     });
 
     expect(parsed.tools.allow).toEqual(["read", "bash"]);
+  });
+
+  it("accepts canonical tool exposure selectors for MCP and tools", () => {
+    const parsed = AgentConfig.parse({
+      model: { model: "openai/gpt-5.4" },
+      mcp: {
+        bundle: "workspace-default",
+        tier: "advanced",
+      },
+      tools: {
+        bundle: "authoring-core",
+        tier: "default",
+      },
+    });
+
+    expect(parsed.mcp.bundle).toBe("workspace-default");
+    expect(parsed.mcp.tier).toBe("advanced");
+    expect(parsed.tools.bundle).toBe("authoring-core");
+    expect(parsed.tools.tier).toBe("default");
   });
 
   it("rejects overlapping access overrides", () => {

--- a/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
@@ -43,10 +43,12 @@ export function registerHttpClientOpsAdminTests(): void {
     expect(init.method).toBe("GET");
   });
 
-  it("agentConfig reads and updates persona config through /config/agents/:key", async () => {
+  it("agentConfig reads and updates canonical tool exposure config through /config/agents/:key", async () => {
+    let updateBody: Record<string, unknown> | undefined;
     const fetch = makeFetchMock(async (input, init) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.endsWith("/config/agents/agent-1") && init?.method === "PUT") {
+        updateBody = JSON.parse(String(init.body)) as Record<string, unknown>;
         return jsonResponse({
           revision: 2,
           tenant_id: "tenant-1",
@@ -61,8 +63,20 @@ export function registerHttpClientOpsAdminTests(): void {
               character: "builder",
             },
             skills: { default_mode: "allow", allow: [], deny: [], workspace_trusted: true },
-            mcp: { default_mode: "allow", allow: [], deny: [] },
-            tools: { default_mode: "allow", allow: [], deny: [] },
+            mcp: {
+              bundle: "workspace-default",
+              tier: "advanced",
+              default_mode: "allow",
+              allow: [],
+              deny: [],
+            },
+            tools: {
+              bundle: "authoring-core",
+              tier: "default",
+              default_mode: "allow",
+              allow: [],
+              deny: [],
+            },
             conversations: { ttl_days: 30, max_turns: 20 },
           },
           persona: {
@@ -93,8 +107,20 @@ export function registerHttpClientOpsAdminTests(): void {
             character: "architect",
           },
           skills: { default_mode: "allow", allow: [], deny: [], workspace_trusted: true },
-          mcp: { default_mode: "allow", allow: [], deny: [] },
-          tools: { default_mode: "allow", allow: [], deny: [] },
+          mcp: {
+            bundle: "workspace-default",
+            tier: "advanced",
+            default_mode: "allow",
+            allow: [],
+            deny: [],
+          },
+          tools: {
+            bundle: "authoring-core",
+            tier: "default",
+            default_mode: "allow",
+            allow: [],
+            deny: [],
+          },
           conversations: { ttl_days: 30, max_turns: 20 },
         },
         persona: {
@@ -115,6 +141,10 @@ export function registerHttpClientOpsAdminTests(): void {
     const admin = client as unknown as Record<string, any>;
     const current = await admin.agentConfig.get("agent-1");
     expect(current.persona.name).toBe("Hypatia");
+    expect(current.config.mcp.bundle).toBe("workspace-default");
+    expect(current.config.mcp.tier).toBe("advanced");
+    expect(current.config.tools.bundle).toBe("authoring-core");
+    expect(current.config.tools.tier).toBe("default");
 
     const updated = await admin.agentConfig.update("agent-1", {
       config: {
@@ -125,10 +155,27 @@ export function registerHttpClientOpsAdminTests(): void {
           palette: "moss",
           character: "builder",
         },
+        mcp: {
+          bundle: "workspace-default",
+          tier: "advanced",
+        },
+        tools: {
+          bundle: "authoring-core",
+          tier: "default",
+        },
       },
       reason: "update persona",
     });
     expect(updated.persona.name).toBe("Ada");
+    expect(updated.config.mcp.bundle).toBe("workspace-default");
+    expect(updated.config.tools.bundle).toBe("authoring-core");
+    expect(updateBody).toMatchObject({
+      config: {
+        mcp: { bundle: "workspace-default", tier: "advanced" },
+        tools: { bundle: "authoring-core", tier: "default" },
+      },
+      reason: "update persona",
+    });
   });
 
   it("toolRegistry.list sends GET /config/tools and validates tool metadata", async () => {

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -7292,6 +7292,14 @@
           "tool_access": {
             "type": "object",
             "properties": {
+              "bundle": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tier": {
+                "type": "string",
+                "enum": ["default", "advanced"]
+              },
               "default_mode": {
                 "default": "allow",
                 "type": "string",
@@ -7740,6 +7748,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -7790,6 +7806,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -9404,6 +9428,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -9454,6 +9486,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -15475,6 +15515,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -15525,6 +15573,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -15919,6 +15975,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -15969,6 +16033,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19070,6 +19142,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19120,6 +19200,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19468,6 +19556,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19518,6 +19614,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19910,6 +20014,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",
@@ -19960,6 +20072,14 @@
                 "default": {},
                 "type": "object",
                 "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "tier": {
+                    "type": "string",
+                    "enum": ["default", "advanced"]
+                  },
                   "default_mode": {
                     "default": "allow",
                     "type": "string",


### PR DESCRIPTION
Closes #1968

## What changed
- adds optional canonical `bundle` and `tier` selectors to `AgentMcpConfig` and `AgentToolConfig`
- keeps legacy `default_mode` / `allow` / `deny` parsing intact as migration compatibility
- adds contract coverage for canonical parsing and legacy compatibility
- updates transport SDK agent-config test coverage for the canonical config shape
- refreshes `specs/openapi.json` so generated API artifacts stay aligned

## Why
- issue #1968 introduces the canonical tool bundle/tier config write contract needed for the taxonomy rollout
- this keeps the change scoped to contracts and transport compatibility without pulling in runtime resolver, read-surface, seeding, or UI work owned by sibling issues

## How to test
- `pnpm --filter @tyrum/contracts test -- tests/agent-access.test.ts tests/agent.test.ts`
- `pnpm --filter @tyrum/transport-sdk test -- tests/http-client.test-ops-admin-support.ts tests/http-client.test-managed-agents-support.ts`
- `pnpm api:check`
- `pnpm run ci`

## Risk
- low and additive; the change extends shared config schemas with optional fields and preserves legacy parsing behavior
- the main compatibility consideration is that `AgentStatusResponse.tool_access` reuses `AgentToolConfig`, so the optional fields become available there too, but no resolved read-model behavior changes in this PR

## Rollback
- revert commit `7a2a5db7b4d3d1d9a3cc9154461fcec61d7a2e9f`
- if needed, drop the additive schema fields and regenerated OpenAPI snapshot together so contracts and generated artifacts stay in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema change to shared contracts/OpenAPI that may affect downstream validation/serialization, but fields are optional and legacy normalization behavior is preserved.
> 
> **Overview**
> Adds optional canonical tool exposure selectors (`bundle`, `tier`) to `AgentMcpConfig` and `AgentToolConfig`, including trimming/validation, while preserving legacy normalization by spreading unknown legacy fields through preprocessors.
> 
> Updates contract and transport SDK tests to cover parsing/default behavior and PUT payload shape for the new selectors, and refreshes `specs/openapi.json` to expose the new fields in agent config and tool access schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2a5db7b4d3d1d9a3cc9154461fcec61d7a2e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->