### PR TITLE
Canonicalize public runtime and audit payload tool IDs

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/tool-set-builder-lifecycle.ts
+++ b/packages/gateway/src/modules/agent/runtime/tool-set-builder-lifecycle.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { LanguageModel } from "ai";
-import { type ToolLifecycleStatus, type WsEventEnvelope } from "@tyrum/contracts";
+import {
+  canonicalizeToolId,
+  type ToolLifecycleStatus,
+  type WsEventEnvelope,
+} from "@tyrum/contracts";
 import type { ToolDescriptor } from "../tools.js";
 import type { ToolResult } from "../tool-executor.js";
 import { runWebFetchExtractionPass } from "../webfetch-extraction.js";
@@ -56,6 +60,7 @@ export async function syncToolLifecycle(
   },
 ): Promise<void> {
   const updatedAt = new Date().toISOString();
+  const publicToolId = canonicalizeToolId(input.toolId);
 
   if (!deps.wsEventDb) return;
 
@@ -68,7 +73,7 @@ export async function syncToolLifecycle(
       conversation_id: input.context.conversationId,
       thread_id: input.context.threadId,
       tool_call_id: input.toolCallId,
-      tool_id: input.toolId,
+      tool_id: publicToolId,
       status: input.status,
       summary: input.summary,
       duration_ms: input.durationMs,
@@ -83,7 +88,7 @@ export async function syncToolLifecycle(
     await enqueueWsBroadcastMessage(deps.wsEventDb, deps.tenantId, event, OPERATOR_WS_AUDIENCE);
   } catch (error) {
     deps.logger.info("tool.lifecycle_emit_failed", {
-      tool_id: input.toolId,
+      tool_id: publicToolId,
       tool_call_id: input.toolCallId,
       error: error instanceof Error ? error.message : String(error),
     });
@@ -121,7 +126,7 @@ export function recordToolResultContext(
 ): void {
   contextReport.tool_calls.push({
     tool_call_id: input.toolCallId,
-    tool_id: input.toolId,
+    tool_id: canonicalizeToolId(input.toolId),
     injected_chars: input.content.length,
   });
 

--- a/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { ContextReport as ContextReportSchema } from "@tyrum/contracts";
+import {
+  ContextReport as ContextReportSchema,
+  canonicalizeExactToolIdList,
+  canonicalizeToolId,
+} from "@tyrum/contracts";
 import type { ToolDescriptor } from "../tools.js";
 import type { AgentContextReport, AgentLoadedContext } from "./types.js";
 import type { ResolvedExecutionProfile } from "./execution-profile-resolution.js";
@@ -44,6 +48,17 @@ export interface ContextReportInput {
   logger: { warn: (msg: string, data?: Record<string, unknown>) => void };
 }
 
+function canonicalizePreTurnToolReport(
+  preTurnReport: AgentContextReport["pre_turn_tools"][number],
+): AgentContextReport["pre_turn_tools"][number] {
+  return {
+    tool_id: canonicalizeToolId(preTurnReport.tool_id),
+    status: preTurnReport.status,
+    injected_chars: preTurnReport.injected_chars,
+    ...(preTurnReport.error ? { error: preTurnReport.error } : {}),
+  };
+}
+
 export function buildContextReport(input: ContextReportInput): AgentContextReport {
   const {
     conversation,
@@ -81,7 +96,7 @@ export function buildContextReport(input: ContextReportInput): AgentContextRepor
       // Intentional: schema size accounting is best-effort; treat non-serializable schemas as 0 chars.
       chars = 0;
     }
-    return { id: t.id, chars };
+    return { id: canonicalizeToolId(t.id), chars };
   });
   const toolSchemaTotalChars = toolSchemaParts.reduce((total, part) => total + part.chars, 0);
   const toolSchemaTop = toolSchemaParts.toSorted((a, b) => b.chars - a.chars).slice(0, 5);
@@ -124,7 +139,7 @@ export function buildContextReport(input: ContextReportInput): AgentContextRepor
         : []),
       { id: "user_request", chars: resolved.message.length },
     ],
-    selected_tools: filteredTools.map((t) => t.id),
+    selected_tools: canonicalizeExactToolIdList(filteredTools.map((t) => t.id)),
     execution_profile: executionProfile.id,
     execution_profile_source: executionProfile.source,
     tool_schema_top: toolSchemaTop,
@@ -141,7 +156,7 @@ export function buildContextReport(input: ContextReportInput): AgentContextRepor
         }
       : {}),
     memory: memorySummary,
