### PR TITLE
fix: expand canonical memory tool alias normalization

### DIFF
--- a/packages/contracts/src/tool-id.ts
+++ b/packages/contracts/src/tool-id.ts
@@ -3,6 +3,9 @@ const LEGACY_TOOL_ID_MAP = new Map<string, string>([
   ["tool.fs.write", "write"],
   ["tool.exec", "bash"],
   ["tool.http.fetch", "webfetch"],
+  ["mcp.memory.seed", "memory.seed"],
+  ["mcp.memory.search", "memory.search"],
+  ["mcp.memory.write", "memory.write"],
 ]);
 
 const LEGACY_TOOL_ID_LIST_MAP = new Map<string, readonly string[]>([

--- a/packages/contracts/tests/agent-access.test.ts
+++ b/packages/contracts/tests/agent-access.test.ts
@@ -15,7 +15,7 @@ describe("agent access config normalization", () => {
       default_mode: "allow",
       allow: [],
       deny: [],
-      pre_turn_tools: ["mcp.memory.seed"],
+      pre_turn_tools: ["memory.seed"],
       server_settings: {},
     });
   });

--- a/packages/contracts/tests/agent.test.ts
+++ b/packages/contracts/tests/agent.test.ts
@@ -70,12 +70,25 @@ describe("AgentConfig", () => {
       },
     });
 
-    expect(parsed.mcp.pre_turn_tools).toEqual(["mcp.memory.seed"]);
+    expect(parsed.mcp.pre_turn_tools).toEqual(["memory.seed"]);
     expect(BuiltinMemoryServerSettings.parse(parsed.mcp.server_settings["memory"])).toMatchObject({
       enabled: true,
       allow_sensitivities: ["public"],
       keyword: { enabled: false, limit: 25 },
     });
