### PR TITLE
Update agent status/read surfaces for canonical tool exposure

### DIFF
--- a/packages/operator-app/src/stores/agent-status-store.ts
+++ b/packages/operator-app/src/stores/agent-status-store.ts
@@ -1,10 +1,11 @@
+import type { AgentStatusResponse } from "@tyrum/contracts";
 import type { OperatorHttpClient } from "../deps.js";
 import { createStore, type ExternalStore } from "../store.js";
 import { toErrorMessage } from "../to-error-message.js";
 
 export interface AgentStatusState {
   agentKey: string;
-  status: unknown | null;
+  status: AgentStatusResponse | null;
   loading: boolean;
   error: string | null;
   lastSyncedAt: string | null;
@@ -31,10 +32,12 @@ export function createAgentStatusStore(http: OperatorHttpClient): { store: Agent
     const trimmed = agentKey.trim();
     setState((prev) => {
       if (prev.agentKey === trimmed) return prev;
+      activeRefreshRunId = null;
       return {
         ...prev,
         agentKey: trimmed,
         status: null,
+        loading: false,
         error: null,
         lastSyncedAt: null,
       };

--- a/packages/operator-app/tests/agent-status-store.test.ts
+++ b/packages/operator-app/tests/agent-status-store.test.ts
@@ -1,0 +1,116 @@
+import { AgentStatusResponse } from "@tyrum/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { createAgentStatusStore } from "../src/stores/agent-status-store.js";
+import { createDeferred } from "./transcript-store.test-support.js";
+
+function createAgentStatus(agentKey: string, name: string, toolBundle?: string) {
+  return AgentStatusResponse.parse({
+    enabled: true,
+    home: `/tmp/agents/${agentKey}`,
+    persona: {
+      name,
+      tone: "direct",
+      palette: "graphite",
+      character: "architect",
+    },
+    identity: { name },
+    model: {
+      model: "openai/gpt-5.4",
+      variant: "balanced",
+      fallback: ["openai/gpt-5.4"],
+    },
+    skills: ["review"],
+    skills_detailed: [
+      {
+        id: "review",
+        name: "Review",
+        version: "1.0.0",
+        source: "bundled",
+      },
+    ],
+    workspace_skills_trusted: true,
+    mcp: [],
+    tools: ["read"],
+    tool_exposure: {
+      mcp: { bundle: "workspace-default", tier: "advanced" },
+      tools: toolBundle ? { bundle: toolBundle, tier: "default" } : {},
+    },
+    tool_access: {
+      default_mode: "deny",
+      allow: ["read"],
+      deny: [],
+    },
+    conversations: {
+      ttl_days: 365,
+      max_turns: 0,
+      loop_detection: {
+        within_turn: {
+          consecutive_repeat_limit: 2,
+          cycle_repeat_limit: 3,
+        },
+        cross_turn: {
+          window_assistant_messages: 8,
+          similarity_threshold: 0.92,
+        },
+      },
+      context_pruning: {
+        max_messages: 0,
+        tool_prune_keep_last_messages: 4,
+      },
+    },
+  });
+}
+
+describe("createAgentStatusStore", () => {
+  it("ignores stale refresh results when the selected agent changes", async () => {
+    const defaultStatus = createAgentStatus("default", "Default Agent", "authoring-core");
+    const otherStatus = createAgentStatus("agent-1", "Agent One", "workspace-ops");
+    const defaultStatusDeferred = createDeferred<typeof defaultStatus>();
+    const http = {
+      agentStatus: {
+        get: vi.fn(async (payload?: { agent_key?: string }) => {
+          const agentKey = payload?.agent_key ?? "";
+          if (agentKey === "default") {
+            return await defaultStatusDeferred.promise;
+          }
+          if (agentKey === "agent-1") {
+            return otherStatus;
+          }
+          throw new Error(`unexpected agent key: ${agentKey}`);
+        }),
+      },
+    };
+
+    const { store } = createAgentStatusStore(http as never);
+
+    store.setAgentKey("default");
+    const defaultRefresh = store.refresh();
+
+    expect(store.getSnapshot()).toMatchObject({
+      agentKey: "default",
+      loading: true,
+      status: null,
+    });
+
+    store.setAgentKey("agent-1");
+    await store.refresh();
+
+    expect(store.getSnapshot()).toMatchObject({
+      agentKey: "agent-1",
+      loading: false,
+      status: otherStatus,
+    });
+
+    defaultStatusDeferred.resolve(defaultStatus);
+    await defaultRefresh;
+
+    expect(http.agentStatus.get).toHaveBeenNthCalledWith(1, { agent_key: "default" });
+    expect(http.agentStatus.get).toHaveBeenNthCalledWith(2, { agent_key: "agent-1" });
+    expect(store.getSnapshot()).toMatchObject({
+      agentKey: "agent-1",
+      loading: false,
+      status: otherStatus,
+      error: null,
+    });
+  });
+});

--- a/packages/operator-ui/src/components/pages/agents-page-inspector.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page-inspector.tsx
@@ -1,0 +1,262 @@
+import type {
+  AgentStatusResponse,
+  TranscriptConversationSummary,
+  TranscriptTimelineEvent,
+} from "@tyrum/contracts";
+import type { ReactNode } from "react";
+import { Alert } from "../ui/alert.js";
+import { Badge } from "../ui/badge.js";
+import { Card, CardContent, CardHeader } from "../ui/card.js";
+import { ScrollArea } from "../ui/scroll-area.js";
+import { StructuredValue } from "../ui/structured-value.js";
+import {
+  eventKindLabel,
+  formatConversationTitle,
+  type InspectorField,
+} from "./transcripts-page.lib.js";
+
+const EMPTY_TOOL_EXPOSURE: AgentStatusResponse["tool_exposure"] = {
+  mcp: {},
+  tools: {},
+};
+
+function hasResolvedToolExposure(
+  selection: AgentStatusResponse["tool_exposure"]["mcp"] | undefined,
+): boolean {
+  return selection?.bundle !== undefined || selection?.tier !== undefined;
+}
+
+function ExposureSelectionSummary({
+  label,
+  selection,
+  testId,
+}: {
+  label: string;
+  selection: AgentStatusResponse["tool_exposure"]["mcp"] | undefined;
+  testId: string;
+}) {
+  const resolved = hasResolvedToolExposure(selection);
+
+  return (
+    <div
+      className="grid gap-2 rounded-md border border-border bg-bg-subtle/30 p-3"
+      data-testid={testId}
+    >
+      <div className="text-xs font-medium uppercase tracking-wide text-fg-muted">{label}</div>
+      {resolved ? (
+        <div className="flex flex-wrap gap-2">
+          {selection?.bundle ? (
+            <Badge variant="outline">{`Bundle: ${selection.bundle}`}</Badge>
+          ) : null}
+          {selection?.tier ? <Badge variant="outline">{`Tier: ${selection.tier}`}</Badge> : null}
+        </div>
+      ) : (
+        <div className="text-sm text-fg-muted">No canonical bundle/tier resolved.</div>
+      )}
+    </div>
+  );
+}
+
+function LegacyToolAccessSummary({
+  toolAccess,
+}: {
+  toolAccess: NonNullable<AgentStatusResponse["tool_access"]>;
+}) {
+  const renderToolList = (items: readonly string[], emptyText: string): ReactNode => {
+    if (items.length === 0) {
+      return <div className="text-sm text-fg-muted">{emptyText}</div>;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        {items.map((toolId) => (
+          <Badge key={toolId} variant="outline">
+            {toolId}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="grid gap-3 rounded-md border border-border bg-bg-subtle/30 p-3"
+      data-testid="agents-exposure-legacy-tools"
+    >
+      <div className="text-xs font-medium uppercase tracking-wide text-fg-muted">
+        Legacy tool rules
+      </div>
+      <div className="grid gap-3">
+        <div className="grid gap-1">
+          <div className="text-xs font-medium uppercase tracking-wide text-fg-muted">Default</div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline">{toolAccess.default_mode}</Badge>
+          </div>
+        </div>
+        <div className="grid gap-1">
+          <div className="text-xs font-medium uppercase tracking-wide text-fg-muted">Allow</div>
+          {renderToolList(toolAccess.allow, "No explicit allow rules.")}
+        </div>
+        <div className="grid gap-1">
+          <div className="text-xs font-medium uppercase tracking-wide text-fg-muted">Deny</div>
+          {renderToolList(toolAccess.deny, "No explicit deny rules.")}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentExposureCard(props: {
+  agentStatus: AgentStatusResponse | null;
+  agentStatusError: string | null;
+  agentStatusLoading: boolean;
+  selectedAgentKey: string;
+}) {
+  const { agentStatus, agentStatusError, agentStatusLoading, selectedAgentKey } = props;
+  const normalizedAgentKey = selectedAgentKey.trim();
+  const toolExposure = agentStatus?.tool_exposure ?? EMPTY_TOOL_EXPOSURE;
+  const toolsResolved = hasResolvedToolExposure(toolExposure.tools);
+
+  return (
+    <Card data-testid="agents-exposure-card">
+      <CardHeader className="pb-3">
+        <div className="text-sm font-medium text-fg">Agent exposure</div>
+        <div className="text-xs text-fg-muted">
+          Resolved canonical tool exposure for the selected agent.
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        {normalizedAgentKey ? (
+          <div className="grid gap-1 text-sm text-fg-muted">
+            <div className="font-medium text-fg">
+              {agentStatus?.identity.name ?? normalizedAgentKey}
+            </div>
+            <div>{normalizedAgentKey}</div>
+          </div>
+        ) : (
+          <div className="text-sm text-fg-muted">
+            Select an agent to inspect resolved tool exposure.
+          </div>
+        )}
+        {agentStatusError ? (
+          <Alert variant="error" title="Agent status unavailable" description={agentStatusError} />
+        ) : null}
+        {agentStatusLoading ? (
+          <div className="text-sm text-fg-muted">Loading agent exposure…</div>
+        ) : null}
+        {agentStatus ? (
+          <div className="grid gap-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <ExposureSelectionSummary
+                label="MCP"
+                selection={toolExposure.mcp}
+                testId="agents-exposure-mcp"
+              />
+              <ExposureSelectionSummary
+                label="Tools"
+                selection={toolExposure.tools}
+                testId="agents-exposure-tools"
+              />
+            </div>
+            {!toolsResolved && agentStatus.tool_access ? (
+              <LegacyToolAccessSummary toolAccess={agentStatus.tool_access} />
+            ) : null}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TranscriptInspectorPanel(props: {
+  agentStatus: AgentStatusResponse | null;
+  agentStatusError: string | null;
+  agentStatusLoading: boolean;
+  focusConversation: TranscriptConversationSummary | null;
+  inspectorFields: InspectorField[];
+  selectedAgentKey: string;
+  selectedEvent: TranscriptTimelineEvent | null;
+}) {
+  const {
+    agentStatus,
+    agentStatusError,
+    agentStatusLoading,
+    focusConversation,
+    inspectorFields,
+    selectedAgentKey,
+    selectedEvent,
+  } = props;
+  const inspectorHint = focusConversation
+    ? "Select a transcript event to inspect its raw payload."
+    : "Select a transcript to inspect its events.";
+
+  return (
+    <div className="min-h-0">
+      <ScrollArea className="h-full">
+        <div className="grid gap-4 p-4">
+          <AgentExposureCard
+            agentStatus={agentStatus}
+            agentStatusError={agentStatusError}
+            agentStatusLoading={agentStatusLoading}
+            selectedAgentKey={selectedAgentKey}
+          />
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="text-sm font-medium text-fg">Inspector</div>
+              <div className="text-xs text-fg-muted">
+                Raw details for the selected transcript event.
+              </div>
+            </CardHeader>
+            <CardContent className="grid gap-3">
+              {focusConversation ? (
+                <div className="grid gap-1 text-sm text-fg-muted">
+                  <div className="font-medium text-fg">
+                    {formatConversationTitle(focusConversation)}
+                  </div>
+                </div>
+              ) : null}
+              {inspectorFields.length > 0 ? (
+                <div className="grid gap-2">
+                  <div className="grid gap-2 rounded-md border border-border bg-bg-subtle/30 p-3">
+                    {inspectorFields.map((field) => (
+                      <div
+                        key={`${field.label}:${field.value}`}
+                        className="grid gap-1 text-xs text-fg-muted"
+                      >
+                        <div className="font-medium uppercase tracking-wide">{field.label}</div>
+                        <div className="break-all font-mono text-fg">{field.value}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {selectedEvent ? (
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">{eventKindLabel(selectedEvent.kind)}</Badge>
+                    <time
+                      className="text-xs text-fg-muted"
+                      dateTime={selectedEvent.occurred_at}
+                      title={selectedEvent.occurred_at}
+                    >
+                      {selectedEvent.occurred_at}
+                    </time>
+                  </div>
+                  <div className="max-h-[480px] overflow-auto rounded-md border border-border bg-bg-subtle/30 p-3">
+                    <StructuredValue value={selectedEvent} />
+                  </div>
+                </div>
+              ) : focusConversation ? (
+                <div className="max-h-[480px] overflow-auto rounded-md border border-border bg-bg-subtle/30 p-3">
+                  <StructuredValue value={focusConversation} />
+                </div>
+              ) : (
+                <div className="text-sm text-fg-muted">{inspectorHint}</div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/packages/operator-ui/src/components/pages/agents-page.data.ts
+++ b/packages/operator-ui/src/components/pages/agents-page.data.ts
@@ -1,0 +1,140 @@
+import type { OperatorCore } from "@tyrum/operator-app";
+import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from "react";
+import { useOperatorStore } from "../../use-operator-store.js";
+import { normalizeAgentOptions } from "./agent-options.shared.js";
+import { selectInitialAgentKey, type ManagedAgentOption } from "./agents-page.lib.js";
+
+export function useAgentsPageData(input: {
+  core: OperatorCore;
+  isConnected: boolean;
+  selectedAgentKey: string;
+  setAgentOptions: Dispatch<SetStateAction<ManagedAgentOption[]>>;
+  setAgentsError: Dispatch<SetStateAction<string | null>>;
+  setAgentsLoading: Dispatch<SetStateAction<boolean>>;
+  setSelectedAgentKey: Dispatch<SetStateAction<string>>;
+}) {
+  const {
+    core,
+    isConnected,
+    selectedAgentKey,
+    setAgentOptions,
+    setAgentsError,
+    setAgentsLoading,
+    setSelectedAgentKey,
+  } = input;
+  const agentStatus = useOperatorStore(core.agentStatusStore);
+  const selectedAgentKeyRef = useRef(selectedAgentKey);
+  selectedAgentKeyRef.current = selectedAgentKey;
+
+  const syncSelectedAgentStatus = useCallback(
+    async (agentKey: string): Promise<void> => {
+      const normalizedAgentKey = agentKey.trim();
+      core.agentStatusStore.setAgentKey(normalizedAgentKey);
+      if (normalizedAgentKey.length === 0) {
+        return;
+      }
+      await core.agentStatusStore.refresh();
+    },
+    [core.agentStatusStore],
+  );
+
+  const refreshManagedAgents = useCallback(
+    async (preferredAgentKey?: string): Promise<string> => {
+      if (!isConnected) {
+        return "";
+      }
+      setAgentsLoading(true);
+      setAgentsError(null);
+      try {
+        const response = await core.admin.agents.list();
+        const nextAgents = normalizeAgentOptions(
+          response.agents,
+          ({ agentKey, personaName, source }) => ({
+            agentKey,
+            agentId: source.agent_id.trim(),
+            displayName: personaName || agentKey,
+            canDelete: source.can_delete,
+            isPrimary: source.is_primary === true,
+          }),
+          {
+            sort: (left, right) => left.displayName.localeCompare(right.displayName),
+          },
+        );
+        const nextSelectedAgentKey = selectInitialAgentKey({
+          currentAgentKey: preferredAgentKey ?? selectedAgentKeyRef.current,
+          availableAgents: nextAgents,
+        });
+        setAgentOptions(nextAgents);
+        core.agentStatusStore.setAgentKey(nextSelectedAgentKey);
+        setSelectedAgentKey(nextSelectedAgentKey);
+        return nextSelectedAgentKey;
+      } catch (error) {
+        setAgentsError(error instanceof Error ? error.message : String(error));
+        setAgentOptions([]);
+        return "";
+      } finally {
+        setAgentsLoading(false);
+      }
+    },
+    [
+      core.admin.agents,
+      core.agentStatusStore,
+      isConnected,
+      setAgentOptions,
+      setAgentsError,
+      setAgentsLoading,
+      setSelectedAgentKey,
+    ],
+  );
+
+  const refreshEverything = useCallback(async (): Promise<void> => {
+    if (!isConnected) {
+      return;
+    }
+    core.transcriptStore.setAgentKey(null);
+    core.transcriptStore.setChannel(null);
+    core.transcriptStore.setActiveOnly(false);
+    core.transcriptStore.setArchived(false);
+    const [nextSelectedAgentKey] = await Promise.all([
+      refreshManagedAgents(),
+      core.transcriptStore.refresh(),
+    ]);
+    await syncSelectedAgentStatus(nextSelectedAgentKey);
+  }, [core.transcriptStore, isConnected, refreshManagedAgents, syncSelectedAgentStatus]);
+
+  useEffect(() => {
+    if (!isConnected) {
+      core.agentStatusStore.setAgentKey("");
+      return;
+    }
+    void refreshEverything();
+  }, [core.agentStatusStore, isConnected, refreshEverything]);
+
+  useEffect(() => {
+    if (!isConnected) {
+      return;
+    }
+    const normalizedAgentKey = selectedAgentKey.trim();
+    if (normalizedAgentKey.length === 0) {
+      core.agentStatusStore.setAgentKey("");
+      return;
+    }
+    if (agentStatus.agentKey === normalizedAgentKey) {
+      return;
+    }
+    void syncSelectedAgentStatus(normalizedAgentKey);
+  }, [
+    agentStatus.agentKey,
+    core.agentStatusStore,
+    isConnected,
+    selectedAgentKey,
+    syncSelectedAgentStatus,
+  ]);
+
+  return {
+    agentStatus,
+    refreshEverything,
+    refreshManagedAgents,
+    syncSelectedAgentStatus,
+  };
+}

--- a/packages/operator-ui/src/components/pages/agents-page.tsx
+++ b/packages/operator-ui/src/components/pages/agents-page.tsx
@@ -20,6 +20,8 @@ import {
   selectInitialAgentKey,
   type ManagedAgentOption,
 } from "./agents-page.lib.js";
+import { useAgentsPageData } from "./agents-page.data.js";
+import { TranscriptInspectorPanel } from "./agents-page-inspector.js";
 import { useAgentsPageNavigationIntent } from "./agents-page.navigation.js";
 import {
   AgentsPageEditorDialog,
@@ -27,13 +29,12 @@ import {
   EmptyTimelinePanel,
 } from "./agents-page.parts.js";
 import { AgentsPageToolbarActions, StopSubagentErrorBanner } from "./agents-page.toolbar.js";
-import { normalizeAgentOptions } from "./agent-options.shared.js";
 import {
   buildInspectorFields,
   DEFAULT_KIND_FILTERS,
   type TimelineKindFilters,
 } from "./transcripts-page.lib.js";
-import { TranscriptInspectorPanel, TranscriptTimelinePanel } from "./transcripts-page.parts.js";
+import { TranscriptTimelinePanel } from "./transcripts-page.parts.js";
 
 export function AgentsPage({
   core,
@@ -67,7 +68,18 @@ export function AgentsPage({
   const stopAction = useApiAction<void>();
   const agentListScrollAreaRef = useReconnectScrollArea("agents.tree");
   const isConnected = connection.status === "connected";
-  const isRefreshing = agentsLoading || transcript.loadingList || transcript.loadingDetail;
+  const { agentStatus, refreshEverything, refreshManagedAgents, syncSelectedAgentStatus } =
+    useAgentsPageData({
+      core,
+      isConnected,
+      selectedAgentKey,
+      setAgentOptions,
+      setAgentsError,
+      setAgentsLoading,
+      setSelectedAgentKey,
+    });
+  const isRefreshing =
+    agentsLoading || agentStatus.loading || transcript.loadingList || transcript.loadingDetail;
 
   const activeAgentIds = useMemo(() => {
     return collectActiveAgentKeys({
@@ -137,59 +149,6 @@ export function AgentsPage({
     () => buildInspectorFields(selectedEvent, focusConversation),
     [focusConversation, selectedEvent],
   );
-  const refreshManagedAgents = async (preferredAgentKey?: string): Promise<void> => {
-    if (!isConnected) {
-      return;
-    }
-    setAgentsLoading(true);
-    setAgentsError(null);
-    try {
-      const response = await core.admin.agents.list();
-      const nextAgents = normalizeAgentOptions(
-        response.agents,
-        ({ agentKey, personaName, source }) => ({
-          agentKey,
-          agentId: source.agent_id.trim(),
-          displayName: personaName || agentKey,
-          canDelete: source.can_delete,
-          isPrimary: source.is_primary === true,
-        }),
-        {
-          sort: (left, right) => left.displayName.localeCompare(right.displayName),
-        },
-      );
-      setAgentOptions(nextAgents);
-      setSelectedAgentKey((current) =>
-        selectInitialAgentKey({
-          currentAgentKey: preferredAgentKey ?? current,
-          availableAgents: nextAgents,
-        }),
-      );
-    } catch (error) {
-      setAgentsError(error instanceof Error ? error.message : String(error));
-      setAgentOptions([]);
-    } finally {
-      setAgentsLoading(false);
-    }
-  };
-
-  const refreshEverything = async (): Promise<void> => {
-    if (!isConnected) {
-      return;
-    }
-    core.transcriptStore.setAgentKey(null);
-    core.transcriptStore.setChannel(null);
-    core.transcriptStore.setActiveOnly(false);
-    core.transcriptStore.setArchived(false);
-    await Promise.all([refreshManagedAgents(), core.transcriptStore.refresh()]);
-  };
-
-  useEffect(() => {
-    if (!isConnected) {
-      return;
-    }
-    void refreshEverything();
-  }, [isConnected]);
 
   useEffect(() => {
     if (agentOptions.length === 0) {
@@ -370,14 +329,15 @@ export function AgentsPage({
             await core.admin.agents.delete(selectedAgentOption.agentKey);
           });
           setEditorMode("closed");
-          await refreshManagedAgents();
+          const nextSelectedAgentKey = await refreshManagedAgents();
+          await syncSelectedAgentStatus(nextSelectedAgentKey);
         }}
         onClose={() => {
           setEditorMode("closed");
         }}
         onSaved={(savedAgentKey) => {
           setEditorMode("closed");
-          void refreshManagedAgents(savedAgentKey);
+          void refreshManagedAgents(savedAgentKey).then(syncSelectedAgentStatus);
         }}
       />
 
@@ -500,8 +460,12 @@ export function AgentsPage({
         </div>
 
         <TranscriptInspectorPanel
+          agentStatus={agentStatus.status}
+          agentStatusError={agentStatus.error}
+          agentStatusLoading={agentStatus.loading}
           focusConversation={focusConversation}
           inspectorFields={inspectorFields}
+          selectedAgentKey={selectedAgentKey}
           selectedEvent={selectedEvent}
         />
       </div>

--- a/packages/operator-ui/src/components/pages/transcripts-page.parts.tsx
+++ b/packages/operator-ui/src/components/pages/transcripts-page.parts.tsx
@@ -15,11 +15,9 @@ import { formatRelativeTime } from "../../utils/format-relative-time.js";
 import { Alert } from "../ui/alert.js";
 import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
-import { Card, CardContent, CardHeader } from "../ui/card.js";
 import { EmptyState } from "../ui/empty-state.js";
 import { LoadingState } from "../ui/loading-state.js";
 import { ScrollArea } from "../ui/scroll-area.js";
-import { StructuredValue } from "../ui/structured-value.js";
 import { MessageCard } from "./chat-page-ai-sdk-message-card.js";
 import {
   approvalStatusVariant,
@@ -31,7 +29,6 @@ import {
   turnStatusVariant,
   subagentPhaseVariant,
   toRenderableMessage,
-  type InspectorField,
   type TimelineKindFilters,
 } from "./transcripts-page.lib.js";
 
@@ -417,81 +414,6 @@ export function TranscriptTimelinePanel(props: {
               })}
             </div>
           )}
-        </div>
-      </ScrollArea>
-    </div>
-  );
-}
-
-export function TranscriptInspectorPanel(props: {
-  focusConversation: TranscriptConversationSummary | null;
-  inspectorFields: InspectorField[];
-  selectedEvent: TranscriptTimelineEvent | null;
-}) {
-  const { focusConversation, inspectorFields, selectedEvent } = props;
-  const inspectorHint = focusConversation
-    ? "Select a transcript event to inspect its raw payload."
-    : "Select a transcript to inspect its events.";
-
-  return (
-    <div className="min-h-0">
-      <ScrollArea className="h-full">
-        <div className="grid gap-4 p-4">
-          <Card>
-            <CardHeader className="pb-3">
-              <div className="text-sm font-medium text-fg">Inspector</div>
-              <div className="text-xs text-fg-muted">
-                Raw details for the selected transcript event.
-              </div>
-            </CardHeader>
-            <CardContent className="grid gap-3">
-              {focusConversation ? (
-                <div className="grid gap-1 text-sm text-fg-muted">
-                  <div className="font-medium text-fg">
-                    {formatConversationTitle(focusConversation)}
-                  </div>
-                </div>
-              ) : null}
-              {inspectorFields.length > 0 ? (
-                <div className="grid gap-2">
-                  <div className="grid gap-2 rounded-md border border-border bg-bg-subtle/30 p-3">
-                    {inspectorFields.map((field) => (
-                      <div
-                        key={`${field.label}:${field.value}`}
-                        className="grid gap-1 text-xs text-fg-muted"
-                      >
-                        <div className="font-medium uppercase tracking-wide">{field.label}</div>
-                        <div className="break-all font-mono text-fg">{field.value}</div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-              {selectedEvent ? (
-                <div className="grid gap-2">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="outline">{eventKindLabel(selectedEvent.kind)}</Badge>
-                    <time
-                      className="text-xs text-fg-muted"
-                      dateTime={selectedEvent.occurred_at}
-                      title={selectedEvent.occurred_at}
-                    >
-                      {selectedEvent.occurred_at}
-                    </time>
-                  </div>
-                  <div className="max-h-[480px] overflow-auto rounded-md border border-border bg-bg-subtle/30 p-3">
-                    <StructuredValue value={selectedEvent} />
-                  </div>
-                </div>
-              ) : focusConversation ? (
-                <div className="max-h-[480px] overflow-auto rounded-md border border-border bg-bg-subtle/30 p-3">
-                  <StructuredValue value={focusConversation} />
-                </div>
-              ) : (
-                <div className="text-sm text-fg-muted">{inspectorHint}</div>
-              )}
-            </CardContent>
-          </Card>
         </div>
       </ScrollArea>
     </div>

--- a/packages/operator-ui/src/i18n/messages/en.json
+++ b/packages/operator-ui/src/i18n/messages/en.json
@@ -93,6 +93,7 @@
   "Agent list unavailable": "Agent list unavailable",
   "Agent name": "Agent name",
   "Agent scope": "Agent scope",
+  "Agent status unavailable": "Agent status unavailable",
   "Agent setup unavailable": "Agent setup unavailable",
   "Agent turn": "Agent turn",
   "agent-key": "agent-key",

--- a/packages/operator-ui/src/i18n/messages/nl.json
+++ b/packages/operator-ui/src/i18n/messages/nl.json
@@ -93,6 +93,7 @@
   "Agent list unavailable": "Agentlijst niet beschikbaar",
   "Agent name": "Naam agent",
   "Agent scope": "Reikwijdte van de agent",
+  "Agent status unavailable": "Agentstatus niet beschikbaar",
   "Agent setup unavailable": "Agentconfiguratie niet beschikbaar",
   "Agent turn": "Agentbeurt",
   "agent-key": "agent-key",

--- a/packages/operator-ui/tests/pages/agents-page.test-fixtures.ts
+++ b/packages/operator-ui/tests/pages/agents-page.test-fixtures.ts
@@ -1,18 +1,54 @@
-export function sampleAgentStatus() {
-  return {
+import {
+  AgentStatusResponse,
+  type AgentStatusResponse as AgentStatusResponseT,
+} from "@tyrum/contracts";
+
+export function sampleAgentStatus(agentKey = "default"): AgentStatusResponseT {
+  const isDefaultAgent = agentKey === "default";
+
+  return AgentStatusResponse.parse({
     enabled: true,
-    home: "/tmp/agents/default",
-    identity: { name: "Default Agent" },
+    home: `/tmp/agents/${agentKey}`,
+    persona: {
+      name: isDefaultAgent ? "Default Agent" : "Agent One",
+      tone: "direct",
+      palette: isDefaultAgent ? "graphite" : "moss",
+      character: isDefaultAgent ? "architect" : "builder",
+    },
+    identity: { name: isDefaultAgent ? "Default Agent" : "Agent One" },
     model: {
       model: "openai/gpt-5.4",
       variant: "balanced",
       fallback: ["openai/gpt-5.4"],
     },
-    skills: ["review"],
-    skills_detailed: [{ id: "review", name: "Review", version: "1.0.0", source: "bundled" }],
+    skills: [isDefaultAgent ? "review" : "deploy"],
+    skills_detailed: [
+      {
+        id: isDefaultAgent ? "review" : "deploy",
+        name: isDefaultAgent ? "Review" : "Deploy",
+        version: "1.0.0",
+        source: "bundled",
+      },
+    ],
     workspace_skills_trusted: true,
-    mcp: [],
-    tools: ["shell"],
+    mcp: isDefaultAgent
+      ? []
+      : [
+          {
+            id: "filesystem",
+            name: "Filesystem",
+            enabled: true,
+            transport: "stdio",
+          },
+        ],
+    tools: isDefaultAgent ? ["read", "webfetch"] : ["webfetch", "write"],
+    tool_exposure: {
+      mcp: { bundle: "workspace-default", tier: "advanced" },
+      tools: isDefaultAgent ? { bundle: "authoring-core", tier: "default" } : {},
+    },
+    tool_access: isDefaultAgent
+      ? { default_mode: "deny", allow: ["read"], deny: ["bash"] }
+      : { default_mode: "deny", allow: ["webfetch"], deny: ["bash"] },
     conversations: {
       ttl_days: 365,
       max_turns: 0,
@@ -31,7 +67,7 @@ export function sampleAgentStatus() {
         tool_prune_keep_last_messages: 4,
       },
     },
-  } as const;
+  });
 }
 
 export function createTranscriptFixture() {

--- a/packages/operator-ui/tests/pages/agents-page.test-support.tsx
+++ b/packages/operator-ui/tests/pages/agents-page.test-support.tsx
@@ -90,11 +90,15 @@ export function createCore(options?: {
   });
   const { store: agentStatusStore, setState: setAgentStatusState } = createStore({
     agentKey: "missing-agent",
-    status: sampleAgentStatus(),
+    status: null,
     loading: false,
     error: null,
     lastSyncedAt: null,
   });
+  const agentStatusByKey = {
+    default: sampleAgentStatus("default"),
+    "agent-1": sampleAgentStatus("agent-1"),
+  } as const;
   const { store: turnsStore } = createStore({
     turnsById: {},
     turnItemsById: {},
@@ -130,9 +134,26 @@ export function createCore(options?: {
   });
 
   const setAgentKey = vi.fn((agentKey: string) => {
-    setAgentStatusState((prev) => ({ ...prev, agentKey }));
+    const trimmed = agentKey.trim();
+    setAgentStatusState((prev) => ({
+      ...prev,
+      agentKey: trimmed,
+      status: null,
+      loading: false,
+      error: null,
+      lastSyncedAt: null,
+    }));
   });
-  const refresh = vi.fn().mockResolvedValue(undefined);
+  const refresh = vi.fn(async () => {
+    const agentKey = agentStatusStore.getSnapshot().agentKey.trim();
+    setAgentStatusState((prev) => ({
+      ...prev,
+      status: agentStatusByKey[agentKey as keyof typeof agentStatusByKey] ?? null,
+      loading: false,
+      error: null,
+      lastSyncedAt: "2026-03-09T00:00:00.000Z",
+    }));
+  });
   const openConversation = vi.fn(async (conversationKey: string) => {
     const lineage =
       transcriptFixture.lineages[conversationKey as keyof typeof transcriptFixture.lineages] ??

--- a/packages/operator-ui/tests/pages/agents-page.test.ts
+++ b/packages/operator-ui/tests/pages/agents-page.test.ts
@@ -9,15 +9,21 @@ import { createCore, flush } from "./agents-page.test-support.tsx";
 
 describe("AgentsPage", () => {
   it("loads managed agents and opens the latest retained root by default", async () => {
-    const { core, transcriptStore, transcriptFixture } = createCore();
+    const { core, refresh, setAgentKey, transcriptStore, transcriptFixture } = createCore();
 
     const testRoot = renderIntoDocument(React.createElement(AgentsPage, { core }));
     await flush();
 
+    expect(setAgentKey).toHaveBeenCalledWith("default");
+    expect(refresh).toHaveBeenCalledTimes(1);
     expect(transcriptStore.refresh).toHaveBeenCalledTimes(1);
     expect(transcriptStore.openConversation).toHaveBeenCalledWith(
       transcriptFixture.latestRootConversation.conversation_key,
     );
+    expect(testRoot.container.textContent).toContain("Agent exposure");
+    expect(testRoot.container.textContent).toContain("Bundle: workspace-default");
+    expect(testRoot.container.textContent).toContain("Bundle: authoring-core");
+    expect(testRoot.container.textContent).not.toContain("Legacy tool rules");
     expect(testRoot.container.textContent).toContain("Latest retained transcript");
     expect(testRoot.container.textContent).toContain("Delegated child");
     expect(
@@ -40,6 +46,55 @@ describe("AgentsPage", () => {
     );
     expect(childRow).not.toBeNull();
     expect(childRow?.parentElement?.style.marginLeft).toBe("36px");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("shows legacy tool rules only when canonical tools exposure is unresolved", async () => {
+    const { core } = createCore();
+
+    const testRoot = renderIntoDocument(React.createElement(AgentsPage, { core }));
+    await flush();
+
+    expect(
+      testRoot.container.querySelector<HTMLElement>('[data-testid="agents-exposure-legacy-tools"]'),
+    ).toBeNull();
+
+    await act(async () => {
+      click(
+        testRoot.container.querySelector<HTMLElement>('[data-testid="agents-select-agent-1"]')!,
+      );
+      await Promise.resolve();
+    });
+    await flush();
+
+    const exposureCard = testRoot.container.querySelector<HTMLElement>(
+      '[data-testid="agents-exposure-card"]',
+    );
+    expect(exposureCard?.textContent).toContain("Agent One");
+    expect(exposureCard?.textContent).toContain("Legacy tool rules");
+    expect(exposureCard?.textContent).toContain("No canonical bundle/tier resolved.");
+    expect(exposureCard?.textContent).toContain("webfetch");
+    expect(exposureCard?.textContent).toContain("bash");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("refreshes agent exposure from the existing toolbar button", async () => {
+    const { core, refresh } = createCore();
+
+    const testRoot = renderIntoDocument(React.createElement(AgentsPage, { core }));
+    await flush();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      click(testRoot.container.querySelector<HTMLElement>('[data-testid="agents-refresh"]')!);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(refresh).toHaveBeenCalledTimes(2);
 
     cleanupTestRoot(testRoot);
   });


### PR DESCRIPTION
Closes #1977

## What changed
- added a live `Agent exposure` card to the Agents inspector rail so operator read/status surfaces show canonical `tool_exposure.mcp` and `tool_exposure.tools`
- kept legacy `tool_access` visible only as a fallback when canonical tools exposure is unresolved
- typed `agentStatusStore` against `AgentStatusResponse`, extracted the agent-status refresh wiring used by the Agents page, and hardened the shared store against stale refresh races when the selected agent changes
- added targeted regression coverage for canonical exposure rendering, toolbar refresh, unresolved legacy fallback behavior, the stale status race, and the agents layout regression cases
- registered the new inspector alert string in the operator UI `en`/`nl` i18n catalogs

## Why
- `#1977` requires the canonical tool exposure model to be visible outside the main agent editor without reviving deprecated status panes or drifting into setup/create flows
- the active Agents inspector rail is the live read-only surface on current `main`, so this keeps the issue scoped to the intended status/read surface

## How to test
- `pnpm lint`
- `pnpm exec tsc -b packages/contracts/tsconfig.json packages/operator-app/tsconfig.json packages/operator-ui/tsconfig.json`
- `pnpm --filter @tyrum/operator-app build`
- `pnpm exec vitest run packages/operator-app/tests/agent-status-store.test.ts packages/operator-ui/tests/pages/agents-page.test.ts packages/operator-ui/tests/pages/agents-page-layout.test.ts`
- `pnpm exec vitest run apps/web/tests/layout-regression.test.ts -t "keeps agents"`
- `git push -u origin 1977-update-agent-status-read-surfaces-canonical-tool-exposure` (passed repo pre-push `pnpm ci:local`, including the full workspace test suite)

## Risk
- low to moderate: this changes a live operator read surface and shared agent-status refresh behavior, but the backend contract is unchanged and the race fix is covered by a store regression test

## Rollback notes
- revert commits `823f67b9305ce762c1a572d326c43c80c42d9fb0` and `ab4619ae875f1abced00cc6cb6a803f78d5e1a92` to restore the previous inspector behavior and agent-status store behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a live operator read surface and changes agent-status refresh/synchronization logic, which could affect what status is shown during rapid agent switching. Mitigated by added store and UI regression tests.
> 
> **Overview**
> Adds a new **Agent exposure** card to the Agents page inspector rail that shows canonical resolved `tool_exposure` (MCP + Tools) for the selected agent, with a legacy `tool_access` fallback only when canonical tools exposure is unresolved, plus an error/loading state.
> 
> Refactors Agents page data fetching into `useAgentsPageData` to keep the selected agent’s status in sync (including after create/delete and toolbar refresh), and updates `agentStatusStore` to be typed as `AgentStatusResponse` and ignore stale `refresh()` results when the agent selection changes.
> 
> Extends test fixtures and adds regression tests covering stale refresh races, exposure rendering/fallback behavior, and refresh wiring; also registers the new "Agent status unavailable" i18n string in `en`/`nl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4619ae875f1abced00cc6cb6a803f78d5e1a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->