### PR TITLE
Expose canonical tool metadata in agent capabilities

### DIFF
--- a/packages/contracts/src/agent-api.ts
+++ b/packages/contracts/src/agent-api.ts
@@ -4,6 +4,8 @@ import { TurnId } from "./execution.js";
 import {
   AgentAccessDefaultMode,
   AgentToolConfig,
+  AgentToolExposureBundle,
+  AgentToolExposureTier,
   AgentToolExposureReadModel,
 } from "./agent-access.js";
 import {
@@ -329,7 +331,10 @@ export const AgentCapabilitiesResponse = z
       workspace_trusted: z.boolean(),
     }),
     mcp: capabilitySection(AgentMcpCapability),
-    tools: capabilitySection(AgentToolCapability),
+    tools: capabilitySection(AgentToolCapability, {
+      bundle: AgentToolExposureBundle.optional(),
+      tier: AgentToolExposureTier.optional(),
+    }),
   })
   .strict();
 export type AgentCapabilitiesResponse = z.infer<typeof AgentCapabilitiesResponse>;

--- a/packages/contracts/tests/agent-auxiliary.test.ts
+++ b/packages/contracts/tests/agent-auxiliary.test.ts
@@ -45,6 +45,35 @@ describe("AgentCapabilitiesResponse", () => {
 
     expect(parsed.skills.workspace_trusted).toBe(true);
   });
+
+  it("parses canonical tool bundle and tier metadata in capability payloads", () => {
+    const parsed = AgentCapabilitiesResponse.parse({
+      skills: {
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+        workspace_trusted: true,
+        items: [],
+      },
+      mcp: {
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+        items: [],
+      },
+      tools: {
+        bundle: "authoring-core",
+        tier: "default",
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+        items: [],
+      },
+    });
+
+    expect(parsed.tools.bundle).toBe("authoring-core");
+    expect(parsed.tools.tier).toBe("default");
+  });
 });
 
 describe("IdentityPack", () => {

--- a/packages/contracts/tests/dist-entrypoint.test.ts
+++ b/packages/contracts/tests/dist-entrypoint.test.ts
@@ -29,6 +29,8 @@ type WorkspaceBuildLockContents = {
   created_at_ms?: number;
 };
 
+let contractsDistModulePromise: Promise<Record<string, unknown>> | undefined;
+
 function buildContractsDist(): void {
   const result = spawnSync("pnpm", ["--filter", "@tyrum/contracts", "build"], {
     cwd: repoRoot,
@@ -122,18 +124,22 @@ async function acquireWorkspaceBuildLock(timeoutMs = 180_000): Promise<() => voi
 }
 
 async function ensureContractsDistModule(): Promise<Record<string, unknown>> {
-  const release = await acquireWorkspaceBuildLock();
-  try {
+  contractsDistModulePromise ??= (async () => {
+    const release = await acquireWorkspaceBuildLock();
     try {
-      await access(distEntrypointPath);
-    } catch {
-      buildContractsDist();
-    }
+      try {
+        await access(distEntrypointPath);
+      } catch {
+        buildContractsDist();
+      }
 
-    return (await import(pathToFileURL(distEntrypointPath).href)) as Record<string, unknown>;
-  } finally {
-    release();
-  }
+      return (await import(pathToFileURL(distEntrypointPath).href)) as Record<string, unknown>;
+    } finally {
+      release();
+    }
+  })();
+
+  return await contractsDistModulePromise;
 }
 
 function getSchema(module: Record<string, unknown>, name: string): SafeParseSchema {
@@ -149,7 +155,7 @@ describe("@tyrum/contracts dist entrypoint", () => {
     await expect(readFile(distTypesEntrypointPath, "utf8")).resolves.toBe(
       'export * from "./index.mjs";\n',
     );
-  }, 20_000);
+  }, 90_000);
 
   it("accepts the current chat and transcript shapes through the published dist bundle", async () => {
     const contractsDist = await ensureContractsDistModule();
@@ -253,5 +259,5 @@ describe("@tyrum/contracts dist entrypoint", () => {
         last_progress: null,
       }).success,
     ).toBe(true);
-  }, 20_000);
+  }, 90_000);
 });

--- a/packages/contracts/tests/dist-entrypoint.test.ts
+++ b/packages/contracts/tests/dist-entrypoint.test.ts
@@ -1,5 +1,14 @@
 import { spawnSync } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -8,9 +17,16 @@ const testsDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testsDir, "../../..");
 const distEntrypointPath = resolve(testsDir, "../dist/index.mjs");
 const distTypesEntrypointPath = resolve(testsDir, "../dist/index.d.ts");
+// Reuse the same lock that gateway dist tests hold while a packaged child process is alive.
+const workspaceBuildLockPath = resolve(repoRoot, ".tyrum-gateway-build.lock");
 
 type SafeParseSchema = {
   safeParse(input: unknown): { success: boolean };
+};
+
+type WorkspaceBuildLockContents = {
+  pid?: number;
+  created_at_ms?: number;
 };
 
 function buildContractsDist(): void {
@@ -27,14 +43,97 @@ function buildContractsDist(): void {
   }
 }
 
