### PR TITLE
feat(agent-config): seed canonical tool exposure defaults

### DIFF
--- a/packages/gateway/src/modules/agent/default-config.ts
+++ b/packages/gateway/src/modules/agent/default-config.ts
@@ -5,6 +5,16 @@ import type { SqlDb } from "../../statestore/types.js";
 import { AgentConfigDal, type AgentConfigRevision } from "../config/agent-config-dal.js";
 import { buildSeededAgentPersona } from "./persona.js";
 
+const DEFAULT_MCP_EXPOSURE = {
+  bundle: "workspace-default",
+  tier: "advanced",
+} as const;
+
+const DEFAULT_TOOL_EXPOSURE = {
+  bundle: "authoring-core",
+  tier: "default",
+} as const;
+
 export function buildDefaultAgentConfig(
   _stateMode: GatewayStateMode,
   persona?: AgentConfigT["persona"],
@@ -13,8 +23,15 @@ export function buildDefaultAgentConfig(
     model: { model: null },
     ...(persona ? { persona } : {}),
     skills: { default_mode: "allow", workspace_trusted: true },
-    mcp: { default_mode: "allow", pre_turn_tools: ["mcp.memory.seed"] },
-    tools: { default_mode: "allow" },
+    mcp: {
+      ...DEFAULT_MCP_EXPOSURE,
+      default_mode: "allow",
+      pre_turn_tools: ["mcp.memory.seed"],
+    },
+    tools: {
+      ...DEFAULT_TOOL_EXPOSURE,
+      default_mode: "allow",
+    },
   });
 }
 

--- a/packages/gateway/tests/unit/agent-config-dal.test.ts
+++ b/packages/gateway/tests/unit/agent-config-dal.test.ts
@@ -174,6 +174,58 @@ describe("AgentConfigDal", () => {
     }
   });
 
