### PR TITLE
Adopt the canonical tool exposure model in agent setup/create flows

### DIFF
--- a/packages/operator-ui/src/components/pages/agent-setup-wizard.shared.ts
+++ b/packages/operator-ui/src/components/pages/agent-setup-wizard.shared.ts
@@ -25,6 +25,18 @@ export const HIDDEN_AGENT_PERSONA_DEFAULTS = {
   character: "architect",
 } as const;
 
+export const CANONICAL_DEFAULT_MCP_EXPOSURE = {
+  bundle: "workspace-default",
+  tier: "advanced",
+} as const;
+
+export const CANONICAL_DEFAULT_TOOL_EXPOSURE = {
+  bundle: "authoring-core",
+  tier: "default",
+} as const;
+
+export const CANONICAL_MEMORY_SEED_TOOL_ID = "memory.seed";
+
 export function buildAgentConfigFromPreset(input: {
   baseConfig?: AgentConfigT | null;
   preset: ModelPreset;
@@ -53,16 +65,12 @@ export function buildAgentConfigFromPreset(input: {
       workspace_trusted: false,
     },
     mcp: {
-      default_mode: "deny",
-      allow: ["memory"],
-      deny: [],
-      pre_turn_tools: ["mcp.memory.seed"],
+      ...CANONICAL_DEFAULT_MCP_EXPOSURE,
+      pre_turn_tools: [CANONICAL_MEMORY_SEED_TOOL_ID],
       server_settings: memoryServerSettings === undefined ? {} : { memory: memoryServerSettings },
     },
     tools: {
-      default_mode: "allow",
-      allow: [],
-      deny: [],
+      ...CANONICAL_DEFAULT_TOOL_EXPOSURE,
     },
   });
 }

--- a/packages/operator-ui/src/components/pages/agents-page-editor-form.ts
+++ b/packages/operator-ui/src/components/pages/agents-page-editor-form.ts
@@ -4,6 +4,11 @@ import {
   resolvePersonaToneInstructions,
 } from "@tyrum/contracts";
 import type { AgentConfig as AgentConfigT, IdentityPack as IdentityPackT } from "@tyrum/contracts";
