### PR TITLE
Extract a shared agent-scoped tool descriptor source for runtime and downstream consumers

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/agent-runtime-gateway-lifecycle.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime-gateway-lifecycle.ts
@@ -235,7 +235,7 @@ export const gatewayRuntimeLifecycle: GatewayRuntimeLifecycle = {
     const availableTools = await listAvailableRuntimeTools({
       opts: context.deps.opts,
       mcpManager: context.deps.mcpManager,
-      mcpServers: loaded.mcpServers,
+      loaded,
       plugins: context.plugins,
     });
     return buildEnabledAgentStatus({
@@ -263,7 +263,7 @@ export const gatewayRuntimeLifecycle: GatewayRuntimeLifecycle = {
     const availableTools = await listAvailableRuntimeTools({
       opts: context.deps.opts,
       mcpManager: context.deps.mcpManager,
-      mcpServers: loaded.mcpServers,
+      loaded,
       plugins: context.plugins,
     });
     return buildRegisteredToolsResult({

--- a/packages/gateway/src/modules/agent/runtime/agent-runtime-status.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime-status.ts
@@ -9,14 +9,11 @@ import { loadAgentConfigOrDefault } from "../default-config.js";
 import type { AgentContextStore } from "../context-store.js";
 import { loadCurrentAgentContext } from "../load-context.js";
 import { applyPersonaToIdentity, resolveAgentPersona } from "../persona.js";
-import {
-  isBuiltinToolAvailableInStateMode,
-  listBuiltinToolDescriptors,
-  type ToolDescriptor,
-} from "../tools.js";
+import { type ToolDescriptor } from "../tools.js";
 import { resolveEffectiveAgentConfig } from "../../extensions/defaults-dal.js";
 import type { AgentRuntimeOptions } from "./types.js";
 import type { McpManager } from "../mcp-manager.js";
+import { resolveRuntimeToolDescriptorSource } from "./runtime-tool-descriptor-source.js";
 
 export async function loadResolvedRuntimeContext(params: {
   opts: AgentRuntimeOptions;
@@ -49,27 +46,17 @@ export async function loadResolvedRuntimeContext(params: {
 export async function listAvailableRuntimeTools(params: {
   opts: AgentRuntimeOptions;
   mcpManager: McpManager;
-  mcpServers: Parameters<McpManager["listToolDescriptors"]>[0];
+  loaded: Awaited<ReturnType<typeof loadResolvedRuntimeContext>>;
   plugins: PluginRegistry | undefined;
 }): Promise<ToolDescriptor[]> {
   const stateMode = resolveGatewayStateMode(params.opts.container.deploymentConfig);
-  const builtinTools = listBuiltinToolDescriptors();
-  const builtinToolIds = new Set(builtinTools.map((tool) => tool.id));
-  const mcpTools = await params.mcpManager.listToolDescriptors(params.mcpServers);
-  const pluginTools = params.plugins?.getToolDescriptors() ?? [];
-  return Array.from(
-    new Map(
-      [...builtinTools, ...mcpTools, ...pluginTools]
-        .filter((tool) => {
-          const isBuiltinTool =
-            tool.source === "builtin" ||
-            tool.source === "builtin_mcp" ||
-            (tool.source === undefined && builtinToolIds.has(tool.id));
-          return !isBuiltinTool || isBuiltinToolAvailableInStateMode(tool.id, stateMode);
-        })
-        .map((tool) => [tool.id, tool] as const),
-    ).values(),
-  );
+  const toolDescriptorSource = await resolveRuntimeToolDescriptorSource({
+    ctx: params.loaded,
+    mcpManager: params.mcpManager,
+    plugins: params.plugins,
+    stateMode,
+  });
+  return toolDescriptorSource.availableTools;
 }
 
 export function buildEnabledAgentStatus(params: {

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -1,0 +1,198 @@
+import type { AgentConfig } from "@tyrum/contracts";
+import type { PluginRegistry } from "../../plugins/registry.js";
+import { materializeAllowedAgentIds } from "../access-config.js";
+import type { McpManager } from "../mcp-manager.js";
+import { buildSecretClipboardToolDescriptor } from "../tool-secret-definitions.js";
+import {
+  isBuiltinToolAvailableInStateMode,
+  isToolAllowed,
+  listBuiltinToolDescriptors,
+  type ToolDescriptor,
+} from "../tools.js";
+import type { AgentLoadedContext } from "./types.js";
+import type { GatewayStateMode } from "../../runtime-state/mode.js";
+import { resolvePolicyGatedPluginToolExposure } from "./plugin-tool-policy.js";
+
+function canDiscoverMcpTools(toolConfig: AgentConfig["tools"]): boolean {
+  if (toolConfig.default_mode === "allow") {
+    return true;
+  }
+
+  return toolConfig.allow.some((entry: string) => {
+    const normalized = entry.trim();
+    return (
+      normalized === "*" || normalized.startsWith("mcp.") || canPatternMatchMcpToolId(normalized)
+    );
+  });
+}
+
+const MCP_TOOL_SHAPE_CHARS = ["m", "c", "p", ".", "x"] as const;
+const MCP_TOOL_ACCEPTING_STATE = 7;
+
+function nextMcpToolShapeState(state: number, char: string): number | undefined {
+  switch (state) {
+    case 0:
+      return char === "m" ? 1 : undefined;
+    case 1:
+      return char === "c" ? 2 : undefined;
+    case 2:
+      return char === "p" ? 3 : undefined;
+    case 3:
+      return char === "." ? 4 : undefined;
+    case 4:
+      return char === "." ? undefined : 5;
+    case 5:
+      return char === "." ? 6 : 5;
+    case 6:
+      return char === "." ? undefined : 7;
+    case 7:
+      return 7;
+    default:
+      return undefined;
+  }
+}
+
+export function canPatternMatchMcpToolId(pattern: string): boolean {
+  const normalized = pattern.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+
+  const memo = new Map<string, boolean>();
+  const visiting = new Set<string>();
+  const visit = (patternIndex: number, shapeState: number): boolean => {
+    const key = `${String(patternIndex)}:${String(shapeState)}`;
+    const cached = memo.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    if (visiting.has(key)) {
+      return false;
+    }
+
+    if (patternIndex >= normalized.length) {
+      const matches = shapeState === MCP_TOOL_ACCEPTING_STATE;
+      memo.set(key, matches);
+      return matches;
+    }
+
+    const token = normalized[patternIndex];
+    if (token === undefined) {
+      memo.set(key, false);
+      return false;
+    }
+
+    visiting.add(key);
+    let matches = false;
+    if (token === "*") {
+      matches = visit(patternIndex + 1, shapeState);
+      if (!matches) {
+        matches = MCP_TOOL_SHAPE_CHARS.some((char) => {
+          const nextState = nextMcpToolShapeState(shapeState, char);
+          return nextState !== undefined && visit(patternIndex, nextState);
+        });
+      }
+    } else if (token === "?") {
+      matches = MCP_TOOL_SHAPE_CHARS.some((char) => {
+        const nextState = nextMcpToolShapeState(shapeState, char);
+        return nextState !== undefined && visit(patternIndex + 1, nextState);
+      });
+    } else {
+      const nextState = nextMcpToolShapeState(shapeState, token);
+      matches = nextState !== undefined && visit(patternIndex + 1, nextState);
+    }
+
+    visiting.delete(key);
+    memo.set(key, matches);
+    return matches;
+  };
+
+  return visit(0, 0);
+}
+
+function normalizePluginTools(pluginTools: readonly ToolDescriptor[]): ToolDescriptor[] {
+  const normalized: ToolDescriptor[] = [];
+
+  for (const tool of pluginTools) {
+    const id = tool.id.trim();
+    if (!id) {
+      continue;
+    }
+    if (id === tool.id) {
+      normalized.push(tool);
+      continue;
+    }
+    normalized.push({
+      id,
+      description: tool.description,
+      effect: tool.effect,
+      keywords: tool.keywords,
+      inputSchema: tool.inputSchema,
+      source: tool.source,
+      family: tool.family,
+      backingServerId: tool.backingServerId,
+      promptGuidance: tool.promptGuidance,
+      promptExamples: tool.promptExamples,
+      preTurnHydration: tool.preTurnHydration,
+      memoryRole: tool.memoryRole,
+    });
+  }
+
+  return normalized;
+}
+
+function dedupeToolDescriptors(tools: readonly ToolDescriptor[]): ToolDescriptor[] {
+  return Array.from(new Map(tools.map((tool) => [tool.id, tool] as const)).values());
+}
+
+export type RuntimeToolDescriptorSource = {
+  availableTools: ToolDescriptor[];
+  toolAllowlist: string[];
+  promptSelectableTools: ToolDescriptor[];
+};
+
+export async function resolveRuntimeToolDescriptorSource(params: {
+  ctx: Pick<AgentLoadedContext, "config" | "mcpServers">;
+  mcpManager: McpManager;
+  plugins: PluginRegistry | undefined;
+  stateMode: GatewayStateMode;
+  resolvePluginToolExposure?: typeof resolvePolicyGatedPluginToolExposure;
+}): Promise<RuntimeToolDescriptorSource> {
+  const mcpTools = canDiscoverMcpTools(params.ctx.config.tools)
+    ? await params.mcpManager.listToolDescriptors(params.ctx.mcpServers)
+    : [];
+  const dynamicBuiltinTools = [
+    buildSecretClipboardToolDescriptor(params.ctx.config.secret_refs),
+  ].filter((tool): tool is ToolDescriptor => tool !== undefined);
+  const builtinTools = [...listBuiltinToolDescriptors(), ...dynamicBuiltinTools];
+  const pluginToolsRaw = normalizePluginTools(params.plugins?.getToolDescriptors() ?? []);
+  const baseToolAllowlist = materializeAllowedAgentIds(params.ctx.config.tools, [
+    ...builtinTools,
+    ...mcpTools,
+    ...pluginToolsRaw,
+  ]).map((tool) => tool.id);
+  const { allowlist: toolAllowlist, pluginTools } = (
+    params.resolvePluginToolExposure ?? resolvePolicyGatedPluginToolExposure
+  )({
+    allowlist: baseToolAllowlist,
+    pluginTools: pluginToolsRaw,
+  });
+
+  return {
+    availableTools: dedupeToolDescriptors([
+      ...builtinTools.filter(
+        (tool) =>
+          isBuiltinToolAvailableInStateMode(tool.id, params.stateMode) &&
+          isToolAllowed(toolAllowlist, tool.id),
+      ),
+      ...mcpTools,
+      ...pluginTools,
+    ]),
+    toolAllowlist,
+    promptSelectableTools: dedupeToolDescriptors([
+      ...mcpTools,
+      ...pluginTools,
+      ...dynamicBuiltinTools,
+    ]),
+  };
+}

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime-tool-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime-tool-resolution.ts
@@ -1,13 +1,5 @@
 import type { ConversationRow } from "../conversation-dal.js";
-import { materializeAllowedAgentIds } from "../access-config.js";
-import {
-  isToolAllowed,
-  isToolAllowedWithDenylist,
-  isBuiltinToolAvailableInStateMode,
-  listBuiltinToolDescriptors,
-  selectToolDirectory,
-  type ToolDescriptor,
-} from "../tools.js";
+import { isToolAllowedWithDenylist, selectToolDirectory, type ToolDescriptor } from "../tools.js";
 import { validateToolDescriptorInputSchema } from "../tool-schema.js";
 import { resolveGatewayStateMode } from "../../runtime-state/mode.js";
 import { ToolSetBuilder } from "./tool-set-builder.js";
@@ -15,107 +7,9 @@ import type { ToolSetBuilderDeps } from "./tool-set-builder.js";
 import type { ResolvedExecutionProfile } from "./execution-profile-resolution.js";
 import type { AgentLoadedContext } from "./types.js";
 import type { TurnPreparationRuntimeDeps } from "./turn-preparation-runtime.js";
-import { buildSecretClipboardToolDescriptor } from "../tool-secret-definitions.js";
 import { createToolExecutorForTurnPreparation } from "./turn-preparation-runtime-tooling.js";
 import type { ToolExecutor } from "../tool-executor.js";
-
-function canDiscoverMcpTools(toolConfig: AgentLoadedContext["config"]["tools"]): boolean {
-  if (toolConfig.default_mode === "allow") {
-    return true;
-  }
-
-  return toolConfig.allow.some((entry: string) => {
-    const normalized = entry.trim();
-    return (
-      normalized === "*" || normalized.startsWith("mcp.") || canPatternMatchMcpToolId(normalized)
-    );
-  });
-}
-
-const MCP_TOOL_SHAPE_CHARS = ["m", "c", "p", ".", "x"] as const;
-const MCP_TOOL_ACCEPTING_STATE = 7;
-
-function nextMcpToolShapeState(state: number, char: string): number | undefined {
-  switch (state) {
-    case 0:
-      return char === "m" ? 1 : undefined;
-    case 1:
-      return char === "c" ? 2 : undefined;
-    case 2:
-      return char === "p" ? 3 : undefined;
-    case 3:
-      return char === "." ? 4 : undefined;
-    case 4:
-      return char === "." ? undefined : 5;
-    case 5:
-      return char === "." ? 6 : 5;
-    case 6:
-      return char === "." ? undefined : 7;
-    case 7:
-      return 7;
-    default:
-      return undefined;
-  }
-}
-
-export function canPatternMatchMcpToolId(pattern: string): boolean {
-  const normalized = pattern.trim();
-  if (normalized.length === 0) {
-    return false;
-  }
-
-  // Match against the structural language mcp.<server>.<tool...> instead of a single sample id.
-  const memo = new Map<string, boolean>();
-  const visiting = new Set<string>();
-  const visit = (patternIndex: number, shapeState: number): boolean => {
-    const key = `${String(patternIndex)}:${String(shapeState)}`;
-    const cached = memo.get(key);
-    if (cached !== undefined) {
-      return cached;
-    }
-    if (visiting.has(key)) {
-      return false;
-    }
-
-    if (patternIndex >= normalized.length) {
-      const matches = shapeState === MCP_TOOL_ACCEPTING_STATE;
-      memo.set(key, matches);
-      return matches;
-    }
-
-    const token = normalized[patternIndex];
-    if (token === undefined) {
-      memo.set(key, false);
-      return false;
-    }
-
-    visiting.add(key);
-    let matches = false;
-    if (token === "*") {
-      matches = visit(patternIndex + 1, shapeState);
-      if (!matches) {
-        matches = MCP_TOOL_SHAPE_CHARS.some((char) => {
-          const nextState = nextMcpToolShapeState(shapeState, char);
-          return nextState !== undefined && visit(patternIndex, nextState);
-        });
-      }
-    } else if (token === "?") {
-      matches = MCP_TOOL_SHAPE_CHARS.some((char) => {
-        const nextState = nextMcpToolShapeState(shapeState, char);
-        return nextState !== undefined && visit(patternIndex + 1, nextState);
-      });
-    } else {
-      const nextState = nextMcpToolShapeState(shapeState, token);
-      matches = nextState !== undefined && visit(patternIndex + 1, nextState);
-    }
-
-    visiting.delete(key);
-    memo.set(key, matches);
-    return matches;
-  };
-
-  return visit(0, 0);
-}
+import { resolveRuntimeToolDescriptorSource } from "./runtime-tool-descriptor-source.js";
 
 export async function resolveToolExecutionRuntime(
   deps: TurnPreparationRuntimeDeps,
@@ -138,9 +32,6 @@ export async function resolveToolExecutionRuntime(
   filteredTools: ToolDescriptor[];
   toolExecutor: ToolExecutor;
 }> {
-  const mcpTools = canDiscoverMcpTools(ctx.config.tools)
-    ? await deps.mcpManager.listToolDescriptors(ctx.mcpServers)
-    : [];
   const toolSetBuilderDeps = buildToolSetBuilderDeps(
     deps,
     conversation,
@@ -148,46 +39,19 @@ export async function resolveToolExecutionRuntime(
     ctx.config.secret_refs,
   );
   const toolSetBuilder = new ToolSetBuilder(toolSetBuilderDeps);
-  const dynamicBuiltinTools = [buildSecretClipboardToolDescriptor(ctx.config.secret_refs)].filter(
-    (tool): tool is ToolDescriptor => tool !== undefined,
-  );
-  const builtinTools = [...listBuiltinToolDescriptors(), ...dynamicBuiltinTools];
-  const pluginToolsRaw: ToolDescriptor[] = [];
-  for (const tool of deps.plugins?.getToolDescriptors() ?? []) {
-    const id = tool.id.trim();
-    if (!id) {
-      continue;
-    }
-    if (id === tool.id) {
-      pluginToolsRaw.push(tool);
-      continue;
-    }
-    pluginToolsRaw.push({
-      id,
-      description: tool.description,
-      effect: tool.effect,
-      keywords: tool.keywords,
-      inputSchema: tool.inputSchema,
-      source: tool.source,
-      family: tool.family,
-      backingServerId: tool.backingServerId,
-    });
-  }
-  const baseToolAllowlist = materializeAllowedAgentIds(ctx.config.tools, [
-    ...builtinTools,
-    ...mcpTools,
-    ...pluginToolsRaw,
-  ]).map((tool) => tool.id);
-  const { allowlist: toolAllowlist, pluginTools } =
-    toolSetBuilder.resolvePolicyGatedPluginToolExposure({
-      allowlist: baseToolAllowlist,
-      pluginTools: pluginToolsRaw,
-    });
   const stateMode = resolveGatewayStateMode(deps.opts.container.deploymentConfig);
+  const runtimeToolDescriptorSource = await resolveRuntimeToolDescriptorSource({
+    ctx,
+    mcpManager: deps.mcpManager,
+    plugins: deps.plugins,
+    stateMode,
+    resolvePluginToolExposure: (params) =>
+      toolSetBuilder.resolvePolicyGatedPluginToolExposure(params),
+  });
   const toolCandidates = selectToolDirectory(
     resolved.message,
-    toolAllowlist,
-    [...mcpTools, ...pluginTools, ...dynamicBuiltinTools],
+    runtimeToolDescriptorSource.toolAllowlist,
+    runtimeToolDescriptorSource.promptSelectableTools,
     Number.POSITIVE_INFINITY,
     stateMode,
   );
@@ -212,15 +76,7 @@ export async function resolveToolExecutionRuntime(
     validatedToolCache.set(tool.id, normalized);
     return normalized;
   };
-  const availableTools = [
-    ...builtinTools.filter(
-      (tool) =>
-        isBuiltinToolAvailableInStateMode(tool.id, stateMode) &&
-        isToolAllowed(toolAllowlist, tool.id),
-    ),
-    ...mcpTools,
-    ...pluginTools,
-  ]
+  const availableTools = runtimeToolDescriptorSource.availableTools
     .filter((tool) =>
       isToolAllowedWithDenylist(
         executionProfile.profile.tool_allowlist,

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime.ts
@@ -34,9 +34,9 @@ import type { PluginRegistry } from "../../plugins/registry.js";
 import type { PolicyService } from "@tyrum/runtime-policy";
 export {
   buildToolSetBuilderDeps,
-  canPatternMatchMcpToolId,
   resolveToolExecutionRuntime,
 } from "./turn-preparation-runtime-tool-resolution.js";
+export { canPatternMatchMcpToolId } from "./runtime-tool-descriptor-source.js";
 
 export interface TurnPreparationRuntimeDeps extends PrepareTurnHelperDeps {
   home: string;

--- a/packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts
@@ -88,6 +88,23 @@ describe("AgentRuntime MCP tool exposure", () => {
       >[0]["mcpManager"],
     });
 
+    await expect(runtime.status(true)).resolves.toMatchObject({
+      tools: expect.arrayContaining([
+        "mcp.calendar.events_list",
+        "mcp.calendar.events_create",
+        "read",
+      ]),
+    });
+    await expect(runtime.listRegisteredTools()).resolves.toMatchObject({
+      allowlist: ["read", "mcp.calendar.events_list", "mcp.calendar.events_create"],
+      tools: expect.arrayContaining([
+        expect.objectContaining({ id: "mcp.calendar.events_list" }),
+        expect.objectContaining({ id: "mcp.calendar.events_create" }),
+        expect.objectContaining({ id: "read" }),
+      ]),
+      mcpServers: ["calendar"],
+    });
+
     await runtime.turn({
       channel: "test",
       thread_id: "thread-mcp",

--- a/packages/gateway/tests/unit/agent-runtime-shared-context-scope.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-shared-context-scope.test.ts
@@ -10,6 +10,7 @@ import { AgentConfigDal } from "../../src/modules/config/agent-config-dal.js";
 import { AgentRuntime } from "../../src/modules/agent/runtime.js";
 import type { AgentContextScope } from "../../src/modules/agent/context-store.js";
 import { DEFAULT_WORKSPACE_KEY } from "../../src/modules/identity/scope.js";
+import { SECRET_CLIPBOARD_TOOL_ID } from "../../src/modules/agent/tool-secret-definitions.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const migrationsDir = join(__dirname, "../../migrations/sqlite");
@@ -207,9 +208,16 @@ describe("AgentRuntime shared context scopes", () => {
         },
         tools: {
           default_mode: "deny",
-          allow: ["read", "mcp.weather.forecast", "custom.plugin.echo"],
+          allow: ["read", "mcp.weather.forecast", "custom.plugin.echo", SECRET_CLIPBOARD_TOOL_ID],
           deny: [],
         },
+        secret_refs: [
+          {
+            secret_ref_id: "secret-ref-1",
+            secret_alias: "weather-token",
+            allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+          },
+        ],
         conversations: { ttl_days: 30, max_turns: 20 },
       }),
       createdBy: { kind: "test" },
@@ -256,7 +264,20 @@ describe("AgentRuntime shared context scopes", () => {
     });
 
     await expect(runtime.status(true)).resolves.toMatchObject({
-      tools: ["mcp.weather.forecast", "custom.plugin.echo"],
+      tools: expect.arrayContaining([
+        "mcp.weather.forecast",
+        "custom.plugin.echo",
+        SECRET_CLIPBOARD_TOOL_ID,
+      ]),
+    });
+    await expect(runtime.listRegisteredTools()).resolves.toMatchObject({
+      allowlist: [SECRET_CLIPBOARD_TOOL_ID, "mcp.weather.forecast", "custom.plugin.echo"],
+      tools: expect.arrayContaining([
+        expect.objectContaining({ id: "mcp.weather.forecast" }),
+        expect.objectContaining({ id: "custom.plugin.echo" }),
+        expect.objectContaining({ id: SECRET_CLIPBOARD_TOOL_ID }),
+      ]),
+      mcpServers: [],
     });
   });
 });

--- a/packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts
+++ b/packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts
@@ -1,0 +1,129 @@
+import { AgentConfig } from "@tyrum/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { getExecutionProfile } from "../../src/modules/agent/execution-profiles.js";
+import { listAvailableRuntimeTools } from "../../src/modules/agent/runtime/agent-runtime-status.js";
+import { ToolSetBuilder } from "../../src/modules/agent/runtime/tool-set-builder.js";
+import { resolveToolExecutionRuntime } from "../../src/modules/agent/runtime/turn-preparation-runtime.js";
+import { SECRET_CLIPBOARD_TOOL_ID } from "../../src/modules/agent/tool-secret-definitions.js";
+
+describe("runtime tool descriptor source", () => {
+  it("keeps turn preparation and runtime status on the same local-mode tool universe", async () => {
+    vi.spyOn(ToolSetBuilder.prototype, "resolvePolicyGatedPluginToolExposure").mockImplementation(
+      ({ allowlist, pluginTools }) => ({
+        allowlist: [...allowlist],
+        pluginTools: [...pluginTools],
+      }),
+    );
+
+    const mcpTool = {
+      id: "mcp.calendar.events_list",
+      description: "List calendar events.",
+      effect: "read_only" as const,
+      keywords: ["calendar", "events"],
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const pluginTool = {
+      id: " plugin.echo.readonly ",
+      description: "Read plugin state.",
+      effect: "read_only" as const,
+      keywords: ["plugin", "echo"],
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const mcpManager = {
+      listToolDescriptors: vi.fn().mockResolvedValue([mcpTool]),
+    };
+    const plugins = {
+      getToolDescriptors: vi.fn().mockReturnValue([pluginTool]),
+    };
+    const loaded = {
+      config: AgentConfig.parse({
+        model: { model: "openai/gpt-4.1" },
+        tools: {
+          default_mode: "deny",
+          allow: [
+            "read",
+            "mcp.calendar.events_list",
+            "plugin.echo.readonly",
+            SECRET_CLIPBOARD_TOOL_ID,
+          ],
+          deny: [],
+        },
+        secret_refs: [
+          {
+            secret_ref_id: "secret-ref-1",
+            secret_alias: "calendar-token",
+            allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+          },
+        ],
+      }),
+      identity: {} as never,
+      skills: [],
+      mcpServers: [{ id: "calendar" }] as never,
+    };
+    const opts = {
+      container: {
+        deploymentConfig: {},
+        db: {} as never,
+        approvalDal: {} as never,
+        logger: { warn: vi.fn() },
+        redactionEngine: {} as never,
+      },
+    } as never;
+
+    const turnRuntime = await resolveToolExecutionRuntime(
+      {
+        tenantId: "tenant-1",
+        home: "/workspace",
+        contextStore: {} as never,
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        mcpManager: mcpManager as never,
+        plugins: plugins as never,
+        policyService: {} as never,
+        approvalNotifier: {} as never,
+        approvalWaitMs: 1_000,
+        approvalPollMs: 100,
+        conversationDal: {} as never,
+        secretProvider: undefined,
+        opts,
+      },
+      loaded,
+      {
+        tenant_id: "tenant-1",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+      } as never,
+      {
+        message: "calendar plugin secret clipboard",
+      } as never,
+      {
+        id: "interaction",
+        profile: getExecutionProfile("interaction"),
+        source: "interaction_default",
+      },
+    );
+    const runtimeStatusTools = await listAvailableRuntimeTools({
+      opts,
+      mcpManager: mcpManager as never,
+      loaded,
+      plugins: plugins as never,
+    });
+
+    expect(turnRuntime.availableTools.map((tool) => tool.id)).toEqual(
+      runtimeStatusTools.map((tool) => tool.id),
+    );
+    expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain(SECRET_CLIPBOARD_TOOL_ID);
+    expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain("plugin.echo.readonly");
+    expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain("mcp.calendar.events_list");
+  });
+});


### PR DESCRIPTION
Closes #1987

## What changed
- extracted a shared runtime tool descriptor source in `packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts`
- rewired turn preparation, runtime status, and `listRegisteredTools` to start from the same agent-scoped descriptor universe
- kept prompt ranking and execution-profile filtering layered on top instead of folding them into the shared source
- added parity-focused gateway tests for MCP exposure, shared-context runtime status, and the dynamic `tool.secret.copy-to-node-clipboard` built-in

## Why
Turn preparation and runtime status were assembling tool descriptors through different paths, which risked drift across MCP discovery, plugin normalization, and dynamic built-ins. This change makes the shared descriptor universe explicit without taking on the later `/config/tools`, `/context/tools`, or capabilities contract work tracked elsewhere in epic #1961.

## How to test
- `pnpm run ci`
- `pnpm vitest run packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts packages/gateway/tests/unit/turn-preparation-runtime.test.ts packages/gateway/tests/unit/agent-runtime-mcp-tool-exposure.test.ts packages/gateway/tests/unit/agent-runtime-shared-context-scope.test.ts`
- `pnpm vitest run packages/gateway/tests/unit/tool-registry-routes.test.ts packages/gateway/tests/integration/context.test.ts`

## Risk
Low to moderate. The change is contained to gateway runtime descriptor enumeration and related tests, but it affects shared tool-universe wiring used by status and turn preparation.

## Rollback
Revert commit `5413dbbba1e6d9fcb3b68db0306f5b73c3dd0f40` to restore the previous per-call-site descriptor assembly paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how the gateway enumerates and filters runtime tools (builtins/MCP/plugins) for both status and turn preparation; mistakes could change tool exposure/allowlisting in production, but changes are localized and covered by new/updated unit tests.
> 
> **Overview**
> Introduces a shared `resolveRuntimeToolDescriptorSource` to build the agent-scoped “tool universe” (builtin + dynamic secret clipboard tool, MCP, and normalized plugin tools), including allowlist computation, deduping, and shared/shared-mode gating.
> 
> Rewires runtime `status`, `listRegisteredTools`, and turn preparation tool selection to use this shared source, keeping prompt ranking and execution-profile allow/deny filtering layered on top.
> 
> Adds/updates unit tests to assert parity between status and turn-prep tool sets, verify MCP tool exposure/registered-tool results, and cover shared-mode behavior plus the dynamic `tool.secret.copy-to-node-clipboard` builtin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5413dbbba1e6d9fcb3b68db0306f5b73c3dd0f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->