### PR TITLE
Bridge runtime memory alias matching during rollout

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/tool-set-builder-execution.ts
+++ b/packages/gateway/src/modules/agent/runtime/tool-set-builder-execution.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { jsonSchema, tool as aiTool } from "ai";
 import type { LanguageModel, ModelMessage, Tool, ToolExecutionOptions, ToolSet } from "ai";
+import { toolIdsMatchForRollout, toolMatchTargetsMatchForRollout } from "@tyrum/runtime-policy";
 import type { ToolDescriptor } from "../tools.js";
 import { buildModelToolNameMap, registerModelTool } from "../tools.js";
 import type { ToolExecutor, ToolResult } from "../tool-executor.js";
@@ -378,9 +379,9 @@ async function validateExistingExecutionApproval(input: {
       : undefined;
   const matches =
     ctx?.["source"] === "agent-tool-execution" &&
-    ctx["tool_id"] === input.toolDesc.id &&
+    toolIdsMatchForRollout(ctx["tool_id"], input.toolDesc.id) &&
     ctx["tool_call_id"] === input.toolCallId &&
-    ctx["tool_match_target"] === input.matchTarget;
+    toolMatchTargetsMatchForRollout(ctx["tool_match_target"], input.matchTarget);
 
   return approved && matches
     ? undefined

--- a/packages/gateway/src/modules/agent/runtime/tool-set-builder-policy.ts
+++ b/packages/gateway/src/modules/agent/runtime/tool-set-builder-policy.ts
@@ -4,7 +4,11 @@ import { isBuiltinToolAvailableInStateMode, isToolAllowedWithDenylist } from "..
 import { collectSecretHandleIds } from "../../secret/collect-secret-handle-ids.js";
 import { createSecretHandleResolver } from "../../secret/handle-resolver.js";
 import { canonicalizeToolMatchTarget } from "../../policy/match-target.js";
-import { suggestedOverridesForToolCall } from "@tyrum/runtime-policy";
+import {
+  suggestedOverridesForToolCall,
+  toolIdsMatchForRollout,
+  toolMatchTargetsMatchForRollout,
+} from "@tyrum/runtime-policy";
 import { hasToolResult } from "../../ai-sdk/message-utils.js";
 import { coerceRecord } from "../../util/coerce.js";
 import { ConversationQueueInterruptError } from "../../conversation-queue/queue-signal-dal.js";
@@ -137,7 +141,10 @@ async function resolveResumedToolArgs(
   if (!ctx || ctx["source"] !== "agent-tool-execution") {
     return input.args;
   }
-  if (ctx["tool_id"] !== input.toolId || ctx["tool_call_id"] !== input.toolCallId) {
+  if (
+    !toolIdsMatchForRollout(ctx["tool_id"], input.toolId) ||
+    ctx["tool_call_id"] !== input.toolCallId
+  ) {
     return input.args;
   }
 
@@ -311,9 +318,9 @@ async function canReuseResolvedApproval(
   const ctx = coerceRecord(approval.context);
   const matches =
     ctx?.["source"] === "agent-tool-execution" &&
-    ctx["tool_id"] === input.toolId &&
+    toolIdsMatchForRollout(ctx["tool_id"], input.toolId) &&
     ctx["tool_call_id"] === input.toolCallId &&
-    ctx["tool_match_target"] === input.matchTarget;
+    toolMatchTargetsMatchForRollout(ctx["tool_match_target"], input.matchTarget);
 
   return matches && !hasToolResult(input.messages, input.toolCallId);
 }

--- a/packages/gateway/src/modules/agent/tools.ts
+++ b/packages/gateway/src/modules/agent/tools.ts
@@ -1,4 +1,8 @@
 import { createHash } from "node:crypto";
+import {
+  canonicalizeToolIdForRolloutMatching,
+  toolIdMatchCandidatesForRollout,
+} from "@tyrum/runtime-policy";
 import type { GatewayStateMode } from "../runtime-state/mode.js";
 import { BUILTIN_TOOL_REGISTRY } from "./tool-catalog.js";
 
@@ -130,14 +134,22 @@ export function registerModelTool<T>(
 
 export function isToolAllowed(allowlist: readonly string[], toolId: string): boolean {
   const normalizedToolId = toolId.trim();
+  const matchCandidates = toolIdMatchCandidatesForRollout(normalizedToolId);
   for (const entry of allowlist) {
-    if (entry === "*") return true;
-    if (entry.endsWith("*")) {
-      const prefix = entry.slice(0, -1);
-      if (normalizedToolId.startsWith(prefix)) return true;
+    const normalizedEntry = entry.trim();
+    if (normalizedEntry === "*") return true;
+    if (normalizedEntry.endsWith("*")) {
+      const prefix = normalizedEntry.slice(0, -1);
+      if (matchCandidates.some((candidate) => candidate.startsWith(prefix))) return true;
       continue;
     }
-    if (entry === normalizedToolId) return true;
+    if (
+      normalizedEntry === normalizedToolId ||
+      canonicalizeToolIdForRolloutMatching(normalizedEntry) ===
+        canonicalizeToolIdForRolloutMatching(normalizedToolId)
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/gateway/src/modules/execution/gateway-step-executor-tool-set.ts
+++ b/packages/gateway/src/modules/execution/gateway-step-executor-tool-set.ts
@@ -2,6 +2,7 @@ import type { ActionPrimitive as ActionPrimitiveT } from "@tyrum/contracts";
 import type { GatewayContainer } from "../../container.js";
 import type { LanguageModel, ModelMessage, Tool, ToolExecutionOptions, ToolSet } from "ai";
 import { jsonSchema, tool as aiTool } from "ai";
+import { toolIdsMatchForRollout, toolMatchTargetsMatchForRollout } from "@tyrum/runtime-policy";
 import { buildModelToolNameMap, registerModelTool } from "../agent/tools.js";
 import {
   resolveWebFetchResultText,
@@ -223,9 +224,9 @@ function matchesApprovedToolContext(input2: {
   const ctx = coerceRecord(input2.context);
   return (
     ctx?.["source"] === "llm-step-tool-execution" &&
-    ctx["tool_id"] === input2.toolId &&
+    toolIdsMatchForRollout(ctx["tool_id"], input2.toolId) &&
     ctx["tool_call_id"] === input2.toolCallId &&
-    ctx["tool_match_target"] === input2.toolMatchTarget
+    toolMatchTargetsMatchForRollout(ctx["tool_match_target"], input2.toolMatchTarget)
   );
 }
 

--- a/packages/gateway/src/modules/execution/policy-approval-context.ts
+++ b/packages/gateway/src/modules/execution/policy-approval-context.ts
@@ -1,4 +1,7 @@
-import { suggestedOverridesForToolCall } from "@tyrum/runtime-policy";
+import {
+  canonicalizeToolMatchTargetForRolloutMatching,
+  suggestedOverridesForToolCall,
+} from "@tyrum/runtime-policy";
 
 export function buildExecutionPolicyApprovalContext(input: {
   policySnapshotId: string;
@@ -23,7 +26,7 @@ export function buildExecutionPolicyApprovalContext(input: {
     policy["workspace_id"] = workspaceId;
   }
 
-  const matchTarget = input.toolMatchTarget.trim();
+  const matchTarget = canonicalizeToolMatchTargetForRolloutMatching(input.toolMatchTarget);
   if (workspaceId && matchTarget) {
     const suggestedOverrides = suggestedOverridesForToolCall({
       toolId: input.toolId,
@@ -39,7 +42,7 @@ export function buildExecutionPolicyApprovalContext(input: {
     source: "execution-engine",
     policy_snapshot_id: input.policySnapshotId,
     tool_id: input.toolId,
-    tool_match_target: input.toolMatchTarget,
+    tool_match_target: matchTarget,
     ...(input.url ? { url: input.url } : {}),
     decision: input.decision,
     policy,

--- a/packages/gateway/src/modules/policy/match-target.ts
+++ b/packages/gateway/src/modules/policy/match-target.ts
@@ -1,5 +1,6 @@
 import { posix as pathPosix, win32 as pathWin32 } from "node:path";
 import { ActionPrimitiveKind, canonicalizeToolId } from "@tyrum/contracts";
+import { canonicalizeToolMatchTargetForRolloutMatching } from "@tyrum/runtime-policy";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -386,6 +387,11 @@ export function canonicalizeToolMatchTarget(
   ) {
     const placeId = normalizeToken(parsed?.["place_id"]) ?? "";
     return `place_id:${placeId}`;
+  }
+
+  const rolloutMatchTarget = canonicalizeToolMatchTargetForRolloutMatching(normalizedToolId);
+  if (rolloutMatchTarget !== normalizedToolId) {
+    return rolloutMatchTarget;
   }
 
   if (normalizedToolId.startsWith("mcp.")) {

--- a/packages/gateway/tests/unit/agent-runtime-memory-approval-rollout.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-memory-approval-rollout.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayContainer } from "../../src/container.js";
+import {
+  createToolSetBuilder,
+  DEFAULT_AGENT_ID,
+  DEFAULT_TENANT_ID,
+  DEFAULT_WORKSPACE_ID,
+  makeContextReport,
+  migrationsDir,
+  teardownTestEnv,
+} from "./agent-runtime.test-helpers.js";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createContainer } from "../../src/container.js";
+
+describe("AgentRuntime memory approval rollout", () => {
+  let homeDir: string | undefined;
+  let container: GatewayContainer | undefined;
+
+  afterEach(async () => {
+    await teardownTestEnv({ homeDir, container });
+    container = undefined;
+    homeDir = undefined;
+  });
+
+  it("reuses execution approvals when legacy and canonical public memory ids differ only by rollout alias", async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-"));
+    container = await createContainer({
+      dbPath: ":memory:",
+      migrationsDir,
+    });
+
+    const policyService = {
+      isEnabled: () => true,
+      isObserveOnly: () => false,
+      evaluateToolCall: vi.fn(async () => ({ decision: "require_approval" as const })),
+    };
+
+    const toolSetBuilder = createToolSetBuilder({ home: homeDir, container, policyService });
+
+    const approval = await container.approvalDal.create({
+      tenantId: DEFAULT_TENANT_ID,
+      agentId: DEFAULT_AGENT_ID,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      approvalKey: "plan-1:step:0:tool_call:tc-memory",
+      kind: "workflow_step",
+      prompt: "Approve memory write",
+      motivation: "Verify mixed memory rollout aliases resume the same approved execution.",
+      context: {
+        source: "agent-tool-execution",
+        tool_id: "mcp.memory.write",
+        tool_call_id: "tc-memory",
+        tool_match_target: "mcp.memory.write",
+      },
+    });
+    await container.approvalDal.respond({
+      tenantId: DEFAULT_TENANT_ID,
+      approvalId: approval.approval_id,
+      decision: "approved",
+    });
+
+    const toolDesc = {
+      id: "memory.write",
+      description: "Persist durable memory.",
+      effect: "state_changing" as const,
+      keywords: [],
+      inputSchema: {
+        type: "object",
+        properties: {
+          kind: { type: "string", enum: ["note"] },
+          body_md: { type: "string" },
+        },
+        required: ["kind", "body_md"],
+        additionalProperties: false,
+      },
+    };
+
+    const toolExecutor = {
+      execute: vi.fn(async () => ({
+        tool_call_id: "tc-memory",
+        output: "stored",
+        error: undefined,
+        provenance: undefined,
+      })),
+    };
+
+    const usedTools = new Set<string>();
+    const toolSet = toolSetBuilder.buildToolSet(
+      [toolDesc],
+      toolExecutor,
+      usedTools,
+      {
+        planId: "plan-1",
+        conversationId: "conversation-1",
+        channel: "test",
+        threadId: "thread-1",
+        execution: {
+          turnId: "run-1",
+          stepIndex: 0,
+          stepId: "step-1",
+          stepApprovalId: approval.approval_id,
+        },
+      },
+      makeContextReport(),
+    );
+
+    await toolSet["memory.write"]!.execute({ kind: "note", body_md: "remember this" }, {
+      toolCallId: "tc-memory",
+    } as unknown);
+
+    expect(toolExecutor.execute).toHaveBeenCalledTimes(1);
+    expect(usedTools.has("memory.write")).toBe(true);
+  });
+});

--- a/packages/gateway/tests/unit/policy-match-target.test.ts
+++ b/packages/gateway/tests/unit/policy-match-target.test.ts
@@ -74,12 +74,12 @@ describe("canonicalizeToolMatchTarget", () => {
     ).toBe("https://example.com/a");
   });
 
-  it("canonicalizes builtin memory MCP tool targets without leaking memory content", () => {
+  it("canonicalizes builtin memory tool targets to the public memory family without leaking content", () => {
     expect(
       canonicalizeToolMatchTarget("mcp.memory.search", {
         query: "remember my pizza order",
       }),
-    ).toBe("mcp.memory.search");
+    ).toBe("memory.search");
 
     expect(
       canonicalizeToolMatchTarget("mcp.memory.write", {
@@ -87,7 +87,13 @@ describe("canonicalizeToolMatchTarget", () => {
         body_md: "super secret content",
         sensitivity: "private",
       }),
-    ).toBe("mcp.memory.write");
+    ).toBe("memory.write");
+
+    expect(
+      canonicalizeToolMatchTarget("memory.seed", {
+        query: "remember my coffee order",
+      }),
+    ).toBe("memory.seed");
   });
 
   it("canonicalizes messaging destinations without matching on message body", () => {

--- a/packages/gateway/tests/unit/tools.test.ts
+++ b/packages/gateway/tests/unit/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildModelToolNameMap,
+  isToolAllowed,
   listBuiltinToolDescriptors,
   registerModelTool,
   selectToolDirectory,
@@ -42,6 +43,12 @@ describe("selectToolDirectory", () => {
 
     const selected = selectToolDirectory("calendar events", ["mcp.calendar.*"], [mcpTool], 8);
     expect(selected.map((t) => t.id)).toContain("mcp.calendar.list_events");
+  });
+
+  it("treats canonical and legacy public memory ids as equivalent for allowlist matching", () => {
+    expect(isToolAllowed(["mcp.memory.search"], "memory.search")).toBe(true);
+    expect(isToolAllowed(["memory.write"], "mcp.memory.write")).toBe(true);
+    expect(isToolAllowed(["mcp.memory.*"], "memory.seed")).toBe(true);
   });
 });
 

--- a/packages/gateway/tests/unit/turn-preparation-runtime.test.ts
+++ b/packages/gateway/tests/unit/turn-preparation-runtime.test.ts
@@ -255,6 +255,88 @@ describe("turn preparation runtime helpers", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it("keeps canonical memory tool descriptors available under legacy execution-profile allowlists", async () => {
+    vi.spyOn(ToolSetBuilder.prototype, "resolvePolicyGatedPluginToolExposure").mockImplementation(
+      ({ allowlist, pluginTools }) => ({
+        allowlist: [...allowlist],
+        pluginTools: [...pluginTools],
+      }),
+    );
+
+    const canonicalMemorySearchTool = {
+      id: "memory.search",
+      description: "Search durable memory.",
+      effect: "read_only" as const,
+      keywords: ["memory", "search"],
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    };
+
+    const result = await resolveToolExecutionRuntime(
+      {
+        tenantId: "tenant-1",
+        home: "/workspace",
+        contextStore: {} as never,
+        agentId: "agent-1",
+        workspaceId: "workspace-1",
+        mcpManager: {
+          listToolDescriptors: vi.fn().mockResolvedValue([canonicalMemorySearchTool]),
+        } as never,
+        plugins: undefined,
+        policyService: {} as never,
+        approvalNotifier: {} as never,
+        approvalWaitMs: 1_000,
+        approvalPollMs: 100,
+        conversationDal: {} as never,
+        secretProvider: undefined,
+        opts: {
+          container: {
+            deploymentConfig: {},
+            db: {} as never,
+            approvalDal: {} as never,
+            logger: { warn: vi.fn() },
+            redactionEngine: {} as never,
+          },
+        } as never,
+      },
+      {
+        config: AgentConfig.parse({
+          model: { model: "openai/gpt-4.1" },
+          tools: {
+            default_mode: "allow",
+            allow: [],
+            deny: [],
+          },
+        }),
+        identity: {} as never,
+        skills: [],
+        mcpServers: [{ id: "memory" }] as never,
+      },
+      {
+        tenant_id: "tenant-1",
+        agent_id: "agent-1",
+        workspace_id: "workspace-1",
+      } as never,
+      {
+        message: "search memory for the note",
+      } as never,
+      {
+        id: "explorer_ro",
+        profile: getExecutionProfile("explorer_ro"),
+        source: "explorer_ro_default",
+      },
+    );
+
+    expect(result.availableTools.map((tool) => tool.id)).toContain("memory.search");
+    expect(result.filteredTools.map((tool) => tool.id)).toContain("memory.search");
+  });
+
   it("warns once per invalid tool schema even when the tool is reused for pre-turn lookup", async () => {
     vi.spyOn(ToolSetBuilder.prototype, "resolvePolicyGatedPluginToolExposure").mockImplementation(
       ({ allowlist, pluginTools }) => ({

--- a/packages/runtime-policy/src/index.ts
+++ b/packages/runtime-policy/src/index.ts
@@ -37,5 +37,12 @@ export {
 } from "./review-policy.js";
 export { PolicyService, type PolicyEvaluation } from "./service.js";
 export { suggestedOverridesForToolCall, type SuggestedOverride } from "./suggested-overrides.js";
+export {
+  canonicalizeToolIdForRolloutMatching,
+  canonicalizeToolMatchTargetForRolloutMatching,
+  toolIdMatchCandidatesForRollout,
+  toolIdsMatchForRollout,
+  toolMatchTargetsMatchForRollout,
+} from "./tool-id-rollout.js";
 export { evaluateToolCallAgainstBundle, type ToolEffect } from "./tool-evaluation.js";
 export { wildcardMatch } from "./wildcard.js";

--- a/packages/runtime-policy/src/suggested-overrides.ts
+++ b/packages/runtime-policy/src/suggested-overrides.ts
@@ -1,3 +1,4 @@
+import { canonicalizeToolMatchTargetForRolloutMatching } from "./tool-id-rollout.js";
 import { isSafeSuggestedOverridePattern } from "./override-guardrails.js";
 
 export type SuggestedOverride = { tool_id: string; pattern: string; workspace_id: string };
@@ -7,7 +8,7 @@ export function suggestedOverridesForToolCall(input: {
   matchTarget: string;
   workspaceId: string;
 }): SuggestedOverride[] | undefined {
-  const trimmed = input.matchTarget.trim();
+  const trimmed = canonicalizeToolMatchTargetForRolloutMatching(input.matchTarget);
   if (trimmed.length === 0) return undefined;
   if (input.toolId === "tool.automation.schedule.create" && trimmed.includes("execution:steps")) {
     return undefined;

--- a/packages/runtime-policy/src/tool-id-rollout.ts
+++ b/packages/runtime-policy/src/tool-id-rollout.ts
@@ -1,0 +1,58 @@
+const MEMORY_TOOL_VERBS = new Set(["seed", "search", "write"]);
+const LEGACY_MEMORY_PREFIX = "mcp.memory.";
+const CANONICAL_MEMORY_PREFIX = "memory.";
+
+function extractMemoryToolVerb(toolId: string): string | undefined {
+  const normalized = toolId.trim();
+  if (normalized.startsWith(LEGACY_MEMORY_PREFIX)) {
+    const verb = normalized.slice(LEGACY_MEMORY_PREFIX.length);
+    return MEMORY_TOOL_VERBS.has(verb) ? verb : undefined;
+  }
+  if (normalized.startsWith(CANONICAL_MEMORY_PREFIX)) {
+    const verb = normalized.slice(CANONICAL_MEMORY_PREFIX.length);
+    return MEMORY_TOOL_VERBS.has(verb) ? verb : undefined;
+  }
+  return undefined;
+}
+
+export function canonicalizeToolIdForRolloutMatching(toolId: string): string {
+  const normalized = toolId.trim();
+  const memoryVerb = extractMemoryToolVerb(normalized);
+  return memoryVerb ? `${CANONICAL_MEMORY_PREFIX}${memoryVerb}` : normalized;
+}
+
+export function toolIdMatchCandidatesForRollout(toolId: string): string[] {
+  const normalized = toolId.trim();
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  const canonical = canonicalizeToolIdForRolloutMatching(normalized);
+  if (!canonical.startsWith(CANONICAL_MEMORY_PREFIX)) {
+    return [normalized];
+  }
+
+  const legacy = `${LEGACY_MEMORY_PREFIX}${canonical.slice(CANONICAL_MEMORY_PREFIX.length)}`;
+  return normalized === canonical ? [canonical, legacy] : [normalized, canonical];
+}
+
+export function canonicalizeToolMatchTargetForRolloutMatching(matchTarget: string): string {
+  return canonicalizeToolIdForRolloutMatching(matchTarget);
+}
+
+export function toolIdsMatchForRollout(left: unknown, right: unknown): boolean {
+  return (
+    typeof left === "string" &&
+    typeof right === "string" &&
+    canonicalizeToolIdForRolloutMatching(left) === canonicalizeToolIdForRolloutMatching(right)
+  );
+}
+
+export function toolMatchTargetsMatchForRollout(left: unknown, right: unknown): boolean {
+  return (
+    typeof left === "string" &&
+    typeof right === "string" &&
+    canonicalizeToolMatchTargetForRolloutMatching(left) ===
+      canonicalizeToolMatchTargetForRolloutMatching(right)
+  );
+}

--- a/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
+++ b/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
@@ -47,4 +47,34 @@ describe("suggestedOverridesForToolCall", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("normalizes public memory match targets to the canonical memory family during rollout", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "mcp.memory.search",
+        matchTarget: "mcp.memory.search",
+        workspaceId: "workspace-1",
+      }),
+    ).toEqual([
+      {
+        tool_id: "mcp.memory.search",
+        pattern: "memory.search",
+        workspace_id: "workspace-1",
+      },
+    ]);
+
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "memory.write",
+        matchTarget: "mcp.memory.write",
+        workspaceId: "workspace-1",
+      }),
+    ).toEqual([
+      {
+        tool_id: "memory.write",
+        pattern: "memory.write",
+        workspace_id: "workspace-1",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #1980

## What changed
- added rollout-only canonical/legacy memory tool matching helpers in `@tyrum/runtime-policy`
- applied those helpers to suggested overrides, runtime allowlist matching, policy match-target normalization, and approval-context reuse/resume paths in gateway runtime selection
- added focused regression coverage for mixed `memory.*` and `mcp.memory.*` inputs, including approval resume behavior

## Why
`#1980` is the compare-time bridge needed before later parser normalization and execution-profile migration issues can land safely. This keeps canonical public memory IDs as the source of truth while still accepting supported legacy aliases during rollout.

## How to test
- `pnpm test -- packages/runtime-policy/tests/unit/suggested-overrides.test.ts packages/gateway/tests/unit/policy-match-target.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts packages/gateway/tests/unit/turn-preparation-runtime.test.ts packages/gateway/tests/unit/gateway-step-executor-tool-set.test.ts packages/gateway/tests/unit/agent-behavior-policy-approvals.test.ts packages/gateway/tests/unit/tools.test.ts`
- `pnpm exec vitest run packages/gateway/tests/unit/agent-runtime-memory-approval-rollout.test.ts --reporter=dot`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm run ci`

## Risk
Low to medium. The change is intentionally narrow and compare-time only, but it touches runtime tool selection and approval reuse paths where regressions would affect memory tool execution during rollout.

## Rollback
Revert commit `17301c1e4d73395dae3d04db9feb6833b040dfab` to remove the rollout bridge and restore prior exact-match behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval reuse/resume and tool allowlist/policy match-target logic; regressions could incorrectly bypass or re-require approvals for memory tools during rollout, but changes are narrow and scoped to `memory.*` vs `mcp.memory.*` aliasing.
> 
> **Overview**
> Bridges the rollout aliasing between legacy `mcp.memory.*` and canonical `memory.*` tool IDs by adding shared matching/canonicalization helpers in `@tyrum/runtime-policy` and exporting them.
> 
> Updates gateway runtime policy/approval flows to use rollout-aware comparisons for `tool_id`/`tool_match_target`, and adjusts match-target + suggested-override generation to normalize memory targets to the canonical family. Adds unit tests covering allowlist matching, match-target canonicalization, and approval resume/reuse when approvals were created with the legacy alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17301c1e4d73395dae3d04db9feb6833b040dfab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->