### PR TITLE
Apply shared effective exposure to runtime and /config/tools producer

### DIFF
--- a/packages/gateway/src/app-route-registrars.ts
+++ b/packages/gateway/src/app-route-registrars.ts
@@ -296,10 +296,8 @@ export function registerModelsAndConfigRoutes(context: AppRouteContext): void {
     createToolRegistryRoutes({
       agents: context.opts.agents,
       db: context.container.db,
-      logger: context.container.logger,
       plugins: context.opts.plugins,
       pluginCatalogProvider: context.opts.pluginCatalogProvider,
-      stateMode: resolveGatewayStateMode(context.container.deploymentConfig),
     }),
   );
 

--- a/packages/gateway/src/app/modules/agent/runtime/effective-exposure-resolver.ts
+++ b/packages/gateway/src/app/modules/agent/runtime/effective-exposure-resolver.ts
@@ -1,0 +1,4 @@
+export type {
+  EffectiveToolExposureReason,
+  EffectiveToolExposureVerdict,
+} from "../../../../modules/agent/runtime/effective-exposure-resolver.js";

--- a/packages/gateway/src/modules/agent/runtime/agent-runtime-gateway-lifecycle.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime-gateway-lifecycle.ts
@@ -49,7 +49,9 @@ import {
   listAvailableRuntimeTools,
   loadResolvedRuntimeContext,
 } from "./agent-runtime-status.js";
+import { resolveRuntimeToolDescriptorSource } from "./runtime-tool-descriptor-source.js";
 import { resolveExistingRuntimeScopeIds } from "./scope-resolution.js";
+import { resolveGatewayStateMode } from "../../runtime-state/mode.js";
 
 export type GatewayAgentRuntimeDeps = {
   opts: AgentRuntimeOptions;
@@ -260,15 +262,16 @@ export const gatewayRuntimeLifecycle: GatewayRuntimeLifecycle = {
       agentKey: context.agentId,
       workspaceId,
     });
