### PR TITLE
Finalize /context/tools canonical contract across gateway, manifest, and transport SDK

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -516,8 +516,8 @@ Download machine-readable specs:
 - SDK operation: `context.tools`
 - Auth: Required
 - Device scope: operator.read
-- Query schema: `ToolRegistryQuery`
-- Response schema: `ToolRegistryResponse`
+- Query schema: `ToolRegistryListQuery`
+- Response schema: `ToolRegistryListResponse`
 
 #### GET /contracts/jsonschema/\{file\}
 

--- a/packages/gateway/src/api/manifest.generated.json
+++ b/packages/gateway/src/api/manifest.generated.json
@@ -1716,17 +1716,17 @@
       "apiName": "context",
       "methodName": "tools",
       "pathTemplate": "/context/tools",
-      "responseSchemaName": "ToolRegistryResponse",
+      "responseSchemaName": "ToolRegistryListResponse",
       "responseVariants": [
         {
           "statusCode": "200",
-          "schemaName": "ToolRegistryResponse",
+          "schemaName": "ToolRegistryListResponse",
           "transportMethod": "request"
         }
       ],
       "transportMethod": "request",
       "pathParameters": [],
-      "querySchemaName": "ToolRegistryQuery"
+      "querySchemaName": "ToolRegistryListQuery"
     },
     {
       "id": "contracts.getSchema",

--- a/packages/gateway/src/app-route-registrars.ts
+++ b/packages/gateway/src/app-route-registrars.ts
@@ -477,6 +477,8 @@ export function registerAgentsAndWorkspaceRoutes(context: AppRouteContext): void
         agents: context.opts.agents,
         contextReportDal: context.container.contextReportDal,
         identityScopeDal: context.container.identityScopeDal,
+        plugins: context.opts.plugins,
+        pluginCatalogProvider: context.opts.pluginCatalogProvider,
       }),
     );
   }

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -11,17 +11,27 @@ import { Hono } from "hono";
 import type { AgentRegistry } from "../app/modules/agent/registry.js";
 import type { ContextReportDal } from "../app/modules/context/report-dal.js";
 import { requireTenantId } from "../app/modules/auth/claims.js";
-import { isToolAllowed } from "../app/modules/agent/tools.js";
 import {
   resolveRequestedAgentKey,
   ScopeNotFoundError,
   type IdentityScopeDal,
 } from "../app/modules/identity/scope.js";