+  });
+
+  it("canonicalizes memory aliases in tool allow and deny lists", () => {
+    const parsed = AgentConfig.parse({
+      model: { model: "openai/gpt-5.4" },
+      tools: {
+        allow: ["mcp.memory.search", "memory.search"],
+        deny: ["mcp.memory.write"],
+      },
+    });
+
+    expect(parsed.tools.allow).toEqual(["memory.search"]);
+    expect(parsed.tools.deny).toEqual(["memory.write"]);
   });
 
   it("rejects legacy memory.v1 config", () => {

--- a/packages/contracts/tests/playbook.test.ts
+++ b/packages/contracts/tests/playbook.test.ts
@@ -25,12 +25,12 @@ describe("PlaybookStep", () => {
       command: "llm generate",
       llm: {
         ...baseLlm,
-        tools: { allow: ["webfetch", "bash"] },
+        tools: { allow: ["webfetch", "bash", "mcp.memory.write"] },
       },
       output: "json",
     });
 
-    expect(step.llm?.tools?.allow).toEqual(["webfetch", "bash"]);
+    expect(step.llm?.tools?.allow).toEqual(["webfetch", "bash", "memory.write"]);
   });
 
   it("rejects llm steps missing llm config", () => {

--- a/packages/contracts/tests/tool-id.test.ts
+++ b/packages/contracts/tests/tool-id.test.ts
@@ -12,6 +12,9 @@ describe("tool id canonicalization", () => {
     expect(canonicalizeToolId("tool.fs.write")).toBe("write");
     expect(canonicalizeToolId("tool.exec")).toBe("bash");
     expect(canonicalizeToolId("tool.http.fetch")).toBe("webfetch");
+    expect(canonicalizeToolId("mcp.memory.seed")).toBe("memory.seed");
+    expect(canonicalizeToolId("mcp.memory.search")).toBe("memory.search");
+    expect(canonicalizeToolId("mcp.memory.write")).toBe("memory.write");
   });
 
   it("expands legacy fs wildcards to the canonical builtin set", () => {
@@ -38,7 +41,15 @@ describe("tool id canonicalization", () => {
 
   it("canonicalizes exact ids while trimming blanks and removing duplicates", () => {
     expect(
-      canonicalizeExactToolIdList([" tool.fs.read ", "read", "tool.exec", " bash ", "   "]),
-    ).toEqual(["read", "bash"]);
+      canonicalizeExactToolIdList([
+        " tool.fs.read ",
+        "read",
+        "tool.exec",
+        " bash ",
+        "mcp.memory.write",
+        "memory.write",
+        "   ",
+      ]),
+    ).toEqual(["read", "bash", "memory.write"]);
   });
 });

--- a/packages/contracts/tests/tool-intent.test.ts
+++ b/packages/contracts/tests/tool-intent.test.ts
@@ -34,13 +34,13 @@ describe("ToolIntent", () => {
       step_index: 1,
       cost_budget: { max_total_tokens: 123 },
       execution_profile: "default",
-      tool_allowlist: ["webfetch"],
+      tool_allowlist: ["webfetch", "mcp.memory.search"],
       created_at: "2026-02-19T12:00:00Z",
       created_by: "agent:default:main",
     });
 
     expect(parsed.cost_budget.max_total_tokens).toBe(123);
-    expect(parsed.tool_allowlist).toEqual(["webfetch"]);
+    expect(parsed.tool_allowlist).toEqual(["webfetch", "memory.search"]);
   });
 
   it("rejects missing expected_evidence", () => {

--- a/packages/contracts/tests/unit/deployment-policy-config.test.ts
+++ b/packages/contracts/tests/unit/deployment-policy-config.test.ts
@@ -37,15 +37,16 @@ describe("DeploymentPolicyConfig schemas", () => {
         v: 1,
         tools: {
           default: "deny",
-          allow: ["tool.fs.read", "tool.exec"],
+          allow: ["tool.fs.read", "tool.exec", "mcp.memory.search"],
           require_approval: [],
-          deny: [],
+          deny: ["mcp.memory.write"],
         },
       },
       reason: "tighten allowlist",
     });
 
-    expect(parsed.bundle.tools?.allow).toEqual(["read", "bash"]);
+    expect(parsed.bundle.tools?.allow).toEqual(["read", "bash", "memory.search"]);
+    expect(parsed.bundle.tools?.deny).toEqual(["memory.write"]);
   });
 
   it("validates revision list responses and revert inputs", () => {

--- a/packages/operator-ui/tests/pages/agent-setup-wizard.shared.test.ts
+++ b/packages/operator-ui/tests/pages/agent-setup-wizard.shared.test.ts
@@ -49,7 +49,7 @@ describe("agent-setup-wizard.shared", () => {
       default_mode: "deny",
       allow: ["memory"],
       deny: [],
-      pre_turn_tools: ["mcp.memory.seed"],
+      pre_turn_tools: ["memory.seed"],
     });
     expect(config.tools).toEqual({ default_mode: "allow", allow: [], deny: [] });
   });

