### PR TITLE
Complete saved-place taxonomy metadata and compatibility coverage

### DIFF
--- a/packages/gateway/src/modules/agent/tool-catalog-location.ts
+++ b/packages/gateway/src/modules/agent/tool-catalog-location.ts
@@ -10,6 +10,8 @@ const LOCATION_AGENT_SCOPE_PROPERTY = {
     "Optional agent key. Omit to use the current agent scope when the tool runs in an agent turn.",
 } as const;
 
+const LOCATION_PLACE_FAMILY = "tool.location.place";
+
 export const LOCATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
   {
     id: "tool.location.place.list",
@@ -17,7 +19,7 @@ export const LOCATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "read_only",
     keywords: ["location", "place", "places", "saved", "list"],
     source: "builtin",
-    family: "location",
+    family: LOCATION_PLACE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -33,7 +35,7 @@ export const LOCATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     keywords: ["location", "place", "places", "saved", "create"],
     ...LOCATION_PLACE_CREATE_PROMPT_METADATA,
     source: "builtin",
-    family: "location",
+    family: LOCATION_PLACE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -76,7 +78,7 @@ export const LOCATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     keywords: ["location", "place", "places", "saved", "update"],
     ...LOCATION_PLACE_UPDATE_PROMPT_METADATA,
     source: "builtin",
-    family: "location",
+    family: LOCATION_PLACE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {
@@ -116,7 +118,7 @@ export const LOCATION_TOOL_REGISTRY: readonly ToolDescriptor[] = [
     effect: "state_changing",
     keywords: ["location", "place", "places", "saved", "delete"],
     source: "builtin",
-    family: "location",
+    family: LOCATION_PLACE_FAMILY,
     inputSchema: {
       type: "object",
       properties: {

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -49,6 +49,9 @@ type ToolRegistryGroup =
 
 type ToolRegistryTier = "default" | "advanced";
 
+const AUTOMATION_SCHEDULE_FAMILY = "tool.automation.schedule";
+const LOCATION_PLACE_FAMILY = "tool.location.place";
+
 type ToolRegistryEntry = {
   source: "builtin" | "builtin_mcp" | "mcp" | "plugin";
   canonical_id: string;
@@ -113,7 +116,11 @@ function toBaseEntry(
 }
 
 function isAutomationScheduleTool(descriptor: ToolDescriptor): boolean {
-  return descriptor.id.startsWith("tool.automation.schedule.");
+  return descriptor.family === AUTOMATION_SCHEDULE_FAMILY;
+}
+
+function isSavedPlaceTool(descriptor: ToolDescriptor): boolean {
+  return descriptor.family === LOCATION_PLACE_FAMILY;
 }
 
 function resolveToolGroup(
@@ -123,6 +130,10 @@ function resolveToolGroup(
   if (source !== "builtin") return undefined;
 
   if (isAutomationScheduleTool(descriptor)) {
+    return "environment";
+  }
+
+  if (isSavedPlaceTool(descriptor)) {
     return "environment";
   }
 
@@ -148,6 +159,10 @@ function resolveToolTier(
   if (source !== "builtin") return undefined;
 
   if (isAutomationScheduleTool(descriptor)) {
+    return "advanced";
+  }
+
+  if (isSavedPlaceTool(descriptor)) {
     return "advanced";
   }
 

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -419,7 +419,9 @@ describe("tool registry routes", () => {
       expect.objectContaining({
         source: "builtin",
         canonical_id: "tool.location.place.list",
-        family: "location",
+        family: "tool.location.place",
+        group: "environment",
+        tier: "advanced",
       }),
     );
     expect(body.tools).toContainEqual(

--- a/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.page.test.ts
@@ -50,6 +50,7 @@ describe("ConfigurePage (HTTP) tools", () => {
     expect(page.container.textContent).toContain("tool.browser.navigate");
     expect(page.container.textContent).toContain("tool.node.capability.get");
     expect(page.container.textContent).toContain("tool.automation.schedule.list");
+    expect(page.container.textContent).toContain("tool.location.place.list");
     expect(page.container.textContent).toContain("read");
     expect(page.container.textContent).toContain("sandbox.current");
     expect(page.container.textContent).toContain("websearch");

--- a/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
+++ b/packages/operator-ui/tests/pages/admin-http-tools.test-fixtures.ts
@@ -99,6 +99,32 @@ export const DETAILED_TOOL_REGISTRY_FIXTURE = {
     },
     {
       source: "builtin",
+      canonical_id: "tool.location.place.list",
+      description: "List saved places for the current or specified agent.",
+      effect: "read_only",
+      effective_exposure: {
+        enabled: true,
+        reason: "enabled",
+        agent_key: "default",
+      },
+      family: "tool.location.place",
+      group: "environment",
+      tier: "advanced",
+      keywords: ["location", "place", "places", "saved", "list"],
+      input_schema: {
+        type: "object",
+        properties: {
+          agent_key: {
+            type: "string",
+            description:
+              "Optional agent key. Omit to use the current agent scope when the tool runs in an agent turn.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      source: "builtin",
       canonical_id: "read",
       description: "Read files from disk.",
       effect: "read_only",

--- a/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
@@ -245,6 +245,20 @@ export function registerHttpClientOpsAdminTests(): void {
             tier: "advanced",
           },
           {
+            source: "builtin",
+            canonical_id: "tool.location.place.list",
+            description: "List saved places for the current or specified agent.",
+            effect: "read_only",
+            effective_exposure: {
+              enabled: true,
+              reason: "enabled",
+              agent_key: "default",
+            },
+            family: "tool.location.place",
+            group: "environment",
+            tier: "advanced",
+          },
+          {
             source: "builtin_mcp",
             canonical_id: "websearch",
             description: "Search the web.",
@@ -283,7 +297,7 @@ export function registerHttpClientOpsAdminTests(): void {
     const client = createTestClient({ fetch });
 
     const result = await client.toolRegistry.list();
-    expect(result.tools).toHaveLength(6);
+    expect(result.tools).toHaveLength(7);
 
     const toolsById = new Map(result.tools.map((tool) => [tool.canonical_id, tool]));
     expect(toolsById.get("read")?.group).toBe("core");
@@ -299,6 +313,12 @@ export function registerHttpClientOpsAdminTests(): void {
     });
     expect(toolsById.get("tool.automation.schedule.list")).toMatchObject({
       family: "tool.automation.schedule",
+      group: "environment",
+      tier: "advanced",
+      effect: "read_only",
+    });
+    expect(toolsById.get("tool.location.place.list")).toMatchObject({
+      family: "tool.location.place",
       group: "environment",
       tier: "advanced",
       effect: "read_only",


### PR DESCRIPTION
Closes #1985

## What changed
- Canonicalized the saved-place tool family metadata from `location` to `tool.location.place` in the gateway tool catalog.
- Emitted `group: environment` and `tier: advanced` for saved-place tools from `/config/tools` alongside the existing automation-family metadata.
- Updated gateway, transport SDK, and operator UI regression coverage to lock the emitted saved-place taxonomy metadata end to end.

## Why
- The saved-place family was already shipped, but it was still missing the canonical taxonomy metadata expected by epic #1961 and ARCH-21, so registry and downstream consumers saw incomplete family/group/tier information.

## How to test
- `pnpm exec vitest run packages/gateway/tests/unit/tool-registry-routes.test.ts packages/gateway/tests/unit/policy-match-target.test.ts`
- `pnpm exec vitest run packages/operator-ui/tests/pages/admin-http-tools.page.test.ts`
- `pnpm exec vitest run packages/transport-sdk/tests/http-client.test.ts -t "toolRegistry.list sends GET /config/tools and validates tool metadata"`
- `pnpm typecheck`
- `pnpm lint`
- `git push -u origin 1985-saved-place-taxonomy-metadata` (passes the repo pre-push `pnpm run ci` gate; 1067 test files / 6120 tests passed)

## Risk
- Low. This is a scoped metadata and regression-coverage update for an already-shipped tool family; public IDs, executor behavior, and policy canonicalization are unchanged.

## Rollback
- Revert commit `826baedf6d546ca6be00e8ce8d46ba5aead0a571` or close this PR if the saved-place metadata rollout needs to be deferred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that reclassifies saved-place tools and updates registry outputs/tests; main risk is downstream consumers relying on the old `family: "location"` value.
> 
> **Overview**
> Saved-place tools are reclassified under the canonical family `tool.location.place` (replacing the legacy `location` family) in the gateway tool catalog.
> 
> The `/config/tools` registry now treats saved-place tools like automation schedule tools by emitting `group: "environment"` and `tier: "advanced"` based on the tool `family`.
> 
> Regression coverage and fixtures in `gateway`, `operator-ui`, and `transport-sdk` are updated to expect the new family/group/tier metadata and the additional tool entry in the registry list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826baedf6d546ca6be00e8ce8d46ba5aead0a571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->