-async function ensureContractsDistModule(): Promise<Record<string, unknown>> {
-  try {
-    await access(distEntrypointPath);
-  } catch {
-    buildContractsDist();
-  }
+function delay(ms: number): Promise<void> {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
 
-  return (await import(pathToFileURL(distEntrypointPath).href)) as Record<string, unknown>;
+function isLivePid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = error && typeof error === "object" ? (error as { code?: string }).code : undefined;
+    return code !== "ESRCH";
+  }
+}
+
+function readWorkspaceBuildLockContents(): WorkspaceBuildLockContents | undefined {
+  try {
+    const raw = readFileSync(workspaceBuildLockPath, "utf8").trim();
+    if (raw.length === 0) return undefined;
+    const parsed = JSON.parse(raw) as WorkspaceBuildLockContents;
+    return parsed && typeof parsed === "object" ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tryClearStaleWorkspaceBuildLock(timeoutMs: number): boolean {
+  const metadata = readWorkspaceBuildLockContents();
+  const lockAgeMs = Date.now() - statSync(workspaceBuildLockPath).mtimeMs;
+  const pid = metadata?.pid;
+  const isStale = (typeof pid === "number" && !isLivePid(pid)) || lockAgeMs > timeoutMs;
+  if (!isStale) return false;
+  try {
+    unlinkSync(workspaceBuildLockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function acquireWorkspaceBuildLock(timeoutMs = 180_000): Promise<() => void> {
+  const startedAt = Date.now();
+
+  for (;;) {
+    try {
+      const fd = openSync(workspaceBuildLockPath, "wx");
+      writeFileSync(fd, JSON.stringify({ pid: process.pid, created_at_ms: Date.now() }), "utf8");
+      return () => {
+        try {
+          closeSync(fd);
+        } catch {
+          // ignore
+        }
+        try {
+          unlinkSync(workspaceBuildLockPath);
+        } catch {
+          // ignore
+        }
+      };
+    } catch (error) {
+      const code =
+        error && typeof error === "object" ? (error as { code?: string }).code : undefined;
+      if (code !== "EEXIST") throw error;
+
+      if (existsSync(workspaceBuildLockPath) && tryClearStaleWorkspaceBuildLock(timeoutMs)) {
+        continue;
+      }
+
+      if (Date.now() - startedAt > timeoutMs) {
+        throw new Error(
+          `Timed out waiting for workspace build lock (${timeoutMs}ms): ${workspaceBuildLockPath}`,
+        );
+      }
+
+      await delay(200);
+    }
+  }
+}
+
+async function ensureContractsDistModule(): Promise<Record<string, unknown>> {
+  const release = await acquireWorkspaceBuildLock();
+  try {
+    try {
+      await access(distEntrypointPath);
+    } catch {
+      buildContractsDist();
+    }
+
+    return (await import(pathToFileURL(distEntrypointPath).href)) as Record<string, unknown>;
+  } finally {
+    release();
+  }
 }
 
 function getSchema(module: Record<string, unknown>, name: string): SafeParseSchema {

--- a/packages/gateway/src/app-route-registrars.ts
+++ b/packages/gateway/src/app-route-registrars.ts
@@ -421,6 +421,7 @@ export function registerAgentsAndWorkspaceRoutes(context: AppRouteContext): void
       db: context.container.db,
       identityScopeDal: context.container.identityScopeDal,
       stateMode: resolveGatewayStateMode(context.container.deploymentConfig),
+      agents: context.opts.agents,
       logger: context.container.logger,
       pluginCatalogProvider: context.opts.pluginCatalogProvider,
       plugins: context.opts.plugins,

--- a/packages/gateway/src/modules/agent/admin-service.ts
+++ b/packages/gateway/src/modules/agent/admin-service.ts
@@ -15,13 +15,18 @@ import { DEFAULT_WORKSPACE_KEY } from "../identity/scope.js";
 import { AgentConfigDal } from "../config/agent-config-dal.js";
 import { AgentIdentityDal } from "./identity-dal.js";
 import { buildDefaultAgentConfig } from "./default-config.js";
-import { listAgentCapabilities } from "./capability-catalog.js";
+import {
+  hasRuntimeToolInventoryCatalog,
+  listAgentCapabilities,
+  listAgentToolCapabilitiesFromRuntimeInventory,
+} from "./capability-catalog.js";
 import { touchAgentUpdatedAt } from "./updated-at.js";
 import { listLatestAgentConfigsByAgentId } from "./persona.js";
 import { isUniqueViolation } from "../../utils/sql-errors.js";
 import type { Logger } from "../observability/logger.js";
 import type { PluginCatalogProvider } from "../plugins/catalog-provider.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import type { AgentRegistry } from "./registry.js";
 import {
   buildEffectiveIdentity,
   getAgentRow,
@@ -37,6 +42,7 @@ import type { AgentRow } from "./admin-service-support.js";
 export class AgentAlreadyExistsError extends Error {}
 export class AgentDeleteConflictError extends Error {}
 export class AgentRenameConflictError extends Error {}
+export class AgentCapabilitiesUnavailableError extends Error {}
 async function assertNoActiveTurns(
   db: SqlDb,
   tenantId: string,
@@ -80,6 +86,7 @@ export class AgentAdminService {
       db: SqlDb;
       identityScopeDal: IdentityScopeDal;
       stateMode: GatewayStateMode;
+      agents?: AgentRegistry;
       logger?: Logger;
       pluginCatalogProvider?: PluginCatalogProvider;
       plugins?: PluginRegistry;
@@ -401,6 +408,15 @@ export class AgentAdminService {
       ? await this.configDal.getLatest({ tenantId, agentId: row.agent_id })
       : undefined;
     const config = configRevision?.config ?? buildDefaultAgentConfig(this.deps.stateMode);
+    if (!this.deps.agents) {
+      throw new AgentCapabilitiesUnavailableError("agent runtime inventory is unavailable");
+    }
+    const runtime = await this.deps.agents.getRuntime({ tenantId, agentKey });
+    const catalog = await runtime.listRegisteredTools({ executionProfile: "interaction" });
+    if (!hasRuntimeToolInventoryCatalog(catalog)) {
+      throw new AgentCapabilitiesUnavailableError("agent runtime inventory is unavailable");
+    }
+    const toolItems = listAgentToolCapabilitiesFromRuntimeInventory(catalog);
 
     return AgentCapabilitiesResponse.parse(
       await listAgentCapabilities({
@@ -409,6 +425,7 @@ export class AgentAdminService {
         tenantId,
         agentKey,
         stateMode: this.deps.stateMode,
+        toolItems,
         logger: this.deps.logger,
         pluginCatalogProvider: this.deps.pluginCatalogProvider,
         plugins: this.deps.plugins,

--- a/packages/gateway/src/modules/agent/capability-catalog.ts
+++ b/packages/gateway/src/modules/agent/capability-catalog.ts
@@ -4,6 +4,7 @@ import type {
   AgentToolCapability as AgentToolCapabilityT,
   AgentConfig as AgentConfigT,
 } from "@tyrum/contracts";
+import type { AgentRegistry } from "./registry.js";
 import type { GatewayStateMode } from "../runtime-state/mode.js";
 import { RuntimePackageDal } from "./runtime-package-dal.js";
 import { parseManagedMcpPackage, parseManagedSkillPackage } from "../extensions/managed.js";
@@ -15,7 +16,11 @@ import {
   resolveUserSkillsDir,
 } from "./home.js";
 import { listMcpServersFromDir, listSkillsFromDir } from "./workspace.js";
-import { isBuiltinToolAvailableInStateMode, listBuiltinToolDescriptors } from "./tools.js";
+import {
+  isBuiltinToolAvailableInStateMode,
+  listBuiltinToolDescriptors,
+  resolveToolDescriptorTaxonomy,
+} from "./tools.js";
 import { McpManager } from "./mcp-manager.js";
 import type { SqlDb } from "../../statestore/types.js";
 import type { Logger } from "../observability/logger.js";
@@ -23,6 +28,8 @@ import type { PluginCatalogProvider } from "../plugins/catalog-provider.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { buildBuiltinMemoryServerSpec } from "../memory/builtin-mcp.js";
 import { buildSecretClipboardToolDescriptor } from "./tool-secret-definitions.js";
+import { resolveAgentToolExposureReadModel } from "./tool-exposure-read-model.js";
+import type { EffectiveToolExposureVerdict } from "./runtime/effective-exposure-resolver.js";
 
 function upsertCapability<T extends { id: string }>(itemsById: Map<string, T>, item: T): void {
   if (!itemsById.has(item.id)) {
@@ -32,6 +39,44 @@ function upsertCapability<T extends { id: string }>(itemsById: Map<string, T>, i
 
 function sortCapabilities<T extends { id: string }>(itemsById: Map<string, T>): T[] {
   return [...itemsById.values()].toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+type RegisteredToolsCatalog = Awaited<
+  ReturnType<Awaited<ReturnType<AgentRegistry["getRuntime"]>>["listRegisteredTools"]>
+>;
+
+type RuntimeToolInventoryCatalog = {
+  inventory: readonly EffectiveToolExposureVerdict[];
+};
+
+export function hasRuntimeToolInventoryCatalog(
+  value: RegisteredToolsCatalog,
+): value is RegisteredToolsCatalog & RuntimeToolInventoryCatalog {
+  return Array.isArray((value as { inventory?: unknown }).inventory);
+}
+
+export function listAgentToolCapabilitiesFromRuntimeInventory(
+  catalog: RuntimeToolInventoryCatalog,
+): AgentToolCapabilityT[] {
+  return catalog.inventory
+    .map((verdict) => {
+      const descriptor = verdict.descriptor;
+      const taxonomy =
+        descriptor.taxonomy ??
+        resolveToolDescriptorTaxonomy({
+          ...descriptor,
+          source: descriptor.source ?? "builtin",
+        });
+
+      return {
+        id: descriptor.id,
+        description: descriptor.description,
+        source: descriptor.source ?? "builtin",
+        family: taxonomy.family,
+        backing_server_id: descriptor.backingServerId ?? null,
+      };
+    })
+    .toSorted((left, right) => left.id.localeCompare(right.id));
 }
 
 async function resolvePluginRegistry(
@@ -304,14 +349,16 @@ export async function listAgentCapabilities(params: {
   tenantId: string;
   agentKey: string;
   stateMode: GatewayStateMode;
+  toolItems?: readonly AgentToolCapabilityT[];
   logger?: Logger;
   pluginCatalogProvider?: PluginCatalogProvider;
   plugins?: PluginRegistry;
 }) {
+  const toolExposure = resolveAgentToolExposureReadModel(params.config);
   const [skills, mcp, tools] = await Promise.all([
     listAgentSkillCapabilities(params),
     listAgentMcpCapabilities(params),
-    listAgentToolCapabilities(params),
+    params.toolItems ? Promise.resolve([...params.toolItems]) : listAgentToolCapabilities(params),
   ]);
 
   return {
@@ -329,6 +376,8 @@ export async function listAgentCapabilities(params: {
       items: mcp,
     },
     tools: {
+      ...(toolExposure.tools.bundle ? { bundle: toolExposure.tools.bundle } : {}),
+      ...(toolExposure.tools.tier ? { tier: toolExposure.tools.tier } : {}),
       default_mode: params.config.tools.default_mode,
       allow: [...params.config.tools.allow],
       deny: [...params.config.tools.deny],

--- a/packages/gateway/src/routes/agents.ts
+++ b/packages/gateway/src/routes/agents.ts
@@ -10,6 +10,7 @@ import { requireAuthClaims, requireTenantId } from "../app/modules/auth/claims.j
 import {
   AgentAdminService,
   AgentAlreadyExistsError,
+  AgentCapabilitiesUnavailableError,
   AgentDeleteConflictError,
   AgentRenameConflictError,
 } from "../app/modules/agent/admin-service.js";
@@ -18,11 +19,13 @@ import { normalizeAgentKey } from "./config-key-utils.js";
 import type { Logger } from "../app/modules/observability/logger.js";
 import type { PluginCatalogProvider } from "../app/modules/plugins/catalog-provider.js";
 import type { PluginRegistry } from "../app/modules/plugins/registry.js";
+import type { AgentRegistry } from "../app/modules/agent/registry.js";
 
 export interface AgentsRouteDeps {
   db: SqlDb;
   identityScopeDal: IdentityScopeDal;
   stateMode: GatewayStateMode;
+  agents?: AgentRegistry;
   logger?: Logger;
   pluginCatalogProvider?: PluginCatalogProvider;
   plugins?: PluginRegistry;
@@ -95,7 +98,14 @@ export function createAgentsRoutes(deps: AgentsRouteDeps): Hono {
     } catch (error) {
       return c.json({ error: "invalid_request", message: toErrorMessage(error) }, 400);
     }
-    return c.json(await service.getCapabilities(tenantId, agentKey), 200);
+    try {
+      return c.json(await service.getCapabilities(tenantId, agentKey), 200);
+    } catch (error) {
+      if (error instanceof AgentCapabilitiesUnavailableError) {
+        return c.json({ error: "internal_error", message: error.message }, 500);
+      }
+      throw error;
+    }
   });
 
   app.put("/agents/:key", async (c) => {

--- a/packages/gateway/tests/integration/agents-routes.test.ts
+++ b/packages/gateway/tests/integration/agents-routes.test.ts
@@ -151,6 +151,107 @@ describe("Managed agents routes integration", () => {
     expect(detail.tool_exposure).toEqual(created.tool_exposure);
   });
 
+  it("keeps managed-agent capabilities aligned with the runtime tool inventory", async () => {
+    const { app, agents, container } = await createTestApp({
+      isLocalOnly: false,
+      deploymentConfig: { modelsDev: { disableFetch: true } },
+    });
+
+    const create = await app.request("/agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agent_key: "agent-capabilities",
+        config: AgentConfig.parse({
+          model: { model: "openai/gpt-4.1" },
+          tools: { tier: "default" },
+          secret_refs: [
+            {
+              secret_ref_id: "secret-ref-1",
+              secret_alias: "desktop-login",
+              allowed_tool_ids: ["tool.secret.copy-to-node-clipboard"],
+            },
+          ],
+        }),
+      }),
+    });
+    expect(create.status).toBe(201);
+
+    const runtime = await agents!.getRuntime({
+      tenantId: DEFAULT_TENANT_ID,
+      agentKey: "agent-capabilities",
+    });
+    const catalog = (await runtime.listRegisteredTools({
+      executionProfile: "interaction",
+    })) as Awaited<ReturnType<typeof runtime.listRegisteredTools>> & {
+      inventory: Array<{
+        descriptor: { id: string; taxonomy?: { family?: string | null } };
+      }>;
+    };
+
+    const response = await app.request("/agents/agent-capabilities/capabilities");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      tools: {
+        bundle?: string;
+        tier?: string;
+        items: Array<{ id: string; family: string | null }>;
+      };
+    };
+    expect(body.tools.bundle).toBe("authoring-core");
+    expect(body.tools.tier).toBe("default");
+
+    const routeToolIds = body.tools.items.map((tool) => tool.id).toSorted();
+    const runtimeToolIds = catalog.inventory.map((entry) => entry.descriptor.id).toSorted();
+    expect(routeToolIds).toEqual(runtimeToolIds);
+
+    const routeFamiliesById = new Map(
+      body.tools.items.map((tool) => [tool.id, tool.family] as const),
+    );
+    for (const entry of catalog.inventory) {
+      expect(routeFamiliesById.get(entry.descriptor.id)).toBe(entry.descriptor.taxonomy?.family);
+    }
+
+    await agents?.shutdown();
+    await container.db.close();
+  });
+
+  it("fails clearly on capabilities reads when the shared runtime inventory is not wired", async () => {
+    const tyrumHome = mkdtempSync(join(tmpdir(), "tyrum-agents-route-test-home-"));
+    const container = await createContainer(
+      {
+        dbPath: ":memory:",
+        migrationsDir: join(import.meta.dirname, "../../migrations/sqlite"),
+        tyrumHome,
+      },
+      { deploymentConfig: { modelsDev: { disableFetch: true } } },
+    );
+
+    try {
+      const app = createAgentsApp(container);
+      const create = await app.request("/agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_key: "agent-no-runtime",
+          config: sampleConfig("No Runtime Agent"),
+        }),
+      });
+      expect(create.status).toBe(201);
+
+      const response = await app.request("/agents/agent-no-runtime/capabilities");
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "internal_error",
+        message: "agent runtime inventory is unavailable",
+      });
+    } finally {
+      await container.db.close();
+      rmSync(tyrumHome, { recursive: true, force: true });
+    }
+  });
+
   it("returns 404 when updating a missing managed agent", async () => {
     const { app } = await createTestApp({
       isLocalOnly: false,

--- a/packages/gateway/tests/integration/startup-process.gateway-support.ts
+++ b/packages/gateway/tests/integration/startup-process.gateway-support.ts
@@ -406,17 +406,12 @@ async function waitForGatewayHealth(
   throw new Error(`Gateway did not become healthy within ${timeoutMs}ms.\n${output()}`);
 }
 
-export async function withGatewayBuild<T>(
-  action: () => MaybePromise<T>,
-  options: { releaseAfterBuild?: boolean } = {},
-): Promise<T> {
-  let releaseBuildLock = acquireGatewayBuildLock();
+export async function withGatewayBuild<T>(action: () => MaybePromise<T>): Promise<T> {
+  const releaseBuildLock = acquireGatewayBuildLock();
   try {
+    // Keep the shared build lock until the caller finishes using the packaged child
+    // process so concurrent tests cannot rebuild and temporarily delete dist assets.
     ensureGatewayBuild();
-    if (options.releaseAfterBuild) {
-      releaseBuildLock();
-      releaseBuildLock = () => {};
-    }
     return await action();
   } finally {
     releaseBuildLock();

--- a/packages/gateway/tests/integration/startup-process.test.ts
+++ b/packages/gateway/tests/integration/startup-process.test.ts
@@ -36,32 +36,29 @@ describe("gateway startup process", () => {
     "starts the real gateway and serves /healthz and /agent/status",
     { timeout: 300_000 },
     async () => {
-      await withGatewayBuild(
-        async () => {
-          const gateway = await startGatewayFixture({ tempPrefix: "tyrum-gateway-startup-" });
-          const agentStatusUrl = `http://127.0.0.1:${gateway.port}/agent/status`;
-          try {
-            const healthResponse = await fetch(gateway.healthUrl);
-            expect(healthResponse.status).toBe(200);
-            const healthBody = (await healthResponse.json()) as { status: string };
-            expect(healthBody.status).toBe("ok");
+      await withGatewayBuild(async () => {
+        const gateway = await startGatewayFixture({ tempPrefix: "tyrum-gateway-startup-" });
+        const agentStatusUrl = `http://127.0.0.1:${gateway.port}/agent/status`;
+        try {
+          const healthResponse = await fetch(gateway.healthUrl);
+          expect(healthResponse.status).toBe(200);
+          const healthBody = (await healthResponse.json()) as { status: string };
+          expect(healthBody.status).toBe("ok");
 
-            const agentStatusResponse = await fetch(agentStatusUrl, {
-              headers: {
-                Authorization: `Bearer ${gateway.tenantAdminToken}`,
-              },
-            });
-            expect(agentStatusResponse.status).toBe(200);
-            const agentStatusBody = (await agentStatusResponse.json()) as {
-              enabled: boolean;
-            };
-            expect(agentStatusBody.enabled).toBe(true);
-          } finally {
-            await gateway.stopAndCleanup();
-          }
-        },
-        { releaseAfterBuild: true },
-      );
+          const agentStatusResponse = await fetch(agentStatusUrl, {
+            headers: {
+              Authorization: `Bearer ${gateway.tenantAdminToken}`,
+            },
+          });
+          expect(agentStatusResponse.status).toBe(200);
+          const agentStatusBody = (await agentStatusResponse.json()) as {
+            enabled: boolean;
+          };
+          expect(agentStatusBody.enabled).toBe(true);
+        } finally {
+          await gateway.stopAndCleanup();
+        }
+      });
     },
   );
 
@@ -69,58 +66,55 @@ describe("gateway startup process", () => {
     "cancels agent tool-execution runs on denied approvals over WebSocket",
     { timeout: 180_000 },
     async () => {
-      await withGatewayBuild(
-        async () => {
-          const gateway = await startGatewayFixture({ tempPrefix: "tyrum-gateway-ws-approval-" });
+      await withGatewayBuild(async () => {
+        const gateway = await startGatewayFixture({ tempPrefix: "tyrum-gateway-ws-approval-" });
+        try {
+          const db = openTestDatabase(gateway.dbPath);
           try {
-            const db = openTestDatabase(gateway.dbPath);
+            seedPausedApprovalRun(db, deniedApprovalFixture);
+
+            const ws = new WebSocket(
+              `ws://127.0.0.1:${gateway.port}/ws`,
+              authProtocols(gateway.tenantAdminToken),
+            );
             try {
-              seedPausedApprovalRun(db, deniedApprovalFixture);
+              await waitForOpen(ws);
+              await completeHandshake(ws, {
+                requestIdPrefix: "r",
+                role: "client",
+                capabilities: [],
+              });
 
-              const ws = new WebSocket(
-                `ws://127.0.0.1:${gateway.port}/ws`,
-                authProtocols(gateway.tenantAdminToken),
+              ws.send(
+                JSON.stringify({
+                  request_id: `approval-${deniedApprovalFixture.approvalId}`,
+                  type: "approval.resolve",
+                  payload: {
+                    approval_id: deniedApprovalFixture.approvalId,
+                    decision: "denied",
+                    reason: "denied in ws test",
+                  },
+                }),
               );
-              try {
-                await waitForOpen(ws);
-                await completeHandshake(ws, {
-                  requestIdPrefix: "r",
-                  role: "client",
-                  capabilities: [],
-                });
 
-                ws.send(
-                  JSON.stringify({
-                    request_id: `approval-${deniedApprovalFixture.approvalId}`,
-                    type: "approval.resolve",
-                    payload: {
-                      approval_id: deniedApprovalFixture.approvalId,
-                      decision: "denied",
-                      reason: "denied in ws test",
-                    },
-                  }),
-                );
-
-                const status = await waitForExecutionRunStatus(
-                  db,
-                  deniedApprovalFixture.turnId,
-                  "cancelled",
-                );
-                expect(status, gateway.output()).toBe("cancelled");
-              } finally {
-                if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-                  ws.close();
-                }
-              }
+              const status = await waitForExecutionRunStatus(
+                db,
+                deniedApprovalFixture.turnId,
+                "cancelled",
+              );
+              expect(status, gateway.output()).toBe("cancelled");
             } finally {
-              db.close();
+              if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+                ws.close();
+              }
             }
           } finally {
-            await gateway.stopAndCleanup();
+            db.close();
           }
-        },
-        { releaseAfterBuild: true },
-      );
+        } finally {
+          await gateway.stopAndCleanup();
+        }
+      });
     },
   );
 
@@ -128,60 +122,57 @@ describe("gateway startup process", () => {
     "cancels runs when an approval is approved but missing a resume token over WebSocket",
     { timeout: 180_000 },
     async () => {
-      await withGatewayBuild(
-        async () => {
-          const gateway = await startGatewayFixture({
-            tempPrefix: "tyrum-gateway-ws-approval-missing-token-",
-          });
+      await withGatewayBuild(async () => {
+        const gateway = await startGatewayFixture({
+          tempPrefix: "tyrum-gateway-ws-approval-missing-token-",
+        });
+        try {
+          const db = openTestDatabase(gateway.dbPath);
           try {
-            const db = openTestDatabase(gateway.dbPath);
+            seedPausedApprovalRun(db, missingResumeTokenApprovalFixture);
+
+            const ws = new WebSocket(
+              `ws://127.0.0.1:${gateway.port}/ws`,
+              authProtocols(gateway.tenantAdminToken),
+            );
             try {
-              seedPausedApprovalRun(db, missingResumeTokenApprovalFixture);
+              await waitForOpen(ws);
+              await completeHandshake(ws, {
+                requestIdPrefix: "r",
+                role: "client",
+                capabilities: [],
+              });
 
-              const ws = new WebSocket(
-                `ws://127.0.0.1:${gateway.port}/ws`,
-                authProtocols(gateway.tenantAdminToken),
+              ws.send(
+                JSON.stringify({
+                  request_id: `approval-${missingResumeTokenApprovalFixture.approvalId}`,
+                  type: "approval.resolve",
+                  payload: {
+                    approval_id: missingResumeTokenApprovalFixture.approvalId,
+                    decision: "approved",
+                    reason: "approved in ws test (missing resume token)",
+                  },
+                }),
               );
-              try {
-                await waitForOpen(ws);
-                await completeHandshake(ws, {
-                  requestIdPrefix: "r",
-                  role: "client",
-                  capabilities: [],
-                });
 
-                ws.send(
-                  JSON.stringify({
-                    request_id: `approval-${missingResumeTokenApprovalFixture.approvalId}`,
-                    type: "approval.resolve",
-                    payload: {
-                      approval_id: missingResumeTokenApprovalFixture.approvalId,
-                      decision: "approved",
-                      reason: "approved in ws test (missing resume token)",
-                    },
-                  }),
-                );
-
-                const status = await waitForExecutionRunStatus(
-                  db,
-                  missingResumeTokenApprovalFixture.turnId,
-                  "cancelled",
-                );
-                expect(status, gateway.output()).toBe("cancelled");
-              } finally {
-                if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-                  ws.close();
-                }
-              }
+              const status = await waitForExecutionRunStatus(
+                db,
+                missingResumeTokenApprovalFixture.turnId,
+                "cancelled",
+              );
+              expect(status, gateway.output()).toBe("cancelled");
             } finally {
-              db.close();
+              if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+                ws.close();
+              }
             }
           } finally {
-            await gateway.stopAndCleanup();
+            db.close();
           }
-        },
-        { releaseAfterBuild: true },
-      );
+        } finally {
+          await gateway.stopAndCleanup();
+        }
+      });
     },
   );
 
@@ -194,47 +185,44 @@ describe("gateway startup process", () => {
     "processes gateway.shutdown hooks before stopping the worker loop",
     { timeout: 180_000 },
     async () => {
-      await withGatewayBuild(
-        async () => {
-          const gateway = await startGatewayFixture({
-            tempPrefix: "tyrum-gateway-shutdown-hooks-",
-            configureHome: ({ dbPath }) => {
-              const db = openTestDatabase(dbPath);
-              try {
-                seedLifecycleHooksConfig(db, [shutdownHookDefinition(shutdownHookKey)]);
-              } finally {
-                db.close();
-              }
-            },
-          });
-          try {
-            await gateway.stop(gracefulShutdownStopTimeoutMs);
-
-            const db = openTestDatabase(gateway.dbPath);
+      await withGatewayBuild(async () => {
+        const gateway = await startGatewayFixture({
+          tempPrefix: "tyrum-gateway-shutdown-hooks-",
+          configureHome: ({ dbPath }) => {
+            const db = openTestDatabase(dbPath);
             try {
-              const row = readLatestHookRunWithPause(db, shutdownHookConversationKey);
-              expect(row, `gateway.shutdown hook run missing.\n${gateway.output()}`).toBeTruthy();
-              if (!row) return;
-
-              expect(row.status, gateway.output()).toBe("paused");
-              expect(row.pausedReason, gateway.output()).toBe("policy");
-
-              const trigger = JSON.parse(row.triggerJson) as {
-                kind?: string;
-                metadata?: Record<string, unknown>;
-              };
-              expect(trigger.kind, gateway.output()).toBe("hook");
-              expect(trigger.metadata?.["hook_event"], gateway.output()).toBe("gateway.shutdown");
-              expect(trigger.metadata?.["hook_key"], gateway.output()).toBe(shutdownHookKey);
+              seedLifecycleHooksConfig(db, [shutdownHookDefinition(shutdownHookKey)]);
             } finally {
               db.close();
             }
+          },
+        });
+        try {
+          await gateway.stop(gracefulShutdownStopTimeoutMs);
+
+          const db = openTestDatabase(gateway.dbPath);
+          try {
+            const row = readLatestHookRunWithPause(db, shutdownHookConversationKey);
+            expect(row, `gateway.shutdown hook run missing.\n${gateway.output()}`).toBeTruthy();
+            if (!row) return;
+
+            expect(row.status, gateway.output()).toBe("paused");
+            expect(row.pausedReason, gateway.output()).toBe("policy");
+
+            const trigger = JSON.parse(row.triggerJson) as {
+              kind?: string;
+              metadata?: Record<string, unknown>;
+            };
+            expect(trigger.kind, gateway.output()).toBe("hook");
+            expect(trigger.metadata?.["hook_event"], gateway.output()).toBe("gateway.shutdown");
+            expect(trigger.metadata?.["hook_key"], gateway.output()).toBe(shutdownHookKey);
           } finally {
-            gateway.cleanup();
+            db.close();
           }
-        },
-        { releaseAfterBuild: true },
-      );
+        } finally {
+          gateway.cleanup();
+        }
+      });
     },
   );
 
@@ -242,66 +230,63 @@ describe("gateway startup process", () => {
     "does not miss gateway.shutdown hooks when the worker is busy",
     { timeout: 180_000 },
     async () => {
-      await withGatewayBuild(
-        async () => {
-          const gateway = await startGatewayFixture({
-            tempPrefix: "tyrum-gateway-shutdown-hooks-busy-",
-            configureHome: ({ dbPath }) => {
-              const db = openTestDatabase(dbPath);
-              try {
-                seedLifecycleHooksConfig(
-                  db,
-                  busyShutdownHookDefinitions(
-                    process.execPath,
-                    busyStartHookKey,
-                    busyShutdownHookKey,
-                  ),
-                );
-                seedDeploymentPolicyBundle(db, busyShutdownPolicyBundle);
-              } finally {
-                db.close();
-              }
-            },
-          });
-          try {
-            const runningDb = openTestDatabase(gateway.dbPath);
+      await withGatewayBuild(async () => {
+        const gateway = await startGatewayFixture({
+          tempPrefix: "tyrum-gateway-shutdown-hooks-busy-",
+          configureHome: ({ dbPath }) => {
+            const db = openTestDatabase(dbPath);
             try {
-              await waitForExecutionRunKeyStatus(
-                runningDb,
-                busyStartHookConversationKey,
-                "running",
-                gateway.output,
+              seedLifecycleHooksConfig(
+                db,
+                busyShutdownHookDefinitions(
+                  process.execPath,
+                  busyStartHookKey,
+                  busyShutdownHookKey,
+                ),
               );
-            } finally {
-              runningDb.close();
-            }
-
-            await gateway.stop(gracefulShutdownStopTimeoutMs);
-
-            const db = openTestDatabase(gateway.dbPath);
-            try {
-              const row = readLatestHookRun(db, busyShutdownHookConversationKey);
-              expect(row, `gateway.shutdown hook run missing.\n${gateway.output()}`).toBeTruthy();
-              if (!row) return;
-
-              expect(row.status, gateway.output()).not.toBe("queued");
-
-              const trigger = JSON.parse(row.triggerJson) as {
-                kind?: string;
-                metadata?: Record<string, unknown>;
-              };
-              expect(trigger.kind, gateway.output()).toBe("hook");
-              expect(trigger.metadata?.["hook_event"], gateway.output()).toBe("gateway.shutdown");
-              expect(trigger.metadata?.["hook_key"], gateway.output()).toBe(busyShutdownHookKey);
+              seedDeploymentPolicyBundle(db, busyShutdownPolicyBundle);
             } finally {
               db.close();
             }
+          },
+        });
+        try {
+          const runningDb = openTestDatabase(gateway.dbPath);
+          try {
+            await waitForExecutionRunKeyStatus(
+              runningDb,
+              busyStartHookConversationKey,
+              "running",
+              gateway.output,
+            );
           } finally {
-            gateway.cleanup();
+            runningDb.close();
           }
-        },
-        { releaseAfterBuild: true },
-      );
+
+          await gateway.stop(gracefulShutdownStopTimeoutMs);
+
+          const db = openTestDatabase(gateway.dbPath);
+          try {
+            const row = readLatestHookRun(db, busyShutdownHookConversationKey);
+            expect(row, `gateway.shutdown hook run missing.\n${gateway.output()}`).toBeTruthy();
+            if (!row) return;
+
+            expect(row.status, gateway.output()).not.toBe("queued");
+
+            const trigger = JSON.parse(row.triggerJson) as {
+              kind?: string;
+              metadata?: Record<string, unknown>;
+            };
+            expect(trigger.kind, gateway.output()).toBe("hook");
+            expect(trigger.metadata?.["hook_event"], gateway.output()).toBe("gateway.shutdown");
+            expect(trigger.metadata?.["hook_key"], gateway.output()).toBe(busyShutdownHookKey);
+          } finally {
+            db.close();
+          }
+        } finally {
+          gateway.cleanup();
+        }
+      });
     },
   );
 });

--- a/packages/transport-sdk/tests/http-client.test-managed-agents-support.ts
+++ b/packages/transport-sdk/tests/http-client.test-managed-agents-support.ts
@@ -246,6 +246,8 @@ export function registerHttpClientManagedAgentTests(): void {
           ],
         },
         tools: {
+          bundle: "authoring-core",
+          tier: "default",
           default_mode: "allow",
           allow: [],
           deny: [],
@@ -265,6 +267,8 @@ export function registerHttpClientManagedAgentTests(): void {
 
     const result = await client.agents.capabilities("agent-2");
     expect(result.skills.items[0]?.id).toBe("review");
+    expect(result.tools.bundle).toBe("authoring-core");
+    expect(result.tools.tier).toBe("default");
 
     const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
       string,

--- a/specs/openapi.json
+++ b/specs/openapi.json
@@ -8385,6 +8385,14 @@
                   "required": ["id", "description", "source", "family", "backing_server_id"],
                   "additionalProperties": false
                 }
+              },
+              "bundle": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tier": {
+                "type": "string",
+                "enum": ["default", "advanced"]
               }
             },
             "required": ["default_mode", "allow", "deny", "items"],


### PR DESCRIPTION
Closes #1970

## What changed
- added additive `tools.bundle` and `tools.tier` metadata to the agent capabilities contract
- switched managed-agent capability tool enumeration to the shared runtime inventory path instead of the legacy hand-built catalog
- made the route fail explicitly if runtime inventory wiring is unavailable instead of silently falling back to legacy data
- updated gateway integration, contracts, transport SDK, and generated OpenAPI coverage for the new metadata and fail-fast behavior

## Why
Issue #1970 is part of epic #1961 and requires agent capabilities to expose the canonical bundle/tier metadata from the shared tool inventory so public tool taxonomy data stays aligned across runtime, contracts, and consumers.

## How to test
- `pnpm exec vitest run apps/docs/tests/generated-api-artifacts.test.ts packages/gateway/tests/integration/agents-routes.test.ts packages/contracts/tests/agent-auxiliary.test.ts packages/transport-sdk/tests/http-client.test-managed-agents-support.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git push -u origin 1970-expose-canonical-tool-bundle-tier-metadata` (runs the repo pre-push `pnpm ci:local` gate)

## Risk
Low to moderate. The contract change is additive, but the gateway now fails fast if the managed-agent runtime inventory is miswired instead of returning stale legacy capability data.

## Rollback notes
Revert commits `ed109a158` and `a7cf2a73c` on `1970-expose-canonical-tool-bundle-tier-metadata`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API fields are low risk, but changing capabilities tool enumeration to depend on runtime inventory and returning 500 when it’s unavailable can impact existing deployments if wiring is misconfigured.
> 
> **Overview**
> Agent capabilities responses now include optional canonical tool exposure metadata (`tools.bundle` and `tools.tier`) in the contracts schema and generated OpenAPI, with updated contract/SDK tests to validate parsing.
> 
> The gateway’s managed-agent capabilities endpoint is changed to enumerate tools from the shared runtime inventory (including taxonomy family resolution) rather than the legacy catalog, and it now **fails fast** with a clear 500 when runtime inventory wiring is missing. Test infrastructure was also hardened by introducing a shared workspace build lock and longer dist/startup test timeouts to reduce flaky parallel rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb29356fbafce94f72898203f450f6a1da5cb6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->