--- a/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
@@ -44,7 +44,7 @@ describe("agents-page-editor-form", () => {
         default_mode: "deny",
         allow: ["filesystem"],
         deny: ["secrets"],
-        pre_turn_tools: ["mcp.memory.seed"],
+        pre_turn_tools: ["memory.seed"],
         server_settings: expect.objectContaining({
           filesystem: {
             namespace: "agents",

--- a/packages/operator-ui/tests/pages/agents-page-editor.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor.test.ts
@@ -177,7 +177,7 @@ describe("AgentsPage editor", () => {
             default_mode: "deny",
             allow: ["filesystem"],
             deny: ["secrets"],
-            pre_turn_tools: ["mcp.memory.seed"],
+            pre_turn_tools: ["memory.seed"],
             server_settings: expect.objectContaining({
               filesystem: expect.objectContaining({
                 namespace: "shared",

--- a/packages/transport-sdk/tests/http-client.test-policy-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-policy-support.ts
@@ -108,7 +108,7 @@ export function registerHttpClientPolicyTests(): void {
           v: 1,
           tools: {
             allow: ["read"],
-            require_approval: [],
+            require_approval: ["memory.write"],
             deny: [],
           },
         },
@@ -126,7 +126,7 @@ export function registerHttpClientPolicyTests(): void {
         v: 1,
         tools: {
           allow: ["tool.fs.read"],
-          require_approval: [],
+          require_approval: ["mcp.memory.write"],
           deny: [],
         },
       },
@@ -134,6 +134,7 @@ export function registerHttpClientPolicyTests(): void {
     });
     expect(result.revision).toBe(4);
     expect(result.bundle.tools?.allow).toEqual(["read"]);
+    expect(result.bundle.tools?.require_approval).toEqual(["memory.write"]);
 
     const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
       string,
@@ -151,7 +152,7 @@ export function registerHttpClientPolicyTests(): void {
         },
         tools: {
           allow: ["read"],
-          require_approval: [],
+          require_approval: ["memory.write"],
           deny: [],
         },
       },


### PR DESCRIPTION
Closes #1963

## What Changed

- extended the contracts-side legacy tool alias table so `mcp.memory.seed`, `mcp.memory.search`, and `mcp.memory.write` normalize to canonical `memory.seed`, `memory.search`, and `memory.write`
- updated parser-boundary tests for agent access, agent config, tool intent, playbook LLM tool allowlists, deployment policy config, and transport SDK policy-config coverage
- preserved the existing shipped alias slice for filesystem, shell, `tool.http.fetch -> webfetch`, and wildcard compatibility

## Why

Issue #1963 is the parser-compatibility step after the runtime-sensitive memory rollout work. Supported legacy public memory IDs still need deterministic parse-time normalization to canonical IDs without pulling in runtime selection, defaults/docs, execution-profile, or stored-data migration scope.

## How To Test

- `pnpm vitest packages/contracts/tests/tool-id.test.ts packages/contracts/tests/agent-access.test.ts packages/contracts/tests/agent.test.ts packages/contracts/tests/unit/deployment-policy-config.test.ts`
- `pnpm vitest packages/gateway/tests/unit/access-config.test.ts packages/gateway/tests/unit/policy-match-target.test.ts packages/gateway/tests/unit/policy-service-effect-defaults.test.ts`
- `pnpm vitest packages/contracts/tests/tool-intent.test.ts packages/contracts/tests/playbook.test.ts`
- `pnpm vitest packages/transport-sdk/tests/http-client.test.ts`
- `pnpm --filter @tyrum/contracts build`
- `pnpm --filter @tyrum/transport-sdk build`
- `pnpm run ci`

## Risk

- low: the production change is isolated to parser canonicalization for three legacy memory aliases
- main regression risk is broadening alias behavior beyond those three IDs or breaking existing parser compatibility, which is covered by focused alias and parser-boundary tests

## Rollback Notes

- revert commit `74ca5b4a6f51dbcef80ba3287d577cc4424c5cf3`
- rollback is isolated to the contracts alias helper and associated parser/operator-ui test expectations; no data migration or runtime-path rollback is involved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small parser-side alias expansion for three legacy memory tool IDs, with updated tests to lock in expected normalization behavior across schemas and SDK policy payloads.
> 
> **Overview**
> Extends contracts tool-id canonicalization so legacy `mcp.memory.seed`/`mcp.memory.search`/`mcp.memory.write` are normalized to canonical `memory.seed`/`memory.search`/`memory.write`.
> 
> Updates parser-boundary expectations and adds coverage to ensure these aliases are deduped and consistently canonicalized in agent configs (including `pre_turn_tools`, tool allow/deny), playbook LLM tool allowlists, tool intents, deployment policy update requests, operator-ui payload preservation, and transport-sdk policy config requests/responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ca5b4a6f51dbcef80ba3287d577cc4424c5cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->