### PR TITLE
Complete automation schedule taxonomy metadata coverage

### DIFF
--- a/packages/gateway/src/modules/agent/tool-catalog-automation.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog-automation.ts
@@ -4,6 +4,8 @@ import {
   AUTOMATION_SCHEDULE_UPDATE_PROMPT_METADATA,
 } from "./tool-catalog-prompt-metadata.js";
 
+const AUTOMATION_SCHEDULE_FAMILY = "tool.automation.schedule";
+
 export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
   {
     id: "tool.automation.schedule.list",
@@ -11,7 +13,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "read_only",
     keywords: ["automation", "schedule", "heartbeat", "cron", "list"],
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -28,7 +30,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "read_only",
     keywords: ["automation", "schedule", "heartbeat", "cron", "get"],
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -46,7 +48,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     keywords: ["automation", "schedule", "heartbeat", "cron", "create"],
     ...AUTOMATION_SCHEDULE_CREATE_PROMPT_METADATA,
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -82,7 +84,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     keywords: ["automation", "schedule", "heartbeat", "cron", "update"],
     ...AUTOMATION_SCHEDULE_UPDATE_PROMPT_METADATA,
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -109,7 +111,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "state_changing",
     keywords: ["automation", "schedule", "pause", "disable"],
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -125,7 +127,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "state_changing",
     keywords: ["automation", "schedule", "resume", "enable"],
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -141,7 +143,7 @@ export const AUTOMATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "state_changing",
     keywords: ["automation", "schedule", "delete", "remove"],
     source: "builtin",
-    family: "automation",
+    family: AUTOMATION_SCHEDULE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -47,6 +47,8 @@ type ToolRegistryGroup =
   | "orchestration"
   | "extension";
 
+type ToolRegistryTier = "default" | "advanced";
+
 type ToolRegistryEntry = {
   source: "builtin" | "builtin_mcp" | "mcp" | "plugin";
   canonical_id: string;
@@ -55,6 +57,7 @@ type ToolRegistryEntry = {
   effective_exposure: ToolEffectiveExposure;
   family?: string;
   group?: ToolRegistryGroup;
+  tier?: ToolRegistryTier;
   keywords?: string[];
   input_schema?: Record<string, unknown>;
   backing_server?: {
@@ -103,9 +106,14 @@ function toBaseEntry(
     effective_exposure: effectiveExposure,
     family: descriptor.family,
     group: resolveToolGroup(descriptor, source),
+    tier: resolveToolTier(descriptor, source),
     keywords: descriptor.keywords.length > 0 ? [...descriptor.keywords] : undefined,
     input_schema: validatedSchema.ok ? validatedSchema.schema : undefined,
   };
+}
+
+function isAutomationScheduleTool(descriptor: ToolDescriptor): boolean {
+  return descriptor.id.startsWith("tool.automation.schedule.");
 }
 
 function resolveToolGroup(
@@ -113,6 +121,10 @@ function resolveToolGroup(
   source: ToolRegistryEntry["source"],
 ): ToolRegistryGroup | undefined {
   if (source !== "builtin") return undefined;
+
+  if (isAutomationScheduleTool(descriptor)) {
+    return "environment";
+  }
 
   if (
     descriptor.family === "filesystem" ||
@@ -124,6 +136,19 @@ function resolveToolGroup(
 
   if (descriptor.family === "sandbox") {
     return "orchestration";
+  }
+
+  return undefined;
+}
+
+function resolveToolTier(
+  descriptor: ToolDescriptor,
+  source: ToolRegistryEntry["source"],
+): ToolRegistryTier | undefined {
+  if (source !== "builtin") return undefined;
+
+  if (isAutomationScheduleTool(descriptor)) {
+    return "advanced";
   }
 
   return undefined;
@@ -143,6 +168,7 @@ function toPluginEntry(
     effective_exposure: base.effective_exposure,
     family: base.family,
     group: base.group,
+    tier: base.tier,
     keywords: base.keywords,
     input_schema: base.input_schema,
     plugin: toPluginInfo(plugin),
@@ -162,6 +188,7 @@ function toBuiltinEntry(
     effective_exposure: base.effective_exposure,
     family: base.family,
     group: base.group,
+    tier: base.tier,
     keywords: base.keywords,
     input_schema: base.input_schema,
     backing_server: toBuiltinBackingServer(descriptor),

--- a/packages/gateway/tests/unit/policy-suggested-overrides.test.ts
+++ b/packages/gateway/tests/unit/policy-suggested-overrides.test.ts
@@ -27,4 +27,20 @@ describe("suggestedOverridesForToolCall", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("suggests exact direct schedule action overrides", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.automation.schedule.pause",
+        matchTarget: "schedule_id:11111111-1111-1111-1111-111111111111",
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual([
+      {
+        tool_id: "tool.automation.schedule.pause",
+        pattern: "schedule_id:11111111-1111-1111-1111-111111111111",
+        workspace_id: "11111111-1111-4111-8111-111111111111",
+      },
+    ]);
+  });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -440,7 +440,9 @@ describe("tool registry routes", () => {
       expect.objectContaining({
         source: "builtin",
         canonical_id: "tool.automation.schedule.list",
-        family: "automation",
+        family: "tool.automation.schedule",
+        group: "environment",
+        tier: "advanced",
       }),
     );
     expect(listServerToolDescriptors).toHaveBeenCalledTimes(1);

--- a/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
@@ -49,6 +49,7 @@ describe("ConfigurePage (HTTP) tools", () => {
     ).not.toBeNull();
     expect(page.container.textContent).toContain("tool.browser.navigate");
     expect(page.container.textContent).toContain("tool.node.capability.get");
+    expect(page.container.textContent).toContain("tool.automation.schedule.list");
     expect(page.container.textContent).toContain("read");
     expect(page.container.textContent).toContain("sandbox.current");
     expect(page.container.textContent).toContain("websearch");

--- a/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
@@ -69,6 +69,36 @@ export const DETAILED_TOOL_REGISTRY_FIXTURE = {
     },
     {
       source: "builtin",
+      canonical_id: "tool.automation.schedule.list",
+      description: "List automation schedules for the current or specified agent/workspace scope.",
+      effect: "read_only",
+      effective_exposure: {
+        enabled: true,
+        reason: "enabled",
+        agent_key: "default",
+      },
+      family: "tool.automation.schedule",
+      group: "environment",
+      tier: "advanced",
+      keywords: ["automation", "schedule", "heartbeat", "cron", "list"],
+      input_schema: {
+        type: "object",
+        properties: {
+          agent_key: {
+            type: "string",
+          },
+          workspace_key: {
+            type: "string",
+          },
+          include_deleted: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      source: "builtin",
       canonical_id: "read",
       description: "Read files from disk.",
       effect: "read_only",

--- a/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
+++ b/packages/runtime-policy/tests/unit/suggested-overrides.test.ts
@@ -28,6 +28,22 @@ describe("suggestedOverridesForToolCall", () => {
     ).toBeUndefined();
   });
 
+  it("suggests exact direct schedule action overrides", () => {
+    expect(
+      suggestedOverridesForToolCall({
+        toolId: "tool.automation.schedule.pause",
+        matchTarget: "schedule_id:11111111-1111-1111-1111-111111111111",
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual([
+      {
+        tool_id: "tool.automation.schedule.pause",
+        pattern: "schedule_id:11111111-1111-1111-1111-111111111111",
+        workspace_id: "11111111-1111-4111-8111-111111111111",
+      },
+    ]);
+  });
+
   it("returns undefined for blank match targets", () => {
     expect(
       suggestedOverridesForToolCall({

--- a/packages/transport-sdk/src/http/generated/tool-registry.generated.ts
+++ b/packages/transport-sdk/src/http/generated/tool-registry.generated.ts
@@ -14,6 +14,7 @@ const ToolRegistryGroup = z.enum([
   "orchestration",
   "extension",
 ]);
+const ToolRegistryTier = z.enum(["default", "advanced"]);
 const ToolRegistryBackingServer = z
   .object({
     id: z.string().trim().min(1),
@@ -49,6 +50,7 @@ const ToolRegistryEntry = z
       .strict(),
     family: z.string().trim().min(1).optional(),
     group: ToolRegistryGroup.optional(),
+    tier: ToolRegistryTier.optional(),
     keywords: z.array(z.string().trim().min(1)).optional(),
     input_schema: z.record(z.string(), z.unknown()).optional(),
     backing_server: ToolRegistryBackingServer.optional(),

--- a/packages/transport-sdk/src/http/tool-registry.ts
+++ b/packages/transport-sdk/src/http/tool-registry.ts
@@ -11,6 +11,7 @@ const ToolRegistryGroup = z.enum([
   "orchestration",
   "extension",
 ]);
+const ToolRegistryTier = z.enum(["default", "advanced"]);
 
 const ToolRegistryBackingServer = z
   .object({
@@ -49,6 +50,7 @@ const ToolRegistryEntry = z
       .strict(),
     family: z.string().trim().min(1).optional(),
     group: ToolRegistryGroup.optional(),
+    tier: ToolRegistryTier.optional(),
     keywords: z.array(z.string().trim().min(1)).optional(),
     input_schema: z.record(z.string(), z.unknown()).optional(),
     backing_server: ToolRegistryBackingServer.optional(),

--- a/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
@@ -230,6 +230,21 @@ export function registerHttpClientOpsAdminTests(): void {
             group: "core",
           },
           {
+            source: "builtin",
+            canonical_id: "tool.automation.schedule.list",
+            description:
+              "List automation schedules for the current or specified agent/workspace scope.",
+            effect: "read_only",
+            effective_exposure: {
+              enabled: true,
+              reason: "enabled",
+              agent_key: "default",
+            },
+            family: "tool.automation.schedule",
+            group: "environment",
+            tier: "advanced",
+          },
+          {
             source: "builtin_mcp",
             canonical_id: "websearch",
             description: "Search the web.",
@@ -268,7 +283,7 @@ export function registerHttpClientOpsAdminTests(): void {
     const client = createTestClient({ fetch });
 
     const result = await client.toolRegistry.list();
-    expect(result.tools).toHaveLength(5);
+    expect(result.tools).toHaveLength(6);
 
     const toolsById = new Map(result.tools.map((tool) => [tool.canonical_id, tool]));
     expect(toolsById.get("read")?.group).toBe("core");
@@ -280,6 +295,12 @@ export function registerHttpClientOpsAdminTests(): void {
     expect(toolsById.get("artifact.describe")).toMatchObject({
       family: "artifact",
       group: "core",
+      effect: "read_only",
+    });
+    expect(toolsById.get("tool.automation.schedule.list")).toMatchObject({
+      family: "tool.automation.schedule",
+      group: "environment",
+      tier: "advanced",
       effect: "read_only",
     });
     expect(toolsById.get("websearch")?.backing_server?.id).toBe("exa");


### PR DESCRIPTION
Closes #1984

## What changed
- updated the shipped `tool.automation.schedule.*` descriptors to emit the canonical family label `tool.automation.schedule`
- added automation schedule taxonomy metadata to `/config/tools`, including `group: environment` and `tier: advanced`
- aligned the transport SDK tool-registry schema with the new optional `tier` field
- added regression coverage for registry metadata and direct schedule-action suggested override behavior

## Why
- completes the remaining taxonomy metadata and compatibility coverage for the already-shipped automation schedule family without reopening scheduler behavior or broadening into the later `/config/tools` contract work owned by `#1969`

## How to test
- `pnpm exec vitest run packages/contracts/tests/tool-id.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts packages/gateway/tests/unit/policy-match-target.test.ts packages/gateway/tests/unit/policy-suggested-overrides.test.ts packages/runtime-policy/tests/unit/suggested-overrides.test.ts packages/transport-sdk/tests/http-client.test-ops-admin-support.ts packages/operator-ui/tests/pages/admin-http-tools.page.test.ts packages/gateway/tests/integration/automation-schedules.test.ts`
- `pnpm lint`
- `pnpm exec tsc -b --pretty false packages/runtime-policy/tsconfig.json packages/transport-sdk/tsconfig.json packages/gateway/tsconfig.json packages/operator-ui/tsconfig.json`
- `pnpm api:check`
- `git push -u origin 1984-automation-schedule-taxonomy-metadata` (runs the repo pre-push `pnpm ci:local` gate; passed locally)

## Risk
- low and family-local to automation schedule taxonomy metadata, registry emission, and contract typing
- main compatibility risk is the new optional `tier` field on tool-registry entries; the gateway and transport SDK were updated together, and existing consumers continue to receive optional metadata

## Rollback
- revert commit `ae72c9aad7096a7c902fa9eda0a9e0005117e28c` to remove the added automation schedule metadata and transport schema change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the emitted tool taxonomy for `tool.automation.schedule.*` (new canonical `family`, plus `group`/`tier` metadata) and extends the `/config/tools` contract with an optional `tier` field, which may affect downstream consumers that assume older values or a fixed schema.
> 
> **Overview**
> Updates built-in `tool.automation.schedule.*` descriptors to use the canonical `family` value `tool.automation.schedule`.
> 
> Enhances `/config/tools` registry entries by adding an optional `tier` field and by classifying automation schedule tools as `group: environment` and `tier: advanced`.
> 
> Aligns the transport SDK Zod schema and updates unit/UI/SDK tests and fixtures to cover the new metadata and to assert suggested override generation for direct schedule actions (e.g. `tool.automation.schedule.pause`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae72c9aad7096a7c902fa9eda0a9e0005117e28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->