-    const availableTools = await listAvailableRuntimeTools({
-      opts: context.deps.opts,
+    const stateMode = resolveGatewayStateMode(context.deps.opts.container.deploymentConfig);
+    const toolDescriptorSource = await resolveRuntimeToolDescriptorSource({
+      ctx: loaded,
       mcpManager: context.deps.mcpManager,
-      loaded,
       plugins: context.plugins,
+      stateMode,
     });
     return buildRegisteredToolsResult({
       loaded,
-      availableTools,
+      toolDescriptorSource,
     });
   },
   turn: async (context, input) => {

--- a/packages/gateway/src/modules/agent/runtime/agent-runtime-status.ts
+++ b/packages/gateway/src/modules/agent/runtime/agent-runtime-status.ts
@@ -12,7 +12,10 @@ import { type ToolDescriptor } from "../tools.js";
 import { resolveEffectiveAgentConfig } from "../../extensions/defaults-dal.js";
 import type { AgentRuntimeOptions } from "./types.js";
 import type { McpManager } from "../mcp-manager.js";
-import { resolveRuntimeToolDescriptorSource } from "./runtime-tool-descriptor-source.js";
+import {
+  resolveRuntimeToolDescriptorSource,
+  type RuntimeToolDescriptorSource,
+} from "./runtime-tool-descriptor-source.js";
 
 export async function loadResolvedRuntimeContext(params: {
   opts: AgentRuntimeOptions;
@@ -103,11 +106,17 @@ export function buildEnabledAgentStatus(params: {
 
 export function buildRegisteredToolsResult(params: {
   loaded: Awaited<ReturnType<typeof loadResolvedRuntimeContext>>;
-  availableTools: ToolDescriptor[];
+  toolDescriptorSource: RuntimeToolDescriptorSource;
 }) {
   return {
-    allowlist: params.availableTools.map((tool) => tool.id),
-    tools: params.availableTools.toSorted((left, right) => left.id.localeCompare(right.id)),
+    allowlist: params.toolDescriptorSource.availableTools.map((tool) => tool.id),
+    tools: params.toolDescriptorSource.availableTools.toSorted((left, right) =>
+      left.id.localeCompare(right.id),
+    ),
     mcpServers: params.loaded.mcpServers.map((server) => server.id),
+    inventory: params.toolDescriptorSource.effectiveExposureVerdicts.toSorted((left, right) =>
+      left.descriptor.id.localeCompare(right.descriptor.id),
+    ),
+    mcpServerSpecs: params.toolDescriptorSource.mcpServerSpecs,
   };
 }

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "@tyrum/contracts";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import type { McpManager } from "../mcp-manager.js";
 import { buildSecretClipboardToolDescriptor } from "../tool-secret-definitions.js";
+import { validateToolDescriptorInputSchema } from "../tool-schema.js";
 import {
   listBuiltinToolDescriptors,
   type ToolDescriptor,
@@ -12,6 +13,7 @@ import type { GatewayStateMode } from "../../runtime-state/mode.js";
 import {
   hasCanonicalExposureSelector,
   resolveEffectiveToolExposureVerdicts,
+  type EffectiveToolExposureVerdict,
 } from "./effective-exposure-resolver.js";
 import { resolvePolicyGatedPluginToolExposure } from "./plugin-tool-policy.js";
 
@@ -161,7 +163,16 @@ export type RuntimeToolDescriptorSource = {
   availableTools: ToolDescriptor[];
   toolAllowlist: string[];
   promptSelectableTools: ToolDescriptor[];
+  effectiveExposureVerdicts: EffectiveToolExposureVerdict[];
+  mcpServerSpecs: AgentLoadedContext["mcpServers"];
 };
+
+function resolveInvalidSchemaToolIds(candidates: readonly ToolDescriptor[]): string[] {
+  return candidates.flatMap((descriptor) => {
+    const validated = validateToolDescriptorInputSchema(descriptor);
+    return validated.ok ? [] : [descriptor.id];
+  });
+}
 
 export async function resolveRuntimeToolDescriptorSource(params: {
   ctx: Pick<AgentLoadedContext, "config" | "mcpServers">;
@@ -183,7 +194,7 @@ export async function resolveRuntimeToolDescriptorSource(params: {
   ].filter((tool): tool is ToolDescriptor => tool !== undefined);
   const builtinTools = [...listBuiltinToolDescriptors(), ...dynamicBuiltinTools];
   const pluginToolsRaw = normalizePluginTools(params.plugins?.getToolDescriptors() ?? []);
-  const candidates = [...builtinTools, ...mcpTools, ...pluginToolsRaw];
+  const candidates = dedupeToolDescriptors([...builtinTools, ...mcpTools, ...pluginToolsRaw]);
   const baseExposureVerdicts = resolveEffectiveToolExposureVerdicts({
     candidates,
     toolConfig: params.ctx.config.tools,
@@ -203,11 +214,13 @@ export async function resolveRuntimeToolDescriptorSource(params: {
   });
   const toolAllowlistIds = new Set(toolAllowlist);
   const pluginPolicyAllowedToolIds = pluginTools.map((tool) => tool.id);
+  const invalidSchemaToolIds = resolveInvalidSchemaToolIds(candidates);
   const effectiveExposureVerdicts = resolveEffectiveToolExposureVerdicts({
     candidates,
     toolConfig: params.ctx.config.tools,
     mcpConfig: params.ctx.config.mcp,
     stateMode: params.stateMode,
+    invalidSchemaToolIds,
     pluginPolicyAllowedToolIds,
   });
   const promptSelectableBuiltinIds = new Set(dynamicBuiltinTools.map((tool) => tool.id));
@@ -223,7 +236,7 @@ export async function resolveRuntimeToolDescriptorSource(params: {
       effectiveExposureVerdicts
         .filter(
           (verdict) =>
-            verdict.enabledByAgent &&
+            verdict.enabled &&
             toolAllowlistIds.has(verdict.descriptor.id) &&
             (verdict.exposureClass === "mcp" ||
               verdict.exposureClass === "plugin" ||
@@ -231,5 +244,7 @@ export async function resolveRuntimeToolDescriptorSource(params: {
         )
         .map((verdict) => verdict.descriptor),
     ),
+    effectiveExposureVerdicts,
+    mcpServerSpecs: [...params.ctx.mcpServers],
   };
 }

--- a/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
+++ b/packages/gateway/src/modules/agent/runtime/runtime-tool-descriptor-source.ts
@@ -236,7 +236,7 @@ export async function resolveRuntimeToolDescriptorSource(params: {
       effectiveExposureVerdicts
         .filter(
           (verdict) =>
-            verdict.enabled &&
+            verdict.enabledByAgent &&
             toolAllowlistIds.has(verdict.descriptor.id) &&
             (verdict.exposureClass === "mcp" ||
               verdict.exposureClass === "plugin" ||

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -79,6 +79,15 @@ export interface ToolRegistryRouteDeps {
   pluginCatalogProvider?: PluginCatalogProvider;
 }
 
+function isInvalidRequestError(error: unknown): error is Error & { code: "invalid_request" } {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "invalid_request"
+  );
+}
+
 async function resolvePluginRegistry(
   deps: ToolRegistryRouteDeps,
   tenantId: string,
@@ -391,11 +400,14 @@ export function createToolRegistryRoutes(deps: ToolRegistryRouteDeps): Hono {
 
       return c.json({ status: "ok", tools }, 200);
     } catch (error) {
+      if (isInvalidRequestError(error)) {
+        return c.json({ error: "invalid_request", message: error.message }, 400);
+      }
       if (error instanceof ScopeNotFoundError) {
         return c.json({ error: error.code, message: error.message }, 404);
       }
       const message = error instanceof Error ? error.message : String(error);
-      return c.json({ error: "invalid_request", message }, 400);
+      return c.json({ error: "internal_error", message }, 500);
     }
   });
 

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -1,22 +1,14 @@
-import {
-  McpServerSpec,
-  type McpServerSpec as McpServerSpecT,
-  type ToolTaxonomyMetadata,
-} from "@tyrum/contracts";
+import { type McpServerSpec as McpServerSpecT, type ToolTaxonomyMetadata } from "@tyrum/contracts";
 import type { PluginManifest as PluginManifestT } from "@tyrum/contracts";
 import { Hono } from "hono";
 import { BUILTIN_EXA_SERVER_ID } from "../app/modules/agent/builtin-exa.js";
-import { McpManager } from "../app/modules/agent/mcp-manager.js";
 import type { AgentRegistry } from "../app/modules/agent/registry.js";
-import { RuntimePackageDal } from "../app/modules/agent/runtime-package-dal.js";
-import {
-  isBuiltinToolAvailableInStateMode,
-  isToolAllowed,
-  listBuiltinToolDescriptors,
-  resolveToolDescriptorTaxonomy,
-  type ToolDescriptor,
-} from "../app/modules/agent/tools.js";
+import type {
+  EffectiveToolExposureReason,
+  EffectiveToolExposureVerdict,
+} from "../app/modules/agent/runtime/effective-exposure-resolver.js";
 import { validateToolDescriptorInputSchema } from "../app/modules/agent/tool-schema.js";
+import { resolveToolDescriptorTaxonomy, type ToolDescriptor } from "../app/modules/agent/tools.js";
 import { requireTenantId } from "../app/modules/auth/claims.js";
 import {
   IdentityScopeDal,
@@ -37,11 +29,6 @@ type ToolEffectiveExposure = {
     | "disabled_by_state_mode"
     | "disabled_invalid_schema";
   agent_key?: string;
-};
-
-type SharedStateMcpServerTools = {
-  server: McpServerSpecT;
-  descriptors: readonly ToolDescriptor[];
 };
 
 type ToolRegistryGroup =
@@ -78,6 +65,15 @@ type ToolRegistryEntry = {
   };
 };
 
+type RegisteredToolsCatalog = Awaited<
+  ReturnType<Awaited<ReturnType<AgentRegistry["getRuntime"]>>["listRegisteredTools"]>
+>;
+
+type RuntimeToolInventoryCatalog = {
+  inventory: readonly EffectiveToolExposureVerdict[];
+  mcpServerSpecs: readonly McpServerSpecT[];
+};
+
 export interface ToolRegistryRouteDeps {
   agents?: AgentRegistry;
   db: SqlDb;
@@ -95,6 +91,15 @@ async function resolvePluginRegistry(
     return await deps.pluginCatalogProvider.loadTenantRegistry(tenantId);
   }
   return deps.plugins;
+}
+
+function hasRuntimeToolInventoryCatalog(
+  value: RegisteredToolsCatalog,
+): value is RegisteredToolsCatalog & RuntimeToolInventoryCatalog {
+  return (
+    Array.isArray((value as { inventory?: unknown }).inventory) &&
+    Array.isArray((value as { mcpServerSpecs?: unknown }).mcpServerSpecs)
+  );
 }
 
 function resolveDescriptorTaxonomy(
@@ -246,178 +251,110 @@ function toPluginInfo(
   };
 }
 
-async function listSharedStateMcpServers(
-  db: SqlDb,
-  tenantId: string,
-  logger?: Logger,
-): Promise<McpServerSpecT[]> {
-  const runtimePackageDal = new RuntimePackageDal(db);
-  const revisions = await runtimePackageDal.listLatest({
-    tenantId,
-    packageKind: "mcp",
-    enabledOnly: true,
-  });
-  const serversById = new Map<string, McpServerSpecT>();
-
-  for (const revision of revisions) {
-    const parsed = McpServerSpec.safeParse(revision.packageData);
-    if (!parsed.success) {
-      logger?.warn("tool_registry.invalid_mcp_package", {
-        tenant_id: tenantId,
-        package_key: revision.packageKey,
-        revision: revision.revision,
-        error: parsed.error.message,
-      });
-      continue;
-    }
-    if (!parsed.data.enabled) continue;
-    serversById.set(parsed.data.id, parsed.data);
+function mapEffectiveExposureReason(
+  reason: EffectiveToolExposureReason,
+): ToolEffectiveExposure["reason"] {
+  switch (reason) {
+    case "enabled":
+      return "enabled";
+    case "disabled_by_state_mode":
+      return "disabled_by_state_mode";
+    case "disabled_invalid_schema":
+      return "disabled_invalid_schema";
+    default:
+      return "disabled_by_agent_allowlist";
   }
+}
 
-  return [...serversById.values()].toSorted((a, b) => a.id.localeCompare(b.id));
+function toToolEffectiveExposure(
+  verdict: EffectiveToolExposureVerdict,
+  agentKey: string,
+): ToolEffectiveExposure {
+  return {
+    enabled: verdict.enabled,
+    reason: mapEffectiveExposureReason(verdict.reason),
+    agent_key: agentKey,
+  };
+}
+
+function listBuiltinEntries(
+  verdicts: readonly EffectiveToolExposureVerdict[],
+  agentKey: string,
+): ToolRegistryEntry[] {
+  return verdicts
+    .filter((verdict) => verdict.exposureClass !== "mcp" && verdict.exposureClass !== "plugin")
+    .map((verdict) =>
+      toBuiltinEntry(verdict.descriptor, toToolEffectiveExposure(verdict, agentKey)),
+    )
+    .toSorted((left, right) => left.canonical_id.localeCompare(right.canonical_id));
+}
+
+function listPluginEntries(
+  registry: PluginRegistry | undefined,
+  verdicts: readonly EffectiveToolExposureVerdict[],
+  agentKey: string,
+): ToolRegistryEntry[] {
+  return verdicts
+    .filter((verdict) => verdict.exposureClass === "plugin")
+    .map((verdict) =>
+      toPluginEntry(
+        verdict.descriptor,
+        registry?.getTool(verdict.descriptor.id)?.plugin,
+        toToolEffectiveExposure(verdict, agentKey),
+      ),
+    )
+    .toSorted((left, right) => left.canonical_id.localeCompare(right.canonical_id));
 }
 
 function listMcpEntries(
-  sharedStateMcpServerTools: readonly SharedStateMcpServerTools[],
-  effectiveExposureByToolId: ReadonlyMap<string, ToolEffectiveExposure>,
+  verdicts: readonly EffectiveToolExposureVerdict[],
+  mcpServersById: ReadonlyMap<string, McpServerSpecT>,
+  agentKey: string,
 ): ToolRegistryEntry[] {
-  return sharedStateMcpServerTools
-    .flatMap(({ server, descriptors }) =>
-      descriptors.map((descriptor) => ({
-        ...toBaseEntry(
-          descriptor,
-          "mcp",
-          effectiveExposureByToolId.get(descriptor.id) ?? { enabled: true, reason: "enabled" },
-        ),
-        backing_server: toMcpBackingServer(server),
-      })),
-    )
-    .toSorted((a, b) => a.canonical_id.localeCompare(b.canonical_id));
+  return verdicts
+    .filter((verdict) => verdict.exposureClass === "mcp")
+    .map((verdict) => {
+      const descriptor = verdict.descriptor;
+      const backingServerId = descriptor.backingServerId ?? descriptor.id.split(".")[1];
+      const server = backingServerId ? mcpServersById.get(backingServerId) : undefined;
+      const base = toBaseEntry(descriptor, "mcp", toToolEffectiveExposure(verdict, agentKey));
+
+      return {
+        source: base.source,
+        canonical_id: base.canonical_id,
+        description: base.description,
+        effect: base.effect,
+        effective_exposure: base.effective_exposure,
+        family: base.family,
+        group: base.group,
+        tier: base.tier,
+        keywords: base.keywords,
+        input_schema: base.input_schema,
+        backing_server: server ? toMcpBackingServer(server) : undefined,
+      };
+    })
+    .toSorted((left, right) => left.canonical_id.localeCompare(right.canonical_id));
 }
 
-async function listPluginEntries(
-  deps: ToolRegistryRouteDeps,
-  tenantId: string,
-  effectiveExposureByToolId: ReadonlyMap<string, ToolEffectiveExposure>,
-): Promise<ToolRegistryEntry[]> {
-  const registry = await resolvePluginRegistry(deps, tenantId);
-  if (!registry) return [];
-
-  return registry
-    .getToolDescriptors()
-    .map((descriptor) =>
-      toPluginEntry(
-        descriptor,
-        registry.getTool(descriptor.id)?.plugin,
-        effectiveExposureByToolId.get(descriptor.id) ?? { enabled: true, reason: "enabled" },
-      ),
-    )
-    .toSorted((a, b) => a.canonical_id.localeCompare(b.canonical_id));
-}
-
-async function resolveEffectiveExposureByToolId(input: {
-  deps: ToolRegistryRouteDeps;
-  tenantId: string;
+function resolveInventoryToolEntries(params: {
+  catalog: RuntimeToolInventoryCatalog;
+  pluginRegistry: PluginRegistry | undefined;
   agentKey: string;
-  sharedStateMcpServerTools?: readonly SharedStateMcpServerTools[];
-}): Promise<ReadonlyMap<string, ToolEffectiveExposure>> {
-  const effectiveExposureByToolId = new Map<string, ToolEffectiveExposure>();
-  let allowlist: readonly string[] | undefined;
-
-  if (input.deps.agents) {
-    const runtime = await input.deps.agents.getRuntime({
-      tenantId: input.tenantId,
-      agentKey: input.agentKey,
-    });
-    allowlist = (await runtime.listRegisteredTools()).allowlist;
-  }
-
-  const setExposure = (descriptor: ToolDescriptor) => {
-    const validated = validateToolDescriptorInputSchema(descriptor);
-    if (!validated.ok) {
-      effectiveExposureByToolId.set(descriptor.id, {
-        enabled: false,
-        reason: "disabled_invalid_schema",
-        agent_key: input.agentKey,
-      });
-      return;
-    }
-
-    if (
-      (descriptor.source === undefined || descriptor.source === "builtin") &&
-      !isBuiltinToolAvailableInStateMode(descriptor.id, input.deps.stateMode)
-    ) {
-      effectiveExposureByToolId.set(descriptor.id, {
-        enabled: false,
-        reason: "disabled_by_state_mode",
-        agent_key: input.agentKey,
-      });
-      return;
-    }
-
-    if (allowlist && !isToolAllowed(allowlist, descriptor.id)) {
-      effectiveExposureByToolId.set(descriptor.id, {
-        enabled: false,
-        reason: "disabled_by_agent_allowlist",
-        agent_key: input.agentKey,
-      });
-      return;
-    }
-
-    effectiveExposureByToolId.set(descriptor.id, {
-      enabled: true,
-      reason: "enabled",
-      agent_key: input.agentKey,
-    });
-  };
-
-  for (const descriptor of listBuiltinToolDescriptors()) {
-    setExposure(descriptor);
-  }
-
-  const pluginRegistry = await resolvePluginRegistry(input.deps, input.tenantId);
-  for (const descriptor of pluginRegistry?.getToolDescriptors() ?? []) {
-    setExposure(descriptor);
-  }
-
-  const sharedStateMcpServerTools =
-    input.sharedStateMcpServerTools ??
-    (await (async (): Promise<SharedStateMcpServerTools[]> => {
-      const mcpManager = new McpManager({ logger: input.deps.logger });
-      try {
-        return await listSharedStateMcpServerTools(
-          input.deps.db,
-          input.tenantId,
-          mcpManager,
-          input.deps.logger,
-        );
-      } finally {
-        await mcpManager.shutdown();
-      }
-    })());
-
-  for (const descriptor of sharedStateMcpServerTools.flatMap((entry) => entry.descriptors)) {
-    setExposure(descriptor);
-  }
-
-  return effectiveExposureByToolId;
-}
-
-async function listSharedStateMcpServerTools(
-  db: SqlDb,
-  tenantId: string,
-  mcpManager: McpManager,
-  logger?: Logger,
-): Promise<SharedStateMcpServerTools[]> {
-  const servers = await listSharedStateMcpServers(db, tenantId, logger);
-  if (servers.length === 0) return [];
-
-  return await Promise.all(
-    servers.map(async (server) => ({
-      server,
-      descriptors: await mcpManager.listServerToolDescriptors(server),
-    })),
+}): ToolRegistryEntry[] {
+  const mcpServersById = new Map(
+    params.catalog.mcpServerSpecs.map((server) => [server.id, server] as const),
   );
+
+  return [
+    ...listBuiltinEntries(params.catalog.inventory, params.agentKey),
+    ...listPluginEntries(params.pluginRegistry, params.catalog.inventory, params.agentKey),
+    ...listMcpEntries(params.catalog.inventory, mcpServersById, params.agentKey),
+  ].toSorted((left, right) => {
+    if (left.source !== right.source) {
+      return left.source.localeCompare(right.source);
+    }
+    return left.canonical_id.localeCompare(right.canonical_id);
+  });
 }
 
 export function createToolRegistryRoutes(deps: ToolRegistryRouteDeps): Hono {
@@ -439,36 +376,21 @@ export function createToolRegistryRoutes(deps: ToolRegistryRouteDeps): Hono {
       const message = error instanceof Error ? error.message : String(error);
       return c.json({ error: "invalid_request", message }, 400);
     }
-    const mcpManager = new McpManager({ logger: deps.logger });
-    try {
-      const sharedStateMcpServerTools = await listSharedStateMcpServerTools(
-        deps.db,
-        tenantId,
-        mcpManager,
-        deps.logger,
-      );
-      const effectiveExposureByToolId = await resolveEffectiveExposureByToolId({
-        deps,
-        tenantId,
-        agentKey,
-        sharedStateMcpServerTools,
-      });
-      const builtinEntries = listBuiltinToolDescriptors()
-        .map((descriptor) =>
-          toBuiltinEntry(
-            descriptor,
-            effectiveExposureByToolId.get(descriptor.id) ?? { enabled: true, reason: "enabled" },
-          ),
-        )
-        .toSorted((a, b) => a.canonical_id.localeCompare(b.canonical_id));
-      const [pluginEntries, mcpEntries] = await Promise.all([
-        listPluginEntries(deps, tenantId, effectiveExposureByToolId),
-        Promise.resolve(listMcpEntries(sharedStateMcpServerTools, effectiveExposureByToolId)),
-      ]);
 
-      const tools = [...builtinEntries, ...pluginEntries, ...mcpEntries].toSorted((a, b) => {
-        if (a.source !== b.source) return a.source.localeCompare(b.source);
-        return a.canonical_id.localeCompare(b.canonical_id);
+    try {
+      if (!deps.agents) {
+        throw new Error("agent registry is unavailable");
+      }
+      const runtime = await deps.agents.getRuntime({ tenantId, agentKey });
+      const catalog = await runtime.listRegisteredTools();
+      if (!hasRuntimeToolInventoryCatalog(catalog)) {
+        throw new Error("runtime tool inventory is unavailable");
+      }
+      const pluginRegistry = await resolvePluginRegistry(deps, tenantId);
+      const tools = resolveInventoryToolEntries({
+        catalog,
+        pluginRegistry,
+        agentKey,
       });
 
       return c.json({ status: "ok", tools }, 200);
@@ -478,8 +400,6 @@ export function createToolRegistryRoutes(deps: ToolRegistryRouteDeps): Hono {
       }
       const message = error instanceof Error ? error.message : String(error);
       return c.json({ error: "invalid_request", message }, 400);
-    } finally {
-      await mcpManager.shutdown();
     }
   });
 

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -15,10 +15,8 @@ import {
   resolveRequestedAgentKey,
   ScopeNotFoundError,
 } from "../app/modules/identity/scope.js";
-import type { Logger } from "../app/modules/observability/logger.js";
 import type { PluginCatalogProvider } from "../app/modules/plugins/catalog-provider.js";
 import type { PluginRegistry } from "../app/modules/plugins/registry.js";
-import type { GatewayStateMode } from "../app/modules/runtime-state/mode.js";
 import type { SqlDb } from "../statestore/types.js";
 
 type ToolEffectiveExposure = {
@@ -77,10 +75,8 @@ type RuntimeToolInventoryCatalog = {
 export interface ToolRegistryRouteDeps {
   agents?: AgentRegistry;
   db: SqlDb;
-  logger?: Logger;
   plugins?: PluginRegistry;
   pluginCatalogProvider?: PluginCatalogProvider;
-  stateMode: GatewayStateMode;
 }
 
 async function resolvePluginRegistry(

--- a/packages/gateway/tests/integration/tool-registry.test.ts
+++ b/packages/gateway/tests/integration/tool-registry.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, it } from "vitest";
+import type { EffectiveToolExposureReason } from "../../src/modules/agent/runtime/effective-exposure-resolver.js";
+import { SECRET_CLIPBOARD_TOOL_ID } from "../../src/modules/agent/tool-secret-definitions.js";
+import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
+import { seedAgentConfig } from "../unit/agent-runtime.test-helpers.js";
 import { createTestApp } from "./helpers.js";
+
+function mapRouteReason(reason: EffectiveToolExposureReason): string {
+  switch (reason) {
+    case "enabled":
+      return "enabled";
+    case "disabled_by_state_mode":
+      return "disabled_by_state_mode";
+    case "disabled_invalid_schema":
+      return "disabled_invalid_schema";
+    default:
+      return "disabled_by_agent_allowlist";
+  }
+}
 
 describe("/config/tools", () => {
   it("returns 404 for a missing explicit agent without creating it", async () => {
@@ -23,6 +40,81 @@ describe("/config/tools", () => {
       [tenantId],
     );
     expect(after?.count ?? 0).toBe(before?.count ?? 0);
+
+    await agents?.shutdown();
+    await container.db.close();
+  });
+
+  it("matches runtime inventory exposure for agent-scoped dynamic built-ins", async () => {
+    const { request, container, agents } = await createTestApp();
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { default_mode: "allow", workspace_trusted: true },
+        mcp: {
+          default_mode: "allow",
+          allow: [],
+          deny: [],
+        },
+        tools: {
+          default_mode: "allow",
+          allow: [SECRET_CLIPBOARD_TOOL_ID],
+          deny: [],
+        },
+        secret_refs: [
+          {
+            secret_ref_id: "secret-ref-1",
+            secret_alias: "desktop-login",
+            allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+          },
+        ],
+      },
+    });
+
+    const runtime = await agents!.getRuntime({
+      tenantId: DEFAULT_TENANT_ID,
+      agentKey: "default",
+    });
+    const catalog = (await runtime.listRegisteredTools()) as Awaited<
+      ReturnType<typeof runtime.listRegisteredTools>
+    > & {
+      inventory: Array<{
+        descriptor: { id: string };
+        reason: EffectiveToolExposureReason;
+      }>;
+    };
+
+    const response = await request("/config/tools?agent_key=default");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      status: string;
+      tools: Array<{
+        canonical_id: string;
+        effective_exposure: {
+          enabled: boolean;
+          reason: string;
+        };
+      }>;
+    };
+    expect(body.status).toBe("ok");
+
+    const routeToolIds = body.tools.map((tool) => tool.canonical_id).toSorted();
+    const runtimeInventoryIds = catalog.inventory.map((entry) => entry.descriptor.id).toSorted();
+    expect(routeToolIds).toEqual(runtimeInventoryIds);
+    expect(routeToolIds).toContain(SECRET_CLIPBOARD_TOOL_ID);
+
+    const routeExposureById = new Map(
+      body.tools.map((tool) => [tool.canonical_id, tool.effective_exposure] as const),
+    );
+    for (const entry of catalog.inventory) {
+      expect(routeExposureById.get(entry.descriptor.id)?.reason).toBe(mapRouteReason(entry.reason));
+    }
+
+    expect(routeExposureById.get(SECRET_CLIPBOARD_TOOL_ID)).toMatchObject({
+      enabled: true,
+      reason: "enabled",
+    });
 
     await agents?.shutdown();
     await container.db.close();

--- a/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
+++ b/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
@@ -92,6 +92,7 @@ describe("runtime tool descriptor source shared resolver wiring", () => {
     });
 
     expect(source.availableTools.map((tool) => tool.id)).not.toContain("plugin.echo.invalid");
+    expect(source.promptSelectableTools.map((tool) => tool.id)).toContain("plugin.echo.invalid");
     expect(source.effectiveExposureVerdicts).toContainEqual(
       expect.objectContaining({
         exposureClass: "plugin",

--- a/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
+++ b/packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts
@@ -1,6 +1,7 @@
 import { AgentConfig } from "@tyrum/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { listAvailableRuntimeTools } from "../../src/modules/agent/runtime/agent-runtime-status.js";
+import { resolveRuntimeToolDescriptorSource } from "../../src/modules/agent/runtime/runtime-tool-descriptor-source.js";
 import * as effectiveExposureResolver from "../../src/modules/agent/runtime/effective-exposure-resolver.js";
 
 describe("runtime tool descriptor source shared resolver wiring", () => {
@@ -54,5 +55,51 @@ describe("runtime tool descriptor source shared resolver wiring", () => {
         ([input]) => input.stateMode === "local" && input.candidates.length > 0,
       ),
     ).toBe(true);
+  });
+
+  it("keeps invalid-schema tools in the shared inventory but out of available runtime tools", async () => {
+    const source = await resolveRuntimeToolDescriptorSource({
+      ctx: {
+        config: AgentConfig.parse({
+          model: { model: "openai/gpt-4.1" },
+          tools: {
+            default_mode: "deny",
+            allow: ["plugin.echo.invalid"],
+            deny: [],
+          },
+        }),
+        identity: {} as never,
+        skills: [],
+        mcpServers: [],
+      },
+      mcpManager: {
+        listToolDescriptors: vi.fn().mockResolvedValue([]),
+      } as never,
+      plugins: {
+        getToolDescriptors: vi.fn().mockReturnValue([
+          {
+            id: "plugin.echo.invalid",
+            description: "Invalid plugin state.",
+            effect: "read_only" as const,
+            keywords: ["plugin", "echo"],
+            inputSchema: {
+              oneOf: [{ type: "object", properties: {} }],
+            },
+          },
+        ]),
+      } as never,
+      stateMode: "local",
+    });
+
+    expect(source.availableTools.map((tool) => tool.id)).not.toContain("plugin.echo.invalid");
+    expect(source.effectiveExposureVerdicts).toContainEqual(
+      expect.objectContaining({
+        exposureClass: "plugin",
+        enabledByAgent: true,
+        enabled: false,
+        reason: "disabled_invalid_schema",
+        descriptor: expect.objectContaining({ id: "plugin.echo.invalid" }),
+      }),
+    );
   });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test-support.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test-support.ts
@@ -1,0 +1,144 @@
+import {
+  buildSecretClipboardToolDescriptor,
+  SECRET_CLIPBOARD_TOOL_ID,
+} from "../../src/modules/agent/tool-secret-definitions.js";
+import { listBuiltinToolDescriptors } from "../../src/modules/agent/tools.js";
+
+export function buildToolRegistryCatalogFixture() {
+  const pluginDescriptors = [
+    {
+      id: "plugin.echo.say",
+      description: "Echo text back to the caller.",
+      effect: "read_only" as const,
+      keywords: ["echo"],
+      inputSchema: {
+        type: "object",
+        properties: { text: { type: "string" } },
+      },
+    },
+    {
+      id: "plugin.echo.invalid",
+      description: "Invalid schema tool.",
+      effect: "read_only" as const,
+      keywords: ["echo"],
+      inputSchema: {
+        oneOf: [{ type: "object", properties: {} }],
+      },
+    },
+    {
+      id: "plugin.echo.optional",
+      description: "Echo text back without an explicit schema.",
+      effect: "read_only" as const,
+      keywords: ["echo"],
+    },
+    {
+      id: "plugin.echo.union",
+      description: "Echo text or markdown back to the caller.",
+      effect: "read_only" as const,
+      keywords: ["echo"],
+      inputSchema: {
+        type: "object",
+        properties: {
+          kind: { type: "string", enum: ["text", "markdown"] },
+          text: { type: "string" },
+          markdown: { type: "string" },
+        },
+        required: ["kind"],
+        additionalProperties: false,
+        oneOf: [
+          {
+            properties: {
+              kind: { type: "string", enum: ["text"] },
+            },
+            required: ["kind", "text"],
+          },
+          {
+            properties: {
+              kind: { type: "string", enum: ["markdown"] },
+            },
+            required: ["kind", "markdown"],
+          },
+        ],
+      },
+    },
+    {
+      id: "plugin.echo.blocked",
+      description: "Blocked by plugin policy.",
+      effect: "read_only" as const,
+      keywords: ["echo"],
+      inputSchema: {
+        type: "object",
+        properties: { text: { type: "string" } },
+      },
+    },
+  ];
+  const rawMcpDescriptor = {
+    id: "mcp.exa.web_search_exa",
+    description: "Search the web with Exa.",
+    effect: "state_changing" as const,
+    keywords: ["mcp", "exa", "search"],
+    source: "mcp" as const,
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+    },
+  };
+  const secretClipboardDescriptor = buildSecretClipboardToolDescriptor([
+    {
+      secret_ref_id: "secret-ref-1",
+      secret_alias: "echo-token",
+      allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+    },
+  ]);
+  if (!secretClipboardDescriptor) {
+    throw new Error("expected secret clipboard descriptor");
+  }
+  const descriptors = [
+    ...listBuiltinToolDescriptors(),
+    ...pluginDescriptors,
+    rawMcpDescriptor,
+    secretClipboardDescriptor,
+  ];
+  const disabledByReason = new Map<string, string>([
+    ["edit", "disabled_by_state_mode"],
+    ["plugin.echo.invalid", "disabled_invalid_schema"],
+    ["plugin.echo.optional", "disabled_by_plugin_opt_in"],
+    ["plugin.echo.blocked", "disabled_by_plugin_policy"],
+  ]);
+  const inventory = descriptors.map((descriptor) => ({
+    descriptor,
+    exposureClass:
+      descriptor.id === rawMcpDescriptor.id
+        ? ("mcp" as const)
+        : descriptor.id.startsWith("plugin.")
+          ? ("plugin" as const)
+          : descriptor.source === "builtin_mcp"
+            ? ("builtin_mcp" as const)
+            : ("builtin" as const),
+    enabledByAgent: !disabledByReason.has(descriptor.id),
+    enabled: !disabledByReason.has(descriptor.id),
+    reason: (disabledByReason.get(descriptor.id) ?? "enabled") as
+      | "enabled"
+      | "disabled_by_state_mode"
+      | "disabled_invalid_schema"
+      | "disabled_by_plugin_opt_in"
+      | "disabled_by_plugin_policy",
+  }));
+
+  return {
+    disabledByReason,
+    descriptors,
+    inventory,
+    mcpServerSpecs: [
+      {
+        id: "exa",
+        name: "Exa",
+        transport: "remote" as const,
+        url: "https://mcp.exa.ai/mcp",
+      },
+    ],
+    pluginDescriptors,
+  };
+}

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -19,6 +19,18 @@ function authClaims() {
   };
 }
 
+function createAuthenticatedToolRegistryApp(
+  deps: Parameters<typeof createToolRegistryRoutes>[0],
+): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("authClaims", authClaims());
+    await next();
+  });
+  app.route("/", createToolRegistryRoutes(deps));
+  return app;
+}
+
 describe("tool registry routes", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -28,85 +40,77 @@ describe("tool registry routes", () => {
     const { descriptors, disabledByReason, inventory, mcpServerSpecs, pluginDescriptors } =
       buildToolRegistryCatalogFixture();
 
-    const app = new Hono();
-    app.use("*", async (c, next) => {
-      c.set("authClaims", authClaims());
-      await next();
+    const app = createAuthenticatedToolRegistryApp({
+      agents: {
+        getRuntime: vi.fn(async () => ({
+          listRegisteredTools: vi.fn(async () => ({
+            allowlist: [
+              "read",
+              "websearch",
+              "webfetch",
+              "codesearch",
+              "plugin.echo.say",
+              "plugin.echo.union",
+              "mcp.exa.web_search_exa",
+              SECRET_CLIPBOARD_TOOL_ID,
+            ],
+            tools: descriptors.filter((descriptor) => !disabledByReason.has(descriptor.id)),
+            mcpServers: ["exa"],
+            inventory,
+            mcpServerSpecs,
+          })),
+        })),
+      } as never,
+      db: {
+        all: vi.fn(async () => []),
+      } as never,
+      pluginCatalogProvider: {
+        loadGlobalRegistry: vi.fn(),
+        loadTenantRegistry: vi.fn(async () => ({
+          getToolDescriptors: () => pluginDescriptors,
+          getTool: (toolId: string) =>
+            toolId === "plugin.echo.say"
+              ? {
+                  plugin: {
+                    id: "echo",
+                    name: "Echo",
+                    version: "0.0.1",
+                    entry: "index.mjs",
+                    contributes: {
+                      tools: [],
+                      commands: [],
+                      routes: [],
+                      mcp_servers: [],
+                    },
+                    permissions: {
+                      tools: [],
+                      network_egress: [],
+                      secrets: [],
+                      db: false,
+                    },
+                    config_schema: {
+                      type: "object",
+                      properties: {},
+                      required: [],
+                      additionalProperties: false,
+                    },
+                  },
+                  tool: {
+                    descriptor: {
+                      id: "plugin.echo.say",
+                      description: "Echo text back to the caller.",
+                      effect: "read_only" as const,
+                      keywords: ["echo"],
+                    },
+                    execute: vi.fn(),
+                  },
+                }
+              : undefined,
+        })),
+        invalidateTenantRegistry: vi.fn(async () => undefined),
+        shutdown: vi.fn(async () => undefined),
+      } as never,
     });
-    app.route(
-      "/",
-      createToolRegistryRoutes({
-        agents: {
-          getRuntime: vi.fn(async () => ({
-            listRegisteredTools: vi.fn(async () => ({
-              allowlist: [
-                "read",
-                "websearch",
-                "webfetch",
-                "codesearch",
-                "plugin.echo.say",
-                "plugin.echo.union",
-                "mcp.exa.web_search_exa",
-                SECRET_CLIPBOARD_TOOL_ID,
-              ],
-              tools: descriptors.filter((descriptor) => !disabledByReason.has(descriptor.id)),
-              mcpServers: ["exa"],
-              inventory,
-              mcpServerSpecs,
-            })),
-          })),
-        } as never,
-        db: {
-          all: vi.fn(async () => []),
-        } as never,
-        pluginCatalogProvider: {
-          loadGlobalRegistry: vi.fn(),
-          loadTenantRegistry: vi.fn(async () => ({
-            getToolDescriptors: () => pluginDescriptors,
-            getTool: (toolId: string) =>
-              toolId === "plugin.echo.say"
-                ? {
-                    plugin: {
-                      id: "echo",
-                      name: "Echo",
-                      version: "0.0.1",
-                      entry: "index.mjs",
-                      contributes: {
-                        tools: [],
-                        commands: [],
-                        routes: [],
-                        mcp_servers: [],
-                      },
-                      permissions: {
-                        tools: [],
-                        network_egress: [],
-                        secrets: [],
-                        db: false,
-                      },
-                      config_schema: {
-                        type: "object",
-                        properties: {},
-                        required: [],
-                        additionalProperties: false,
-                      },
-                    },
-                    tool: {
-                      descriptor: {
-                        id: "plugin.echo.say",
-                        description: "Echo text back to the caller.",
-                        effect: "read_only" as const,
-                        keywords: ["echo"],
-                      },
-                      execute: vi.fn(),
-                    },
-                  }
-                : undefined,
-          })),
-          invalidateTenantRegistry: vi.fn(async () => undefined),
-          shutdown: vi.fn(async () => undefined),
-        } as never,
-      }),
-    );
 
     const response = await app.request("/config/tools?agent_key=default");
     expect(response.status).toBe(200);
@@ -419,5 +423,44 @@ describe("tool registry routes", () => {
         tier: "advanced",
       }),
     );
+  });
+
+  it("returns internal_error when the agent registry is unavailable", async () => {
+    const app = createAuthenticatedToolRegistryApp({
+      db: {
+        all: vi.fn(async () => []),
+      } as never,
+    });
+
+    const response = await app.request("/config/tools?agent_key=default");
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "internal_error",
+      message: "agent registry is unavailable",
+    });
+  });
+
+  it("returns internal_error when runtime tool inventory is unavailable", async () => {
+    const app = createAuthenticatedToolRegistryApp({
+      agents: {
+        getRuntime: vi.fn(async () => ({
+          listRegisteredTools: vi.fn(async () => ({
+            allowlist: [],
+            tools: [],
+            mcpServers: [],
+          })),
+        })),
+      } as never,
+      db: {
+        all: vi.fn(async () => []),
+      } as never,
+    });
+
+    const response = await app.request("/config/tools?agent_key=default");
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "internal_error",
+      message: "runtime tool inventory is unavailable",
+    });
   });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
-import { McpManager } from "../../src/modules/agent/mcp-manager.js";
+import { SECRET_CLIPBOARD_TOOL_ID } from "../../src/modules/agent/tool-secret-definitions.js";
 import { createToolRegistryRoutes } from "../../src/routes/tool-registry.js";
+import { buildToolRegistryCatalogFixture } from "./tool-registry-routes.test-support.js";
 
 const LEGACY_NODE_DISPATCH_TOOL_ID = ["tool", "node", "dispatch"].join(".");
 const LEGACY_NODE_INSPECT_TOOL_ID = ["tool", "node", "inspect"].join(".");
@@ -23,48 +24,9 @@ describe("tool registry routes", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns built-in, plugin, and MCP tool descriptors with source metadata", async () => {
-    const listServerToolDescriptors = vi
-      .spyOn(McpManager.prototype, "listServerToolDescriptors")
-      .mockResolvedValue([
-        {
-          id: "mcp.exa.web_search_exa",
-          description: "Search the web with Exa.",
-          effect: "state_changing",
-          keywords: ["mcp", "exa", "search"],
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: { type: "string" },
-            },
-          },
-        },
-      ]);
-    vi.spyOn(McpManager.prototype, "shutdown").mockResolvedValue(undefined);
-
-    const db = {
-      all: vi.fn(async () => [
-        {
-          revision: 1,
-          tenant_id: DEFAULT_TENANT_ID,
-          package_kind: "mcp",
-          package_key: "exa",
-          package_json: JSON.stringify({
-            id: "exa",
-            name: "Exa",
-            enabled: true,
-            transport: "remote",
-            url: "https://mcp.exa.ai/mcp",
-          }),
-          artifact_id: null,
-          enabled: 1,
-          created_at: new Date(0).toISOString(),
-          created_by_json: "{}",
-          reason: null,
-          reverted_from_revision: null,
-        },
-      ]),
-    };
+  it("formats runtime inventory with shared exposure verdicts and source metadata", async () => {
+    const { descriptors, disabledByReason, inventory, mcpServerSpecs, pluginDescriptors } =
+      buildToolRegistryCatalogFixture();
 
     const app = new Hono();
     app.use("*", async (c, next) => {
@@ -85,73 +47,22 @@ describe("tool registry routes", () => {
                 "plugin.echo.say",
                 "plugin.echo.union",
                 "mcp.exa.web_search_exa",
+                SECRET_CLIPBOARD_TOOL_ID,
               ],
-              tools: [],
-              mcpServers: [],
+              tools: descriptors.filter((descriptor) => !disabledByReason.has(descriptor.id)),
+              mcpServers: ["exa"],
+              inventory,
+              mcpServerSpecs,
             })),
           })),
         } as never,
-        db: db as never,
+        db: {
+          all: vi.fn(async () => []),
+        } as never,
         pluginCatalogProvider: {
           loadGlobalRegistry: vi.fn(),
           loadTenantRegistry: vi.fn(async () => ({
-            getToolDescriptors: () => [
-              {
-                id: "plugin.echo.say",
-                description: "Echo text back to the caller.",
-                effect: "read_only" as const,
-                keywords: ["echo"],
-                inputSchema: {
-                  type: "object",
-                  properties: { text: { type: "string" } },
-                },
-              },
-              {
-                id: "plugin.echo.invalid",
-                description: "Invalid schema tool.",
-                effect: "read_only" as const,
-                keywords: ["echo"],
-                inputSchema: {
-                  oneOf: [{ type: "object", properties: {} }],
-                },
-              },
-              {
-                id: "plugin.echo.optional",
-                description: "Echo text back without an explicit schema.",
-                effect: "read_only" as const,
-                keywords: ["echo"],
-              },
-              {
-                id: "plugin.echo.union",
-                description: "Echo text or markdown back to the caller.",
-                effect: "read_only" as const,
-                keywords: ["echo"],
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    kind: { type: "string", enum: ["text", "markdown"] },
-                    text: { type: "string" },
-                    markdown: { type: "string" },
-                  },
-                  required: ["kind"],
-                  additionalProperties: false,
-                  oneOf: [
-                    {
-                      properties: {
-                        kind: { type: "string", enum: ["text"] },
-                      },
-                      required: ["kind", "text"],
-                    },
-                    {
-                      properties: {
-                        kind: { type: "string", enum: ["markdown"] },
-                      },
-                      required: ["kind", "markdown"],
-                    },
-                  ],
-                },
-              },
-            ],
+            getToolDescriptors: () => pluginDescriptors,
             getTool: (toolId: string) =>
               toolId === "plugin.echo.say"
                 ? {
@@ -237,10 +148,35 @@ describe("tool registry routes", () => {
         }),
       );
     }
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
+        source: "builtin",
+        canonical_id: SECRET_CLIPBOARD_TOOL_ID,
+        effective_exposure: expect.objectContaining({
+          enabled: true,
+          reason: "enabled",
+          agent_key: "default",
+        }),
+      }),
+    );
     const rawMcpWebSearch = body.tools.find(
       (tool: { canonical_id?: string }) => tool.canonical_id === "mcp.exa.web_search_exa",
     );
     expect(rawMcpWebSearch).toBeDefined();
+    expect(rawMcpWebSearch).toMatchObject({
+      source: "mcp",
+      effective_exposure: expect.objectContaining({
+        enabled: true,
+        reason: "enabled",
+        agent_key: "default",
+      }),
+      backing_server: expect.objectContaining({
+        id: "exa",
+        name: "Exa",
+        transport: "remote",
+        url: "https://mcp.exa.ai/mcp",
+      }),
+    });
     expect(rawMcpWebSearch).not.toHaveProperty("group");
     expect(rawMcpWebSearch).not.toHaveProperty("tier");
     expect(body.tools).toContainEqual(
@@ -263,6 +199,11 @@ describe("tool registry routes", () => {
       expect.objectContaining({
         source: "plugin",
         canonical_id: "plugin.echo.optional",
+        effective_exposure: expect.objectContaining({
+          enabled: false,
+          reason: "disabled_by_agent_allowlist",
+          agent_key: "default",
+        }),
         input_schema: {
           type: "object",
           additionalProperties: true,
@@ -292,28 +233,33 @@ describe("tool registry routes", () => {
     );
     expect(body.tools).toContainEqual(
       expect.objectContaining({
-        source: "mcp",
-        canonical_id: "mcp.exa.web_search_exa",
+        source: "plugin",
+        canonical_id: "plugin.echo.invalid",
         effective_exposure: expect.objectContaining({
-          enabled: true,
-          reason: "enabled",
+          enabled: false,
+          reason: "disabled_invalid_schema",
           agent_key: "default",
-        }),
-        backing_server: expect.objectContaining({
-          id: "exa",
-          name: "Exa",
-          transport: "remote",
-          url: "https://mcp.exa.ai/mcp",
         }),
       }),
     );
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         source: "plugin",
-        canonical_id: "plugin.echo.invalid",
+        canonical_id: "plugin.echo.blocked",
         effective_exposure: expect.objectContaining({
           enabled: false,
-          reason: "disabled_invalid_schema",
+          reason: "disabled_by_agent_allowlist",
+          agent_key: "default",
+        }),
+      }),
+    );
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
+        source: "builtin",
+        canonical_id: "edit",
+        effective_exposure: expect.objectContaining({
+          enabled: false,
+          reason: "disabled_by_state_mode",
           agent_key: "default",
         }),
       }),
@@ -474,6 +420,5 @@ describe("tool registry routes", () => {
         tier: "advanced",
       }),
     );
-    expect(listServerToolDescriptors).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -105,7 +105,6 @@ describe("tool registry routes", () => {
           invalidateTenantRegistry: vi.fn(async () => undefined),
           shutdown: vi.fn(async () => undefined),
         } as never,
-        stateMode: "local",
       }),
     );
 


### PR DESCRIPTION
Closes #1982

## What Changed
- switched `/config/tools` to format the runtime-produced agent-scoped inventory instead of rebuilding its own tool universe and exposure verdicts
- extended the shared runtime descriptor source to retain shared `effectiveExposureVerdicts`, MCP server specs, dynamic built-ins, and invalid-schema visibility for downstream inventory consumers
- updated `listRegisteredTools()` to expose the shared inventory data needed by the `/config/tools` producer while keeping the public `/config/tools` wire contract unchanged
- added regression coverage for route formatting, dynamic built-in parity, and invalid-schema inventory retention
- restored the existing invalid-schema pre-turn warning path so broader CI continues to pass

## Why
Runtime selection and `/config/tools` were still drifting from each other. Runtime already used the shared effective-exposure resolver and shared agent-scoped descriptor source, but `/config/tools` still rebuilt exposure locally from a narrower tool set and reduced reason model. This change converges those paths without taking on the later `/config/tools` contract work from `#1969`.

## How To Test
- `pnpm exec vitest run packages/gateway/tests/unit/turn-preparation-runtime.test.ts packages/gateway/tests/unit/effective-exposure-resolver.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source-shared-resolver.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts packages/gateway/tests/integration/tool-registry.test.ts`
- `pnpm --filter @tyrum/gateway exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`
- `pnpm run ci`

## Risk
- low to medium: the main risk is gateway-internal inventory consumers depending on `listRegisteredTools()` only returning enabled tool data
- `/config/tools` intentionally still collapses richer internal disable reasons back to the current public reason enum, so this does not change the transport contract

## Rollback
- revert this PR to restore the previous `/config/tools` producer path and runtime inventory shape
- no database or config migration is involved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the source of truth for `/config/tools` to use runtime-produced inventory and expands `listRegisteredTools()` output shape, which could affect internal consumers relying on the prior enabled-tools-only behavior. Public API contract is intended to remain stable, but errors now surface as `internal_error` in more cases.
> 
> **Overview**
> `/config/tools` now formats the *runtime-produced* tool inventory (including effective exposure verdicts and MCP server specs) instead of rebuilding tool lists/exposure locally, aligning the route with the shared effective-exposure resolver.
> 
> Runtime tool aggregation (`resolveRuntimeToolDescriptorSource` and `listRegisteredTools`) is extended to retain full `effectiveExposureVerdicts`, MCP server specs, and to dedupe candidates while tracking invalid input-schema tools so they stay visible in inventory but are excluded from `availableTools`.
> 
> Tests are updated/added to assert route formatting matches runtime inventory (including dynamic built-ins like the secret clipboard tool), preserve invalid-schema visibility, and validate new `internal_error` cases when runtime inventory data is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f8abb99fa434ed1b40ae1c4882032cc632f4eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->