-    pre_turn_tools: preTurnReports,
+    pre_turn_tools: preTurnReports.map(canonicalizePreTurnToolReport),
     tool_calls: [],
     injected_files: [],
   };

--- a/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-context-report.ts
@@ -52,10 +52,8 @@ function canonicalizePreTurnToolReport(
   preTurnReport: AgentContextReport["pre_turn_tools"][number],
 ): AgentContextReport["pre_turn_tools"][number] {
   return {
+    ...preTurnReport,
     tool_id: canonicalizeToolId(preTurnReport.tool_id),
-    status: preTurnReport.status,
-    injected_chars: preTurnReport.injected_chars,
-    ...(preTurnReport.error ? { error: preTurnReport.error } : {}),
   };
 }
 

--- a/packages/gateway/src/modules/agent/runtime/turn-finalization.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-finalization.ts
@@ -4,7 +4,7 @@ import type {
   AttemptCost as AttemptCostT,
   TyrumUIMessage,
 } from "@tyrum/contracts";
-import { AgentTurnResponse } from "@tyrum/contracts";
+import { AgentTurnResponse, canonicalizeExactToolIdList } from "@tyrum/contracts";
 import type { GatewayContainer } from "../../../container.js";
 import type { ModelMessage } from "ai";
 import type { ArtifactRecordInsertInput } from "../../artifact/dal.js";
@@ -461,7 +461,7 @@ export async function finalizeTurn(input: {
     conversation_id: input.conversation.conversation_id,
     conversation_key: input.conversation.conversation_key,
     attachments: responseAttachments,
-    used_tools: Array.from(input.usedTools),
+    used_tools: canonicalizeExactToolIdList(Array.from(input.usedTools)),
     memory_written: memoryWritten,
   });
 }

