### PR TITLE
Add shared tool taxonomy metadata for descriptor-bearing surfaces

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -152,6 +152,17 @@ export { ToolIntentCostBudget, ToolIntentV1, ToolIntent } from "./tool-intent.js
 // prettier-ignore
 export { canonicalizeToolId, canonicalizeToolIdList, canonicalizeExactToolIdList } from "./tool-id.js";
 // prettier-ignore
+export { resolveToolTaxonomyMetadata } from "./tool-taxonomy.js";
+export type {
+  ResolveToolTaxonomyInput,
+  ToolTaxonomyGroup,
+  ToolTaxonomyLifecycle,
+  ToolTaxonomyMetadata,
+  ToolTaxonomySource,
+  ToolTaxonomyTier,
+  ToolTaxonomyVisibility,
+} from "./tool-taxonomy.js";
+// prettier-ignore
 export { DecisionRecordId, DecisionRecord } from "./work-decisions.js";
 // prettier-ignore
 export { WorkSignalId, WorkSignalTriggerKind, WorkSignalStatus, WorkSignal } from "./work-signals.js";

--- a/packages/contracts/src/tool-taxonomy.ts
+++ b/packages/contracts/src/tool-taxonomy.ts
@@ -51,7 +51,6 @@ export interface ResolveToolTaxonomyInput {
   toolId: string;
   source?: ToolTaxonomySource;
   family?: string | null;
-  backingServerId?: string | null;
 }
 
 function normalizeOptionalFamily(family: string | null | undefined): string | null {

--- a/packages/contracts/src/tool-taxonomy.ts
+++ b/packages/contracts/src/tool-taxonomy.ts
@@ -1,0 +1,290 @@
+import { canonicalizeToolId } from "./tool-id.js";
+
+const CORE_TOOL_IDS = new Set([
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "glob",
+  "grep",
+  "bash",
+  "artifact.describe",
+]);
+
+const RETRIEVAL_TOOL_IDS = new Set(["websearch", "webfetch", "codesearch"]);
+const RUNTIME_ONLY_TOOL_IDS = new Set(["guardian_review_decision"]);
+
+const LEGACY_MEMORY_PREFIX = "mcp.memory.";
+const CANONICAL_MEMORY_PREFIX = "memory.";
+
+const LOCATION_PLACE_PREFIX = "tool.location.place.";
+const AUTOMATION_SCHEDULE_PREFIX = "tool.automation.schedule.";
+const SANDBOX_PREFIX = "sandbox.";
+const SUBAGENT_PREFIX = "subagent.";
+const WORKBOARD_PREFIX = "workboard.";
+const MCP_PREFIX = "mcp.";
+const PLUGIN_PREFIX = "plugin.";
+
+export type ToolTaxonomySource = "builtin" | "builtin_mcp" | "mcp" | "plugin";
+export type ToolTaxonomyLifecycle = "canonical" | "alias" | "deprecated";
+export type ToolTaxonomyVisibility = "public" | "internal" | "runtime_only";
+export type ToolTaxonomyGroup =
+  | "core"
+  | "retrieval"
+  | "memory"
+  | "environment"
+  | "node"
+  | "orchestration"
+  | "extension";
+export type ToolTaxonomyTier = "default" | "advanced";
+
+export interface ToolTaxonomyMetadata {
+  canonicalId: string;
+  lifecycle: ToolTaxonomyLifecycle;
+  visibility: ToolTaxonomyVisibility;
+  family: string | null;
+  group: ToolTaxonomyGroup | null;
+  tier: ToolTaxonomyTier | null;
+}
+
+export interface ResolveToolTaxonomyInput {
+  toolId: string;
+  source?: ToolTaxonomySource;
+  family?: string | null;
+  backingServerId?: string | null;
+}
+
+function normalizeOptionalFamily(family: string | null | undefined): string | null {
+  if (typeof family !== "string") {
+    return null;
+  }
+  const normalized = family.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeToolId(toolId: string): string {
+  return toolId.trim();
+}
+
+function resolveCoreFamily(canonicalId: string): string {
+  if (canonicalId === "bash") {
+    return "shell";
+  }
+  if (canonicalId === "artifact.describe") {
+    return "artifact";
+  }
+  return "filesystem";
+}
+
+function resolveNodeFamily(canonicalId: string): string {
+  if (canonicalId.startsWith("tool.desktop.")) {
+    return "tool.desktop";
+  }
+  if (canonicalId.startsWith("tool.browser.")) {
+    return "tool.browser";
+  }
+  if (canonicalId.startsWith("tool.node.")) {
+    return "tool.node";
+  }
+  if (canonicalId === "tool.location.get") {
+    return "tool.location";
+  }
+  if (canonicalId.startsWith("tool.camera.")) {
+    return "tool.camera";
+  }
+  if (canonicalId.startsWith("tool.audio.")) {
+    return "tool.audio";
+  }
+  if (canonicalId === "tool.secret.copy-to-node-clipboard") {
+    return "tool.secret";
+  }
+  return "node";
+}
+
+function isNodeCanonicalToolId(canonicalId: string): boolean {
+  return (
+    canonicalId.startsWith("tool.") &&
+    !canonicalId.startsWith(LOCATION_PLACE_PREFIX) &&
+    !canonicalId.startsWith(AUTOMATION_SCHEDULE_PREFIX)
+  );
+}
+
+function isLegacyMemoryAlias(normalizedToolId: string, canonicalId: string): boolean {
+  return (
+    normalizedToolId.startsWith(LEGACY_MEMORY_PREFIX) &&
+    canonicalId.startsWith(CANONICAL_MEMORY_PREFIX)
+  );
+}
+
+function resolveLifecycle(normalizedToolId: string, canonicalId: string): ToolTaxonomyLifecycle {
+  if (normalizedToolId === canonicalId) {
+    return "canonical";
+  }
+  if (isLegacyMemoryAlias(normalizedToolId, canonicalId)) {
+    return "deprecated";
+  }
+  return "alias";
+}
+
+function classifyCanonicalTool(input: {
+  canonicalId: string;
+  source?: ToolTaxonomySource;
+  family: string | null;
+}): Omit<ToolTaxonomyMetadata, "canonicalId" | "lifecycle"> {
+  const { canonicalId, source, family } = input;
+
+  if (RUNTIME_ONLY_TOOL_IDS.has(canonicalId)) {
+    return {
+      visibility: "runtime_only",
+      family,
+      group: null,
+      tier: null,
+    };
+  }
+
+  if (canonicalId.startsWith(CANONICAL_MEMORY_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "memory",
+      group: "memory",
+      tier: "default",
+    };
+  }
+
+  if (CORE_TOOL_IDS.has(canonicalId)) {
+    return {
+      visibility: "public",
+      family: resolveCoreFamily(canonicalId),
+      group: "core",
+      tier: "default",
+    };
+  }
+
+  if (RETRIEVAL_TOOL_IDS.has(canonicalId)) {
+    return {
+      visibility: "public",
+      family: family ?? "web",
+      group: "retrieval",
+      tier: "default",
+    };
+  }
+
+  if (canonicalId.startsWith(LOCATION_PLACE_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "tool.location.place",
+      group: "environment",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(AUTOMATION_SCHEDULE_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "tool.automation.schedule",
+      group: "environment",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(SANDBOX_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "sandbox",
+      group: "orchestration",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(SUBAGENT_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "subagent",
+      group: "orchestration",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(WORKBOARD_PREFIX)) {
+    return {
+      visibility: "public",
+      family: "workboard",
+      group: "orchestration",
+      tier: "advanced",
+    };
+  }
+
+  if (isNodeCanonicalToolId(canonicalId)) {
+    return {
+      visibility: "public",
+      family: resolveNodeFamily(canonicalId),
+      group: "node",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(MCP_PREFIX) || source === "mcp") {
+    return {
+      visibility: "public",
+      family: family ?? "mcp",
+      group: "extension",
+      tier: "advanced",
+    };
+  }
+
+  if (canonicalId.startsWith(PLUGIN_PREFIX) || source === "plugin") {
+    return {
+      visibility: "public",
+      family: family ?? "plugin",
+      group: "extension",
+      tier: "advanced",
+    };
+  }
+
+  if (source === "builtin_mcp") {
+    return {
+      visibility: "public",
+      family,
+      group: "extension",
+      tier: "advanced",
+    };
+  }
+
+  return {
+    visibility: "internal",
+    family,
+    group: null,
+    tier: null,
+  };
+}
+
+export function resolveToolTaxonomyMetadata(input: ResolveToolTaxonomyInput): ToolTaxonomyMetadata {
+  const normalizedToolId = normalizeToolId(input.toolId);
+  const canonicalId = canonicalizeToolId(normalizedToolId);
+  const lifecycle = resolveLifecycle(normalizedToolId, canonicalId);
+  const canonicalClassification = classifyCanonicalTool({
+    canonicalId,
+    source: input.source,
+    family: normalizeOptionalFamily(input.family),
+  });
+
+  if (lifecycle === "alias") {
+    return {
+      canonicalId,
+      lifecycle,
+      visibility: "runtime_only",
+      family: canonicalClassification.family,
+      group: canonicalClassification.group,
+      tier: canonicalClassification.tier,
+    };
+  }
+
+  return {
+    canonicalId,
+    lifecycle,
+    visibility: canonicalClassification.visibility,
+    family: canonicalClassification.family,
+    group: canonicalClassification.group,
+    tier: canonicalClassification.tier,
+  };
+}

--- a/packages/contracts/tests/tool-id.test.ts
+++ b/packages/contracts/tests/tool-id.test.ts
@@ -5,6 +5,7 @@ import {
   canonicalizeToolIdList,
   normalizeStringIdList,
 } from "../src/tool-id.js";
+import { resolveToolTaxonomyMetadata } from "../src/tool-taxonomy.js";
 
 describe("tool id canonicalization", () => {
   it("maps legacy tool ids to canonical ids", () => {
@@ -51,5 +52,57 @@ describe("tool id canonicalization", () => {
         "   ",
       ]),
     ).toEqual(["read", "bash", "memory.write"]);
+  });
+
+  it("resolves deterministic taxonomy metadata for canonical and legacy ids", () => {
+    expect(resolveToolTaxonomyMetadata({ toolId: "read" })).toMatchObject({
+      canonicalId: "read",
+      lifecycle: "canonical",
+      visibility: "public",
+      family: "filesystem",
+      group: "core",
+      tier: "default",
+    });
+
+    expect(resolveToolTaxonomyMetadata({ toolId: "tool.fs.read" })).toMatchObject({
+      canonicalId: "read",
+      lifecycle: "alias",
+      visibility: "runtime_only",
+      family: "filesystem",
+      group: "core",
+      tier: "default",
+    });
+
+    expect(resolveToolTaxonomyMetadata({ toolId: "mcp.memory.seed", source: "mcp" })).toMatchObject(
+      {
+        canonicalId: "memory.seed",
+        lifecycle: "deprecated",
+        visibility: "public",
+        family: "memory",
+        group: "memory",
+        tier: "default",
+      },
+    );
+  });
+
+  it("classifies extension and runtime-only tool ids for shared descriptor metadata", () => {
+    expect(
+      resolveToolTaxonomyMetadata({ toolId: "plugin.echo.say", source: "plugin" }),
+    ).toMatchObject({
+      canonicalId: "plugin.echo.say",
+      lifecycle: "canonical",
+      visibility: "public",
+      family: "plugin",
+      group: "extension",
+      tier: "advanced",
+    });
+
+    expect(resolveToolTaxonomyMetadata({ toolId: "guardian_review_decision" })).toMatchObject({
+      canonicalId: "guardian_review_decision",
+      lifecycle: "canonical",
+      visibility: "runtime_only",
+      group: null,
+      tier: null,
+    });
   });
 });

--- a/packages/contracts/tests/tool-id.test.ts
+++ b/packages/contracts/tests/tool-id.test.ts
@@ -83,6 +83,21 @@ describe("tool id canonicalization", () => {
         tier: "default",
       },
     );
+
+    expect(
+      resolveToolTaxonomyMetadata({
+        toolId: "websearch",
+        source: "builtin_mcp",
+        family: "web",
+      }),
+    ).toMatchObject({
+      canonicalId: "websearch",
+      lifecycle: "canonical",
+      visibility: "public",
+      family: "web",
+      group: "retrieval",
+      tier: "default",
+    });
   });
 
   it("classifies extension and runtime-only tool ids for shared descriptor metadata", () => {

--- a/packages/gateway/src/modules/agent/mcp-manager.ts
+++ b/packages/gateway/src/modules/agent/mcp-manager.ts
@@ -1,5 +1,5 @@
 import type { McpServerSpec as McpServerSpecT } from "@tyrum/contracts";
-import type { ToolDescriptor } from "./tools.js";
+import { withResolvedToolDescriptorTaxonomy, type ToolDescriptor } from "./tools.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -182,7 +182,7 @@ function toDescriptor(spec: McpServerSpecT, tool: McpToolInfo, logger?: Logger):
     });
   }
 
-  return {
+  return withResolvedToolDescriptorTaxonomy({
     id: toolId,
     description,
     effect: effect ?? "state_changing",
@@ -209,7 +209,7 @@ function toDescriptor(spec: McpServerSpecT, tool: McpToolInfo, logger?: Logger):
         }
       : tool.preTurnHydration,
     memoryRole: override?.memory_role ?? tool.memoryRole,
-  };
+  });
 }
 
 function createTransport(

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -8,6 +8,7 @@ import {
   isToolAllowed,
   listBuiltinToolDescriptors,
   type ToolDescriptor,
+  withResolvedToolDescriptorTaxonomy,
 } from "../tools.js";
 import type { AgentLoadedContext } from "./types.js";
 import type { GatewayStateMode } from "../../runtime-state/mode.js";
@@ -111,31 +112,34 @@ export function canPatternMatchMcpToolId(pattern: string): boolean {
 }
 
 function normalizePluginTools(pluginTools: readonly ToolDescriptor[]): ToolDescriptor[] {
+  return normalizeToolDescriptors(pluginTools);
+}
+
+function normalizeToolDescriptors(tools: readonly ToolDescriptor[]): ToolDescriptor[] {
   const normalized: ToolDescriptor[] = [];
 
-  for (const tool of pluginTools) {
+  for (const tool of tools) {
     const id = tool.id.trim();
     if (!id) {
       continue;
     }
-    if (id === tool.id) {
-      normalized.push(tool);
-      continue;
-    }
-    normalized.push({
-      id,
-      description: tool.description,
-      effect: tool.effect,
-      keywords: tool.keywords,
-      inputSchema: tool.inputSchema,
-      source: tool.source,
-      family: tool.family,
-      backingServerId: tool.backingServerId,
-      promptGuidance: tool.promptGuidance,
-      promptExamples: tool.promptExamples,
-      preTurnHydration: tool.preTurnHydration,
-      memoryRole: tool.memoryRole,
-    });
+    normalized.push(
+      withResolvedToolDescriptorTaxonomy({
+        id,
+        description: tool.description,
+        effect: tool.effect,
+        keywords: tool.keywords,
+        inputSchema: tool.inputSchema,
+        source: tool.source,
+        family: tool.family,
+        backingServerId: tool.backingServerId,
+        promptGuidance: tool.promptGuidance,
+        promptExamples: tool.promptExamples,
+        preTurnHydration: tool.preTurnHydration,
+        memoryRole: tool.memoryRole,
+        taxonomy: tool.taxonomy,
+      }),
+    );
   }
 
   return normalized;
@@ -158,9 +162,11 @@ export async function resolveRuntimeToolDescriptorSource(params: {
   stateMode: GatewayStateMode;
   resolvePluginToolExposure?: typeof resolvePolicyGatedPluginToolExposure;
 }): Promise<RuntimeToolDescriptorSource> {
-  const mcpTools = canDiscoverMcpTools(params.ctx.config.tools)
-    ? await params.mcpManager.listToolDescriptors(params.ctx.mcpServers)
-    : [];
+  const mcpTools = normalizeToolDescriptors(
+    canDiscoverMcpTools(params.ctx.config.tools)
+      ? await params.mcpManager.listToolDescriptors(params.ctx.mcpServers)
+      : [],
+  );
   const dynamicBuiltinTools = [
     buildSecretClipboardToolDescriptor(params.ctx.config.secret_refs),
   ].filter((tool): tool is ToolDescriptor => tool !== undefined);

--- a/packages/gateway/src/modules/agent/tool-secret-definitions.ts
+++ b/packages/gateway/src/modules/agent/tool-secret-definitions.ts
@@ -3,7 +3,7 @@ import {
   type AgentSecretReference,
   type SecretReferenceSelector,
 } from "@tyrum/contracts";
-import type { ToolDescriptor } from "./tools.js";
+import { withResolvedToolDescriptorTaxonomy, type ToolDescriptor } from "./tools.js";
 
 export const SECRET_CLIPBOARD_TOOL_ID = "tool.secret.copy-to-node-clipboard";
 export const SECRET_CLIPBOARD_CAPABILITY_ID = "tyrum.desktop.clipboard-write";
@@ -74,7 +74,7 @@ export function buildSecretClipboardToolDescriptor(
     .join("; ");
   const remainingSecretRefCount = Math.max(0, allowedSecretRefs.length - 20);
 
-  return {
+  return withResolvedToolDescriptorTaxonomy({
     id: SECRET_CLIPBOARD_TOOL_ID,
     description:
       "Copy an allowlisted secret reference to the clipboard of an eligible desktop node without returning the plaintext secret.",
@@ -92,7 +92,7 @@ export function buildSecretClipboardToolDescriptor(
     source: "builtin",
     family: "node",
     inputSchema: jsonSchemaOf(SecretCopyToNodeClipboardArgs),
-  };
+  });
 }
 
 export function resolveAllowedSecretReference(

--- a/packages/gateway/src/modules/agent/tools.ts
+++ b/packages/gateway/src/modules/agent/tools.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeToolIdForRolloutMatching,
   toolIdMatchCandidatesForRollout,
 } from "@tyrum/runtime-policy";
+import { resolveToolTaxonomyMetadata, type ToolTaxonomyMetadata } from "@tyrum/contracts";
 import type { GatewayStateMode } from "../runtime-state/mode.js";
 import { BUILTIN_TOOL_REGISTRY } from "./tool-catalog.js";
 
@@ -29,6 +30,25 @@ export interface ToolDescriptor {
   source?: ToolSource;
   family?: string;
   backingServerId?: string;
+  taxonomy?: ToolTaxonomyMetadata;
+}
+
+export function resolveToolDescriptorTaxonomy(
+  descriptor: Pick<ToolDescriptor, "id" | "source" | "family" | "backingServerId">,
+): ToolTaxonomyMetadata {
+  return resolveToolTaxonomyMetadata({
+    toolId: descriptor.id,
+    source: descriptor.source,
+    family: descriptor.family ?? null,
+    backingServerId: descriptor.backingServerId ?? null,
+  });
+}
+
+export function withResolvedToolDescriptorTaxonomy<T extends ToolDescriptor>(descriptor: T): T {
+  return {
+    ...descriptor,
+    taxonomy: resolveToolDescriptorTaxonomy(descriptor),
+  };
 }
 
 function shortToolIdHash(toolId: string): string {
@@ -190,7 +210,7 @@ export function isBuiltinToolAvailableInStateMode(
 }
 
 export function listBuiltinToolDescriptors(): ToolDescriptor[] {
-  return BUILTIN_TOOL_REGISTRY.map((tool) => ({ ...tool }));
+  return BUILTIN_TOOL_REGISTRY.map((tool) => withResolvedToolDescriptorTaxonomy({ ...tool }));
 }
 
 export function resolveBuiltinToolEffect(toolId: string): ToolEffect | undefined {

--- a/packages/gateway/src/modules/agent/tools.ts
+++ b/packages/gateway/src/modules/agent/tools.ts
@@ -34,13 +34,12 @@ export interface ToolDescriptor {
 }
 
 export function resolveToolDescriptorTaxonomy(
-  descriptor: Pick<ToolDescriptor, "id" | "source" | "family" | "backingServerId">,
+  descriptor: Pick<ToolDescriptor, "id" | "source" | "family">,
 ): ToolTaxonomyMetadata {
   return resolveToolTaxonomyMetadata({
     toolId: descriptor.id,
     source: descriptor.source,
     family: descriptor.family ?? null,
-    backingServerId: descriptor.backingServerId ?? null,
   });
 }
 

--- a/packages/gateway/src/modules/plugins/registry.ts
+++ b/packages/gateway/src/modules/plugins/registry.ts
@@ -4,7 +4,7 @@ import { type Dirent } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { GatewayContainer } from "../../container.js";
-import type { ToolDescriptor } from "../agent/tools.js";
+import { withResolvedToolDescriptorTaxonomy, type ToolDescriptor } from "../agent/tools.js";
 import type { Logger } from "../observability/logger.js";
 import type { PluginInstallInfo } from "./lockfile.js";
 import { type PluginDir, resolvePluginSearchDirs } from "./directories.js";
@@ -126,7 +126,7 @@ export class PluginRegistry {
             default_effect: "state_changing",
           });
         }
-        return {
+        return withResolvedToolDescriptorTaxonomy({
           id: tool.descriptor.id,
           description: tool.descriptor.description,
           effect: effect ?? "state_changing",
@@ -135,7 +135,7 @@ export class PluginRegistry {
           source: "plugin" as const,
           family: tool.descriptor.family ?? "plugin",
           backingServerId: tool.descriptor.backingServerId,
-        };
+        });
       }),
     );
   }

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -140,7 +140,7 @@ function resolveToolGroup(
     if (taxonomy.group === "environment") {
       return taxonomy.group;
     }
-    if (taxonomy.group === "orchestration") {
+    if (taxonomy.group === "orchestration" && taxonomy.family === "sandbox") {
       return taxonomy.group;
     }
   }

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -1,4 +1,8 @@
-import { McpServerSpec, type McpServerSpec as McpServerSpecT } from "@tyrum/contracts";
+import {
+  McpServerSpec,
+  type McpServerSpec as McpServerSpecT,
+  type ToolTaxonomyMetadata,
+} from "@tyrum/contracts";
 import type { PluginManifest as PluginManifestT } from "@tyrum/contracts";
 import { Hono } from "hono";
 import { BUILTIN_EXA_SERVER_ID } from "../app/modules/agent/builtin-exa.js";
@@ -9,6 +13,7 @@ import {
   isBuiltinToolAvailableInStateMode,
   isToolAllowed,
   listBuiltinToolDescriptors,
+  resolveToolDescriptorTaxonomy,
   type ToolDescriptor,
 } from "../app/modules/agent/tools.js";
 import { validateToolDescriptorInputSchema } from "../app/modules/agent/tool-schema.js";
@@ -48,10 +53,6 @@ type ToolRegistryGroup =
   | "extension";
 
 type ToolRegistryTier = "default" | "advanced";
-
-const AUTOMATION_SCHEDULE_FAMILY = "tool.automation.schedule";
-const LOCATION_PLACE_FAMILY = "tool.location.place";
-const BUILTIN_WEB_FACADE_IDS = new Set(["websearch", "webfetch", "codesearch"]);
 
 type ToolRegistryEntry = {
   source: "builtin" | "builtin_mcp" | "mcp" | "plugin";
@@ -96,11 +97,19 @@ async function resolvePluginRegistry(
   return deps.plugins;
 }
 
+function resolveDescriptorTaxonomy(
+  descriptor: ToolDescriptor,
+  source: ToolRegistryEntry["source"],
+): ToolTaxonomyMetadata {
+  return descriptor.taxonomy ?? resolveToolDescriptorTaxonomy({ ...descriptor, source });
+}
+
 function toBaseEntry(
   descriptor: ToolDescriptor,
   source: ToolRegistryEntry["source"],
   effectiveExposure: ToolEffectiveExposure,
 ): Omit<ToolRegistryEntry, "backing_server" | "plugin"> {
+  const taxonomy = resolveDescriptorTaxonomy(descriptor, source);
   const validatedSchema = validateToolDescriptorInputSchema(descriptor);
   return {
     source,
@@ -109,82 +118,46 @@ function toBaseEntry(
     effect: descriptor.effect,
     effective_exposure: effectiveExposure,
     family: descriptor.family,
-    group: resolveToolGroup(descriptor, source),
-    tier: resolveToolTier(descriptor, source),
+    group: resolveToolGroup(source, taxonomy),
+    tier: resolveToolTier(source, taxonomy),
     keywords: descriptor.keywords.length > 0 ? [...descriptor.keywords] : undefined,
     input_schema: validatedSchema.ok ? validatedSchema.schema : undefined,
   };
 }
 
-function isAutomationScheduleTool(descriptor: ToolDescriptor): boolean {
-  return descriptor.family === AUTOMATION_SCHEDULE_FAMILY;
-}
-
-function isSavedPlaceTool(descriptor: ToolDescriptor): boolean {
-  return descriptor.family === LOCATION_PLACE_FAMILY;
-}
-
-function isBuiltinWebFacade(
-  descriptor: ToolDescriptor,
-  source: ToolRegistryEntry["source"],
-): boolean {
-  return (
-    source === "builtin_mcp" &&
-    descriptor.family === "web" &&
-    descriptor.backingServerId === BUILTIN_EXA_SERVER_ID &&
-    BUILTIN_WEB_FACADE_IDS.has(descriptor.id)
-  );
-}
-
 function resolveToolGroup(
-  descriptor: ToolDescriptor,
   source: ToolRegistryEntry["source"],
+  taxonomy: ToolTaxonomyMetadata,
 ): ToolRegistryGroup | undefined {
-  if (isBuiltinWebFacade(descriptor, source)) {
-    return "retrieval";
+  if (source === "builtin_mcp" && taxonomy.group === "retrieval") {
+    return taxonomy.group;
   }
 
-  if (source !== "builtin") return undefined;
-
-  if (isAutomationScheduleTool(descriptor)) {
-    return "environment";
-  }
-
-  if (isSavedPlaceTool(descriptor)) {
-    return "environment";
-  }
-
-  if (
-    descriptor.family === "filesystem" ||
-    descriptor.family === "shell" ||
-    descriptor.family === "artifact"
-  ) {
-    return "core";
-  }
-
-  if (descriptor.family === "sandbox") {
-    return "orchestration";
+  if (source === "builtin" && taxonomy.group) {
+    if (taxonomy.group === "core") {
+      return taxonomy.group;
+    }
+    if (taxonomy.group === "environment") {
+      return taxonomy.group;
+    }
+    if (taxonomy.group === "orchestration") {
+      return taxonomy.group;
+    }
   }
 
   return undefined;
 }
 
 function resolveToolTier(
-  descriptor: ToolDescriptor,
   source: ToolRegistryEntry["source"],
+  taxonomy: ToolTaxonomyMetadata,
 ): ToolRegistryTier | undefined {
-  if (isBuiltinWebFacade(descriptor, source)) {
-    return "default";
+  if (source === "builtin_mcp" && taxonomy.group === "retrieval" && taxonomy.tier === "default") {
+    return taxonomy.tier;
   }
 
-  if (source !== "builtin") return undefined;
-
-  if (isAutomationScheduleTool(descriptor)) {
-    return "advanced";
-  }
-
-  if (isSavedPlaceTool(descriptor)) {
-    return "advanced";
+  if (source === "builtin" && taxonomy.group === "environment" && taxonomy.tier === "advanced") {
+    return taxonomy.tier;
   }
 
   return undefined;

--- a/packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts
+++ b/packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts
@@ -125,5 +125,83 @@ describe("runtime tool descriptor source", () => {
     expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain(SECRET_CLIPBOARD_TOOL_ID);
     expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain("plugin.echo.readonly");
     expect(turnRuntime.availableTools.map((tool) => tool.id)).toContain("mcp.calendar.events_list");
+
+    const pluginDescriptor = turnRuntime.availableTools.find(
+      (tool) => tool.id === "plugin.echo.readonly",
+    );
+    const mcpDescriptor = turnRuntime.availableTools.find(
+      (tool) => tool.id === "mcp.calendar.events_list",
+    );
+    expect(pluginDescriptor?.taxonomy).toMatchObject({
+      canonicalId: "plugin.echo.readonly",
+      lifecycle: "canonical",
+      visibility: "public",
+      group: "extension",
+      tier: "advanced",
+    });
+    expect(mcpDescriptor?.taxonomy).toMatchObject({
+      canonicalId: "mcp.calendar.events_list",
+      lifecycle: "canonical",
+      visibility: "public",
+      group: "extension",
+      tier: "advanced",
+    });
+  });
+
+  it("preserves deprecated memory-alias taxonomy metadata through runtime descriptor aggregation", async () => {
+    const mcpManager = {
+      listToolDescriptors: vi.fn().mockResolvedValue([
+        {
+          id: "mcp.memory.search",
+          description: "Search memory.",
+          effect: "read_only" as const,
+          keywords: ["memory", "search"],
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+      ]),
+    };
+    const loaded = {
+      config: AgentConfig.parse({
+        model: { model: "openai/gpt-4.1" },
+        tools: {
+          default_mode: "allow",
+          allow: [],
+          deny: [],
+        },
+      }),
+      identity: {} as never,
+      skills: [],
+      mcpServers: [{ id: "memory" }] as never,
+    };
+    const opts = {
+      container: {
+        deploymentConfig: {},
+        db: {} as never,
+        approvalDal: {} as never,
+        logger: { warn: vi.fn() },
+        redactionEngine: {} as never,
+      },
+    } as never;
+
+    const runtimeStatusTools = await listAvailableRuntimeTools({
+      opts,
+      mcpManager: mcpManager as never,
+      loaded,
+      plugins: undefined,
+    });
+
+    const memorySearch = runtimeStatusTools.find((tool) => tool.id === "mcp.memory.search");
+    expect(memorySearch?.taxonomy).toMatchObject({
+      canonicalId: "memory.search",
+      lifecycle: "deprecated",
+      visibility: "public",
+      family: "memory",
+      group: "memory",
+      tier: "default",
+    });
   });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -207,79 +207,36 @@ describe("tool registry routes", () => {
     };
     expect(body.status).toBe("ok");
     expect(body.tools.some((tool) => tool.source === "builtin")).toBe(true);
-    expect(body.tools).not.toContainEqual(
-      expect.objectContaining({
-        canonical_id: LEGACY_NODE_INSPECT_TOOL_ID,
-      }),
-    );
-    expect(body.tools).not.toContainEqual(
-      expect.objectContaining({
-        canonical_id: LEGACY_NODE_DISPATCH_TOOL_ID,
-      }),
-    );
-    expect(body.tools).toContainEqual(
-      expect.objectContaining({
-        source: "builtin_mcp",
-        canonical_id: "websearch",
-        family: "web",
-        group: "retrieval",
-        tier: "default",
-        effect: "read_only",
-        effective_exposure: expect.objectContaining({
-          enabled: true,
-          reason: "enabled",
-          agent_key: "default",
+    for (const legacyNodeToolId of [LEGACY_NODE_INSPECT_TOOL_ID, LEGACY_NODE_DISPATCH_TOOL_ID]) {
+      expect(body.tools).not.toContainEqual(
+        expect.objectContaining({
+          canonical_id: legacyNodeToolId,
         }),
-        backing_server: expect.objectContaining({
-          id: "exa",
-          name: "Exa",
-          transport: "remote",
-          url: "https://mcp.exa.ai/mcp",
+      );
+    }
+    for (const canonicalId of ["websearch", "webfetch", "codesearch"]) {
+      expect(body.tools).toContainEqual(
+        expect.objectContaining({
+          source: "builtin_mcp",
+          canonical_id: canonicalId,
+          family: "web",
+          group: "retrieval",
+          tier: "default",
+          effect: "read_only",
+          effective_exposure: expect.objectContaining({
+            enabled: true,
+            reason: "enabled",
+            agent_key: "default",
+          }),
+          backing_server: expect.objectContaining({
+            id: "exa",
+            name: "Exa",
+            transport: "remote",
+            url: "https://mcp.exa.ai/mcp",
+          }),
         }),
-      }),
-    );
-    expect(body.tools).toContainEqual(
-      expect.objectContaining({
-        source: "builtin_mcp",
-        canonical_id: "webfetch",
-        family: "web",
-        group: "retrieval",
-        tier: "default",
-        effect: "read_only",
-        effective_exposure: expect.objectContaining({
-          enabled: true,
-          reason: "enabled",
-          agent_key: "default",
-        }),
-        backing_server: expect.objectContaining({
-          id: "exa",
-          name: "Exa",
-          transport: "remote",
-          url: "https://mcp.exa.ai/mcp",
-        }),
-      }),
-    );
-    expect(body.tools).toContainEqual(
-      expect.objectContaining({
-        source: "builtin_mcp",
-        canonical_id: "codesearch",
-        family: "web",
-        group: "retrieval",
-        tier: "default",
-        effect: "read_only",
-        effective_exposure: expect.objectContaining({
-          enabled: true,
-          reason: "enabled",
-          agent_key: "default",
-        }),
-        backing_server: expect.objectContaining({
-          id: "exa",
-          name: "Exa",
-          transport: "remote",
-          url: "https://mcp.exa.ai/mcp",
-        }),
-      }),
-    );
+      );
+    }
     const rawMcpWebSearch = body.tools.find(
       (tool: { canonical_id?: string }) => tool.canonical_id === "mcp.exa.web_search_exa",
     );
@@ -482,6 +439,7 @@ describe("tool registry routes", () => {
       expect.objectContaining({
         source: "builtin",
         canonical_id: "workboard.artifact.get",
+        family: "workboard",
         input_schema: {
           type: "object",
           properties: {
@@ -492,6 +450,21 @@ describe("tool registry routes", () => {
         },
       }),
     );
+    const workboardArtifactTool = body.tools.find(
+      (tool: { canonical_id?: string }) => tool.canonical_id === "workboard.artifact.get",
+    );
+    expect(workboardArtifactTool).not.toHaveProperty("group");
+    expect(workboardArtifactTool).not.toHaveProperty("tier");
+    const subagentSpawnTool = body.tools.find(
+      (tool: { canonical_id?: string }) => tool.canonical_id === "subagent.spawn",
+    );
+    expect(subagentSpawnTool).toMatchObject({
+      source: "builtin",
+      canonical_id: "subagent.spawn",
+      family: "subagent",
+    });
+    expect(subagentSpawnTool).not.toHaveProperty("group");
+    expect(subagentSpawnTool).not.toHaveProperty("tier");
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         source: "builtin",


### PR DESCRIPTION
Closes #1974

## What changed
- added a shared internal tool taxonomy resolver in `@tyrum/contracts` for canonical, alias/deprecated, and visibility classification
- propagated taxonomy metadata through gateway descriptor producers for builtin, MCP, plugin, dynamic secret, and runtime-normalized tool descriptors
- updated internal tool-registry consumption to read shared taxonomy-derived grouping/tiering without changing the public `/config/tools` or `/context/tools` wire contracts
- added regression coverage for canonical built-ins, legacy aliases, and memory-alias taxonomy propagation

## Why
- `#1974` requires one shared emitted metadata model for descriptor-bearing tool surfaces during taxonomy rollout
- later registry/capability/inventory issues need a reusable shared taxonomy source without reintroducing surface-specific variants or pulling this PR into later contract-alignment work

## How to test
- `pnpm exec vitest run packages/contracts/tests/tool-id.test.ts packages/gateway/tests/unit/capability-catalog.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git push -u origin 1974-define-and-emit-shared-tool-taxonomy-metadata` (pre-push ran `pnpm run ci` successfully)

## Risk
- low to moderate; this changes internal descriptor metadata propagation and shared taxonomy classification, but intentionally avoids public route/schema changes
- main residual risk is taxonomy misclassification for a tool family not explicitly covered by the shared resolver

## Rollback notes
- revert commit `dc22e8446714fb7254a2837ff0c8d40032c1db40`
- no database migration or persisted-data rollback is required because the change is internal and schema-neutral

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new shared taxonomy classifier and threads the resulting metadata through builtin/MCP/plugin tool descriptor generation, which can subtly change tool grouping/tiering and visibility across registry/runtime surfaces. Public route schemas are unchanged, but misclassification could affect internal filtering, UI categorization, or downstream consumers relying on these fields.
> 
> **Overview**
> Introduces a shared `@tyrum/contracts` tool taxonomy resolver (`resolveToolTaxonomyMetadata`) that canonicalizes tool IDs and classifies them by *lifecycle* (canonical/alias/deprecated), *visibility*, and *family/group/tier*.
> 
> Propagates this taxonomy onto gateway `ToolDescriptor`s (new optional `taxonomy` field) by wrapping builtin, MCP, plugin, and dynamic secret tool descriptor construction/normalization, and updates the tool registry routes to derive `group`/`tier` from taxonomy rather than local heuristics (without changing the `/config/tools` response shape).
> 
> Adds unit/regression tests covering canonical vs legacy IDs (including deprecated `mcp.memory.*` aliases) and ensuring taxonomy survives runtime aggregation and registry listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aceb1ee60a72835f3dbb0d188c8dd78780ee6f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->