### PR TITLE
fix: migrate public memory ids through defaults prompts and docs

### DIFF
--- a/apps/docs/tests/memory-operator-workflows-docs.test.ts
+++ b/apps/docs/tests/memory-operator-workflows-docs.test.ts
@@ -15,9 +15,9 @@ describe("Memory architecture docs (Issue #666)", () => {
     );
 
     expect(memoryDoc).toMatch(/MCP-native capability/i);
-    expect(memoryDoc).toMatch(/mcp\.memory\.seed\b/);
-    expect(memoryDoc).toMatch(/mcp\.memory\.search\b/);
-    expect(memoryDoc).toMatch(/mcp\.memory\.write\b/);
+    expect(memoryDoc).toMatch(/\bmemory\.seed\b/);
+    expect(memoryDoc).toMatch(/\bmemory\.search\b/);
+    expect(memoryDoc).toMatch(/\bmemory\.write\b/);
     expect(memoryDoc).toMatch(/pre_turn_tools/i);
     expect(memoryDoc).toMatch(/server_settings\.memory/i);
     expect(memoryDoc).toMatch(/tombstone/i);
@@ -27,7 +27,7 @@ describe("Memory architecture docs (Issue #666)", () => {
     const mdFiles = await listMarkdownFiles(resolve(repoRoot, "docs"));
     const generatedApiReference = resolve(repoRoot, "docs/api-reference.md");
     const legacyEndpointPattern =
-      /(^|[^.\w])(memory\.(list|search|get|create|update|delete|forget|export)|\/memory\/exports\/:id)\b/i;
+      /(^|[^.\w])(memory\.(list|get|create|update|delete|forget|export)|\/memory\/exports\/:id)\b/i;
 
     for (const file of mdFiles) {
       if (file === generatedApiReference) {

--- a/docs/architecture/agent/memory/index.md
+++ b/docs/architecture/agent/memory/index.md
@@ -14,9 +14,9 @@ Go deeper: [Memory consolidation and retention](/architecture/memory/consolidati
 
 ```mermaid
 flowchart TB
-  Cue["Turn cues + task context"] --> Retrieve["Retrieve bounded recall<br/>mcp.memory.seed + mcp.memory.search"]
+  Cue["Turn cues + task context"] --> Retrieve["Retrieve bounded recall<br/>memory.seed + memory.search"]
   Retrieve --> Use["Use recall in active turn"]
-  Use --> Write["Write durable outcomes<br/>mcp.memory.write"]
+  Use --> Write["Write durable outcomes<br/>memory.write"]
   Write --> Store["Canonical memory store<br/>(agent-scoped)"]
   Store --> Consolidate["Budget-driven consolidation<br/>and eviction"]
   Consolidate --> Retrieve
@@ -33,11 +33,11 @@ Memory is Tyrum's durable, agent-scoped knowledge layer. It converts useful outc
 
 Memory is an **MCP-native capability**, not a gateway-owned CRUD surface. The runtime interacts through stable tools:
 
-ARCH-21 defines the canonical public taxonomy for built-in memory helpers as the `memory` family with the existing verbs `seed`, `search`, and `write`. The current runtime still ships and consumes the legacy `mcp.memory.*` IDs shown below until the migration issues under epic `#1961` land.
+ARCH-21 defines the canonical public taxonomy for built-in memory helpers as the `memory` family with the existing verbs `seed`, `search`, and `write`. During the rollout tracked by epic `#1961`, the legacy `mcp.memory.*` IDs remain accepted as compatibility aliases, but public docs and user-facing guidance should use the canonical IDs below.
 
-- `mcp.memory.seed` for pre-turn hydration.
-- `mcp.memory.search` for bounded recall during a turn.
-- `mcp.memory.write` for durable facts, notes, procedures, and episodic updates.
+- `memory.seed` for pre-turn hydration.
+- `memory.search` for bounded recall during a turn.
+- `memory.write` for durable facts, notes, procedures, and episodic updates.
 
 Memory configuration is carried in `server_settings.memory`. Retrieval hooks are wired through `pre_turn_tools` so recall can be assembled before inference starts.
 

--- a/packages/gateway/src/modules/agent/default-config.ts
+++ b/packages/gateway/src/modules/agent/default-config.ts
@@ -26,7 +26,7 @@ export function buildDefaultAgentConfig(
     mcp: {
       ...DEFAULT_MCP_EXPOSURE,
       default_mode: "allow",
-      pre_turn_tools: ["mcp.memory.seed"],
+      pre_turn_tools: ["memory.seed"],
     },
     tools: {
       ...DEFAULT_TOOL_EXPOSURE,

--- a/packages/gateway/src/modules/agent/runtime/preturn-hydration.ts
+++ b/packages/gateway/src/modules/agent/runtime/preturn-hydration.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  canonicalizeToolIdForRolloutMatching,
+  toolIdsMatchForRollout,
+} from "@tyrum/runtime-policy";
 import { createToolSetPolicyRuntime } from "./tool-set-builder-policy.js";
 import type { ToolDescriptor } from "../tools.js";
 import type { ToolExecutor } from "../tool-executor.js";
@@ -32,6 +36,25 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     return undefined;
   }
   return value as Record<string, unknown>;
+}
+
+function toPublicToolId(toolId: string): string {
+  return canonicalizeToolIdForRolloutMatching(toolId);
+}
+
+function resolvePreTurnTool(
+  availableTools: readonly ToolDescriptor[],
+  requestedToolId: string,
+): ToolDescriptor | undefined {
+  const exactMatch = availableTools.find((tool) => tool.id === requestedToolId);
+  if (exactMatch) {
+    return exactMatch;
+  }
+  return availableTools.find((tool) => toolIdsMatchForRollout(tool.id, requestedToolId));
+}
+
+function supportsPreTurnHydration(tool: ToolDescriptor): boolean {
+  return tool.source === "mcp" || tool.source === "builtin_mcp" || tool.id.startsWith("mcp.");
 }
 
 function resolvePreferredPromptArgName(
@@ -107,7 +130,6 @@ export async function runPreTurnHydration(params: {
 }): Promise<PreTurnHydrationResult> {
   const sections: PreTurnHydrationSection[] = [];
   const reports: AgentContextPreTurnToolReport[] = [];
-  const toolById = new Map(params.availableTools.map((tool) => [tool.id, tool]));
   const policyRuntime = createToolSetPolicyRuntime({
     deps: params.toolSetBuilderDeps,
     toolExecutionContext: params.toolExecutionContext,
@@ -120,19 +142,20 @@ export async function runPreTurnHydration(params: {
   };
 
   for (const toolId of params.toolIds) {
-    const tool = toolById.get(toolId);
+    const publicToolId = toPublicToolId(toolId);
+    const tool = resolvePreTurnTool(params.availableTools, toolId);
     if (!tool) {
       reports.push({
-        tool_id: toolId,
+        tool_id: publicToolId,
         status: "skipped",
         injected_chars: 0,
         error: "tool unavailable",
       });
       continue;
     }
-    if (!tool.id.startsWith("mcp.")) {
+    if (!supportsPreTurnHydration(tool)) {
       reports.push({
-        tool_id: tool.id,
+        tool_id: publicToolId,
         status: "skipped",
         injected_chars: 0,
         error: "pre-turn hydration currently supports MCP tools only",
@@ -143,7 +166,7 @@ export async function runPreTurnHydration(params: {
     const hydration = buildPreTurnArgs(tool, params.conversation, params.resolved);
     if (!hydration) {
       reports.push({
-        tool_id: tool.id,
+        tool_id: publicToolId,
         status: "skipped",
         injected_chars: 0,
         error:
@@ -167,7 +190,7 @@ export async function runPreTurnHydration(params: {
       });
       if (policyState.shouldRequireApproval) {
         reports.push({
-          tool_id: tool.id,
+          tool_id: publicToolId,
           status: "skipped",
           injected_chars: 0,
           error: "policy requires approval",
@@ -185,7 +208,7 @@ export async function runPreTurnHydration(params: {
 
       if (result.error) {
         reports.push({
-          tool_id: tool.id,
+          tool_id: publicToolId,
           status: "failed",
           injected_chars: 0,
           error: result.error,
@@ -210,10 +233,10 @@ export async function runPreTurnHydration(params: {
           metaParts.push(hitParts.join(" "));
         }
         const header = metaParts.length > 0 ? `[${metaParts.join(" | ")}]\n` : "";
-        const text = `Pre-turn recall (${tool.id}):\n${header}${result.output}`;
-        sections.push({ toolId: tool.id, text });
+        const text = `Pre-turn recall (${publicToolId}):\n${header}${result.output}`;
+        sections.push({ toolId: publicToolId, text });
         reports.push({
-          tool_id: tool.id,
+          tool_id: publicToolId,
           status: "succeeded",
           injected_chars: text.length,
         });
@@ -222,17 +245,17 @@ export async function runPreTurnHydration(params: {
         memory.structured_hits += meta.structured_item_count;
         memory.included_items += included;
       } else {
-        const text = `Pre-turn recall (${tool.id}):\n${result.output}`;
-        sections.push({ toolId: tool.id, text });
+        const text = `Pre-turn recall (${publicToolId}):\n${result.output}`;
+        sections.push({ toolId: publicToolId, text });
         reports.push({
-          tool_id: tool.id,
+          tool_id: publicToolId,
           status: "succeeded",
           injected_chars: text.length,
         });
       }
     } catch (error) {
       reports.push({
-        tool_id: tool.id,
+        tool_id: publicToolId,
         status: "failed",
         injected_chars: 0,
         error: formatPreTurnHydrationError(error),

--- a/packages/gateway/src/modules/agent/runtime/prompts.ts
+++ b/packages/gateway/src/modules/agent/runtime/prompts.ts
@@ -2,6 +2,7 @@ import type {
   IdentityPack as IdentityPackT,
   SkillManifest as SkillManifestT,
 } from "@tyrum/contracts";
+import { canonicalizeToolIdForRolloutMatching } from "@tyrum/runtime-policy";
 import { resolvePersonaToneInstructions } from "@tyrum/contracts";
 import type { ToolDescriptor } from "../tools.js";
 import type { ConversationState } from "../conversation-dal.js";
@@ -241,9 +242,9 @@ export function formatMemoryGuidancePrompt(
   tools: readonly ToolDescriptor[],
   options?: { isAutomationTurn?: boolean },
 ): string | undefined {
-  const toolIds = new Set(tools.map((tool) => tool.id));
-  const hasWrite = toolIds.has("mcp.memory.write");
-  const hasSearch = toolIds.has("mcp.memory.search");
+  const toolIds = new Set(tools.map((tool) => canonicalizeToolIdForRolloutMatching(tool.id)));
+  const hasWrite = toolIds.has("memory.write");
+  const hasSearch = toolIds.has("memory.search");
 
   if (!hasWrite && !hasSearch) return undefined;
 
@@ -264,7 +265,7 @@ export function formatMemoryGuidancePrompt(
     );
     if (options?.isAutomationTurn) {
       lines.push(
-        "For triggered automation work, call mcp.memory.write only when the work yields a meaningful outcome, decision, lesson, or durable state worth reusing. If nothing worth reusing emerged, do not write memory.",
+        "For triggered automation work, call memory.write only when the work yields a meaningful outcome, decision, lesson, or durable state worth reusing. If nothing worth reusing emerged, do not write memory.",
       );
     }
   }
@@ -277,7 +278,7 @@ export function formatMemoryGuidancePrompt(
       "Do not assume pre-turn recall is complete or that missing details are unavailable in memory. Pre-turn recall is seed-based and may omit relevant memory that uses different terms.",
     );
     lines.push(
-      "If the requested information is not in pre-turn recall, run mcp.memory.search before answering. Do this for broad questions and for follow-up probes about specific topics.",
+      "If the requested information is not in pre-turn recall, run memory.search before answering. Do this for broad questions and for follow-up probes about specific topics.",
     );
     lines.push(
       "When the user asks for stored profile details such as addresses, defaults, preferences, contact info, or prior decisions, search memory before asking the user to repeat them.",

--- a/packages/gateway/src/modules/config/agent-config-dal.ts
+++ b/packages/gateway/src/modules/config/agent-config-dal.ts
@@ -63,7 +63,7 @@ function normalizeLegacyAgentConfig(value: unknown): AgentConfig | undefined {
     !Array.isArray(mcp["pre_turn_tools"]) &&
     (legacyV1["enabled"] === undefined || legacyV1["enabled"] === true)
   ) {
-    normalizedMcp["pre_turn_tools"] = ["mcp.memory.seed"];
+    normalizedMcp["pre_turn_tools"] = ["memory.seed"];
   }
 
   const normalized: Record<string, unknown> = {

--- a/packages/gateway/tests/unit/agent-behavior.test-support.test.ts
+++ b/packages/gateway/tests/unit/agent-behavior.test-support.test.ts
@@ -13,7 +13,7 @@ describe("agent behavior test support", () => {
         {
           role: "system",
           content:
-            "Conversation state:\nknown facts\n\nPre-turn recall (mcp.memory.seed):\nmy name is Ron",
+            "Conversation state:\nknown facts\n\nPre-turn recall (memory.seed):\nmy name is Ron",
         },
         { role: "user", content: "what is my name" },
       ],
@@ -30,7 +30,7 @@ describe("agent behavior test support", () => {
         {
           role: "user",
           content: [
-            { type: "text", text: "Pre-turn recall (mcp.memory.seed):\nmy name is Ron" },
+            { type: "text", text: "Pre-turn recall (memory.seed):\nmy name is Ron" },
             { type: "text", text: "what is my name" },
           ],
         },

--- a/packages/gateway/tests/unit/agent-behavior.test-support.ts
+++ b/packages/gateway/tests/unit/agent-behavior.test-support.ts
@@ -8,7 +8,7 @@ import { simulateReadableStream } from "ai";
 import type { NormalizedThreadMessage } from "@tyrum/contracts";
 
 export const TITLE_PROMPT_TEXT = "Write a concise conversation title.";
-export const PRETURN_MEMORY_SECTION_LABEL = "Pre-turn recall (mcp.memory.seed):";
+export const PRETURN_MEMORY_SECTION_LABEL = "Pre-turn recall (memory.seed):";
 const PROMPT_ROLE_MARKER_PREFIX = "[[role:";
 const PROMPT_PART_MARKER_PREFIX = "[[part:";
 

--- a/packages/gateway/tests/unit/agent-config-dal.test.ts
+++ b/packages/gateway/tests/unit/agent-config-dal.test.ts
@@ -95,7 +95,7 @@ describe("AgentConfigDal", () => {
       const latest = await dal.getLatest({ tenantId, agentId });
       expect(latest?.revision).toBe(2);
       expect(latest?.reason).toBe("migrate legacy memory.v1 config");
-      expect(latest?.config.mcp.pre_turn_tools).toEqual(["mcp.memory.seed"]);
+      expect(latest?.config.mcp.pre_turn_tools).toEqual(["memory.seed"]);
       expect(
         BuiltinMemoryServerSettings.parse(latest?.config.mcp.server_settings["memory"]),
       ).toMatchObject({
@@ -105,7 +105,7 @@ describe("AgentConfigDal", () => {
       });
 
       const original = await dal.getByRevision({ tenantId, agentId, revision: 1 });
-      expect(original?.config.mcp.pre_turn_tools).toEqual(["mcp.memory.seed"]);
+      expect(original?.config.mcp.pre_turn_tools).toEqual(["memory.seed"]);
       expect(
         BuiltinMemoryServerSettings.parse(original?.config.mcp.server_settings["memory"]),
       ).toMatchObject({
@@ -250,7 +250,7 @@ describe("AgentConfigDal", () => {
             keyword: { enabled: false, limit: 25 },
           },
         },
-        pre_turn_tools: ["mcp.memory.seed"],
+        pre_turn_tools: ["memory.seed"],
       },
     });
     const migratedConfigJson = JSON.stringify(migratedConfig);

--- a/packages/gateway/tests/unit/agent-default-config.test.ts
+++ b/packages/gateway/tests/unit/agent-default-config.test.ts
@@ -56,7 +56,7 @@ describe("agent default config loading", () => {
     expect(config.mcp.bundle).toBe("workspace-default");
     expect(config.mcp.tier).toBe("advanced");
     expect(config.mcp.default_mode).toBe("allow");
-    expect(config.mcp.pre_turn_tools).toEqual(["mcp.memory.seed"]);
+    expect(config.mcp.pre_turn_tools).toEqual(["memory.seed"]);
     expect(config.tools.bundle).toBe("authoring-core");
     expect(config.tools.tier).toBe("default");
     expect(config.tools.default_mode).toBe("allow");
@@ -112,7 +112,7 @@ describe("agent default config loading", () => {
       bundle: "workspace-default",
       tier: "advanced",
       default_mode: "allow",
-      pre_turn_tools: ["mcp.memory.seed"],
+      pre_turn_tools: ["memory.seed"],
     });
     expect(storedTools).toMatchObject({
       bundle: "authoring-core",

--- a/packages/gateway/tests/unit/agent-runtime-memory-injection.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-memory-injection.test.ts
@@ -139,10 +139,10 @@ describe("AgentRuntime (memory MCP pre-turn injection)", () => {
     const stitched = content.map((part) => part.text).join("\n\n");
 
     expect(report?.pre_turn_tools?.[0]).toMatchObject({
-      tool_id: "mcp.memory.seed",
+      tool_id: "memory.seed",
       status: "succeeded",
     });
-    expect(stitched).toContain("Pre-turn recall (mcp.memory.seed):");
+    expect(stitched).toContain("Pre-turn recall (memory.seed):");
     expect(stitched).toContain('<data source="tool">');
     expect(stitched).toContain(item.memory_item_id);
   });
@@ -196,7 +196,7 @@ describe("AgentRuntime (memory MCP pre-turn injection)", () => {
     expect(call?.system).not.toContain("Turn memory protocol:");
     expect(call?.system).not.toContain("memory_turn_decision");
     expect(call?.tools).not.toHaveProperty("memory_turn_decision");
-    expect(stitched).not.toContain("Pre-turn recall (mcp.memory.seed):");
+    expect(stitched).not.toContain("Pre-turn recall (memory.seed):");
   });
 
   it("still injects pre-turn memory context when memory MCP settings are partial", async () => {
@@ -262,10 +262,10 @@ describe("AgentRuntime (memory MCP pre-turn injection)", () => {
     expect(call?.system).not.toContain("memory_turn_decision");
     expect(call?.tools).not.toHaveProperty("memory_turn_decision");
     expect(report?.pre_turn_tools?.[0]).toMatchObject({
-      tool_id: "mcp.memory.seed",
+      tool_id: "memory.seed",
       status: "succeeded",
     });
-    expect(stitched).toContain("Pre-turn recall (mcp.memory.seed):");
+    expect(stitched).toContain("Pre-turn recall (memory.seed):");
   });
 
   it("injects fact recall for punctuated identity questions", async () => {
@@ -329,7 +329,7 @@ describe("AgentRuntime (memory MCP pre-turn injection)", () => {
       | undefined;
     const stitched = (call?.messages?.[0]?.content ?? []).map((part) => part.text).join("\n\n");
 
-    expect(stitched).toContain("Pre-turn recall (mcp.memory.seed):");
+    expect(stitched).toContain("Pre-turn recall (memory.seed):");
     expect(stitched).toContain(item.memory_item_id);
     expect(stitched).toContain("key=user_name");
     expect(stitched).toContain('value="Ron"');

--- a/packages/gateway/tests/unit/preturn-hydration.test.ts
+++ b/packages/gateway/tests/unit/preturn-hydration.test.ts
@@ -99,7 +99,7 @@ describe("runPreTurnHydration", () => {
     });
     expect(result.reports).toEqual([
       {
-        tool_id: memorySeedTool.id,
+        tool_id: "memory.seed",
         status: "failed",
         injected_chars: 0,
         error: "policy store unavailable",
@@ -148,15 +148,47 @@ describe("runPreTurnHydration", () => {
     );
     expect(result.sections).toEqual([
       {
-        toolId: memorySeedTool.id,
-        text: "Pre-turn recall (mcp.memory.seed):\nStored recall",
+        toolId: "memory.seed",
+        text: "Pre-turn recall (memory.seed):\nStored recall",
       },
     ]);
     expect(result.reports).toEqual([
       {
-        tool_id: memorySeedTool.id,
+        tool_id: "memory.seed",
         status: "succeeded",
-        injected_chars: "Pre-turn recall (mcp.memory.seed):\nStored recall".length,
+        injected_chars: "Pre-turn recall (memory.seed):\nStored recall".length,
+      },
+    ]);
+  });
+
+  it("accepts canonical memory.seed config entries for legacy runtime tools", async () => {
+    const execute = vi.fn(async () => ({
+      output: "Stored recall",
+      error: undefined,
+      meta: undefined,
+    }));
+
+    const result = await runPreTurnHydration({
+      toolIds: ["memory.seed"],
+      availableTools: [memorySeedTool],
+      toolExecutor: { execute } as unknown as ToolExecutor,
+      toolSetBuilderDeps: createToolSetBuilderDeps({}),
+      toolExecutionContext,
+      conversation,
+      resolved,
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      memorySeedTool.id,
+      expect.stringMatching(/^preturn-/),
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(result.reports).toEqual([
+      {
+        tool_id: "memory.seed",
+        status: "succeeded",
+        injected_chars: "Pre-turn recall (memory.seed):\nStored recall".length,
       },
     ]);
   });
@@ -268,7 +300,7 @@ describe("runPreTurnHydration", () => {
     expect(result.sections).toEqual([]);
     expect(result.reports).toEqual([
       {
-        tool_id: memorySeedTool.id,
+        tool_id: "memory.seed",
         status: "failed",
         injected_chars: 0,
         error: "executor crashed",

--- a/packages/gateway/tests/unit/runtime-prompts.test.ts
+++ b/packages/gateway/tests/unit/runtime-prompts.test.ts
@@ -167,11 +167,7 @@ describe("formatMemoryGuidancePrompt", () => {
   });
 
   it("returns write and search guidance when all memory tools are present", () => {
-    const tools = [
-      makeTool("mcp.memory.seed"),
-      makeTool("mcp.memory.search"),
-      makeTool("mcp.memory.write"),
-    ];
+    const tools = [makeTool("memory.seed"), makeTool("memory.search"), makeTool("memory.write")];
     const result = formatMemoryGuidancePrompt(tools);
     expect(result).toBeDefined();
     expect(result).toContain("Proactively persist durable memory");
@@ -181,7 +177,7 @@ describe("formatMemoryGuidancePrompt", () => {
     expect(result).toContain("Do not assume pre-turn recall is complete");
     expect(result).toContain("Pre-turn recall is seed-based");
     expect(result).toContain("If the requested information is not in pre-turn recall");
-    expect(result).toContain("run mcp.memory.search before answering");
+    expect(result).toContain("run memory.search before answering");
     expect(result).toContain("stored profile details such as addresses");
     expect(result).toContain("search memory before asking the user to repeat them");
     expect(result).toContain("When memory contains an exact answer");
@@ -190,14 +186,11 @@ describe("formatMemoryGuidancePrompt", () => {
   });
 
   it("adds automation-specific write guidance for triggered work", () => {
-    const tools = [
-      makeTool("mcp.memory.seed"),
-      makeTool("mcp.memory.search"),
-      makeTool("mcp.memory.write"),
-    ];
+    const tools = [makeTool("memory.seed"), makeTool("memory.search"), makeTool("memory.write")];
     const result = formatMemoryGuidancePrompt(tools, { isAutomationTurn: true });
     expect(result).toContain("For triggered automation work");
     expect(result).toContain("If nothing worth reusing emerged, do not write memory.");
+    expect(result).toContain("call memory.write only when the work yields");
   });
 
   it("returns only search guidance for read-only profiles without mcp.memory.write", () => {
@@ -208,14 +201,14 @@ describe("formatMemoryGuidancePrompt", () => {
     expect(result).not.toContain("Never write");
     expect(result).toContain("Search memory when pre-turn recall");
     expect(result).toContain("Pre-turn recall is seed-based");
-    expect(result).toContain("run mcp.memory.search before answering");
+    expect(result).toContain("run memory.search before answering");
     expect(result).toContain("stored profile details such as addresses");
     expect(result).toContain("When memory contains an exact answer");
     expect(result).toContain("search with alternative terms, paraphrases");
   });
 
   it("returns undefined when only seed is present", () => {
-    const result = formatMemoryGuidancePrompt([makeTool("mcp.memory.seed")]);
+    const result = formatMemoryGuidancePrompt([makeTool("memory.seed")]);
     expect(result).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #1973

## What changed
- switched seeded and migrated `pre_turn_tools` defaults from `mcp.memory.seed` to canonical `memory.seed`
- made pre-turn hydration and runtime memory guidance use canonical public memory IDs while keeping rollout-time compatibility with legacy `mcp.memory.*` entries
- updated memory architecture docs and docs regression coverage to assert canonical `memory.seed`, `memory.search`, and `memory.write`

## Why
- this issue removes remaining user-facing leaks of transport-facing memory IDs from defaults, pre-turn hydration, prompts, and contributor docs
- it keeps the rollout aligned with the upstream compatibility work from `#1980` and `#1991` without absorbing later-scope parser/execution-profile/setup changes

## How to test
- `cd /tmp/tyrum-1973 && pnpm exec vitest run apps/docs/tests/memory-operator-workflows-docs.test.ts --reporter=dot`
- `cd /tmp/tyrum-1973 && pnpm exec vitest run packages/gateway/tests/unit/agent-default-config.test.ts packages/gateway/tests/unit/agent-config-dal.test.ts packages/gateway/tests/unit/preturn-hydration.test.ts packages/gateway/tests/unit/runtime-prompts.test.ts packages/gateway/tests/unit/agent-runtime-memory-injection.test.ts packages/gateway/tests/unit/agent-behavior.test-support.test.ts --reporter=dot`
- `git -C /tmp/tyrum-1973 push -u origin 1973-public-memory-id-rollout` (ran repo pre-push gate: `pnpm run ci`, passed locally)

## Risk
- low to moderate: touches public memory naming in defaults, prompt text, pre-turn reporting, and docs
- rollout compatibility relies on existing canonical/legacy matching paths rather than new alias behavior

## Rollback notes
- revert commit `a6f245482f090ec2647bced29c3b060f4eb84f4c` to restore legacy-facing defaults, prompt text, and docs wording
- no migration or persisted data rollback is required for this issue alone

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk string/identifier migration affecting default config seeding, prompt/report labeling, and docs/tests; main risk is missed compatibility edge cases where configs or tool registries still use legacy `mcp.memory.*` IDs.
> 
> **Overview**
> Updates public-facing memory tool identifiers from legacy `mcp.memory.*` to canonical `memory.*` across docs, seeded/migrated agent config defaults (`pre_turn_tools`), and runtime prompt/report text.
> 
> Pre-turn hydration now resolves requested tool IDs via rollout-compatible matching and reports/injects sections using canonicalized IDs, while `formatMemoryGuidancePrompt` detects memory capabilities using canonicalized tool IDs. Tests and docs regression coverage are updated to assert the new canonical IDs and avoid documenting legacy v1 memory APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f245482f090ec2647bced29c3b060f4eb84f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->