--- a/packages/gateway/src/modules/plugins/registry-events.ts
+++ b/packages/gateway/src/modules/plugins/registry-events.ts
@@ -117,10 +117,10 @@ export async function emitPluginToolInvokedEvent(
 ): Promise<void> {
   const sourcePlanId = params.auditPlanId?.trim();
   if (!opts.container || !sourcePlanId) return;
+  const publicToolId = canonicalizeToolId(params.toolId);
   try {
     const auditPlanId = `${PLUGIN_TOOL_INVOKED_AUDIT_PLAN_PREFIX}:${sourcePlanId}`,
       occurredAt = new Date().toISOString();
-    const publicToolId = canonicalizeToolId(params.toolId);
     const action = {
       type: "plugin_tool.invoked",
       plugin_id: params.pluginId,
@@ -178,7 +178,7 @@ export async function emitPluginToolInvokedEvent(
   } catch (err) {
     opts.logger.warn("plugins.tool_invoked_emit_failed", {
       plugin_id: params.pluginId,
-      tool_id: canonicalizeToolId(params.toolId),
+      tool_id: publicToolId,
       tool_call_id: params.toolCallId,
       plan_id: sourcePlanId,
       audit_plan_id: `${PLUGIN_TOOL_INVOKED_AUDIT_PLAN_PREFIX}:${sourcePlanId}`,

--- a/packages/gateway/src/modules/plugins/registry-events.ts
+++ b/packages/gateway/src/modules/plugins/registry-events.ts
@@ -1,7 +1,7 @@
 import {
   canonicalizeToolId,
   type PluginManifest as PluginManifestT,
-  WsEventEnvelope,
+  type WsEventEnvelope,
 } from "@tyrum/contracts";
 import { randomUUID } from "node:crypto";
 import type { GatewayContainer } from "../../container.js";

--- a/packages/gateway/src/modules/plugins/registry-events.ts
+++ b/packages/gateway/src/modules/plugins/registry-events.ts
@@ -1,4 +1,8 @@
-import type { PluginManifest as PluginManifestT, WsEventEnvelope } from "@tyrum/contracts";
+import {
+  canonicalizeToolId,
+  type PluginManifest as PluginManifestT,
+  WsEventEnvelope,
+} from "@tyrum/contracts";
 import { randomUUID } from "node:crypto";
 import type { GatewayContainer } from "../../container.js";
 import { OPERATOR_WS_AUDIENCE } from "../../ws/audience.js";
@@ -116,11 +120,12 @@ export async function emitPluginToolInvokedEvent(
   try {
     const auditPlanId = `${PLUGIN_TOOL_INVOKED_AUDIT_PLAN_PREFIX}:${sourcePlanId}`,
       occurredAt = new Date().toISOString();
+    const publicToolId = canonicalizeToolId(params.toolId);
     const action = {
       type: "plugin_tool.invoked",
       plugin_id: params.pluginId,
       plugin_version: params.pluginVersion,
-      tool_id: params.toolId,
+      tool_id: publicToolId,
       tool_call_id: params.toolCallId,
       agent_id: params.agentId,
       workspace_id: params.workspaceId,
@@ -149,7 +154,7 @@ export async function emitPluginToolInvokedEvent(
           payload: {
             plugin_id: params.pluginId,
             plugin_version: params.pluginVersion,
-            tool_id: params.toolId,
+            tool_id: publicToolId,
             tool_call_id: params.toolCallId,
             agent_id: params.agentId,
             workspace_id: params.workspaceId,
@@ -173,7 +178,7 @@ export async function emitPluginToolInvokedEvent(
   } catch (err) {
     opts.logger.warn("plugins.tool_invoked_emit_failed", {
       plugin_id: params.pluginId,
-      tool_id: params.toolId,
+      tool_id: canonicalizeToolId(params.toolId),
       tool_call_id: params.toolCallId,
       plan_id: sourcePlanId,
       audit_plan_id: `${PLUGIN_TOOL_INVOKED_AUDIT_PLAN_PREFIX}:${sourcePlanId}`,

--- a/packages/gateway/tests/unit/agent-runtime-public-tool-id-emission.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-public-tool-id-emission.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentContextReport } from "../../src/modules/agent/runtime/types.js";
+import type { ContextReportInput } from "../../src/modules/agent/runtime/turn-context-report.js";
+import { buildContextReport } from "../../src/modules/agent/runtime/turn-context-report.js";
+import {
+  recordToolResultContext,
+  syncToolLifecycle,
+} from "../../src/modules/agent/runtime/tool-set-builder-lifecycle.js";
+import { enqueueWsBroadcastMessage } from "../../src/ws/outbox.js";
+
+vi.mock("../../src/ws/outbox.js", () => ({
+  enqueueWsBroadcastMessage: vi.fn(),
+}));
+
+const enqueueWsBroadcastMessageMock = vi.mocked(enqueueWsBroadcastMessage);
+
+function createContextReportInput(): ContextReportInput {
+  return {
+    conversation: {
+      conversation_id: "conversation-1",
+      agent_id: "default",
+      workspace_id: "default",
+    } as ContextReportInput["conversation"],
+    resolved: {
+      channel: "ui",
+      thread_id: "thread-1",
+      message: "remember this note",
+    } as ContextReportInput["resolved"],
+    ctx: {
+      skills: [],
+      mcpServers: [],
+    } as ContextReportInput["ctx"],
+    executionProfile: {
+      id: "interaction",
+      source: "interaction_default",
+    } as ContextReportInput["executionProfile"],
+    filteredTools: [
+      {
+        id: "mcp.memory.search",
+        description: "Search memory",
+        effect: "read_only",
+        keywords: ["memory"],
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+        },
+      },
+    ],
+    systemPrompt: "system prompt",
+    identityPrompt: "identity",
+    promptContractPrompt: "prompt contract",
+    runtimePrompt: "runtime",
+    safetyPrompt: "safety",
+    sandboxPrompt: "sandbox",
+    skillsText: "",
+    toolsText: "",
+    workOrchestrationText: undefined,
+    memoryGuidanceText: undefined,
+    conversationText: "conversation",
+    workFocusText: "focus",
+    preTurnTexts: [],
+    preTurnReports: [
+      {
+        tool_id: "mcp.memory.seed",
+        status: "succeeded",
+        injected_chars: 18,
+      },
+    ],
+    automationDirectiveText: undefined,
+    automationContextText: undefined,
+    memorySummary: {
+      keyword_hits: 1,
+      semantic_hits: 2,
+      structured_hits: 0,
+      included_items: 1,
+    },
+    automation: undefined,
+    logger: { warn: vi.fn() },
+  };
+}
+
+describe("agent runtime public tool ID emission", () => {
+  beforeEach(() => {
+    enqueueWsBroadcastMessageMock.mockReset();
+  });
+
+  it("canonicalizes context report tool identifiers at emission time", () => {
+    const report = buildContextReport(createContextReportInput());
+
+    expect(report.selected_tools).toEqual(["memory.search"]);
+    expect(report.tool_schema_top).toContainEqual({
+      id: "memory.search",
+      chars: expect.any(Number),
+    });
+    expect(report.pre_turn_tools).toEqual([
+      expect.objectContaining({
+        tool_id: "memory.seed",
+        status: "succeeded",
+      }),
+    ]);
+  });
+
+  it("canonicalizes tool call report identifiers before attaching context", () => {
+    const contextReport = {
+      tool_calls: [],
+      injected_files: [],
+    } as AgentContextReport;
+
+    recordToolResultContext(contextReport, {
+      toolCallId: "tool-call-1",
+      toolId: "mcp.memory.write",
+      content: "stored memory",
+      result: {
+        tool_call_id: "tool-call-1",
+        output: "ok",
+      },
+    });
+
+    expect(contextReport.tool_calls).toEqual([
+      {
+        tool_call_id: "tool-call-1",
+        tool_id: "memory.write",
+        injected_chars: "stored memory".length,
+      },
+    ]);
+  });
+
+  it("canonicalizes tool lifecycle event payload identifiers before broadcast", async () => {
+    await syncToolLifecycle(
+      {
+        conversationDal: undefined,
+        tenantId: "tenant-1",
+        agentId: "default",
+        workspaceId: "default",
+        wsEventDb: {} as NonNullable<Parameters<typeof syncToolLifecycle>[0]["wsEventDb"]>,
+        logger: { info: vi.fn(), warn: vi.fn() },
+      },
+      {
+        context: {
+          conversationId: "conversation-1",
+          channel: "ui",
+          threadId: "thread-1",
+        },
+        toolCallId: "tool-call-1",
+        toolId: "mcp.memory.write",
+        status: "completed",
+        summary: "Saved a durable memory.",
+      },
+    );
+
+    expect(enqueueWsBroadcastMessageMock).toHaveBeenCalledTimes(1);
+    expect(enqueueWsBroadcastMessageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "tenant-1",
+      expect.objectContaining({
+        type: "tool.lifecycle",
+        payload: expect.objectContaining({
+          tool_id: "memory.write",
+          tool_call_id: "tool-call-1",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/packages/gateway/tests/unit/agent-runtime-public-tool-id-emission.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-public-tool-id-emission.test.ts
@@ -102,6 +102,27 @@ describe("agent runtime public tool ID emission", () => {
     ]);
   });
 
+  it("preserves passthrough pre-turn report fields while canonicalizing tool ids", () => {
+    const report = buildContextReport({
+      ...createContextReportInput(),
+      preTurnReports: [
+        {
+          tool_id: "mcp.memory.seed",
+          status: "succeeded",
+          injected_chars: 18,
+          source: "preloaded-memory",
+        },
+      ],
+    });
+
+    expect(report.pre_turn_tools).toEqual([
+      expect.objectContaining({
+        tool_id: "memory.seed",
+        source: "preloaded-memory",
+      }),
+    ]);
+  });
+
   it("canonicalizes tool call report identifiers before attaching context", () => {
     const contextReport = {
       tool_calls: [],

--- a/packages/gateway/tests/unit/agent-runtime-tool-memory-queue.test.ts
+++ b/packages/gateway/tests/unit/agent-runtime-tool-memory-queue.test.ts
@@ -133,7 +133,7 @@ describe("AgentRuntime - tool tracking, memory, and conversation queue signals",
     );
   }, 10_000);
 
-  it("does not mark memory_written when mcp.memory.write returns an error", async () => {
+  it("canonicalizes memory aliases before reporting used_tools", async () => {
     homeDir = await mkdtemp(join(tmpdir(), "tyrum-agent-runtime-"));
     container = await createObservedContainer();
     await seedAgentConfig(container, {
@@ -163,7 +163,8 @@ describe("AgentRuntime - tool tracking, memory, and conversation queue signals",
       message: "remember that I prefer tea",
     });
 
-    expect(result.used_tools).toContain("mcp.memory.write");
+    expect(result.used_tools).toContain("memory.write");
+    expect(result.used_tools).not.toContain("mcp.memory.write");
     expect(result.memory_written).toBe(false);
   }, 10_000);
 

--- a/packages/gateway/tests/unit/plugin-registry-events.test.ts
+++ b/packages/gateway/tests/unit/plugin-registry-events.test.ts
@@ -1,0 +1,51 @@
+import { rm } from "node:fs/promises";
+import { afterEach, describe, it } from "vitest";
+import { emitPluginToolInvokedEvent } from "../../src/modules/plugins/registry-events.js";
+import {
+  createEchoPluginHome,
+  createSilentLogger,
+  expectToolInvokedAuditLinkage,
+  getLastBroadcastEvent,
+  withTestContainer,
+} from "./plugin-registry.test-support.js";
+
+describe("plugin registry event emission", () => {
+  let home: string | undefined;
+
+  afterEach(async () => {
+    if (home) {
+      await rm(home, { recursive: true, force: true });
+      home = undefined;
+    }
+  });
+
+  it("canonicalizes supported legacy aliases before emitting plugin tool audit payloads", async () => {
+    const fixture = await createEchoPluginHome();
+    home = fixture.home;
+
+    await withTestContainer(fixture.home, async (container) => {
+      await emitPluginToolInvokedEvent(
+        { logger: createSilentLogger(), container },
+        {
+          pluginId: "echo",
+          pluginVersion: "1.0.0",
+          toolId: "mcp.memory.write",
+          toolCallId: "call-legacy-memory",
+          agentId: "default",
+          workspaceId: "default",
+          auditPlanId: "agent-turn-test",
+          outcome: "succeeded",
+          durationMs: 12,
+        },
+      );
+
+      const lastOutbox = await getLastBroadcastEvent(container);
+      await expectToolInvokedAuditLinkage(container, lastOutbox, {
+        planKey: "gateway.plugins.tool_invoked:agent-turn-test",
+        pluginId: "echo",
+        toolId: "memory.write",
+        toolCallId: "call-legacy-memory",
+      });
+    });
+  });
+});

--- a/packages/gateway/tests/unit/transcript-handlers.timeline.test.ts
+++ b/packages/gateway/tests/unit/transcript-handlers.timeline.test.ts
@@ -93,9 +93,9 @@ describe("transcript WS handlers timeline events", () => {
       conversationId: root1.conversation_id,
       threadId: "thread-root-1",
       toolCallId: "tool-call-1",
-      toolId: "tool.location.get",
+      toolId: "memory.write",
       status: "completed",
-      summary: "Resolved device location.",
+      summary: "Saved a durable memory.",
       occurredAt: "2026-02-17T00:00:15.000Z",
     });
     await insertTranscriptContextReport({
@@ -118,14 +118,26 @@ describe("transcript WS handlers timeline events", () => {
         workspace_id: root1.workspace_id,
         system_prompt: { chars: 10, sections: [] },
         user_parts: [],
-        selected_tools: [],
+        selected_tools: ["memory.search"],
         tool_schema_top: [],
         tool_schema_total_chars: 0,
         enabled_skills: [],
         mcp_servers: [],
         memory: { keyword_hits: 1, semantic_hits: 2 },
-        pre_turn_tools: [],
-        tool_calls: [],
+        pre_turn_tools: [
+          {
+            tool_id: "memory.seed",
+            status: "succeeded",
+            injected_chars: 42,
+          },
+        ],
+        tool_calls: [
+          {
+            tool_call_id: "tool-call-1",
+            tool_id: "memory.write",
+            injected_chars: 24,
+          },
+        ],
         injected_files: [],
       },
     });
@@ -146,7 +158,12 @@ describe("transcript WS handlers timeline events", () => {
           conversation_key: string;
           payload?: {
             tool_event?: { tool_id: string };
-            report?: { memory?: { keyword_hits?: number } };
+            report?: {
+              memory?: { keyword_hits?: number };
+              selected_tools?: string[];
+              pre_turn_tools?: Array<{ tool_id: string }>;
+              tool_calls?: Array<{ tool_id: string }>;
+            };
           };
         }>;
       };
@@ -157,14 +174,19 @@ describe("transcript WS handlers timeline events", () => {
       event_id: "tool_lifecycle:550e8400-e29b-41d4-a716-446655440401",
       conversation_key: root1.conversation_key,
       payload: {
-        tool_event: { tool_id: "tool.location.get" },
+        tool_event: { tool_id: "memory.write" },
       },
     });
     expect(response.result.events.find((event) => event.kind === "context_report")).toMatchObject({
       event_id: "context_report:550e8400-e29b-41d4-a716-446655440402",
       conversation_key: root1.conversation_key,
       payload: {
-        report: { memory: { keyword_hits: 1 } },
+        report: {
+          memory: { keyword_hits: 1 },
+          selected_tools: ["memory.search"],
+          pre_turn_tools: [{ tool_id: "memory.seed" }],
+          tool_calls: [{ tool_id: "memory.write" }],
+        },
       },
     });
   });

--- a/packages/operator-ui/tests/pages/transcripts-page.lib.test.ts
+++ b/packages/operator-ui/tests/pages/transcripts-page.lib.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildConversationTreeEntries } from "../../src/components/pages/transcripts-page.lib.js";
+import {
+  buildConversationTreeEntries,
+  buildInspectorFields,
+} from "../../src/components/pages/transcripts-page.lib.js";
 
 function createConversation(overrides: Record<string, unknown> = {}) {
   return {
@@ -41,5 +44,34 @@ describe("buildConversationTreeEntries", () => {
       "conversation-a",
       "conversation-b",
     ]);
+  });
+});
+
+describe("buildInspectorFields", () => {
+  it("renders canonical tool IDs from transcript payloads without remapping", () => {
+    const fields = buildInspectorFields(
+      {
+        event_id: "tool-event-1",
+        kind: "tool_lifecycle",
+        occurred_at: "2026-03-13T12:00:00.000Z",
+        conversation_key: "conversation-root",
+        payload: {
+          tool_event: {
+            conversation_id: "conversation-root-id",
+            thread_id: "thread-root",
+            tool_call_id: "tool-call-1",
+            tool_id: "memory.write",
+            status: "completed",
+            summary: "Saved a durable memory.",
+            agent_id: "default",
+            workspace_id: "default",
+            channel: "ui",
+          },
+        },
+      },
+      null,
+    );
+
+    expect(fields).toContainEqual({ label: "Tool", value: "memory.write" });
   });
 });


### PR DESCRIPTION
Closes #1997

## What changed
- canonicalized public tool IDs at the runtime/reporting emission boundary for turn finalization, context report assembly, tool lifecycle broadcasts, and plugin tool invocation events
- kept transcript and operator transcript consumers as pass-through readers of the canonical payload values
- added regression coverage for canonical `used_tools`, context report tool IDs, transcript payload wrappers, plugin tool invocation events, and transcript inspector rendering

## Why
Public runtime and audit payloads could still leak supported legacy tool aliases such as `mcp.memory.*` even after the taxonomy rollout introduced canonical public IDs. This change makes those public emissions converge on the canonical IDs without changing internal rollout matching or ingestion compatibility.

## How to test
- `pnpm vitest packages/gateway/tests/unit/agent-runtime-public-tool-id-emission.test.ts packages/gateway/tests/unit/agent-runtime-tool-memory-queue.test.ts packages/gateway/tests/unit/plugin-registry-events.test.ts packages/gateway/tests/integration/context.test.ts packages/gateway/tests/unit/transcript-handlers.timeline.test.ts packages/gateway/tests/unit/plugin-registry.test.ts packages/operator-ui/tests/pages/transcripts-page.lib.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run ci`

## Risk
Low to moderate. The change is intentionally limited to public emission paths and regression tests. The main residual risk is historical persisted transcript or audit rows, which still retain any legacy IDs they were stored with until separate stored-data migration work lands.

## Rollback
Revert commit `98e7a38d8` to restore the previous emission behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool IDs emitted in runtime responses, context reports, and WS/audit events, which could affect downstream consumers expecting legacy aliases. Logic is localized to emission boundaries and covered by new regression tests, reducing risk of functional impact.
> 
> **Overview**
> Public-facing runtime/audit payloads now **canonicalize tool identifiers** (e.g. emitting `memory.write` instead of legacy aliases like `mcp.memory.write`) when producing tool lifecycle WS events, context reports (`selected_tools`, `pre_turn_tools`, `tool_calls`, schema size reporting), and final turn responses (`used_tools`).
> 
> Plugin tool-invocation audit/event emission is updated to broadcast/store canonical tool IDs, and new/updated tests assert canonical IDs flow through gateway transcript handlers and operator transcript inspector rendering without additional remapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6ea930bcb51a5c8df24fc698eac0965ba3c903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->