+import type { PluginCatalogProvider } from "../app/modules/plugins/catalog-provider.js";
+import type { PluginRegistry } from "../app/modules/plugins/registry.js";
+import {
+  hasRuntimeToolInventoryCatalog,
+  isInvalidRequestError,
+  resolveInventoryToolEntries,
+  resolvePluginRegistry,
+  resolveRequestedExecutionProfile,
+} from "./tool-registry.js";
 
 export interface ContextRouteDeps {
   agents: AgentRegistry;
   contextReportDal: ContextReportDal;
   identityScopeDal: IdentityScopeDal;
+  plugins?: PluginRegistry;
+  pluginCatalogProvider?: PluginCatalogProvider;
 }
 
 export function createContextRoutes(deps: ContextRouteDeps): Hono {
@@ -83,12 +93,14 @@ export function createContextRoutes(deps: ContextRouteDeps): Hono {
   app.get("/context/tools", async (c) => {
     const tenantId = requireTenantId(c);
     let agentKey: string;
+    let executionProfile: string;
     try {
       agentKey = await resolveRequestedAgentKey({
         identityScopeDal: deps.identityScopeDal,
         tenantId,
         agentKey: c.req.query("agent_key"),
       });
+      executionProfile = resolveRequestedExecutionProfile(c.req.query("execution_profile"));
     } catch (err) {
       if (err instanceof ScopeNotFoundError) {
         return c.json({ error: err.code, message: err.message }, 404);
@@ -105,25 +117,27 @@ export function createContextRoutes(deps: ContextRouteDeps): Hono {
     }
 
     try {
-      const registry = await runtime.listRegisteredTools();
-      return c.json({
-        status: "ok",
-        allowlist: registry.allowlist,
-        mcp_servers: registry.mcpServers,
-        tools: registry.tools.map((tool) => ({
-          id: tool.id,
-          description: tool.description,
-          source: tool.source ?? "builtin",
-          family: tool.family ?? null,
-          backing_server_id: tool.backingServerId ?? null,
-          enabled_by_agent: isToolAllowed(registry.allowlist, tool.id),
-        })),
+      const catalog = await runtime.listRegisteredTools({ executionProfile });
+      if (!hasRuntimeToolInventoryCatalog(catalog)) {
+        throw new Error("runtime tool inventory is unavailable");
+      }
+      const pluginRegistry = await resolvePluginRegistry(deps, tenantId);
+      const tools = resolveInventoryToolEntries({
+        catalog,
+        pluginRegistry,
+        agentKey,
       });
+
+      return c.json({ status: "ok", tools }, 200);
     } catch (err) {
+      if (isInvalidRequestError(err)) {
+        return c.json({ error: "invalid_request", message: err.message }, 400);
+      }
       if (err instanceof ScopeNotFoundError) {
         return c.json({ error: err.code, message: err.message }, 404);
       }
-      throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: "internal_error", message }, 500);
     }
   });
 

--- a/packages/gateway/src/routes/tool-registry.ts
+++ b/packages/gateway/src/routes/tool-registry.ts
@@ -75,6 +75,8 @@ type RuntimeToolInventoryCatalog = {
   mcpServerSpecs: readonly McpServerSpecT[];
 };
 
+type ToolInventoryPluginDeps = Pick<ToolRegistryRouteDeps, "plugins" | "pluginCatalogProvider">;
+
 export interface ToolRegistryRouteDeps {
   agents?: AgentRegistry;
   db: SqlDb;
@@ -82,7 +84,9 @@ export interface ToolRegistryRouteDeps {
   pluginCatalogProvider?: PluginCatalogProvider;
 }
 
-function isInvalidRequestError(error: unknown): error is Error & { code: "invalid_request" } {
+export function isInvalidRequestError(
+  error: unknown,
+): error is Error & { code: "invalid_request" } {
   return (
     error !== null &&
     typeof error === "object" &&
@@ -91,8 +95,8 @@ function isInvalidRequestError(error: unknown): error is Error & { code: "invali
   );
 }
 
-async function resolvePluginRegistry(
-  deps: ToolRegistryRouteDeps,
+export async function resolvePluginRegistry(
+  deps: ToolInventoryPluginDeps,
   tenantId: string,
 ): Promise<PluginRegistry | undefined> {
   if (deps.pluginCatalogProvider) {
@@ -101,7 +105,7 @@ async function resolvePluginRegistry(
   return deps.plugins;
 }
 
-function hasRuntimeToolInventoryCatalog(
+export function hasRuntimeToolInventoryCatalog(
   value: RegisteredToolsCatalog,
 ): value is RegisteredToolsCatalog & RuntimeToolInventoryCatalog {
   return (
@@ -251,7 +255,7 @@ function toToolEffectiveExposure(
   };
 }
 
-function resolveRequestedExecutionProfile(raw: string | undefined): string {
+export function resolveRequestedExecutionProfile(raw: string | undefined): string {
   if (raw === undefined) {
     return "interaction";
   }
@@ -334,7 +338,7 @@ function listMcpEntries(
     .toSorted((left, right) => left.canonical_id.localeCompare(right.canonical_id));
 }
 
-function resolveInventoryToolEntries(params: {
+export function resolveInventoryToolEntries(params: {
   catalog: RuntimeToolInventoryCatalog;
   pluginRegistry: PluginRegistry | undefined;
   agentKey: string;

--- a/packages/gateway/tests/integration/context.test.ts
+++ b/packages/gateway/tests/integration/context.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { SECRET_CLIPBOARD_TOOL_ID } from "../../src/modules/agent/tool-secret-definitions.js";
+import { DEFAULT_TENANT_ID } from "../../src/modules/identity/scope.js";
 import { createTestApp } from "./helpers.js";
 import { simulateReadableStream } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
+import { seedAgentConfig } from "../unit/agent-runtime.test-helpers.js";
 
 vi.mock("../../src/modules/models/provider-factory.js", () => ({
   createProviderFromNpm: (input: { providerId: string }) => ({
@@ -246,37 +249,173 @@ describe("/context", () => {
     await container.db.close();
   });
 
-  it("omits risk and confirmation metadata from /context/tools", async () => {
+  it("matches runtime inventory exposure and taxonomy for omitted interaction inspection", async () => {
     const { request, container, agents } = await createTestApp({
       tyrumHome: homeDir,
     });
-
-    const response = await request("/context/tools");
-
-    expect(response.status).toBe(200);
-    const payload = (await response.json()) as {
-      status: string;
-      tools: Array<Record<string, unknown>>;
-    };
-    expect(payload).toMatchObject({
-      status: "ok",
-      tools: expect.arrayContaining([
-        expect.objectContaining({
-          id: "read",
-          description: expect.any(String),
-          source: "builtin",
-          family: "filesystem",
-          enabled_by_agent: expect.any(Boolean),
-        }),
-      ]),
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { default_mode: "allow", workspace_trusted: true },
+        mcp: {
+          default_mode: "allow",
+          allow: [],
+          deny: [],
+        },
+        tools: {
+          default_mode: "allow",
+          allow: [SECRET_CLIPBOARD_TOOL_ID],
+          deny: [],
+        },
+        secret_refs: [
+          {
+            secret_ref_id: "secret-ref-1",
+            secret_alias: "desktop-login",
+            allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+          },
+        ],
+      },
     });
 
-    const readTool = payload.tools.find((tool) => tool["id"] === "read");
-    expect(readTool).toBeTruthy();
-    expect(readTool).not.toHaveProperty("risk");
-    expect(readTool).not.toHaveProperty("requires_confirmation");
-    expect(readTool).not.toHaveProperty("effect");
-    expect(readTool).not.toHaveProperty("keywords");
+    const runtime = await agents!.getRuntime({
+      tenantId: DEFAULT_TENANT_ID,
+      agentKey: "default",
+    });
+    const catalog = (await runtime.listRegisteredTools({
+      executionProfile: "interaction",
+    })) as Awaited<ReturnType<typeof runtime.listRegisteredTools>> & {
+      inventory: Array<{
+        descriptor: { id: string; taxonomy?: { canonicalId?: string } };
+        enabled: boolean;
+        reason: string;
+      }>;
+    };
+
+    const response = await request("/context/tools?agent_key=default");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      status: string;
+      tools: Array<{
+        canonical_id: string;
+        lifecycle: string;
+        visibility: string;
+        aliases: Array<{ id: string; lifecycle: string }>;
+        effective_exposure: {
+          enabled: boolean;
+          reason: string;
+        };
+      }>;
+    };
+    expect(body.status).toBe("ok");
+    expect(body).not.toHaveProperty("allowlist");
+    expect(body).not.toHaveProperty("mcp_servers");
+
+    const routeToolIds = body.tools.map((tool) => tool.canonical_id).toSorted();
+    const runtimeInventoryIds = catalog.inventory
+      .map((entry) => entry.descriptor.taxonomy?.canonicalId ?? entry.descriptor.id)
+      .toSorted();
+    expect(routeToolIds).toEqual(runtimeInventoryIds);
+    expect(routeToolIds).toContain(SECRET_CLIPBOARD_TOOL_ID);
+
+    const routeExposureById = new Map(
+      body.tools.map((tool) => [tool.canonical_id, tool.effective_exposure] as const),
+    );
+    for (const entry of catalog.inventory) {
+      expect(
+        routeExposureById.get(entry.descriptor.taxonomy?.canonicalId ?? entry.descriptor.id),
+      ).toMatchObject({
+        enabled: entry.enabled,
+        reason: entry.reason,
+      });
+    }
+
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
+        canonical_id: "read",
+        lifecycle: "canonical",
+        visibility: "public",
+        aliases: [{ id: "tool.fs.read", lifecycle: "alias" }],
+      }),
+    );
+
+    await agents?.shutdown();
+    await container.db.close();
+  });
+
+  it("matches runtime inventory for explicit subagent execution_profile inspection", async () => {
+    const { request, container, agents } = await createTestApp({
+      tyrumHome: homeDir,
+    });
+    await seedAgentConfig(container, {
+      config: {
+        model: { model: "openai/gpt-4.1" },
+        skills: { enabled: [] },
+        mcp: {
+          enabled: [],
+          server_settings: { memory: { enabled: false } },
+        },
+        tools: {
+          allow: ["read", "write", "bash"],
+        },
+        conversations: { ttl_days: 30, max_turns: 20 },
+      },
+    });
+
+    const runtime = await agents!.getRuntime({
+      tenantId: DEFAULT_TENANT_ID,
+      agentKey: "default",
+    });
+    const explorerCatalog = (await runtime.listRegisteredTools({
+      executionProfile: "explorer_ro",
+    })) as Awaited<ReturnType<typeof runtime.listRegisteredTools>> & {
+      inventory: Array<{
+        descriptor: { id: string; taxonomy?: { canonicalId?: string } };
+        enabled: boolean;
+        reason: string;
+      }>;
+    };
+
+    const response = await request(
+      "/context/tools?agent_key=default&execution_profile=explorer_ro",
+    );
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      status: string;
+      tools: Array<{
+        canonical_id: string;
+        effective_exposure: {
+          enabled: boolean;
+          reason: string;
+        };
+      }>;
+    };
+
+    const routeExposureById = new Map(
+      body.tools.map((tool) => [tool.canonical_id, tool.effective_exposure] as const),
+    );
+    for (const entry of explorerCatalog.inventory) {
+      expect(
+        routeExposureById.get(entry.descriptor.taxonomy?.canonicalId ?? entry.descriptor.id),
+      ).toMatchObject({
+        enabled: entry.enabled,
+        reason: entry.reason,
+      });
+    }
+
+    expect(routeExposureById.get("write")).toMatchObject({
+      enabled: false,
+      reason: "disabled_by_execution_profile",
+    });
+    expect(routeExposureById.get("bash")).toMatchObject({
+      enabled: false,
+      reason: "disabled_by_execution_profile",
+    });
+    expect(routeExposureById.get("read")).toMatchObject({
+      enabled: true,
+      reason: "enabled",
+    });
 
     await agents?.shutdown();
     await container.db.close();

--- a/packages/transport-sdk/src/http/context.ts
+++ b/packages/transport-sdk/src/http/context.ts
@@ -14,6 +14,12 @@ import {
   validateOrThrow,
   type TyrumRequestOptions,
 } from "./shared.js";
+import {
+  SharedToolRegistryListQuery as ToolRegistryListQuery,
+  SharedToolRegistryListResponse as ToolRegistryListResponse,
+  type ToolRegistryListQueryInput,
+  type ToolRegistryListResult,
+} from "./tool-registry.js";
 
 const ContextGetQuery = z
   .object({
@@ -64,36 +70,10 @@ const ContextDetailResponse = z
   })
   .strict();
 
-const ToolRegistryQuery = z
-  .object({
-    agent_key: AgentKey.optional(),
-  })
-  .strict();
-
-const ToolRegistryEntry = z
-  .object({
-    id: NonEmptyString,
-    description: z.string(),
-    source: z.enum(["builtin", "builtin_mcp", "mcp", "plugin"]),
-    family: z.string().nullable(),
-    backing_server_id: z.string().nullable(),
-    enabled_by_agent: z.boolean(),
-  })
-  .strict();
-
-const ToolRegistryResponse = z
-  .object({
-    status: z.literal("ok"),
-    allowlist: z.array(z.string()),
-    mcp_servers: z.array(z.string()),
-    tools: z.array(ToolRegistryEntry),
-  })
-  .strict();
-
 export type ContextGetResponse = z.infer<typeof ContextGetResponse>;
 export type ContextListResponse = z.infer<typeof ContextListResponse>;
 export type ContextDetailResponse = z.infer<typeof ContextDetailResponse>;
-export type ToolRegistryResponse = z.infer<typeof ToolRegistryResponse>;
+export type ContextToolsResponse = ToolRegistryListResult;
 
 export interface ContextApi {
   get(
@@ -106,9 +86,9 @@ export interface ContextApi {
   ): Promise<ContextListResponse>;
   detail(id: string, options?: TyrumRequestOptions): Promise<ContextDetailResponse>;
   tools(
-    query?: z.input<typeof ToolRegistryQuery>,
+    query?: ToolRegistryListQueryInput,
     options?: TyrumRequestOptions,
-  ): Promise<ToolRegistryResponse>;
+  ): Promise<ContextToolsResponse>;
 }
 
 export function createContextApi(transport: HttpTransport): ContextApi {
@@ -146,12 +126,16 @@ export function createContextApi(transport: HttpTransport): ContextApi {
     },
 
     async tools(query, options) {
-      const parsedQuery = validateOrThrow(ToolRegistryQuery, query ?? {}, "context tools query");
+      const parsedQuery = validateOrThrow(
+        ToolRegistryListQuery,
+        query ?? {},
+        "context tools query",
+      );
       return await transport.request({
         method: "GET",
         path: "/context/tools",
         query: parsedQuery,
-        response: ToolRegistryResponse,
+        response: ToolRegistryListResponse,
         signal: options?.signal,
       });
     },

--- a/packages/transport-sdk/src/http/generated/context.generated.ts
+++ b/packages/transport-sdk/src/http/generated/context.generated.ts
@@ -11,6 +11,10 @@ import {
   WorkspaceId,
 } from "@tyrum/contracts";
 import { HttpTransport, NonEmptyString, validateOrThrow } from "../shared.js";
+import {
+  SharedToolRegistryListQuery as ToolRegistryListQuery,
+  SharedToolRegistryListResponse as ToolRegistryListResponse,
+} from "../tool-registry.js";
 import { z } from "zod";
 
 const ContextGetQuery = z
@@ -56,29 +60,6 @@ const ContextDetailResponse = z
     report: ContextReportRow,
   })
   .strict();
-const ToolRegistryQuery = z
-  .object({
-    agent_key: AgentKey.optional(),
-  })
-  .strict();
-const ToolRegistryEntry = z
-  .object({
-    id: NonEmptyString,
-    description: z.string(),
-    source: z.enum(["builtin", "builtin_mcp", "mcp", "plugin"]),
-    family: z.string().nullable(),
-    backing_server_id: z.string().nullable(),
-    enabled_by_agent: z.boolean(),
-  })
-  .strict();
-const ToolRegistryResponse = z
-  .object({
-    status: z.literal("ok"),
-    allowlist: z.array(z.string()),
-    mcp_servers: z.array(z.string()),
-    tools: z.array(ToolRegistryEntry),
-  })
-  .strict();
 export function createContextApi(transport: HttpTransport): ContextApi {
   return {
     async get(query, options) {
@@ -114,12 +95,16 @@ export function createContextApi(transport: HttpTransport): ContextApi {
     },
 
     async tools(query, options) {
-      const parsedQuery = validateOrThrow(ToolRegistryQuery, query ?? {}, "context tools query");
+      const parsedQuery = validateOrThrow(
+        ToolRegistryListQuery,
+        query ?? {},
+        "context tools query",
+      );
       return await transport.request({
         method: "GET",
         path: "/context/tools",
         query: parsedQuery,
-        response: ToolRegistryResponse,
+        response: ToolRegistryListResponse,
         signal: options?.signal,
       });
     },

--- a/packages/transport-sdk/src/http/tool-registry.ts
+++ b/packages/transport-sdk/src/http/tool-registry.ts
@@ -83,6 +83,8 @@ const ToolRegistryListResponse = z
   })
   .strict();
 
+export const SharedToolRegistryListResponse = ToolRegistryListResponse;
+
 export type ToolRegistryListResult = z.output<typeof ToolRegistryListResponse>;
 
 const ToolRegistryListQuery = z
@@ -91,6 +93,8 @@ const ToolRegistryListQuery = z
     execution_profile: ToolRegistryExecutionProfile.optional(),
   })
   .strict();
+
+export const SharedToolRegistryListQuery = ToolRegistryListQuery;
 
 export type ToolRegistryListQueryInput = z.input<typeof ToolRegistryListQuery>;
 

--- a/packages/transport-sdk/tests/http-client.admin-coverage.test.ts
+++ b/packages/transport-sdk/tests/http-client.admin-coverage.test.ts
@@ -417,16 +417,23 @@ describe("admin HTTP client coverage", () => {
       if (url.endsWith("/context/tools?agent_key=agent-1")) {
         return jsonResponse({
           status: "ok",
-          allowlist: ["read"],
-          mcp_servers: ["exa"],
           tools: [
             {
-              id: "read",
-              description: "Read files from disk.",
               source: "builtin",
-              family: "fs",
-              backing_server_id: null,
-              enabled_by_agent: true,
+              canonical_id: "read",
+              lifecycle: "canonical",
+              visibility: "public",
+              aliases: [{ id: "tool.fs.read", lifecycle: "alias" }],
+              description: "Read files from disk.",
+              effect: "read_only",
+              effective_exposure: {
+                enabled: true,
+                reason: "enabled",
+                agent_key: "agent-1",
+              },
+              family: "filesystem",
+              group: "core",
+              tier: "default",
             },
           ],
         });
@@ -463,7 +470,7 @@ describe("admin HTTP client coverage", () => {
     expect(currentContext.report).toBeNull();
     expect(listedContext.reports[0]?.context_report_id).toBe(contextReportRow.context_report_id);
     expect(detailContext.report.thread_id).toBe("thread-1");
-    expect(tools.tools[0]?.id).toBe("read");
+    expect(tools.tools[0]?.canonical_id).toBe("read");
 
     const importSkillCall = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[2] as [
       string,

--- a/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-ops-admin-support.ts
@@ -147,6 +147,90 @@ export function registerHttpClientOpsAdminTests(): void {
     expect(init.method).toBe("GET");
   });
 
+  it("context.tools sends GET /context/tools with explicit profile inspection and validates canonical metadata", async () => {
+    const fetch = makeFetchMock(async () =>
+      jsonResponse({
+        status: "ok",
+        tools: [
+          {
+            source: "builtin",
+            canonical_id: "read",
+            lifecycle: "canonical",
+            visibility: "public",
+            aliases: [{ id: "tool.fs.read", lifecycle: "alias" }],
+            description: "Read files from disk.",
+            effect: "read_only",
+            effective_exposure: {
+              enabled: true,
+              reason: "enabled",
+              agent_key: "default",
+            },
+            family: "filesystem",
+            group: "core",
+            tier: "default",
+            keywords: ["read", "file"],
+            input_schema: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+              },
+            },
+          },
+          {
+            source: "builtin",
+            canonical_id: "write",
+            lifecycle: "canonical",
+            visibility: "public",
+            aliases: [{ id: "tool.fs.write", lifecycle: "alias" }],
+            description: "Write files to disk.",
+            effect: "state_changing",
+            effective_exposure: {
+              enabled: false,
+              reason: "disabled_by_execution_profile",
+              agent_key: "default",
+            },
+            family: "filesystem",
+            group: "core",
+            tier: "default",
+          },
+        ],
+      }),
+    );
+    const client = createTestClient({ fetch });
+
+    const result = await client.context.tools({
+      agent_key: "default",
+      execution_profile: "explorer_ro",
+    });
+    expect(result.tools).toHaveLength(2);
+
+    const toolsById = new Map(result.tools.map((tool) => [tool.canonical_id, tool]));
+    expect(toolsById.get("read")).toMatchObject({
+      lifecycle: "canonical",
+      visibility: "public",
+      aliases: [{ id: "tool.fs.read", lifecycle: "alias" }],
+      group: "core",
+      tier: "default",
+    });
+    expect(toolsById.get("write")).toMatchObject({
+      effect: "state_changing",
+      effective_exposure: {
+        enabled: false,
+        reason: "disabled_by_execution_profile",
+        agent_key: "default",
+      },
+    });
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://gateway.example/context/tools?agent_key=default&execution_profile=explorer_ro",
+    );
+    expect(init.method).toBe("GET");
+  });
+
   it("health.get sends GET /healthz and validates response", async () => {
     const fetch = mockJsonFetch({ status: "ok", is_exposed: false });
     const client = createTestClient({ fetch });

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -3018,7 +3018,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/ToolRegistryQuery"
+              "$ref": "#/components/schemas/ToolRegistryListQuery"
             }
           }
         ],
@@ -3028,7 +3028,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ToolRegistryResponse"
+                  "$ref": "#/components/schemas/ToolRegistryListResponse"
                 }
               }
             }
@@ -12293,18 +12293,6 @@
         "title": "ContextListQuery",
         "type": "object",
         "description": "Query for context.list",
-        "additionalProperties": true
-      },
-      "ToolRegistryResponse": {
-        "title": "ToolRegistryResponse",
-        "type": "object",
-        "description": "Response for context.tools",
-        "additionalProperties": true
-      },
-      "ToolRegistryQuery": {
-        "title": "ToolRegistryQuery",
-        "type": "object",
-        "description": "Query for context.tools",
         "additionalProperties": true
       },
       "ContractSchemaFilename": {


### PR DESCRIPTION
Closes #1976

## What changed
- updated `GET /context/tools` to use the shared canonical tool inventory path already used by `/config/tools`
- added optional `execution_profile` inspection for `/context/tools`, defaulting omitted input to `interaction`
- aligned the transport SDK, generated manifest/OpenAPI artifacts, and API reference docs with the finalized `/context/tools` contract
- added parity coverage for omitted-profile and explicit subagent-profile `/context/tools` inspection

## Why
`/context/tools` was still exposing a route-local shallow schema while runtime selection, `/config/tools`, and the shared taxonomy/effective-exposure work had already converged. This change removes that contract drift and makes `/context/tools` report the same canonical inventory and post-gating exposure state as runtime selection for the same declared inputs.

## How to test
- `pnpm exec vitest run packages/gateway/tests/integration/context.test.ts packages/gateway/tests/integration/tool-registry.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts packages/transport-sdk/tests/http-client.test-ops-admin-support.ts packages/transport-sdk/tests/http-client.admin-coverage.test.ts`
- `pnpm api:check`
- `pnpm lint`
- `pnpm typecheck`

## Risk
Low. This is a contract-alignment change on an existing read-only route. The main risk is schema drift between gateway and SDK artifacts; that is covered by regenerated artifacts plus targeted parity tests.

## Rollback
Revert commit `efe8725ef57056296db53a755cc47ada32f405ac` to restore the previous `/context/tools` contract and generated artifacts if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `GET /context/tools` response/query contract (including new `execution_profile` support), which can break existing consumers despite being read-only. Risk is mainly around runtime/tool-inventory availability and keeping gateway/SDK/spec artifacts in sync.
> 
> **Overview**
> `GET /context/tools` now returns the same **canonical tool inventory** shape used by the tool registry (`ToolRegistryListResponse`), replacing the previous shallow response that included `allowlist`, `mcp_servers`, and `enabled_by_agent`.
> 
> The route now accepts optional `execution_profile` (defaulting to `interaction`) and resolves tool entries via shared inventory/taxonomy helpers (including plugin registry resolution), with updated error handling.
> 
> Transport SDK types/validation, generated manifest/OpenAPI, and docs are updated to match the new contract, and tests are expanded to assert parity between the route output and the runtime inventory for both default and explicit profiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe8725ef57056296db53a755cc47ada32f405ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->