+import {
+  CANONICAL_DEFAULT_MCP_EXPOSURE,
+  CANONICAL_DEFAULT_TOOL_EXPOSURE,
+  CANONICAL_MEMORY_SEED_TOOL_ID,
+} from "./agent-setup-wizard.shared.js";
 
 const DEFAULT_CONFIG = AgentConfig.parse({
   model: { model: null },
@@ -70,6 +75,10 @@ export type AgentEditorFormState = {
   episodeItems: string;
   episodeChars: string;
   episodeTokens: string;
+  createModeMcpBundle: NonNullable<AgentConfigT["mcp"]["bundle"]> | null;
+  createModeMcpTier: NonNullable<AgentConfigT["mcp"]["tier"]> | null;
+  createModeToolsBundle: NonNullable<AgentConfigT["tools"]["bundle"]> | null;
+  createModeToolsTier: NonNullable<AgentConfigT["tools"]["tier"]> | null;
 };
 
 export type AgentEditorSetField = <K extends keyof AgentEditorFormState>(
@@ -174,14 +183,24 @@ export function snapshotToForm(snapshot: {
     episodeChars: String(perKind.episode.max_chars),
     episodeTokens:
       perKind.episode.max_tokens === undefined ? "" : String(perKind.episode.max_tokens),
+    createModeMcpBundle: null,
+    createModeMcpTier: null,
+    createModeToolsBundle: null,
+    createModeToolsTier: null,
   };
 }
 
 export function createBlankForm(): AgentEditorFormState {
-  return snapshotToForm({
-    agentKey: "",
-    config: DEFAULT_CONFIG,
-  });
+  return {
+    ...snapshotToForm({
+      agentKey: "",
+      config: DEFAULT_CONFIG,
+    }),
+    createModeMcpBundle: CANONICAL_DEFAULT_MCP_EXPOSURE.bundle,
+    createModeMcpTier: CANONICAL_DEFAULT_MCP_EXPOSURE.tier,
+    createModeToolsBundle: CANONICAL_DEFAULT_TOOL_EXPOSURE.bundle,
+    createModeToolsTier: CANONICAL_DEFAULT_TOOL_EXPOSURE.tier,
+  };
 }
 
 function readPersonaFromForm(form: AgentEditorFormState): NonNullable<AgentConfigT["persona"]> {
@@ -314,7 +333,9 @@ export function buildPayload(
   const preservedServerSettings = preservedMcpConfig?.server_settings ?? {};
   const preTurnTools =
     preservedMcpConfig?.pre_turn_tools ??
-    (form.memorySettingsMode === "inherit" || form.memoryEnabled ? ["mcp.memory.seed"] : []);
+    (form.memorySettingsMode === "inherit" || form.memoryEnabled
+      ? [CANONICAL_MEMORY_SEED_TOOL_ID]
+      : []);
   const serverSettings =
     form.memorySettingsMode === "inherit"
       ? Object.fromEntries(
@@ -350,6 +371,8 @@ export function buildPayload(
         workspace_trusted: form.workspaceSkillsTrusted,
       },
       mcp: {
+        ...(form.createModeMcpBundle ? { bundle: form.createModeMcpBundle } : {}),
+        ...(form.createModeMcpTier ? { tier: form.createModeMcpTier } : {}),
         default_mode: form.mcpDefaultMode,
         allow: form.mcpAllow,
         deny: form.mcpDeny,
@@ -357,6 +380,8 @@ export function buildPayload(
         server_settings: serverSettings,
       },
       tools: {
+        ...(form.createModeToolsBundle ? { bundle: form.createModeToolsBundle } : {}),
+        ...(form.createModeToolsTier ? { tier: form.createModeToolsTier } : {}),
         default_mode: form.toolsDefaultMode,
         allow: form.toolsAllow,
         deny: form.toolsDeny,

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-agent-config-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-agent-config-test-support.ts
@@ -251,12 +251,33 @@ export function registerFirstRunOnboardingAgentConfigTests(): void {
         expect(headers.get("authorization")).toBe("Bearer test-elevated-token");
 
         const body = JSON.parse(String(init?.body)) as {
-          config: { model: { model: string | null }; persona: { name: string; tone: string } };
+          config: {
+            model: { model: string | null };
+            persona: { name: string; tone: string };
+            mcp: {
+              bundle?: string;
+              tier?: string;
+              pre_turn_tools?: string[];
+            };
+            tools: {
+              bundle?: string;
+              tier?: string;
+            };
+          };
           reason?: string;
         };
         expect(body.config.model.model).toBe("openai/gpt-4.1");
         expect(body.config.persona.name).toBe("Research Agent");
         expect(body.config.persona.tone).toBe(resolvePersonaToneInstructions("warm"));
+        expect(body.config.mcp).toMatchObject({
+          bundle: "workspace-default",
+          tier: "advanced",
+          pre_turn_tools: ["memory.seed"],
+        });
+        expect(body.config.tools).toMatchObject({
+          bundle: "authoring-core",
+          tier: "default",
+        });
         expect(body.reason).toBe("onboarding: configure primary agent");
 
         agentConfigResponse = createAgentConfigResponse({

--- a/packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts
+++ b/packages/operator-ui/tests/operator-ui.first-run-onboarding-flow-test-support.ts
@@ -287,6 +287,15 @@ export function registerFirstRunOnboardingFlowTests(): void {
           config: typeof agentConfig.config;
           reason?: string;
         };
+        expect(body.config.mcp).toMatchObject({
+          bundle: "workspace-default",
+          tier: "advanced",
+          pre_turn_tools: ["memory.seed"],
+        });
+        expect(body.config.tools).toMatchObject({
+          bundle: "authoring-core",
+          tier: "default",
+        });
         agentConfig = createAgentConfigResponse({
           agentKey: primaryAgentKey,
           modelRef: body.config.model.model,

--- a/packages/operator-ui/tests/pages/agent-setup-wizard.shared.test.ts
+++ b/packages/operator-ui/tests/pages/agent-setup-wizard.shared.test.ts
@@ -46,12 +46,20 @@ describe("agent-setup-wizard.shared", () => {
       deny: [],
     });
     expect(config.mcp).toMatchObject({
-      default_mode: "deny",
-      allow: ["memory"],
+      bundle: "workspace-default",
+      tier: "advanced",
+      default_mode: "allow",
+      allow: [],
       deny: [],
       pre_turn_tools: ["memory.seed"],
     });
-    expect(config.tools).toEqual({ default_mode: "allow", allow: [], deny: [] });
+    expect(config.tools).toEqual({
+      bundle: "authoring-core",
+      tier: "default",
+      default_mode: "allow",
+      allow: [],
+      deny: [],
+    });
   });
 
   it("builds the moderate workspace policy bundle", () => {

--- a/packages/operator-ui/tests/pages/agents-page-create-wizard.test.tsx
+++ b/packages/operator-ui/tests/pages/agents-page-create-wizard.test.tsx
@@ -110,6 +110,17 @@ describe("AgentsPageCreateWizard", () => {
     expect(createAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agent_key: "operations-agent",
+        config: expect.objectContaining({
+          mcp: expect.objectContaining({
+            bundle: "workspace-default",
+            tier: "advanced",
+            pre_turn_tools: ["memory.seed"],
+          }),
+          tools: expect.objectContaining({
+            bundle: "authoring-core",
+            tier: "default",
+          }),
+        }),
         reason: "agents: create via setup wizard",
       }),
     );
@@ -216,6 +227,17 @@ describe("AgentsPageCreateWizard", () => {
     expect(createAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agent_key: "operations-agent-2",
+        config: expect.objectContaining({
+          mcp: expect.objectContaining({
+            bundle: "workspace-default",
+            tier: "advanced",
+            pre_turn_tools: ["memory.seed"],
+          }),
+          tools: expect.objectContaining({
+            bundle: "authoring-core",
+            tier: "default",
+          }),
+        }),
       }),
     );
     expect(onSaved).toHaveBeenCalledWith("operations-agent-2");

--- a/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page-editor-form.test.ts
@@ -22,6 +22,27 @@ describe("agents-page-editor-form", () => {
     expect(payload.config.model).toEqual({ model: null });
   });
 
+  it("seeds canonical tool exposure defaults for create-mode payloads", () => {
+    const form = createBlankForm();
+    form.agentKey = "agent-create-defaults";
+
+    const payload = buildPayload(form);
+
+    expect(payload.config.mcp).toEqual(
+      expect.objectContaining({
+        bundle: "workspace-default",
+        tier: "advanced",
+        pre_turn_tools: ["memory.seed"],
+      }),
+    );
+    expect(payload.config.tools).toEqual(
+      expect.objectContaining({
+        bundle: "authoring-core",
+        tier: "default",
+      }),
+    );
+  });
+
   it("preserves hidden MCP settings when building a payload", () => {
     const form = createBlankForm();
     form.agentKey = "agent-mcp-preserve";


### PR DESCRIPTION
## Summary
- seed canonical MCP and tools bundle/tier defaults in operator setup/create flows
- replace create-flow `mcp.memory.seed` seeding with canonical `memory.seed`
- add regression coverage for setup wizard, create wizard, onboarding, and create payload generation

## Why
- issue #1989 requires operator create/setup flows to match the canonical tool exposure model already adopted elsewhere in the stack
- this keeps new agent creation aligned with gateway defaults and removes transport-facing memory tool IDs from these creation paths

## How to test
- `pnpm exec vitest run packages/operator-ui/tests/pages/agent-setup-wizard.shared.test.ts packages/operator-ui/tests/pages/agents-page-create-wizard.test.tsx packages/operator-ui/tests/pages/agents-page-editor-form.test.ts packages/operator-ui/tests/operator-ui.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run ci`

## Risk
- low to moderate: this changes only operator create/setup default seeding paths, but it affects the initial config created for new agents
- regression risk is concentrated in operator UI payload generation and onboarding flow defaults

## Rollback
- revert commit `de9212ab05fa6746f1809aa69cb444c3f11e61ee` to restore the previous create/setup default seeding behavior

Closes #1989

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default config emitted when creating/configuring agents (MCP/tools exposure and pre-turn tool ids), which can affect initial agent capabilities. Scope is limited to Operator UI creation/setup paths and is covered by updated regression tests.
> 
> **Overview**
> Adopts the canonical MCP/tools exposure model for Operator UI agent setup and creation by introducing shared defaults (`bundle`/`tier`) and switching memory seeding to the canonical `memory.seed` tool id.
> 
> Agent config/payload generation now includes these canonical defaults in both the setup wizard preset-derived config and the agents editor create-mode payload (with new create-mode form fields for MCP/tools `bundle`/`tier`). Tests are updated/added across onboarding, create wizard, and form payload generation to assert the new defaults and tool id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9212ab05fa6746f1809aa69cb444c3f11e61ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->