### PR TITLE
Add shared effective-exposure resolver core

### DIFF
--- a/packages/gateway/src/modules/agent/runtime/effective-exposure-resolver.ts
+++ b/packages/gateway/src/modules/agent/runtime/effective-exposure-resolver.ts
@@ -14,6 +14,9 @@ type ToolExposureConfig = Pick<
 >;
 type McpExposureConfig = Pick<AgentConfig["mcp"], "bundle" | "tier">;
 type RuntimeExposureSurface = "tools" | "mcp";
+type CanonicalExposureSelectorConfig =
+  | Pick<ToolExposureConfig, "bundle" | "tier">
+  | Pick<McpExposureConfig, "bundle" | "tier">;
 
 export type EffectiveToolExposureReason =
   | "enabled"
@@ -57,7 +60,7 @@ const TOOL_TIER_ORDER: Record<ToolTaxonomyTier, number> = {
 
 function resolveRuntimeExposureBundle(
   surface: RuntimeExposureSurface,
-  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
+  config: CanonicalExposureSelectorConfig,
 ): string | undefined {
   if (config.bundle) {
     return config.bundle;
@@ -68,9 +71,7 @@ function resolveRuntimeExposureBundle(
   return undefined;
 }
 
-function hasCanonicalExposureSelector(
-  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
-): boolean {
+export function hasCanonicalExposureSelector(config: CanonicalExposureSelectorConfig): boolean {
   return config.bundle !== undefined || config.tier !== undefined;
 }
 
@@ -78,8 +79,10 @@ function isRawMcpTool(tool: ToolDescriptor): boolean {
   return tool.source === "mcp" || tool.id.startsWith("mcp.");
 }
 
-function isPluginTool(tool: ToolDescriptor): boolean {
-  return tool.source === "plugin" || tool.id.trim().startsWith("plugin.");
+export function isPluginExposureTool(tool: Pick<ToolDescriptor, "id" | "source">): boolean {
+  return (
+    tool.source === "plugin" || (tool.source === undefined && tool.id.trim().startsWith("plugin."))
+  );
 }
 
 function isBuiltinExposureClass(
@@ -112,16 +115,16 @@ function matchesExposureBundle(
 
   switch (bundle) {
     case "authoring-core":
-      return !isRawMcpTool(tool) && !isPluginTool(tool);
+      return !isRawMcpTool(tool) && !isPluginExposureTool(tool);
     case "workspace-default":
-      return surface === "mcp" ? isRawMcpTool(tool) : !isPluginTool(tool);
+      return surface === "mcp" ? isRawMcpTool(tool) : !isPluginExposureTool(tool);
     default:
       return false;
   }
 }
 
 function resolveExposureClass(tool: ToolDescriptor): EffectiveToolExposureClass {
-  if (isPluginTool(tool)) {
+  if (isPluginExposureTool(tool)) {
     return "plugin";
   }
   if (isRawMcpTool(tool)) {

--- a/packages/gateway/src/modules/agent/runtime/effective-exposure-resolver.ts
+++ b/packages/gateway/src/modules/agent/runtime/effective-exposure-resolver.ts
@@ -1,0 +1,347 @@
+import type { AgentConfig, ToolTaxonomyTier } from "@tyrum/contracts";
+import { isAgentAccessAllowed } from "../access-config.js";
+import {
+  isBuiltinToolAvailableInStateMode,
+  isToolAllowed,
+  isToolAllowedWithDenylist,
+  type ToolDescriptor,
+} from "../tools.js";
+import type { GatewayStateMode } from "../../runtime-state/mode.js";
+
+type ToolExposureConfig = Pick<
+  AgentConfig["tools"],
+  "bundle" | "tier" | "default_mode" | "allow" | "deny"
+>;
+type McpExposureConfig = Pick<AgentConfig["mcp"], "bundle" | "tier">;
+type RuntimeExposureSurface = "tools" | "mcp";
+
+export type EffectiveToolExposureReason =
+  | "enabled"
+  | "disabled_by_agent_allowlist"
+  | "disabled_by_agent_bundle"
+  | "disabled_by_agent_denylist"
+  | "disabled_by_agent_tier"
+  | "disabled_by_execution_profile"
+  | "disabled_by_plugin_opt_in"
+  | "disabled_by_plugin_policy"
+  | "disabled_by_state_mode"
+  | "disabled_invalid_schema";
+
+export type EffectiveToolExposureClass = "builtin" | "builtin_mcp" | "mcp" | "plugin";
+
+export type EffectiveToolExposureVerdict = {
+  descriptor: ToolDescriptor;
+  exposureClass: EffectiveToolExposureClass;
+  enabledByAgent: boolean;
+  enabled: boolean;
+  reason: EffectiveToolExposureReason;
+};
+
+export type ResolveEffectiveToolExposureParams = {
+  candidates: readonly ToolDescriptor[];
+  toolConfig: ToolExposureConfig;
+  mcpConfig: McpExposureConfig;
+  stateMode?: GatewayStateMode;
+  invalidSchemaToolIds?: readonly string[];
+  pluginPolicyAllowedToolIds?: readonly string[];
+  executionProfile?: {
+    allowlist: readonly string[];
+    denylist?: readonly string[];
+  };
+};
+
+const TOOL_TIER_ORDER: Record<ToolTaxonomyTier, number> = {
+  default: 0,
+  advanced: 1,
+};
+
+function resolveRuntimeExposureBundle(
+  surface: RuntimeExposureSurface,
+  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
+): string | undefined {
+  if (config.bundle) {
+    return config.bundle;
+  }
+  if (config.tier) {
+    return surface === "mcp" ? "workspace-default" : "authoring-core";
+  }
+  return undefined;
+}
+
+function hasCanonicalExposureSelector(
+  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
+): boolean {
+  return config.bundle !== undefined || config.tier !== undefined;
+}
+
+function isRawMcpTool(tool: ToolDescriptor): boolean {
+  return tool.source === "mcp" || tool.id.startsWith("mcp.");
+}
+
+function isPluginTool(tool: ToolDescriptor): boolean {
+  return tool.source === "plugin" || tool.id.trim().startsWith("plugin.");
+}
+
+function isBuiltinExposureClass(
+  exposureClass: EffectiveToolExposureClass,
+): exposureClass is "builtin" | "builtin_mcp" {
+  return exposureClass === "builtin" || exposureClass === "builtin_mcp";
+}
+
+function matchesExposureTier(
+  selectedTier: ToolTaxonomyTier | undefined,
+  toolTier: ToolTaxonomyTier | null | undefined,
+): boolean {
+  if (toolTier === null || toolTier === undefined) {
+    return false;
+  }
+  if (!selectedTier) {
+    return true;
+  }
+  return TOOL_TIER_ORDER[toolTier] <= TOOL_TIER_ORDER[selectedTier];
+}
+
+function matchesExposureBundle(
+  surface: RuntimeExposureSurface,
+  bundle: string | undefined,
+  tool: ToolDescriptor,
+): boolean {
+  if (tool.taxonomy?.visibility !== "public") {
+    return false;
+  }
+
+  switch (bundle) {
+    case "authoring-core":
+      return !isRawMcpTool(tool) && !isPluginTool(tool);
+    case "workspace-default":
+      return surface === "mcp" ? isRawMcpTool(tool) : !isPluginTool(tool);
+    default:
+      return false;
+  }
+}
+
+function resolveExposureClass(tool: ToolDescriptor): EffectiveToolExposureClass {
+  if (isPluginTool(tool)) {
+    return "plugin";
+  }
+  if (isRawMcpTool(tool)) {
+    return "mcp";
+  }
+  if (tool.source === "builtin_mcp") {
+    return "builtin_mcp";
+  }
+  return "builtin";
+}
+
+function resolveExposureSurface(exposureClass: EffectiveToolExposureClass): RuntimeExposureSurface {
+  return exposureClass === "mcp" ? "mcp" : "tools";
+}
+
+function extractExplicitAllowEntries(allowEntries: readonly string[]): string[] {
+  return allowEntries.filter((entry) => {
+    const normalized = entry.trim();
+    return normalized.length > 0 && !normalized.includes("*") && !normalized.includes("?");
+  });
+}
+
+function matchesCompatibilitySelection(params: {
+  toolId: string;
+  toolConfig: ToolExposureConfig;
+  explicitToolAllowEntries: readonly string[];
+}): boolean {
+  if (!hasCanonicalExposureSelector(params.toolConfig)) {
+    return isAgentAccessAllowed(params.toolConfig, params.toolId);
+  }
+
+  return isToolAllowed(params.explicitToolAllowEntries, params.toolId);
+}
+
+function resolveNonPluginDisabledReason(params: {
+  descriptor: ToolDescriptor;
+  exposureClass: Exclude<EffectiveToolExposureClass, "plugin">;
+  toolConfig: ToolExposureConfig;
+  mcpConfig: McpExposureConfig;
+}): Extract<
+  EffectiveToolExposureReason,
+  "disabled_by_agent_allowlist" | "disabled_by_agent_bundle" | "disabled_by_agent_tier"
+> {
+  const surface = resolveExposureSurface(params.exposureClass);
+  const canonicalConfig = params.exposureClass === "mcp" ? params.mcpConfig : params.toolConfig;
+
+  if (!hasCanonicalExposureSelector(canonicalConfig)) {
+    return "disabled_by_agent_allowlist";
+  }
+
+  const bundle = resolveRuntimeExposureBundle(surface, canonicalConfig);
+  if (!matchesExposureBundle(surface, bundle, params.descriptor)) {
+    return "disabled_by_agent_bundle";
+  }
+  if (!matchesExposureTier(canonicalConfig.tier, params.descriptor.taxonomy?.tier)) {
+    return "disabled_by_agent_tier";
+  }
+  return "disabled_by_agent_allowlist";
+}
+
+function resolveEnabledByAgent(params: {
+  descriptor: ToolDescriptor;
+  exposureClass: EffectiveToolExposureClass;
+  toolConfig: ToolExposureConfig;
+  mcpConfig: McpExposureConfig;
+  explicitToolAllowEntries: readonly string[];
+  pluginPolicyAllowedToolIds?: ReadonlySet<string>;
+}): Pick<EffectiveToolExposureVerdict, "enabledByAgent" | "reason"> {
+  if (isToolAllowed(params.toolConfig.deny, params.descriptor.id)) {
+    return {
+      enabledByAgent: false,
+      reason: "disabled_by_agent_denylist",
+    };
+  }
+
+  if (params.exposureClass === "plugin") {
+    if (!isToolAllowed(params.explicitToolAllowEntries, params.descriptor.id)) {
+      return {
+        enabledByAgent: false,
+        reason: "disabled_by_plugin_opt_in",
+      };
+    }
+    if (
+      params.pluginPolicyAllowedToolIds &&
+      !params.pluginPolicyAllowedToolIds.has(params.descriptor.id)
+    ) {
+      return {
+        enabledByAgent: false,
+        reason: "disabled_by_plugin_policy",
+      };
+    }
+    return {
+      enabledByAgent: true,
+      reason: "enabled",
+    };
+  }
+
+  const surface = resolveExposureSurface(params.exposureClass);
+  const canonicalConfig = params.exposureClass === "mcp" ? params.mcpConfig : params.toolConfig;
+  const selectedByCanonical =
+    matchesExposureBundle(
+      surface,
+      resolveRuntimeExposureBundle(surface, canonicalConfig),
+      params.descriptor,
+    ) && matchesExposureTier(canonicalConfig.tier, params.descriptor.taxonomy?.tier);
+  const selectedByCompatibility = matchesCompatibilitySelection({
+    toolId: params.descriptor.id,
+    toolConfig: params.toolConfig,
+    explicitToolAllowEntries: params.explicitToolAllowEntries,
+  });
+
+  if (selectedByCanonical || selectedByCompatibility) {
+    return {
+      enabledByAgent: true,
+      reason: "enabled",
+    };
+  }
+
+  return {
+    enabledByAgent: false,
+    reason: resolveNonPluginDisabledReason({
+      descriptor: params.descriptor,
+      exposureClass: params.exposureClass,
+      toolConfig: params.toolConfig,
+      mcpConfig: params.mcpConfig,
+    }),
+  };
+}
+
+function resolveFinalExposure(params: {
+  descriptor: ToolDescriptor;
+  exposureClass: EffectiveToolExposureClass;
+  enabledByAgent: boolean;
+  agentReason: EffectiveToolExposureReason;
+  stateMode?: GatewayStateMode;
+  invalidSchemaToolIds?: ReadonlySet<string>;
+  executionProfile?: ResolveEffectiveToolExposureParams["executionProfile"];
+}): Pick<EffectiveToolExposureVerdict, "enabled" | "reason"> {
+  if (params.invalidSchemaToolIds?.has(params.descriptor.id)) {
+    return {
+      enabled: false,
+      reason: "disabled_invalid_schema",
+    };
+  }
+
+  if (
+    params.stateMode &&
+    isBuiltinExposureClass(params.exposureClass) &&
+    !isBuiltinToolAvailableInStateMode(params.descriptor.id, params.stateMode)
+  ) {
+    return {
+      enabled: false,
+      reason: "disabled_by_state_mode",
+    };
+  }
+
+  if (!params.enabledByAgent) {
+    return {
+      enabled: false,
+      reason: params.agentReason,
+    };
+  }
+
+  if (
+    params.executionProfile &&
+    !isToolAllowedWithDenylist(
+      params.executionProfile.allowlist,
+      params.executionProfile.denylist,
+      params.descriptor.id,
+    )
+  ) {
+    return {
+      enabled: false,
+      reason: "disabled_by_execution_profile",
+    };
+  }
+
+  return {
+    enabled: true,
+    reason: "enabled",
+  };
+}
+
+export function resolveEffectiveToolExposureVerdicts(
+  params: ResolveEffectiveToolExposureParams,
+): EffectiveToolExposureVerdict[] {
+  const explicitToolAllowEntries = extractExplicitAllowEntries(params.toolConfig.allow);
+  const invalidSchemaToolIds =
+    params.invalidSchemaToolIds === undefined ? undefined : new Set(params.invalidSchemaToolIds);
+  const pluginPolicyAllowedToolIds =
+    params.pluginPolicyAllowedToolIds === undefined
+      ? undefined
+      : new Set(params.pluginPolicyAllowedToolIds);
+
+  return params.candidates.map((descriptor) => {
+    const exposureClass = resolveExposureClass(descriptor);
+    const agentExposure = resolveEnabledByAgent({
+      descriptor,
+      exposureClass,
+      toolConfig: params.toolConfig,
+      mcpConfig: params.mcpConfig,
+      explicitToolAllowEntries,
+      pluginPolicyAllowedToolIds,
+    });
+    const finalExposure = resolveFinalExposure({
+      descriptor,
+      exposureClass,
+      enabledByAgent: agentExposure.enabledByAgent,
+      agentReason: agentExposure.reason,
+      stateMode: params.stateMode,
+      invalidSchemaToolIds,
+      executionProfile: params.executionProfile,
+    });
+
+    return {
+      descriptor,
+      exposureClass,
+      enabledByAgent: agentExposure.enabledByAgent,
+      enabled: finalExposure.enabled,
+      reason: finalExposure.reason,
+    };
+  });
+}

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -9,16 +9,11 @@ import {
 } from "../tools.js";
 import type { AgentLoadedContext } from "./types.js";
 import type { GatewayStateMode } from "../../runtime-state/mode.js";
-import { resolveEffectiveToolExposureVerdicts } from "./effective-exposure-resolver.js";
+import {
+  hasCanonicalExposureSelector,
+  resolveEffectiveToolExposureVerdicts,
+} from "./effective-exposure-resolver.js";
 import { resolvePolicyGatedPluginToolExposure } from "./plugin-tool-policy.js";
-
-function hasCanonicalExposureSelector(
-  config:
-    | Pick<AgentConfig["tools"], "bundle" | "tier">
-    | Pick<AgentConfig["mcp"], "bundle" | "tier">,
-): boolean {
-  return config.bundle !== undefined || config.tier !== undefined;
-}
 
 function canDiscoverMcpTools(params: {
   toolConfig: AgentConfig["tools"];

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -1,185 +1,23 @@
-import type { AgentConfig, ToolTaxonomyTier } from "@tyrum/contracts";
+import type { AgentConfig } from "@tyrum/contracts";
 import type { PluginRegistry } from "../../plugins/registry.js";
-import { materializeAllowedAgentIds } from "../access-config.js";
 import type { McpManager } from "../mcp-manager.js";
 import { buildSecretClipboardToolDescriptor } from "../tool-secret-definitions.js";
 import {
-  isBuiltinToolAvailableInStateMode,
-  isToolAllowed,
   listBuiltinToolDescriptors,
   type ToolDescriptor,
   withResolvedToolDescriptorTaxonomy,
 } from "../tools.js";
 import type { AgentLoadedContext } from "./types.js";
 import type { GatewayStateMode } from "../../runtime-state/mode.js";
+import { resolveEffectiveToolExposureVerdicts } from "./effective-exposure-resolver.js";
 import { resolvePolicyGatedPluginToolExposure } from "./plugin-tool-policy.js";
 
-type ToolExposureConfig = Pick<
-  AgentConfig["tools"],
-  "bundle" | "tier" | "default_mode" | "allow" | "deny"
->;
-type McpExposureConfig = Pick<AgentConfig["mcp"], "bundle" | "tier">;
-type RuntimeExposureSurface = "tools" | "mcp";
-
-const TOOL_TIER_ORDER: Record<ToolTaxonomyTier, number> = {
-  default: 0,
-  advanced: 1,
-};
-
-function resolveRuntimeExposureBundle(
-  surface: RuntimeExposureSurface,
-  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
-): string | undefined {
-  if (config.bundle) {
-    return config.bundle;
-  }
-  if (config.tier) {
-    return surface === "mcp" ? "workspace-default" : "authoring-core";
-  }
-  return undefined;
-}
-
 function hasCanonicalExposureSelector(
-  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">,
+  config:
+    | Pick<AgentConfig["tools"], "bundle" | "tier">
+    | Pick<AgentConfig["mcp"], "bundle" | "tier">,
 ): boolean {
   return config.bundle !== undefined || config.tier !== undefined;
-}
-
-function isRawMcpTool(tool: ToolDescriptor): boolean {
-  return tool.source === "mcp" || tool.id.startsWith("mcp.");
-}
-
-function isPluginTool(tool: ToolDescriptor): boolean {
-  return tool.source === "plugin";
-}
-
-function matchesExposureTier(
-  selectedTier: ToolTaxonomyTier | undefined,
-  toolTier: ToolTaxonomyTier | null | undefined,
-): boolean {
-  if (toolTier === null || toolTier === undefined) {
-    return false;
-  }
-  if (!selectedTier) {
-    return true;
-  }
-  return TOOL_TIER_ORDER[toolTier] <= TOOL_TIER_ORDER[selectedTier];
-}
-
-function matchesExposureBundle(
-  surface: RuntimeExposureSurface,
-  bundle: string | undefined,
-  tool: ToolDescriptor,
-): boolean {
-  if (tool.taxonomy?.visibility !== "public") {
-    return false;
-  }
-
-  switch (bundle) {
-    case "authoring-core":
-      return !isRawMcpTool(tool) && !isPluginTool(tool);
-    case "workspace-default":
-      return surface === "mcp" ? isRawMcpTool(tool) : !isPluginTool(tool);
-    default:
-      return false;
-  }
-}
-
-function resolveCanonicalToolExposureIds(params: {
-  surface: RuntimeExposureSurface;
-  config: Pick<ToolExposureConfig, "bundle" | "tier"> | Pick<McpExposureConfig, "bundle" | "tier">;
-  candidates: readonly ToolDescriptor[];
-}): string[] {
-  const bundle = resolveRuntimeExposureBundle(params.surface, params.config);
-  const selectedTier = params.config.tier;
-  const selected = params.candidates.filter(
-    (tool) =>
-      matchesExposureBundle(params.surface, bundle, tool) &&
-      matchesExposureTier(selectedTier, tool.taxonomy?.tier),
-  );
-
-  return selected.map((tool) => tool.id);
-}
-
-function resolveCompatibilityToolExposureIds(
-  config: ToolExposureConfig,
-  candidates: readonly ToolDescriptor[],
-): string[] {
-  if (!hasCanonicalExposureSelector(config)) {
-    return materializeAllowedAgentIds(config, candidates).map((tool) => tool.id);
-  }
-
-  return resolveExplicitToolExposureIds(config.allow, candidates);
-}
-
-function resolveExplicitToolExposureIds(
-  allowEntries: readonly string[],
-  candidates: readonly ToolDescriptor[],
-): string[] {
-  const explicitAllowEntries = allowEntries.filter((entry) => {
-    const normalized = entry.trim();
-    return normalized.length > 0 && !normalized.includes("*") && !normalized.includes("?");
-  });
-  const selectedIds = new Set<string>();
-
-  for (const tool of candidates) {
-    if (isToolAllowed(explicitAllowEntries, tool.id)) {
-      selectedIds.add(tool.id);
-    }
-  }
-
-  return [...selectedIds];
-}
-
-function resolveExplicitPluginToolDescriptors(
-  config: ToolExposureConfig,
-  candidates: readonly ToolDescriptor[],
-): ToolDescriptor[] {
-  const selectedIds = new Set(resolveExplicitToolExposureIds(config.allow, candidates));
-  return candidates.filter(
-    (tool) => selectedIds.has(tool.id) && !isToolAllowed(config.deny, tool.id),
-  );
-}
-
-function selectToolDescriptorsById(
-  candidates: readonly ToolDescriptor[],
-  selectedIds: ReadonlySet<string>,
-): ToolDescriptor[] {
-  return candidates.filter((tool) => selectedIds.has(tool.id));
-}
-
-function resolveToolDescriptorsForSurface(params: {
-  surface: RuntimeExposureSurface;
-  canonicalConfig:
-    | Pick<ToolExposureConfig, "bundle" | "tier">
-    | Pick<McpExposureConfig, "bundle" | "tier">;
-  compatibilityConfig: ToolExposureConfig;
-  candidates: readonly ToolDescriptor[];
-}): ToolDescriptor[] {
-  const selectedIds = new Set<string>();
-
-  for (const toolId of resolveCanonicalToolExposureIds({
-    surface: params.surface,
-    config: params.canonicalConfig,
-    candidates: params.candidates,
-  })) {
-    selectedIds.add(toolId);
-  }
-
-  for (const toolId of resolveCompatibilityToolExposureIds(
-    params.compatibilityConfig,
-    params.candidates,
-  )) {
-    selectedIds.add(toolId);
-  }
-
-  for (const tool of params.candidates) {
-    if (isToolAllowed(params.compatibilityConfig.deny, tool.id)) {
-      selectedIds.delete(tool.id);
-    }
-  }
-
-  return selectToolDescriptorsById(params.candidates, selectedIds);
 }
 
 function canDiscoverMcpTools(params: {
@@ -350,49 +188,53 @@ export async function resolveRuntimeToolDescriptorSource(params: {
   ].filter((tool): tool is ToolDescriptor => tool !== undefined);
   const builtinTools = [...listBuiltinToolDescriptors(), ...dynamicBuiltinTools];
   const pluginToolsRaw = normalizePluginTools(params.plugins?.getToolDescriptors() ?? []);
-  const builtinToolsSelected = resolveToolDescriptorsForSurface({
-    surface: "tools",
-    canonicalConfig: params.ctx.config.tools,
-    compatibilityConfig: params.ctx.config.tools,
-    candidates: builtinTools.filter((tool) => !isPluginTool(tool) && !isRawMcpTool(tool)),
+  const candidates = [...builtinTools, ...mcpTools, ...pluginToolsRaw];
+  const baseExposureVerdicts = resolveEffectiveToolExposureVerdicts({
+    candidates,
+    toolConfig: params.ctx.config.tools,
+    mcpConfig: params.ctx.config.mcp,
   });
-  const mcpToolsSelected = resolveToolDescriptorsForSurface({
-    surface: "mcp",
-    canonicalConfig: params.ctx.config.mcp,
-    compatibilityConfig: params.ctx.config.tools,
-    candidates: mcpTools,
-  });
-  const pluginToolsSelected = resolveExplicitPluginToolDescriptors(
-    params.ctx.config.tools,
-    pluginToolsRaw,
-  );
-  const baseToolAllowlist = [
-    ...builtinToolsSelected.map((tool) => tool.id),
-    ...mcpToolsSelected.map((tool) => tool.id),
-    ...pluginToolsSelected.map((tool) => tool.id),
-  ];
+  const baseToolAllowlist = baseExposureVerdicts
+    .filter((verdict) => verdict.enabledByAgent)
+    .map((verdict) => verdict.descriptor.id);
+  const pluginToolsSelected = baseExposureVerdicts
+    .filter((verdict) => verdict.enabledByAgent && verdict.exposureClass === "plugin")
+    .map((verdict) => verdict.descriptor);
   const { allowlist: toolAllowlist, pluginTools } = (
     params.resolvePluginToolExposure ?? resolvePolicyGatedPluginToolExposure
   )({
     allowlist: baseToolAllowlist,
     pluginTools: pluginToolsSelected,
   });
+  const toolAllowlistIds = new Set(toolAllowlist);
+  const pluginPolicyAllowedToolIds = pluginTools.map((tool) => tool.id);
+  const effectiveExposureVerdicts = resolveEffectiveToolExposureVerdicts({
+    candidates,
+    toolConfig: params.ctx.config.tools,
+    mcpConfig: params.ctx.config.mcp,
+    stateMode: params.stateMode,
+    pluginPolicyAllowedToolIds,
+  });
+  const promptSelectableBuiltinIds = new Set(dynamicBuiltinTools.map((tool) => tool.id));
 
   return {
-    availableTools: dedupeToolDescriptors([
-      ...builtinToolsSelected.filter(
-        (tool) =>
-          isBuiltinToolAvailableInStateMode(tool.id, params.stateMode) &&
-          isToolAllowed(toolAllowlist, tool.id),
-      ),
-      ...mcpToolsSelected.filter((tool) => isToolAllowed(toolAllowlist, tool.id)),
-      ...pluginTools,
-    ]),
-    toolAllowlist,
-    promptSelectableTools: dedupeToolDescriptors([
-      ...mcpToolsSelected.filter((tool) => isToolAllowed(toolAllowlist, tool.id)),
-      ...pluginTools,
-      ...dynamicBuiltinTools.filter((tool) => isToolAllowed(toolAllowlist, tool.id)),
-    ]),
+    availableTools: dedupeToolDescriptors(
+      effectiveExposureVerdicts
+        .filter((verdict) => verdict.enabled && toolAllowlistIds.has(verdict.descriptor.id))
+        .map((verdict) => verdict.descriptor),
+    ),
+    toolAllowlist: [...toolAllowlist],
+    promptSelectableTools: dedupeToolDescriptors(
+      effectiveExposureVerdicts
+        .filter(
+          (verdict) =>
+            verdict.enabledByAgent &&
+            toolAllowlistIds.has(verdict.descriptor.id) &&
+            (verdict.exposureClass === "mcp" ||
+              verdict.exposureClass === "plugin" ||
+              promptSelectableBuiltinIds.has(verdict.descriptor.id)),
+        )
+        .map((verdict) => verdict.descriptor),
+    ),
   };
 }

--- a/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime-tool-resolution.ts
+++ b/packages/gateway/src/modules/agent/runtime/turn-preparation-runtime-tool-resolution.ts
@@ -9,6 +9,7 @@ import { validateToolDescriptorInputSchema } from "../tool-schema.js";
 import { resolveGatewayStateMode } from "../../runtime-state/mode.js";
 import { ToolSetBuilder } from "./tool-set-builder.js";
 import type { ToolSetBuilderDeps } from "./tool-set-builder.js";
+import { isPluginExposureTool } from "./effective-exposure-resolver.js";
 import type { ResolvedExecutionProfile } from "./execution-profile-resolution.js";
 import type { AgentLoadedContext } from "./types.js";
 import type { TurnPreparationRuntimeDeps } from "./turn-preparation-runtime.js";
@@ -27,10 +28,7 @@ function resolveExplicitRuntimePluginAllowlist(params: {
   const selected = new Set<string>();
 
   for (const tool of params.runtimeTools) {
-    if (
-      (tool.source === "plugin" || tool.id.trim().startsWith("plugin.")) &&
-      isToolAllowed(explicitAllowEntries, tool.id)
-    ) {
+    if (isPluginExposureTool(tool) && isToolAllowed(explicitAllowEntries, tool.id)) {
       selected.add(tool.id);
     }
   }

--- a/packages/gateway/tests/unit/effective-exposure-resolver.test.ts
+++ b/packages/gateway/tests/unit/effective-exposure-resolver.test.ts
@@ -1,0 +1,291 @@
+import { AgentConfig } from "@tyrum/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  resolveEffectiveToolExposureVerdicts,
+  type EffectiveToolExposureVerdict,
+} from "../../src/modules/agent/runtime/effective-exposure-resolver.js";
+import {
+  withResolvedToolDescriptorTaxonomy,
+  type ToolDescriptor,
+} from "../../src/modules/agent/tools.js";
+
+function descriptor(tool: ToolDescriptor): ToolDescriptor {
+  return withResolvedToolDescriptorTaxonomy(tool);
+}
+
+function buildAgentConfig(input?: Partial<AgentConfig>): AgentConfig {
+  return AgentConfig.parse({
+    model: { model: "openai/gpt-4.1" },
+    tools: {
+      default_mode: "deny",
+      allow: [],
+      deny: [],
+      ...input?.tools,
+    },
+    mcp: {
+      default_mode: "deny",
+      allow: [],
+      deny: [],
+      ...input?.mcp,
+    },
+  });
+}
+
+function verdictById(
+  verdicts: readonly EffectiveToolExposureVerdict[],
+  toolId: string,
+): EffectiveToolExposureVerdict {
+  const verdict = verdicts.find((entry) => entry.descriptor.id === toolId);
+  if (!verdict) {
+    throw new Error(`missing verdict for ${toolId}`);
+  }
+  return verdict;
+}
+
+describe("effective exposure resolver", () => {
+  it("applies canonical bundle and tier rules across builtin and MCP tool classes", () => {
+    const candidates = [
+      descriptor({
+        id: "read",
+        description: "Read a file.",
+        effect: "read_only",
+        keywords: ["read"],
+      }),
+      descriptor({
+        id: "tool.desktop.snapshot",
+        description: "Inspect the desktop.",
+        effect: "read_only",
+        keywords: ["desktop"],
+      }),
+      descriptor({
+        id: "websearch",
+        description: "Search the web.",
+        effect: "read_only",
+        keywords: ["web"],
+        source: "builtin_mcp",
+        family: "web",
+      }),
+      descriptor({
+        id: "mcp.calendar.events_list",
+        description: "List calendar events.",
+        effect: "read_only",
+        keywords: ["calendar"],
+        source: "mcp",
+      }),
+      descriptor({
+        id: "plugin.echo.readonly",
+        description: "Read plugin data.",
+        effect: "read_only",
+        keywords: ["plugin"],
+        source: "plugin",
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        bundle: "authoring-core",
+        tier: "default",
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+      },
+      mcp: {
+        bundle: "workspace-default",
+        tier: "advanced",
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+    });
+
+    expect(verdictById(verdicts, "read")).toMatchObject({
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+      exposureClass: "builtin",
+    });
+    expect(verdictById(verdicts, "websearch")).toMatchObject({
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+      exposureClass: "builtin_mcp",
+    });
+    expect(verdictById(verdicts, "tool.desktop.snapshot")).toMatchObject({
+      enabledByAgent: false,
+      enabled: false,
+      reason: "disabled_by_agent_tier",
+      exposureClass: "builtin",
+    });
+    expect(verdictById(verdicts, "mcp.calendar.events_list")).toMatchObject({
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+      exposureClass: "mcp",
+    });
+    expect(verdictById(verdicts, "plugin.echo.readonly")).toMatchObject({
+      enabledByAgent: false,
+      enabled: false,
+      reason: "disabled_by_plugin_opt_in",
+      exposureClass: "plugin",
+    });
+  });
+
+  it("applies execution-profile gating after agent exposure selection", () => {
+    const candidates = [
+      descriptor({
+        id: "read",
+        description: "Read a file.",
+        effect: "read_only",
+        keywords: ["read"],
+      }),
+      descriptor({
+        id: "websearch",
+        description: "Search the web.",
+        effect: "read_only",
+        keywords: ["web"],
+        source: "builtin_mcp",
+        family: "web",
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      executionProfile: {
+        allowlist: ["websearch"],
+        denylist: [],
+      },
+    });
+
+    expect(verdictById(verdicts, "read")).toMatchObject({
+      enabledByAgent: true,
+      enabled: false,
+      reason: "disabled_by_execution_profile",
+    });
+    expect(verdictById(verdicts, "websearch")).toMatchObject({
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+    });
+  });
+
+  it("applies state-mode gating after agent selection for builtin tools", () => {
+    const candidates = [
+      descriptor({
+        id: "read",
+        description: "Read a file.",
+        effect: "read_only",
+        keywords: ["read"],
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      stateMode: "shared",
+    });
+
+    expect(verdictById(verdicts, "read")).toMatchObject({
+      enabledByAgent: true,
+      enabled: false,
+      reason: "disabled_by_state_mode",
+    });
+  });
+
+  it("marks invalid schemas as disabled without changing agent selection", () => {
+    const candidates = [
+      descriptor({
+        id: "plugin.echo.invalid",
+        description: "Invalid plugin schema.",
+        effect: "read_only",
+        keywords: ["plugin"],
+        source: "plugin",
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        default_mode: "deny",
+        allow: ["plugin.echo.invalid"],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      invalidSchemaToolIds: ["plugin.echo.invalid"],
+      pluginPolicyAllowedToolIds: ["plugin.echo.invalid"],
+    });
+
+    expect(verdictById(verdicts, "plugin.echo.invalid")).toMatchObject({
+      enabledByAgent: true,
+      enabled: false,
+      reason: "disabled_invalid_schema",
+    });
+  });
+
+  it("keeps plugin policy as an explicit post-opt-in input", () => {
+    const candidates = [
+      descriptor({
+        id: "plugin.echo.readonly",
+        description: "Read plugin data.",
+        effect: "read_only",
+        keywords: ["plugin"],
+        source: "plugin",
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        default_mode: "deny",
+        allow: ["plugin.echo.readonly"],
+        deny: [],
+      },
+    });
+
+    const allowedVerdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      pluginPolicyAllowedToolIds: ["plugin.echo.readonly"],
+    });
+    const deniedVerdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      pluginPolicyAllowedToolIds: [],
+    });
+
+    expect(verdictById(allowedVerdicts, "plugin.echo.readonly")).toMatchObject({
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+    });
+    expect(verdictById(deniedVerdicts, "plugin.echo.readonly")).toMatchObject({
+      enabledByAgent: false,
+      enabled: false,
+      reason: "disabled_by_plugin_policy",
+    });
+  });
+});

--- a/packages/gateway/tests/unit/effective-exposure-resolver.test.ts
+++ b/packages/gateway/tests/unit/effective-exposure-resolver.test.ts
@@ -288,4 +288,78 @@ describe("effective exposure resolver", () => {
       reason: "disabled_by_plugin_policy",
     });
   });
+
+  it("treats source-less plugin-prefixed ids as plugin tools", () => {
+    const candidates = [
+      descriptor({
+        id: "plugin.echo.readonly",
+        description: "Read plugin data.",
+        effect: "read_only",
+        keywords: ["plugin"],
+      }),
+    ];
+    const config = buildAgentConfig({
+      tools: {
+        default_mode: "deny",
+        allow: ["plugin.echo.readonly"],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+      pluginPolicyAllowedToolIds: ["plugin.echo.readonly"],
+    });
+
+    expect(verdictById(verdicts, "plugin.echo.readonly")).toMatchObject({
+      exposureClass: "plugin",
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+    });
+  });
+
+  it("does not override an explicit non-plugin source with a plugin-prefixed id", () => {
+    const candidates = [
+      descriptor({
+        id: "plugin.calendar.proxy",
+        description: "Proxy calendar tool.",
+        effect: "read_only",
+        keywords: ["calendar"],
+        source: "mcp",
+        family: "mcp",
+      }),
+    ];
+    const config = buildAgentConfig({
+      mcp: {
+        bundle: "workspace-default",
+        tier: "advanced",
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+      },
+      tools: {
+        bundle: "authoring-core",
+        tier: "default",
+        default_mode: "deny",
+        allow: [],
+        deny: [],
+      },
+    });
+
+    const verdicts = resolveEffectiveToolExposureVerdicts({
+      candidates,
+      toolConfig: config.tools,
+      mcpConfig: config.mcp,
+    });
+
+    expect(verdictById(verdicts, "plugin.calendar.proxy")).toMatchObject({
+      exposureClass: "mcp",
+      enabledByAgent: true,
+      enabled: true,
+      reason: "enabled",
+    });
+  });
 });

--- a/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
+++ b/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
@@ -1,0 +1,58 @@
+import { AgentConfig } from "@tyrum/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { listAvailableRuntimeTools } from "../../src/modules/agent/runtime/agent-runtime-status.js";
+import * as effectiveExposureResolver from "../../src/modules/agent/runtime/effective-exposure-resolver.js";
+
+describe("runtime tool descriptor source shared resolver wiring", () => {
+  it("routes runtime descriptor aggregation through the shared exposure resolver", async () => {
+    const exposureSpy = vi.spyOn(effectiveExposureResolver, "resolveEffectiveToolExposureVerdicts");
+    const loaded = {
+      config: AgentConfig.parse({
+        model: { model: "openai/gpt-4.1" },
+        tools: {
+          bundle: "authoring-core",
+          tier: "default",
+          default_mode: "allow",
+          allow: [],
+          deny: [],
+        },
+        mcp: {
+          bundle: "workspace-default",
+          tier: "advanced",
+          default_mode: "allow",
+          allow: [],
+          deny: [],
+        },
+      }),
+      identity: {} as never,
+      skills: [],
+      mcpServers: [],
+    };
+
+    await listAvailableRuntimeTools({
+      opts: {
+        container: {
+          deploymentConfig: {},
+          db: {} as never,
+          approvalDal: {} as never,
+          logger: { warn: vi.fn() },
+          redactionEngine: {} as never,
+        },
+      } as never,
+      mcpManager: {
+        listToolDescriptors: vi.fn().mockResolvedValue([]),
+      } as never,
+      loaded,
+      plugins: {
+        getToolDescriptors: vi.fn().mockReturnValue([]),
+      } as never,
+    });
+
+    expect(exposureSpy).toHaveBeenCalled();
+    expect(
+      exposureSpy.mock.calls.some(
+        ([input]) => input.stateMode === "local" && input.candidates.length > 0,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared gateway-local effective exposure resolver for builtin, builtin-MCP, raw MCP, and plugin tool descriptors
- wire `runtime-tool-descriptor-source` through the shared resolver without changing `/config/tools` or `/context/tools`
- add focused regression coverage for bundle/tier selection, execution-profile gating, state-mode gating, invalid schemas, plugin opt-in/policy, and runtime wiring

## Why
`#1972` requires one deterministic post-gating answer for "is this tool actually exposed here?" before later issues adopt that logic in runtime and inventory producers. This PR extracts that shared core without absorbing the adopter work that belongs to sibling issues.

Closes #1972

## How To Test
- `pnpm exec vitest run packages/gateway/tests/unit/effective-exposure-resolver.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts packages/gateway/tests/unit/turn-preparation-runtime.test.ts --reporter=verbose`
- `pnpm lint`
- `pnpm typecheck`
- `git push -u origin 1972-shared-effective-exposure-resolver-core` (pre-push hook ran full `pnpm run ci` and passed)

## Risk
Low to moderate. The runtime tool descriptor aggregation path now depends on the shared resolver, so the main risk is behavior drift in bundle/tier or plugin gating. The added resolver and runtime tests cover those branches directly, and full repo CI passed on push.

## Rollback
Revert commit `7ccd0e2ea` to restore the previous inline runtime exposure logic and remove the shared resolver/tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime tool selection/visibility pipeline (bundle/tier, plugin opt-in/policy, state-mode, execution-profile gating), which can alter which tools are exposed at runtime. Risk is mitigated by adding focused unit tests covering the new resolver and its wiring.
> 
> **Overview**
> Introduces a shared `effective-exposure-resolver` that computes per-tool exposure verdicts (class, enabled-by-agent, final enabled, and reason) across builtin, builtin-MCP, MCP, and plugin tools, including post-selection gating for invalid schemas, state mode, execution profiles, and plugin policy.
> 
> Refactors `runtime-tool-descriptor-source` to route tool aggregation and filtering through these verdicts (instead of inline selection logic), and updates turn preparation’s explicit plugin allowlist detection to use the shared `isPluginExposureTool` helper.
> 
> Adds unit coverage for the resolver’s bundle/tier behavior and gating reasons, plus a wiring test ensuring runtime status resolution calls the shared resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92b5cae425e264fbc82c07f9f83c85a4c7b521c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->