### PR TITLE
Adopt canonical tool exposure read model in the operator agent editor

### DIFF
--- a/packages/gateway/tests/integration/startup-process.gateway-support.ts
+++ b/packages/gateway/tests/integration/startup-process.gateway-support.ts
@@ -30,6 +30,19 @@ const SCHEMAS_PACKAGE_JSON = resolve(REPO_ROOT, "packages/contracts/package.json
 const SCHEMAS_TSCONFIG = resolve(REPO_ROOT, "packages/contracts/tsconfig.json");
 const SCHEMAS_SRC_DIR = resolve(REPO_ROOT, "packages/contracts/src");
 const SCHEMAS_SCRIPTS_DIR = resolve(REPO_ROOT, "packages/contracts/scripts");
+const RUNTIME_NODE_CONTROL_DIST = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/dist/index.mjs",
+);
+const RUNTIME_NODE_CONTROL_PACKAGE_JSON = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/package.json",
+);
+const RUNTIME_NODE_CONTROL_TSCONFIG = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/tsconfig.json",
+);
+const RUNTIME_NODE_CONTROL_SRC_DIR = resolve(REPO_ROOT, "packages/runtime-node-control/src");
 const RUNTIME_EXECUTION_DIST = resolve(REPO_ROOT, "packages/runtime-execution/dist/index.mjs");
 const RUNTIME_EXECUTION_PACKAGE_JSON = resolve(
   REPO_ROOT,
@@ -272,6 +285,16 @@ function gatewayBuildIsStale(): boolean {
 
   if (
     workspaceBuildIsStale({
+      outputPath: RUNTIME_NODE_CONTROL_DIST,
+      srcDir: RUNTIME_NODE_CONTROL_SRC_DIR,
+      watchedFiles: [RUNTIME_NODE_CONTROL_PACKAGE_JSON, RUNTIME_NODE_CONTROL_TSCONFIG],
+    })
+  ) {
+    return true;
+  }
+
+  if (
+    workspaceBuildIsStale({
       outputPath: RUNTIME_EXECUTION_DIST,
       srcDir: RUNTIME_EXECUTION_SRC_DIR,
       watchedFiles: [RUNTIME_EXECUTION_PACKAGE_JSON, RUNTIME_EXECUTION_TSCONFIG],
@@ -293,6 +316,7 @@ function gatewayBuildIsStale(): boolean {
   }
 
   if (gatewayMtime < statSync(SCHEMAS_DIST).mtimeMs) return true;
+  if (gatewayMtime < statSync(RUNTIME_NODE_CONTROL_DIST).mtimeMs) return true;
   if (gatewayMtime < statSync(RUNTIME_EXECUTION_DIST).mtimeMs) return true;
 
   return false;
@@ -322,6 +346,11 @@ function ensureGatewayBuild(): void {
     "@tyrum/contracts",
     SCHEMAS_DIST,
     "Failed to build @tyrum/contracts before startup test.",
+  );
+  ensureWorkspaceBuild(
+    "@tyrum/runtime-node-control",
+    RUNTIME_NODE_CONTROL_DIST,
+    "Failed to build @tyrum/runtime-node-control before startup test.",
   );
   ensureWorkspaceBuild(
     "@tyrum/runtime-execution",

--- a/packages/gateway/tests/unit/dist-heartbeat.test.ts
+++ b/packages/gateway/tests/unit/dist-heartbeat.test.ts
@@ -24,6 +24,22 @@ const SCHEMAS_JSONSCHEMA_CATALOG = resolve(
   REPO_ROOT,
   "packages/contracts/dist/jsonschema/catalog.json",
 );
+const SCHEMAS_PACKAGE_JSON = resolve(REPO_ROOT, "packages/contracts/package.json");
+const SCHEMAS_TSCONFIG = resolve(REPO_ROOT, "packages/contracts/tsconfig.json");
+const SCHEMAS_SRC_ROOT = resolve(REPO_ROOT, "packages/contracts/src");
+const RUNTIME_NODE_CONTROL_DIST_ENTRYPOINT = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/dist/index.mjs",
+);
+const RUNTIME_NODE_CONTROL_PACKAGE_JSON = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/package.json",
+);
+const RUNTIME_NODE_CONTROL_TSCONFIG = resolve(
+  REPO_ROOT,
+  "packages/runtime-node-control/tsconfig.json",
+);
+const RUNTIME_NODE_CONTROL_SRC_ROOT = resolve(REPO_ROOT, "packages/runtime-node-control/src");
 const GATEWAY_BUILD_LOCK = resolve(REPO_ROOT, ".tyrum-gateway-build.lock");
 
 interface MockWebSocket {
@@ -108,10 +124,54 @@ function maxMtimeMsInDir(dir: string): number {
   return max;
 }
 
+function buildOutputIsStale(input: {
+  outputPath: string;
+  sourceDirs?: readonly string[];
+  watchedFiles?: readonly string[];
+}): boolean {
+  if (!existsSync(input.outputPath)) return true;
+
+  const outputMtime = statSync(input.outputPath).mtimeMs;
+
+  for (const sourceDir of input.sourceDirs ?? []) {
+    if (existsSync(sourceDir) && outputMtime < maxMtimeMsInDir(sourceDir)) {
+      return true;
+    }
+  }
+
+  for (const watchedFile of input.watchedFiles ?? []) {
+    if (existsSync(watchedFile) && outputMtime < statSync(watchedFile).mtimeMs) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function gatewayBuildIsStale(): boolean {
-  if (!existsSync(DIST_ENTRYPOINT)) return true;
-  if (!existsSync(SCHEMAS_DIST_ENTRYPOINT)) return true;
+  if (
+    buildOutputIsStale({
+      outputPath: SCHEMAS_DIST_ENTRYPOINT,
+      sourceDirs: [SCHEMAS_SRC_ROOT],
+      watchedFiles: [SCHEMAS_PACKAGE_JSON, SCHEMAS_TSCONFIG],
+    })
+  ) {
+    return true;
+  }
+
   if (!existsSync(SCHEMAS_JSONSCHEMA_CATALOG)) return true;
+
+  if (
+    buildOutputIsStale({
+      outputPath: RUNTIME_NODE_CONTROL_DIST_ENTRYPOINT,
+      sourceDirs: [RUNTIME_NODE_CONTROL_SRC_ROOT],
+      watchedFiles: [RUNTIME_NODE_CONTROL_PACKAGE_JSON, RUNTIME_NODE_CONTROL_TSCONFIG],
+    })
+  ) {
+    return true;
+  }
+
+  if (!existsSync(DIST_ENTRYPOINT)) return true;
 
   const distMtime = statSync(DIST_ENTRYPOINT).mtimeMs;
 
@@ -122,6 +182,7 @@ function gatewayBuildIsStale(): boolean {
 
   const schemasMtime = statSync(SCHEMAS_DIST_ENTRYPOINT).mtimeMs;
   if (distMtime < schemasMtime) return true;
+  if (distMtime < statSync(RUNTIME_NODE_CONTROL_DIST_ENTRYPOINT).mtimeMs) return true;
 
   return false;
 }
@@ -187,8 +248,19 @@ async function buildGatewayDistIfStale(): Promise<void> {
   if (!gatewayBuildIsStale()) return;
 
   const commands = [
-    ...(!existsSync(SCHEMAS_DIST_ENTRYPOINT) || !existsSync(SCHEMAS_JSONSCHEMA_CATALOG)
+    ...(buildOutputIsStale({
+      outputPath: SCHEMAS_DIST_ENTRYPOINT,
+      sourceDirs: [SCHEMAS_SRC_ROOT],
+      watchedFiles: [SCHEMAS_PACKAGE_JSON, SCHEMAS_TSCONFIG],
+    }) || !existsSync(SCHEMAS_JSONSCHEMA_CATALOG)
       ? ([["--filter", "@tyrum/contracts", "build"]] as const)
+      : ([] as const)),
+    ...(buildOutputIsStale({
+      outputPath: RUNTIME_NODE_CONTROL_DIST_ENTRYPOINT,
+      sourceDirs: [RUNTIME_NODE_CONTROL_SRC_ROOT],
+      watchedFiles: [RUNTIME_NODE_CONTROL_PACKAGE_JSON, RUNTIME_NODE_CONTROL_TSCONFIG],
+    })
+      ? ([["--filter", "@tyrum/runtime-node-control", "build"]] as const)
       : ([] as const)),
     ["--filter", "@tyrum/gateway", "build"],
   ] as const;

--- a/packages/operator-ui/src/components/pages/agents-page-editor-form.ts
+++ b/packages/operator-ui/src/components/pages/agents-page-editor-form.ts
@@ -87,6 +87,7 @@ export type AgentEditorSetField = <K extends keyof AgentEditorFormState>(
 ) => void;
 
 export type PreservedMcpConfig = Pick<AgentConfigT["mcp"], "pre_turn_tools" | "server_settings">;
+export type PreservedToolExposureSelection = Pick<AgentConfigT["tools"], "bundle" | "tier">;
 
 export function splitList(value: string): string[] {
   return value
@@ -327,9 +328,19 @@ export function buildPayload(
   form: AgentEditorFormState,
   preservedModelOptions?: Record<string, unknown>,
   preservedMcpConfig?: PreservedMcpConfig,
+  preservedMcpSelection?: PreservedToolExposureSelection,
+  preservedToolSelection?: PreservedToolExposureSelection,
 ) {
   const primaryModel = form.model.trim();
   const memorySettings = buildMemoryServerSettings(form);
+  const mcpSelection = {
+    bundle: preservedMcpSelection?.bundle ?? form.createModeMcpBundle ?? undefined,
+    tier: preservedMcpSelection?.tier ?? form.createModeMcpTier ?? undefined,
+  };
+  const toolSelection = {
+    bundle: preservedToolSelection?.bundle ?? form.createModeToolsBundle ?? undefined,
+    tier: preservedToolSelection?.tier ?? form.createModeToolsTier ?? undefined,
+  };
   const preservedServerSettings = preservedMcpConfig?.server_settings ?? {};
   const preTurnTools =
     preservedMcpConfig?.pre_turn_tools ??
@@ -371,8 +382,8 @@ export function buildPayload(
         workspace_trusted: form.workspaceSkillsTrusted,
       },
       mcp: {
-        ...(form.createModeMcpBundle ? { bundle: form.createModeMcpBundle } : {}),
-        ...(form.createModeMcpTier ? { tier: form.createModeMcpTier } : {}),
+        ...(mcpSelection.bundle ? { bundle: mcpSelection.bundle } : {}),
+        ...(mcpSelection.tier ? { tier: mcpSelection.tier } : {}),
         default_mode: form.mcpDefaultMode,
         allow: form.mcpAllow,
         deny: form.mcpDeny,
@@ -380,8 +391,8 @@ export function buildPayload(
         server_settings: serverSettings,
       },
       tools: {
-        ...(form.createModeToolsBundle ? { bundle: form.createModeToolsBundle } : {}),
-        ...(form.createModeToolsTier ? { tier: form.createModeToolsTier } : {}),
+        ...(toolSelection.bundle ? { bundle: toolSelection.bundle } : {}),
+        ...(toolSelection.tier ? { tier: toolSelection.tier } : {}),
         default_mode: form.toolsDefaultMode,
         allow: form.toolsAllow,
         deny: form.toolsDeny,

--- a/packages/operator-ui/src/components/pages/agents-page-editor-sections.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-editor-sections.tsx
@@ -3,6 +3,11 @@ import { ChevronRight } from "lucide-react";
 import type { AgentEditorFormState, AgentEditorSetField } from "./agents-page-editor-form.js";
 import { AgentToneField } from "./agent-tone-field.js";
 import { AccessTransferField } from "./agents-page-editor-access-transfer.js";
+import {
+  CanonicalToolExposureSummary,
+  resolveCanonicalToolExposure,
+  type CanonicalToolExposureSelection,
+} from "./agents-page-editor-tool-exposure.js";
 import type { ModelPreset } from "./admin-http-models.shared.js";
 import {
   AgentEditorMcpOverrides,
@@ -21,6 +26,7 @@ export function AgentEditorSections({
   mode,
   setField,
   capabilities,
+  persistedToolExposure,
   capabilitiesLoading,
   capabilitiesError,
   modelPresets,
@@ -44,6 +50,7 @@ export function AgentEditorSections({
   mode: "create" | "edit";
   setField: AgentEditorSetField;
   capabilities: AgentCapabilitiesResponse | null;
+  persistedToolExposure: CanonicalToolExposureSelection | null;
   capabilitiesLoading: boolean;
   capabilitiesError: string | null;
   modelPresets: ModelPreset[];
@@ -68,6 +75,10 @@ export function AgentEditorSections({
   const mcpSettingsItems = (capabilities?.mcp.items ?? []).filter(
     (item: { id: string }) => item.id !== "memory",
   );
+  const canonicalToolExposure = resolveCanonicalToolExposure({
+    persistedToolExposure,
+    capabilities,
+  });
 
   return (
     <>
@@ -224,41 +235,65 @@ export function AgentEditorSections({
         title="Tools"
         description="Builtin, MCP, and plugin tools available to this agent."
       >
-        <AccessTransferField
-          title="tools"
-          defaultLabel="Default for new tools"
-          helperText={
-            capabilitiesError
-              ? capabilitiesError
-              : capabilitiesLoading
-                ? "Loading discoverable tools..."
-                : "New tools follow the selected default automatically."
-          }
-          items={(capabilities?.tools.items ?? []).map((item: { id: string }) => ({
-            id: item.id,
-            label: item.id,
-          }))}
-          state={{
-            defaultMode: form.toolsDefaultMode,
-            allow: form.toolsAllow,
-            deny: form.toolsDeny,
-          }}
-          disabled={capabilitiesLoading}
-          onDefaultModeChange={(modeValue) => {
-            setField("toolsDefaultMode", modeValue);
-            if (modeValue === "allow") {
-              setField("toolsAllow", []);
-            } else {
-              setField("toolsDeny", []);
-            }
-          }}
-          onAllowChange={(ids) => {
-            setField("toolsAllow", ids);
-          }}
-          onDenyChange={(ids) => {
-            setField("toolsDeny", ids);
-          }}
-        />
+        {canonicalToolExposure ? (
+          <CanonicalToolExposureSummary exposure={canonicalToolExposure} />
+        ) : (
+          <div
+            className="grid gap-1 rounded-lg border border-border/70 bg-bg-subtle/40 p-4"
+            data-testid="agents-editor-tools-legacy-fallback"
+          >
+            <div className="text-sm font-medium text-fg">Legacy tool exposure</div>
+            <div className="text-sm text-fg-muted">
+              Canonical bundle and tier selectors are not available for this record yet. Legacy tool
+              access controls remain available below during migration.
+            </div>
+          </div>
+        )}
+        <details className="group/tool-legacy-details" open={!canonicalToolExposure}>
+          <summary className="cursor-pointer list-none text-sm font-medium text-fg-muted hover:text-fg [&::-webkit-details-marker]:hidden">
+            <span className="inline-flex items-center gap-1.5">
+              <ChevronRight className="h-3.5 w-3.5 transition-transform group-open/tool-legacy-details:rotate-90" />
+              Legacy compatibility controls
+            </span>
+          </summary>
+          <div className="mt-3">
+            <AccessTransferField
+              title="tools"
+              defaultLabel="Default for new tools"
+              helperText={
+                capabilitiesError
+                  ? capabilitiesError
+                  : capabilitiesLoading
+                    ? "Loading discoverable tools..."
+                    : "New tools follow the selected default automatically."
+              }
+              items={(capabilities?.tools.items ?? []).map((item: { id: string }) => ({
+                id: item.id,
+                label: item.id,
+              }))}
+              state={{
+                defaultMode: form.toolsDefaultMode,
+                allow: form.toolsAllow,
+                deny: form.toolsDeny,
+              }}
+              disabled={capabilitiesLoading}
+              onDefaultModeChange={(modeValue) => {
+                setField("toolsDefaultMode", modeValue);
+                if (modeValue === "allow") {
+                  setField("toolsAllow", []);
+                } else {
+                  setField("toolsDeny", []);
+                }
+              }}
+              onAllowChange={(ids) => {
+                setField("toolsAllow", ids);
+              }}
+              onDenyChange={(ids) => {
+                setField("toolsDeny", ids);
+              }}
+            />
+          </div>
+        </details>
       </FieldGroup>
 
       <FieldGroup

--- a/packages/operator-ui/src/components/pages/agents-page-editor-tool-exposure.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-editor-tool-exposure.tsx
@@ -1,0 +1,126 @@
+import type { AgentCapabilitiesResponse, ManagedAgentDetail } from "@tyrum/contracts";
+import type { ReactElement } from "react";
+
+type CanonicalToolExposureSource = "persisted" | "capabilities";
+
+export type CanonicalToolExposureSelection = ManagedAgentDetail["tool_exposure"]["tools"];
+
+type CanonicalToolExposure = CanonicalToolExposureSelection & {
+  source: CanonicalToolExposureSource;
+};
+
+function hasCanonicalToolExposureSelection(selection: CanonicalToolExposureSelection): boolean {
+  return Boolean(selection.bundle ?? selection.tier);
+}
+
+function readCapabilitiesToolExposureSelection(
+  capabilities: AgentCapabilitiesResponse | null,
+): CanonicalToolExposureSelection {
+  const tools = capabilities?.tools;
+  if (!tools || typeof tools !== "object") {
+    return {};
+  }
+
+  const bundle = "bundle" in tools && typeof tools.bundle === "string" ? tools.bundle : undefined;
+  const tier =
+    "tier" in tools && (tools.tier === "default" || tools.tier === "advanced")
+      ? tools.tier
+      : undefined;
+
+  return { bundle, tier };
+}
+
+export function resolveCanonicalToolExposure(input: {
+  persistedToolExposure: CanonicalToolExposureSelection | null;
+  capabilities: AgentCapabilitiesResponse | null;
+}): CanonicalToolExposure | null {
+  if (input.persistedToolExposure !== null) {
+    if (!hasCanonicalToolExposureSelection(input.persistedToolExposure)) {
+      return null;
+    }
+    return {
+      ...input.persistedToolExposure,
+      source: "persisted",
+    };
+  }
+
+  const capabilitiesSelection = readCapabilitiesToolExposureSelection(input.capabilities);
+  if (!hasCanonicalToolExposureSelection(capabilitiesSelection)) {
+    return null;
+  }
+
+  return {
+    ...capabilitiesSelection,
+    source: "capabilities",
+  };
+}
+
+function formatCanonicalToolTier(tier: CanonicalToolExposureSelection["tier"]): string {
+  switch (tier) {
+    case "advanced":
+      return "Advanced";
+    case "default":
+      return "Default";
+    default:
+      return "Not set";
+  }
+}
+
+function StaticExposureField({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: string;
+  testId: string;
+}): ReactElement {
+  return (
+    <div className="grid gap-1">
+      <div className="text-sm font-medium text-fg">{label}</div>
+      <div
+        className="rounded-lg border border-border/70 bg-bg-subtle/40 px-3 py-2 text-sm text-fg"
+        data-testid={testId}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function CanonicalToolExposureSummary({
+  exposure,
+}: {
+  exposure: CanonicalToolExposure;
+}): ReactElement {
+  const summaryLabel =
+    exposure.source === "persisted" ? "Persisted canonical exposure" : "Default canonical exposure";
+  const summaryDescription =
+    exposure.source === "persisted"
+      ? "Loaded from the saved agent detail."
+      : "Derived from the current capabilities because this agent does not have a persisted detail record yet.";
+
+  return (
+    <div
+      className="grid gap-3 rounded-lg border border-border/70 bg-bg-subtle/40 p-4"
+      data-testid="agents-editor-tools-canonical-read-model"
+    >
+      <div className="grid gap-1">
+        <div className="text-sm font-medium text-fg">{summaryLabel}</div>
+        <div className="text-sm text-fg-muted">{summaryDescription}</div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <StaticExposureField
+          label="Bundle"
+          value={exposure.bundle ?? "Not set"}
+          testId="agents-editor-tools-canonical-bundle"
+        />
+        <StaticExposureField
+          label="Tier"
+          value={formatCanonicalToolTier(exposure.tier)}
+          testId="agents-editor-tools-canonical-tier"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/operator-ui/src/components/pages/agents-page-editor.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-editor.tsx
@@ -91,6 +91,7 @@ export function AgentsPageEditor({
   onCancelCreate,
 }: AgentEditorProps): React.ReactElement {
   const [form, setForm] = React.useState<AgentEditorFormState>(createBlankForm());
+  const [agentDetail, setAgentDetail] = React.useState<ManagedAgentDetail | null>(null);
   const [loading, setLoading] = React.useState(mode === "edit");
   const [loadError, setLoadError] = React.useState<string | null>(null);
   const [capabilities, setCapabilities] = React.useState<AgentCapabilitiesResponse | null>(null);
@@ -146,6 +147,7 @@ export function AgentsPageEditor({
 
       if (mode === "create") {
         setForm(createBlankForm());
+        setAgentDetail(null);
         setPreservedModelOptions({});
         setPreservedMcpConfig(createEmptyPreservedMcpConfig());
         setMcpSettingsDrafts({});
@@ -184,6 +186,7 @@ export function AgentsPageEditor({
         if (cancelled) return;
 
         if (detailResult.status === "fulfilled") {
+          setAgentDetail(detailResult.value);
           setForm(
             snapshotToForm({
               agentKey: detailResult.value.agent_key,
@@ -198,6 +201,7 @@ export function AgentsPageEditor({
           });
           setMcpSettingsDrafts({});
         } else {
+          setAgentDetail(null);
           setLoadError(formatErrorMessage(detailResult.reason));
         }
 
@@ -389,7 +393,19 @@ export function AgentsPageEditor({
 
       const updated = await saveAction.runAndThrow(async () => {
         const resolvedMcpConfig = await buildResolvedMcpConfig();
-        const payload = buildPayload(form, preservedModelOptions, resolvedMcpConfig);
+        const payload = buildPayload(
+          form,
+          preservedModelOptions,
+          resolvedMcpConfig,
+          {
+            bundle: agentDetail?.config.mcp.bundle,
+            tier: agentDetail?.config.mcp.tier,
+          },
+          {
+            bundle: agentDetail?.tool_exposure?.tools.bundle,
+            tier: agentDetail?.tool_exposure?.tools.tier,
+          },
+        );
         const targetKey = agentKey ?? payload.agent_key;
         return await core.admin.agents.update(targetKey, {
           config: payload.config,
@@ -479,6 +495,7 @@ export function AgentsPageEditor({
         unsupportedModelOptions={unsupportedModelOptions}
         preservedModelOptionsRaw={preservedModelOptions}
         capabilities={capabilities}
+        persistedToolExposure={mode === "edit" ? (agentDetail?.tool_exposure?.tools ?? {}) : null}
         capabilitiesLoading={capabilitiesLoading}
         capabilitiesError={capabilitiesError}
         mcpExtensionDetailsById={mcpExtensionsById}

--- a/packages/operator-ui/src/i18n/messages/en.json
+++ b/packages/operator-ui/src/i18n/messages/en.json
@@ -204,6 +204,7 @@
   "Built-in default": "Built-in default",
   "Built-in MCP": "Built-in MCP",
   "Builtin, MCP, and plugin tools available to this agent.": "Builtin, MCP, and plugin tools available to this agent.",
+  "Bundle": "Bundle",
   "Bundle events": "Bundle events",
   "Cadence": "Cadence",
   "Calm natural greens.": "Calm natural greens.",

--- a/packages/operator-ui/src/i18n/messages/nl.json
+++ b/packages/operator-ui/src/i18n/messages/nl.json
@@ -204,6 +204,7 @@
   "Built-in default": "Ingebouwde standaard",
   "Built-in MCP": "Ingebouwde MCP",
   "Builtin, MCP, and plugin tools available to this agent.": "Ingebouwde, MCP- en plug-intools die beschikbaar zijn voor deze agent.",
+  "Bundle": "Bundel",
   "Bundle events": "Bundel evenementen",
   "Cadence": "Cadence",
   "Calm natural greens.": "Rustige natuurlijke groentinten.",

--- a/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
@@ -78,6 +78,38 @@ describe("agents-page-editor-form", () => {
     );
   });
 
+  it("prefers preserved canonical exposure when building an update payload", () => {
+    const form = createBlankForm();
+    form.agentKey = "agent-canonical-preserve";
+
+    const payload = buildPayload(
+      form,
+      undefined,
+      undefined,
+      {
+        bundle: "workspace-default",
+        tier: "advanced",
+      },
+      {
+        bundle: "authoring-core",
+        tier: "advanced",
+      },
+    );
+
+    expect(payload.config.mcp).toEqual(
+      expect.objectContaining({
+        bundle: "workspace-default",
+        tier: "advanced",
+      }),
+    );
+    expect(payload.config.tools).toEqual(
+      expect.objectContaining({
+        bundle: "authoring-core",
+        tier: "advanced",
+      }),
+    );
+  });
+
   it("drops explicit memory server settings when inheriting shared defaults", () => {
     const form = createBlankForm();
     form.agentKey = "agent-memory-inherit";

--- a/packages/operator-ui/tests/pages/agents-page-editor-sections.test-support.tsx
+++ b/packages/operator-ui/tests/pages/agents-page-editor-sections.test-support.tsx
@@ -1,0 +1,214 @@
+import type { ManagedExtensionDetail } from "@tyrum/contracts";
+import { setNativeValue } from "../test-utils.js";
+
+export function findLabeledControl(
+  container: HTMLElement,
+  labelText: string,
+): HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
+  const label = Array.from(container.querySelectorAll("label")).find(
+    (element) => element.textContent?.trim() === labelText,
+  );
+  if (!(label instanceof HTMLLabelElement) || !label.htmlFor) {
+    throw new Error(`Missing label: ${labelText}`);
+  }
+  const control =
+    container.ownerDocument.getElementById(label.htmlFor) ??
+    label.parentElement?.querySelector("input, textarea, select");
+  if (
+    !(
+      control instanceof HTMLInputElement ||
+      control instanceof HTMLTextAreaElement ||
+      control instanceof HTMLSelectElement
+    )
+  ) {
+    throw new Error(`Missing control for label: ${labelText}`);
+  }
+  return control;
+}
+
+export function setLabeledValue(container: HTMLElement, labelText: string, value: string): void {
+  const control = findLabeledControl(container, labelText);
+  if (control instanceof HTMLSelectElement) {
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+    if (setter) {
+      setter.call(control, value);
+    }
+    control.dispatchEvent(new Event("input", { bubbles: true }));
+    control.dispatchEvent(new Event("change", { bubbles: true }));
+    return;
+  }
+  setNativeValue(control, value);
+}
+
+export function setMultiSelectValues(element: HTMLSelectElement, values: readonly string[]): void {
+  const selected = new Set(values);
+  for (const option of element.options) {
+    option.selected = selected.has(option.value);
+  }
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+export function findToggle(container: HTMLElement, labelText: string): HTMLElement {
+  const label = Array.from(container.querySelectorAll("label")).find((element) => {
+    return element.textContent?.replace(/\s+/gu, " ").trim() === labelText;
+  });
+  const button = label?.querySelector<HTMLElement>("button");
+  if (!button) {
+    throw new Error(`Missing toggle: ${labelText}`);
+  }
+  return button;
+}
+
+export function sampleModelPresets() {
+  return [
+    {
+      preset_id: "11111111-1111-4111-8111-111111111111",
+      preset_key: "gpt-4-1",
+      display_name: "GPT-4.1",
+      provider_key: "openai",
+      model_id: "gpt-4.1",
+      options: {},
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
+    },
+    {
+      preset_id: "22222222-2222-4222-8222-222222222222",
+      preset_key: "gpt-4-1-mini",
+      display_name: "GPT-4.1 Mini",
+      provider_key: "openai",
+      model_id: "gpt-4.1-mini",
+      options: { reasoning_effort: "medium" as const },
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
+    },
+  ];
+}
+
+export function sampleCapabilities(
+  toolSelection: { bundle?: string; tier?: "default" | "advanced" } = {},
+) {
+  return {
+    skills: {
+      default_mode: "allow" as const,
+      allow: [],
+      deny: [],
+      workspace_trusted: true,
+      items: [
+        { id: "review", name: "Review", version: "1.0.0", source: "bundled" as const },
+        { id: "triage", name: "Triage", version: "1.0.0", source: "managed" as const },
+      ],
+    },
+    mcp: {
+      default_mode: "allow" as const,
+      allow: [],
+      deny: [],
+      items: [
+        {
+          id: "memory",
+          name: "Memory",
+          transport: "stdio" as const,
+          source: "builtin" as const,
+        },
+        {
+          id: "filesystem",
+          name: "Filesystem",
+          transport: "stdio" as const,
+          source: "workspace" as const,
+        },
+      ],
+    },
+    tools: {
+      ...toolSelection,
+      default_mode: "allow" as const,
+      allow: [],
+      deny: [],
+      items: [
+        {
+          id: "read",
+          description: "Read files",
+          source: "builtin" as const,
+          family: null,
+          backing_server_id: null,
+        },
+      ],
+    },
+  };
+}
+
+export function sampleMcpExtensionDetails(): Record<string, ManagedExtensionDetail> {
+  return {
+    memory: {
+      kind: "mcp",
+      key: "memory",
+      name: "Memory",
+      description: null,
+      version: null,
+      enabled: true,
+      revision: null,
+      source: null,
+      source_type: "builtin",
+      refreshable: false,
+      materialized_path: null,
+      assignment_count: 0,
+      transport: "stdio",
+      default_access: "inherit",
+      can_edit_settings: true,
+      can_toggle_source_enabled: false,
+      can_refresh_source: false,
+      can_revert_source: false,
+      manifest: null,
+      spec: {
+        id: "memory",
+        name: "Memory",
+        enabled: true,
+        transport: "stdio",
+        command: "node",
+        args: ["-e", ""],
+      },
+      files: [],
+      revisions: [],
+      default_mcp_server_settings_json: { enabled: true },
+      default_mcp_server_settings_yaml: "enabled: true\n",
+      sources: [],
+    },
+    filesystem: {
+      kind: "mcp",
+      key: "filesystem",
+      name: "Filesystem",
+      description: null,
+      version: null,
+      enabled: true,
+      revision: 1,
+      source: {
+        kind: "npm",
+        npm_spec: "@modelcontextprotocol/server-filesystem",
+        command: "npx",
+        args: ["-y"],
+      },
+      source_type: "managed",
+      refreshable: true,
+      materialized_path: "/tmp/managed/mcp/filesystem/server.yml",
+      assignment_count: 0,
+      transport: "stdio",
+      default_access: "inherit",
+      can_edit_settings: true,
+      can_toggle_source_enabled: true,
+      can_refresh_source: true,
+      can_revert_source: true,
+      manifest: null,
+      spec: {
+        id: "filesystem",
+        name: "Filesystem",
+        enabled: true,
+        transport: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem"],
+      },
+      files: [],
+      revisions: [],
+      default_mcp_server_settings_json: { namespace: "shared" },
+      default_mcp_server_settings_yaml: "namespace: shared\n",
+      sources: [],
+    },
+  };
+}

--- a/packages/operator-ui/tests/pages/agents-page-editor-sections.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor-sections.test.ts
@@ -1,221 +1,20 @@
 // @vitest-environment jsdom
 
-import type { ManagedExtensionDetail } from "@tyrum/contracts";
 import { PERSONA_TONE_PRESETS } from "@tyrum/contracts";
 import { describe, expect, it, vi } from "vitest";
 import React, { act } from "react";
 import { AgentEditorSections } from "../../src/components/pages/agents-page-editor-sections.js";
 import { createBlankForm } from "../../src/components/pages/agents-page-editor-form.js";
-import { cleanupTestRoot, click, renderIntoDocument, setNativeValue } from "../test-utils.js";
-
-function findLabeledControl(
-  container: HTMLElement,
-  labelText: string,
-): HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement {
-  const label = Array.from(container.querySelectorAll("label")).find(
-    (element) => element.textContent?.trim() === labelText,
-  );
-  if (!(label instanceof HTMLLabelElement) || !label.htmlFor) {
-    throw new Error(`Missing label: ${labelText}`);
-  }
-  const control =
-    container.ownerDocument.getElementById(label.htmlFor) ??
-    label.parentElement?.querySelector("input, textarea, select");
-  if (
-    !(
-      control instanceof HTMLInputElement ||
-      control instanceof HTMLTextAreaElement ||
-      control instanceof HTMLSelectElement
-    )
-  ) {
-    throw new Error(`Missing control for label: ${labelText}`);
-  }
-  return control;
-}
-
-function setLabeledValue(container: HTMLElement, labelText: string, value: string): void {
-  const control = findLabeledControl(container, labelText);
-  if (control instanceof HTMLSelectElement) {
-    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
-    if (setter) {
-      setter.call(control, value);
-    }
-    control.dispatchEvent(new Event("input", { bubbles: true }));
-    control.dispatchEvent(new Event("change", { bubbles: true }));
-    return;
-  }
-  setNativeValue(control, value);
-}
-
-function setMultiSelectValues(element: HTMLSelectElement, values: readonly string[]): void {
-  const selected = new Set(values);
-  for (const option of element.options) {
-    option.selected = selected.has(option.value);
-  }
-  element.dispatchEvent(new Event("change", { bubbles: true }));
-}
-
-function findToggle(container: HTMLElement, labelText: string): HTMLElement {
-  const label = Array.from(container.querySelectorAll("label")).find((element) => {
-    return element.textContent?.replace(/\s+/gu, " ").trim() === labelText;
-  });
-  const button = label?.querySelector<HTMLElement>("button");
-  if (!button) {
-    throw new Error(`Missing toggle: ${labelText}`);
-  }
-  return button;
-}
-
-function sampleModelPresets() {
-  return [
-    {
-      preset_id: "11111111-1111-4111-8111-111111111111",
-      preset_key: "gpt-4-1",
-      display_name: "GPT-4.1",
-      provider_key: "openai",
-      model_id: "gpt-4.1",
-      options: {},
-      created_at: "2026-03-01T00:00:00.000Z",
-      updated_at: "2026-03-01T00:00:00.000Z",
-    },
-    {
-      preset_id: "22222222-2222-4222-8222-222222222222",
-      preset_key: "gpt-4-1-mini",
-      display_name: "GPT-4.1 Mini",
-      provider_key: "openai",
-      model_id: "gpt-4.1-mini",
-      options: { reasoning_effort: "medium" as const },
-      created_at: "2026-03-01T00:00:00.000Z",
-      updated_at: "2026-03-01T00:00:00.000Z",
-    },
-  ];
-}
-
-function sampleCapabilities() {
-  return {
-    skills: {
-      default_mode: "allow" as const,
-      allow: [],
-      deny: [],
-      workspace_trusted: true,
-      items: [
-        { id: "review", name: "Review", version: "1.0.0", source: "bundled" as const },
-        { id: "triage", name: "Triage", version: "1.0.0", source: "managed" as const },
-      ],
-    },
-    mcp: {
-      default_mode: "allow" as const,
-      allow: [],
-      deny: [],
-      items: [
-        {
-          id: "memory",
-          name: "Memory",
-          transport: "stdio" as const,
-          source: "builtin" as const,
-        },
-        {
-          id: "filesystem",
-          name: "Filesystem",
-          transport: "stdio" as const,
-          source: "workspace" as const,
-        },
-      ],
-    },
-    tools: {
-      default_mode: "allow" as const,
-      allow: [],
-      deny: [],
-      items: [
-        {
-          id: "read",
-          description: "Read files",
-          source: "builtin" as const,
-          family: null,
-          backing_server_id: null,
-        },
-      ],
-    },
-  };
-}
-
-function sampleMcpExtensionDetails(): Record<string, ManagedExtensionDetail> {
-  return {
-    memory: {
-      kind: "mcp",
-      key: "memory",
-      name: "Memory",
-      description: null,
-      version: null,
-      enabled: true,
-      revision: null,
-      source: null,
-      source_type: "builtin",
-      refreshable: false,
-      materialized_path: null,
-      assignment_count: 0,
-      transport: "stdio",
-      default_access: "inherit",
-      can_edit_settings: true,
-      can_toggle_source_enabled: false,
-      can_refresh_source: false,
-      can_revert_source: false,
-      manifest: null,
-      spec: {
-        id: "memory",
-        name: "Memory",
-        enabled: true,
-        transport: "stdio",
-        command: "node",
-        args: ["-e", ""],
-      },
-      files: [],
-      revisions: [],
-      default_mcp_server_settings_json: { enabled: true },
-      default_mcp_server_settings_yaml: "enabled: true\n",
-      sources: [],
-    },
-    filesystem: {
-      kind: "mcp",
-      key: "filesystem",
-      name: "Filesystem",
-      description: null,
-      version: null,
-      enabled: true,
-      revision: 1,
-      source: {
-        kind: "npm",
-        npm_spec: "@modelcontextprotocol/server-filesystem",
-        command: "npx",
-        args: ["-y"],
-      },
-      source_type: "managed",
-      refreshable: true,
-      materialized_path: "/tmp/managed/mcp/filesystem/server.yml",
-      assignment_count: 0,
-      transport: "stdio",
-      default_access: "inherit",
-      can_edit_settings: true,
-      can_toggle_source_enabled: true,
-      can_refresh_source: true,
-      can_revert_source: true,
-      manifest: null,
-      spec: {
-        id: "filesystem",
-        name: "Filesystem",
-        enabled: true,
-        transport: "stdio",
-        command: "npx",
-        args: ["-y", "@modelcontextprotocol/server-filesystem"],
-      },
-      files: [],
-      revisions: [],
-      default_mcp_server_settings_json: { namespace: "shared" },
-      default_mcp_server_settings_yaml: "namespace: shared\n",
-      sources: [],
-    },
-  };
-}
+import { cleanupTestRoot, click, renderIntoDocument } from "../test-utils.js";
+import {
+  findLabeledControl,
+  findToggle,
+  sampleCapabilities,
+  sampleMcpExtensionDetails,
+  sampleModelPresets,
+  setLabeledValue,
+  setMultiSelectValues,
+} from "./agents-page-editor-sections.test-support.js";
 
 describe("AgentEditorSections", () => {
   it(
@@ -238,6 +37,7 @@ describe("AgentEditorSections", () => {
           },
           modelPresets: sampleModelPresets(),
           capabilities: sampleCapabilities(),
+          persistedToolExposure: null,
           capabilitiesLoading: false,
           capabilitiesError: null,
           modelPresetsLoading: false,
@@ -495,6 +295,7 @@ describe("AgentEditorSections", () => {
         setField,
         modelPresets: sampleModelPresets(),
         capabilities: sampleCapabilities(),
+        persistedToolExposure: {},
         capabilitiesLoading: false,
         capabilitiesError: null,
         modelPresetsLoading: false,

--- a/packages/operator-ui/tests/pages/agents-page-editor-sections.tool-exposure.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor-sections.tool-exposure.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import React from "react";
+import { AgentEditorSections } from "../../src/components/pages/agents-page-editor-sections.js";
+import { createBlankForm } from "../../src/components/pages/agents-page-editor-form.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+import {
+  sampleCapabilities,
+  sampleMcpExtensionDetails,
+  sampleModelPresets,
+} from "./agents-page-editor-sections.test-support.js";
+
+function renderToolExposureSection(props: {
+  mode: "create" | "edit";
+  capabilities: ReturnType<typeof sampleCapabilities>;
+  persistedToolExposure: Record<string, unknown> | null;
+}) {
+  return renderIntoDocument(
+    React.createElement(AgentEditorSections, {
+      form: {
+        ...createBlankForm(),
+        memorySettingsMode: "override",
+      },
+      mode: props.mode,
+      setField: vi.fn(),
+      modelPresets: sampleModelPresets(),
+      capabilities: props.capabilities,
+      persistedToolExposure: props.persistedToolExposure,
+      capabilitiesLoading: false,
+      capabilitiesError: null,
+      modelPresetsLoading: false,
+      modelPresetsError: null,
+      selectedPrimaryPreset: null,
+      legacyPrimarySelection: null,
+      onSelectPrimaryPreset: vi.fn(),
+      onClearPrimaryModel: vi.fn(),
+      unsupportedModelOptions: null,
+      preservedModelOptionsRaw: {},
+      mcpExtensionDetailsById: sampleMcpExtensionDetails(),
+      mcpExplicitServerSettings: {},
+      mcpExtensionsLoading: false,
+      mcpExtensionsError: null,
+      onMemorySettingsModeChange: vi.fn(),
+      mcpSettingsDrafts: {},
+      onMcpSettingsDraftChange: vi.fn(),
+    }),
+  );
+}
+
+describe("AgentEditorSections canonical tool exposure", () => {
+  it("renders canonical tool exposure from capabilities in create mode", () => {
+    const { root, container } = renderToolExposureSection({
+      mode: "create",
+      capabilities: sampleCapabilities({
+        bundle: "authoring-core",
+        tier: "default",
+      }),
+      persistedToolExposure: null,
+    });
+
+    expect(container.textContent).toContain("Default canonical exposure");
+    expect(
+      container.querySelector('[data-testid="agents-editor-tools-canonical-bundle"]')?.textContent,
+    ).toBe("authoring-core");
+    expect(
+      container.querySelector('[data-testid="agents-editor-tools-canonical-tier"]')?.textContent,
+    ).toBe("Default");
+    expect(container.textContent).toContain("Legacy compatibility controls");
+
+    cleanupTestRoot({ root, container });
+  });
+
+  it("falls back to legacy tool exposure messaging when canonical selectors are unavailable", () => {
+    const { root, container } = renderToolExposureSection({
+      mode: "edit",
+      capabilities: sampleCapabilities(),
+      persistedToolExposure: {},
+    });
+
+    expect(container.textContent).toContain("Legacy tool exposure");
+    expect(container.textContent).toContain(
+      "Canonical bundle and tier selectors are not available for this record yet.",
+    );
+    expect(
+      container.querySelector('[data-testid="agents-editor-tools-canonical-read-model"]'),
+    ).toBe(null);
+
+    cleanupTestRoot({ root, container });
+  });
+});

--- a/packages/operator-ui/tests/pages/agents-page-editor.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor.test.ts
@@ -106,6 +106,8 @@ describe("AgentsPage editor", () => {
       config: AgentConfig.parse({
         ...sampleManagedAgentDetail("default").config,
         mcp: {
+          bundle: "workspace-default",
+          tier: "advanced",
           default_mode: "deny",
           allow: ["filesystem"],
           deny: ["secrets"],
@@ -174,6 +176,8 @@ describe("AgentsPage editor", () => {
       expect.objectContaining({
         config: expect.objectContaining({
           mcp: expect.objectContaining({
+            bundle: "workspace-default",
+            tier: "advanced",
             default_mode: "deny",
             allow: ["filesystem"],
             deny: ["secrets"],

--- a/packages/operator-ui/tests/pages/agents-page-editor.tool-exposure.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor.tool-exposure.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { AgentConfig } from "@tyrum/contracts";
+import { describe, expect, it, vi } from "vitest";
+import React, { act } from "react";
+import { AgentsPageEditor } from "../../src/components/pages/agents-page-editor.js";
+import { createCore, flush, sampleManagedAgentDetail } from "./agents-page-editor.test-helpers.js";
+import { cleanupTestRoot, click, renderIntoDocument } from "../test-utils.js";
+
+describe("AgentsPageEditor canonical tool exposure", () => {
+  it("renders persisted canonical tool exposure in edit mode and preserves read-model selectors on save", async () => {
+    const existingDetail = {
+      ...sampleManagedAgentDetail("default"),
+      config: AgentConfig.parse({
+        ...sampleManagedAgentDetail("default").config,
+        tools: {
+          bundle: "legacy-config-bundle",
+          tier: "default",
+          default_mode: "deny",
+          allow: ["read"],
+          deny: ["bash"],
+        },
+      }),
+      tool_exposure: {
+        ...sampleManagedAgentDetail("default").tool_exposure,
+        tools: {
+          bundle: "authoring-core",
+          tier: "advanced" as const,
+        },
+      },
+    };
+    const get = vi.fn().mockResolvedValue(existingDetail);
+    const capabilities = vi.fn(async () => ({
+      skills: { default_mode: "allow", allow: [], deny: [], workspace_trusted: true, items: [] },
+      mcp: {
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+        items: [
+          {
+            id: "memory",
+            name: "Memory",
+            transport: "stdio" as const,
+            source: "builtin" as const,
+          },
+        ],
+      },
+      tools: {
+        bundle: "capabilities-only",
+        tier: "default" as const,
+        default_mode: "allow",
+        allow: [],
+        deny: [],
+        items: [
+          {
+            id: "read",
+            description: "Read files",
+            source: "builtin" as const,
+            family: null,
+            backing_server_id: null,
+          },
+        ],
+      },
+    }));
+    const update = vi.fn().mockResolvedValue(existingDetail);
+    const core = createCore(vi.fn(), get, capabilities, update);
+
+    const testRoot = renderIntoDocument(
+      React.createElement(AgentsPageEditor, {
+        core,
+        mode: "edit",
+        createNonce: 1,
+        agentKey: "default",
+        onSaved: vi.fn(),
+        onCancelCreate: vi.fn(),
+      }),
+    );
+    await flush();
+
+    expect(testRoot.container.textContent).toContain("Persisted canonical exposure");
+    expect(
+      testRoot.container.querySelector('[data-testid="agents-editor-tools-canonical-bundle"]')
+        ?.textContent,
+    ).toBe("authoring-core");
+    expect(
+      testRoot.container.querySelector('[data-testid="agents-editor-tools-canonical-tier"]')
+        ?.textContent,
+    ).toBe("Advanced");
+
+    const saveButton = testRoot.container.querySelector<HTMLButtonElement>(
+      '[data-testid="agents-editor-save"]',
+    );
+    expect(saveButton).not.toBeNull();
+
+    await act(async () => {
+      if (saveButton) click(saveButton);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(update).toHaveBeenCalledWith(
+      "default",
+      expect.objectContaining({
+        config: expect.objectContaining({
+          tools: expect.objectContaining({
+            bundle: "authoring-core",
+            tier: "advanced",
+            default_mode: "deny",
+            allow: ["read"],
+            deny: ["bash"],
+          }),
+        }),
+      }),
+    );
+    expect(update).not.toHaveBeenCalledWith(
+      "default",
+      expect.objectContaining({
+        config: expect.objectContaining({
+          tools: expect.objectContaining({
+            bundle: "legacy-config-bundle",
+            tier: "default",
+          }),
+        }),
+      }),
+    );
+
+    cleanupTestRoot(testRoot);
+  });
+});


### PR DESCRIPTION
Closes #1983

## What Changed
- switched the operator agent editor to read canonical tool exposure from persisted `tool_exposure.tools` when editing an existing managed agent
- kept create-mode fallback behavior on the existing capabilities response so new agents still render bundle and tier defaults
- preserved canonical bundle and tier values when saving edits, while keeping the legacy allow/deny transfer list visible as compatibility detail
- added targeted operator-ui coverage for canonical read-mode rendering and save preservation
- added the missing `Bundle` i18n catalog key required by the new UI labels

## Why
Issue #1983 is part of epic #1961 and scopes the editor read path only. The operator UI needed to stop treating legacy allow/deny lists as the primary source of truth when canonical tool exposure metadata is already persisted.

## How To Test
- `pnpm exec tsc --noEmit --project packages/operator-ui/tsconfig.json`
- `pnpm exec vitest run packages/operator-ui/tests/pages/agents-page-editor.test.ts packages/operator-ui/tests/pages/agents-page-editor.tool-exposure.test.ts packages/operator-ui/tests/pages/agents-page-editor-sections.test.ts packages/operator-ui/tests/pages/agents-page-editor-sections.tool-exposure.test.ts`
- `pnpm run i18n:check`
- `pnpm lint`
- `CI=true git push -u origin 1983-adopt-canonical-tool-exposure-read-model` (runs the repo pre-push local CI gate)

## Risk
Low to moderate. The change is isolated to operator-ui agent editor read/save wiring and related presentation logic, but it affects how existing managed agents display canonical tool exposure metadata.

## Rollback Notes
Revert commits `136ab13fa` and `a148c1a90` to restore the previous editor read model and remove the follow-up i18n key if rollback is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent editor read/save wiring for tool exposure, so regressions could cause existing agents to silently lose or misreport canonical bundle/tier values. Changes are localized and covered by new unit/UI tests, reducing likelihood of broad impact.
> 
> **Overview**
> Updates the operator agent editor to **prefer canonical tool exposure (bundle/tier)** from persisted `tool_exposure.tools` when editing existing agents, while still deriving defaults from the capabilities response in create mode.
> 
> Save behavior is adjusted to **preserve canonical bundle/tier selections** for both `mcp` and `tools` during updates, and the UI now shows a read-only canonical exposure summary with legacy allow/deny controls tucked under a compatibility details section. Test coverage is expanded for the new read model and save preservation, an i18n `Bundle` key is added, and gateway startup/dist tests now ensure `@tyrum/runtime-node-control` is considered/buildable when checking for stale workspace builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8525cb785b5d3427cddc3363730f30c8b16d642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->