+  it("parses legacy tool exposure config shapes when reading stored revisions", async () => {
+    const container = createContainer(
+      { dbPath: ":memory:", migrationsDir },
+      { deploymentConfig: DeploymentConfig.parse({}) },
+    );
+
+    try {
+      const dal = new AgentConfigDal(container.db);
+      const tenantId = DEFAULT_TENANT_ID;
+      const agentId = await container.identityScopeDal.ensureAgentId(tenantId, "default");
+      await container.db.run(
+        `INSERT INTO agent_configs (
+           tenant_id,
+           agent_id,
+           config_json,
+           created_at,
+           created_by_json,
+           reason,
+           reverted_from_revision
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          tenantId,
+          agentId,
+          JSON.stringify({
+            model: { model: "openai/gpt-4.1" },
+            mcp: { enabled: ["memory"] },
+            tools: { allow: ["tool.*"] },
+          }),
+          new Date().toISOString(),
+          JSON.stringify({ kind: "test" }),
+          "legacy tool exposure config",
+          null,
+        ],
+      );
+
+      const latest = await dal.getLatest({ tenantId, agentId });
+
+      expect(latest?.revision).toBe(1);
+      expect(latest?.config.mcp.bundle).toBeUndefined();
+      expect(latest?.config.mcp.tier).toBeUndefined();
+      expect(latest?.config.mcp.default_mode).toBe("deny");
+      expect(latest?.config.mcp.allow).toEqual(["memory"]);
+      expect(latest?.config.tools.bundle).toBeUndefined();
+      expect(latest?.config.tools.tier).toBeUndefined();
+      expect(latest?.config.tools.default_mode).toBe("allow");
+      expect(latest?.config.tools.allow).toEqual([]);
+      expect(latest?.config.tools.deny).toEqual([]);
+    } finally {
+      await container.db.close();
+    }
+  });
+
   it("rechecks the latest revision inside the migration transaction before inserting", async () => {
     const tenantId = DEFAULT_TENANT_ID;
     const agentId = "agent-1";

--- a/packages/gateway/tests/unit/agent-default-config.test.ts
+++ b/packages/gateway/tests/unit/agent-default-config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { join } from "node:path";
 import { createContainer, type GatewayContainer } from "../../src/container.js";
+import { ensureAgentConfigSeeded } from "../../src/modules/agent/default-config.js";
 import { loadAgentConfigFromDb } from "../../src/modules/agent/runtime/turn-preparation-helpers.js";
 import type { ConversationDal } from "../../src/modules/agent/conversation-dal.js";
 
@@ -52,6 +53,71 @@ describe("agent default config loading", () => {
     expect(before?.count ?? 0).toBe(0);
     expect(config.model.model).toBeNull();
     expect(config.skills.default_mode).toBe("allow");
+    expect(config.mcp.bundle).toBe("workspace-default");
+    expect(config.mcp.tier).toBe("advanced");
+    expect(config.mcp.default_mode).toBe("allow");
+    expect(config.mcp.pre_turn_tools).toEqual(["mcp.memory.seed"]);
+    expect(config.tools.bundle).toBe("authoring-core");
+    expect(config.tools.tier).toBe("default");
+    expect(config.tools.default_mode).toBe("allow");
     expect(after?.count ?? 0).toBe(0);
+  });
+
+  it("seeds backend-created agent configs with canonical bundle and tier defaults", async () => {
+    const container = createContainer(
+      { dbPath: ":memory:", migrationsDir },
+      { deploymentConfig: { state: { mode: "shared" } } },
+    );
+    containers.push(container);
+    const tenantId = await container.identityScopeDal.ensureTenantId("seeded-agent-config");
+    const agentId = await container.identityScopeDal.ensureAgentId(tenantId, "primary-agent");
+
+    const seeded = await ensureAgentConfigSeeded({
+      db: container.db,
+      stateMode: "shared",
+      tenantId,
+      agentId,
+      agentKey: "primary-agent",
+      createdBy: { kind: "test" },
+      reason: "seed default config",
+    });
+
+    const stored = await container.db.get<{ config_json: string; count: number }>(
+      `SELECT config_json, COUNT(1) OVER () AS count
+       FROM agent_configs
+       WHERE tenant_id = ? AND agent_id = ?`,
+      [tenantId, agentId],
+    );
+    const storedConfig = JSON.parse(stored?.config_json ?? "{}") as Record<string, unknown>;
+    const storedMcp =
+      storedConfig["mcp"] &&
+      typeof storedConfig["mcp"] === "object" &&
+      !Array.isArray(storedConfig["mcp"])
+        ? (storedConfig["mcp"] as Record<string, unknown>)
+        : {};
+    const storedTools =
+      storedConfig["tools"] &&
+      typeof storedConfig["tools"] === "object" &&
+      !Array.isArray(storedConfig["tools"])
+        ? (storedConfig["tools"] as Record<string, unknown>)
+        : {};
+
+    expect(seeded.revision).toBe(1);
+    expect(seeded.config.mcp.bundle).toBe("workspace-default");
+    expect(seeded.config.mcp.tier).toBe("advanced");
+    expect(seeded.config.tools.bundle).toBe("authoring-core");
+    expect(seeded.config.tools.tier).toBe("default");
+    expect(stored?.count ?? 0).toBe(1);
+    expect(storedMcp).toMatchObject({
+      bundle: "workspace-default",
+      tier: "advanced",
+      default_mode: "allow",
+      pre_turn_tools: ["mcp.memory.seed"],
+    });
+    expect(storedTools).toMatchObject({
+      bundle: "authoring-core",
+      tier: "default",
+      default_mode: "allow",
+    });
   });
 });


### PR DESCRIPTION
Closes #1993

## What changed
- seed backend default agent configs with the canonical tool exposure selectors from the landed bundle/tier contract work
- keep the existing default allow behavior and legacy memory pre-turn seed behavior for this issue
- add targeted gateway regressions for fallback loading, persisted seeding, and legacy tool-exposure parsing

## Why
Backend-generated defaults were still treating implicit allow-all as the canonical model after the canonical bundle/tier config contract landed. This aligns backend-created defaults with the explicit model introduced for the epic without absorbing later read-surface or operator-flow work.

## How to test
- `pnpm exec vitest run packages/gateway/tests/unit/agent-default-config.test.ts packages/gateway/tests/unit/agent-config-dal.test.ts`
- `pnpm lint`
- `pnpm run ci`

## Risk
Low. The change is backend-only and confined to the shared default agent-config builder plus targeted unit coverage. Legacy parsing behavior is preserved and covered.

## Rollback notes
Revert commit `aea4e56f5` to restore the prior backend default-config seeding behavior if this needs to be backed out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the backend default agent config shape by adding explicit `bundle`/`tier` selectors while keeping existing allow-by-default behavior, and adds unit coverage to prevent regressions and ensure legacy stored shapes still load.
> 
> **Overview**
> Backend-generated default agent configs now include explicit canonical tool-exposure selectors: `mcp` defaults to `bundle: "workspace-default"`, `tier: "advanced"` and `tools` defaults to `bundle: "authoring-core"`, `tier: "default"` (while preserving existing `default_mode` and `mcp.memory.seed` pre-turn behavior).
> 
> Tests are expanded to assert these defaults are returned without persisting a revision, are persisted when `ensureAgentConfigSeeded` runs, and that `AgentConfigDal.getLatest` can still read legacy stored `mcp.enabled` / `tools.allow` shapes without injecting `bundle`/`tier`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea4e56f58402b111dbb7e78a03ac7adea20180d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->