### PR TITLE
Adopt canonical tool taxonomy metadata in approval suggestion and standing-rule operator surfaces

### DIFF
--- a/packages/operator-ui/src/components/pages/approval-actions.tsx
+++ b/packages/operator-ui/src/components/pages/approval-actions.tsx
@@ -3,6 +3,13 @@ import { useEffect, useMemo, useState, type ReactElement } from "react";
 import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
 import {
+  PolicyToolMetadataPanel,
+  buildPolicyToolLookup,
+  resolvePolicyTool,
+  type PolicyToolOption,
+  type ResolvedPolicyTool,
+} from "./admin-http-policy-overrides.shared.js";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -24,6 +31,7 @@ type SuggestedOverrideOption = SuggestedOverride & {
   key: string;
   title: string;
   description: string;
+  resolvedTool: ResolvedPolicyTool | null;
 };
 
 function extractSuggestedOverrides(approval: Approval | null | undefined): SuggestedOverride[] {
@@ -45,39 +53,42 @@ function extractSuggestedOverrides(approval: Approval | null | undefined): Sugge
   return overrides;
 }
 
-function describeSuggestedOverride(input: SuggestedOverride): {
+function describeSuggestedOverride(
+  input: SuggestedOverride,
+  displayToolId: string,
+): {
   title: string;
   description: string;
 } {
-  if (input.tool_id === "tool.desktop.act") {
+  if (displayToolId === "tool.desktop.act") {
     return {
       title: "Desktop act actions in this scope",
       description: "Covers future Desktop act operations for this agent/workspace.",
     };
   }
 
-  if (input.tool_id === "tool.desktop.query") {
+  if (displayToolId === "tool.desktop.query") {
     return {
       title: "Desktop query actions in this scope",
       description: "Covers read-only Desktop queries for this agent/workspace.",
     };
   }
 
-  if (input.tool_id === "tool.desktop.snapshot" || input.tool_id === "tool.desktop.screenshot") {
+  if (displayToolId === "tool.desktop.snapshot" || displayToolId === "tool.desktop.screenshot") {
     return {
       title: "Desktop snapshots in this scope",
       description: "Covers Desktop screenshot or snapshot operations for this agent/workspace.",
     };
   }
 
-  if (input.tool_id === "connector.send") {
+  if (displayToolId === "connector.send") {
     return {
       title: "Sends to this destination",
       description: "Covers future sends to the same connector/account destination.",
     };
   }
 
-  if (input.tool_id === "tool.automation.schedule.create") {
+  if (displayToolId === "tool.automation.schedule.create") {
     if (input.pattern.includes("kind:heartbeat")) {
       return {
         title: "Heartbeat schedule creation in this scope",
@@ -97,11 +108,11 @@ function describeSuggestedOverride(input: SuggestedOverride): {
   }
 
   if (
-    input.tool_id === "tool.automation.schedule.update" ||
-    input.tool_id === "tool.automation.schedule.pause" ||
-    input.tool_id === "tool.automation.schedule.resume" ||
-    input.tool_id === "tool.automation.schedule.delete" ||
-    input.tool_id === "tool.automation.schedule.get"
+    displayToolId === "tool.automation.schedule.update" ||
+    displayToolId === "tool.automation.schedule.pause" ||
+    displayToolId === "tool.automation.schedule.resume" ||
+    displayToolId === "tool.automation.schedule.delete" ||
+    displayToolId === "tool.automation.schedule.get"
   ) {
     return {
       title: "This exact schedule target",
@@ -117,9 +128,12 @@ function describeSuggestedOverride(input: SuggestedOverride): {
 
 function listApprovalSuggestedOverrideOptions(
   approval: Approval | null | undefined,
+  toolLookup: ReadonlyMap<string, ResolvedPolicyTool>,
 ): SuggestedOverrideOption[] {
   return extractSuggestedOverrides(approval).map((override) => {
-    const described = describeSuggestedOverride(override);
+    const resolvedTool = resolvePolicyTool(toolLookup, override.tool_id);
+    const displayToolId = resolvedTool?.entry.canonical_id ?? override.tool_id;
+    const described = describeSuggestedOverride(override, displayToolId);
     return {
       tool_id: override.tool_id,
       pattern: override.pattern,
@@ -127,6 +141,7 @@ function listApprovalSuggestedOverrideOptions(
       key: `${override.tool_id}::${override.pattern}::${override.workspace_id ?? ""}`,
       title: described.title,
       description: described.description,
+      resolvedTool,
     };
   });
 }
@@ -137,10 +152,12 @@ export function ApprovalActions(props: {
   resolvingState?: "approved" | "denied" | "always";
   onResolve: (input: ResolveApprovalInput) => void;
   className?: string;
+  tools?: readonly PolicyToolOption[];
 }): ReactElement {
+  const toolLookup = useMemo(() => buildPolicyToolLookup(props.tools ?? []), [props.tools]);
   const options = useMemo(
-    () => listApprovalSuggestedOverrideOptions(props.approval),
-    [props.approval],
+    () => listApprovalSuggestedOverrideOptions(props.approval, toolLookup),
+    [props.approval, toolLookup],
   );
   const hasAlwaysApprove = options.length > 0;
   const [alwaysOpen, setAlwaysOpen] = useState(false);
@@ -232,9 +249,15 @@ export function ApprovalActions(props: {
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium text-fg">{option.title}</span>
                     {index === 0 ? <Badge variant="success">Recommended</Badge> : null}
-                    <Badge variant="outline">{option.tool_id}</Badge>
                   </div>
                   <div className="text-sm text-fg-muted">{option.description}</div>
+                  <PolicyToolMetadataPanel
+                    title="Canonical tool"
+                    toolId={option.tool_id}
+                    resolved={option.resolvedTool}
+                    rawToolIdLabel="Suggested tool ID"
+                    unavailableMessage="Shared tool metadata unavailable for this suggestion."
+                  />
                   <code className="rounded bg-bg-subtle px-2 py-1 font-mono text-xs text-fg">
                     {option.pattern}
                   </code>

--- a/packages/operator-ui/src/components/pages/approvals-page.expanded-row.tsx
+++ b/packages/operator-ui/src/components/pages/approvals-page.expanded-row.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { Badge } from "../ui/badge.js";
 import { Button } from "../ui/button.js";
 import { ApprovalActions } from "./approval-actions.js";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
 import {
   describeApprovalOutcome,
   describeDesktopApprovalContext,
@@ -24,6 +25,7 @@ export function ApprovalExpandedRow(props: {
   intl: IntlShape;
   resolvingDecision?: "approved" | "denied" | "always";
   runsState: TurnsState;
+  tools?: readonly PolicyToolOption[];
   onResolve: (input: ResolveApprovalInput) => void;
   onOpenTakeover: (input: { environmentId: string; title: string }) => Promise<void>;
 }) {
@@ -58,6 +60,7 @@ export function ApprovalExpandedRow(props: {
             approval={approval}
             resolvingState={resolvingDecision}
             onResolve={props.onResolve}
+            tools={props.tools}
           />
         ) : (
           <div className="text-sm text-fg-muted">

--- a/packages/operator-ui/src/components/pages/approvals-page.tsx
+++ b/packages/operator-ui/src/components/pages/approvals-page.tsx
@@ -5,6 +5,10 @@ import { toast } from "sonner";
 import { AppPage } from "../layout/app-page.js";
 import { ApprovalExpandedRow } from "./approvals-page.expanded-row.js";
 import {
+  normalizePolicyToolOptions,
+  type PolicyToolOption,
+} from "./admin-http-policy-overrides.shared.js";
+import {
   createManagedAgentLookup,
   describeApprovalTableContext,
   formatAgentLabel,
@@ -79,6 +83,7 @@ export function ApprovalsPage({ core }: { core: OperatorCore }) {
     Record<string, "approved" | "denied" | "always" | undefined>
   >({});
   const [managedAgents, setManagedAgents] = useState<ManagedAgentOption[]>([]);
+  const [toolOptions, setToolOptions] = useState<PolicyToolOption[]>([]);
   const [agentFilter, setAgentFilter] = useState("all");
   const [expandedSelection, setExpandedSelection] = useState<ExpandedApprovalSelection | null>(
     null,
@@ -115,6 +120,34 @@ export function ApprovalsPage({ core }: { core: OperatorCore }) {
     };
 
     void loadAgents();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [core.admin]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const listTools = core.admin?.toolRegistry?.list;
+
+    if (typeof listTools !== "function") {
+      setToolOptions([]);
+      return;
+    }
+
+    const loadTools = async (): Promise<void> => {
+      try {
+        const response = await listTools();
+        if (cancelled) return;
+        setToolOptions(normalizePolicyToolOptions((response as { tools?: unknown }).tools));
+      } catch {
+        if (!cancelled) {
+          setToolOptions([]);
+        }
+      }
+    };
+
+    void loadTools();
 
     return () => {
       cancelled = true;
@@ -415,6 +448,7 @@ export function ApprovalsPage({ core }: { core: OperatorCore }) {
                       intl={intl}
                       resolvingDecision={resolvingById[row.approvalId]}
                       runsState={runsState}
+                      tools={toolOptions}
                       onResolve={(input) => {
                         void resolveApproval(input);
                       }}

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-approval-data-part-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-approval-data-part-card.tsx
@@ -1,5 +1,11 @@
 import type { Approval, ResolveApprovalInput } from "@tyrum/operator-app";
 import { ShieldCheck } from "lucide-react";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
+import {
+  PolicyToolMetadataPanel,
+  buildPolicyToolLookup,
+  resolvePolicyTool,
+} from "./admin-http-policy-overrides.shared.js";
 import { Badge } from "../ui/badge.js";
 import { ApprovalActions } from "./approval-actions.js";
 
@@ -21,6 +27,7 @@ export function ApprovalDataPartCard({
   onResolveApproval,
   part,
   resolvingApproval,
+  tools = [],
 }: {
   approval: Approval | null;
   interactiveApprovals: boolean;
@@ -31,8 +38,11 @@ export function ApprovalDataPartCard({
     tool_name: string;
   };
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
+  tools?: readonly PolicyToolOption[];
 }) {
   const pending = part.state === "pending";
+  const toolLookup = buildPolicyToolLookup(tools);
+  const resolvedTool = resolvePolicyTool(toolLookup, part.tool_name);
   return (
     <div className="rounded-lg border border-warning-300/70 bg-warning-50/70 px-2 py-1.5">
       <div className="flex items-start justify-between gap-3">
@@ -41,9 +51,17 @@ export function ApprovalDataPartCard({
             <ShieldCheck className="h-4 w-4 shrink-0" />
             <span className="truncate">Approval request</span>
           </div>
-          <div className="mt-1 text-xs text-warning-900/80">{part.tool_name}</div>
         </div>
         <Badge variant={approvalStateVariant(part.state)}>{part.state}</Badge>
+      </div>
+      <div className="mt-2">
+        <PolicyToolMetadataPanel
+          title="Canonical tool"
+          toolId={part.tool_name}
+          resolved={resolvedTool}
+          rawToolIdLabel="Requested tool ID"
+          unavailableMessage="Shared tool metadata unavailable for this approval."
+        />
       </div>
 
       {interactiveApprovals && pending ? (
@@ -61,6 +79,7 @@ export function ApprovalDataPartCard({
             }
             onResolve={onResolveApproval}
             className="mt-2"
+            tools={tools}
           />
         </div>
       ) : null}

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-approval-data-part-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-approval-data-part-card.tsx
@@ -1,9 +1,8 @@
 import type { Approval, ResolveApprovalInput } from "@tyrum/operator-app";
 import { ShieldCheck } from "lucide-react";
-import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
+import type { PolicyToolOption, ResolvedPolicyTool } from "./admin-http-policy-overrides.shared.js";
 import {
   PolicyToolMetadataPanel,
-  buildPolicyToolLookup,
   resolvePolicyTool,
 } from "./admin-http-policy-overrides.shared.js";
 import { Badge } from "../ui/badge.js";
@@ -27,6 +26,7 @@ export function ApprovalDataPartCard({
   onResolveApproval,
   part,
   resolvingApproval,
+  toolLookup,
   tools = [],
 }: {
   approval: Approval | null;
@@ -38,10 +38,10 @@ export function ApprovalDataPartCard({
     tool_name: string;
   };
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
+  toolLookup: ReadonlyMap<string, ResolvedPolicyTool>;
   tools?: readonly PolicyToolOption[];
 }) {
   const pending = part.state === "pending";
-  const toolLookup = buildPolicyToolLookup(tools);
   const resolvedTool = resolvePolicyTool(toolLookup, part.tool_name);
   return (
     <div className="rounded-lg border border-warning-300/70 bg-warning-50/70 px-2 py-1.5">

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-conversation.tsx
@@ -20,6 +20,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { AiSdkChatMessageList } from "./chat-page-ai-sdk-messages.js";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
 import { getConversationDisplayTitle } from "./chat-page-ai-sdk-shared.js";
 import { ChatQueueModeControl } from "./chat-page-ai-sdk-queue-mode-control.js";
 import { Alert } from "../ui/alert.js";
@@ -129,6 +130,7 @@ export function AiSdkConversation({
   renderMode,
   resolvingApproval,
   resolveAttachedNodeId,
+  approvalToolOptions,
   conversation,
   conversationClient,
   toolSchemasById,
@@ -144,6 +146,7 @@ export function AiSdkConversation({
   renderMode: "markdown" | "text";
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
   resolveAttachedNodeId: () => Promise<string | null>;
+  approvalToolOptions: readonly PolicyToolOption[];
   conversation: ChatConversationWithQueueMode;
   conversationClient: ReturnType<typeof createTyrumAiSdkChatConversationClient>;
   toolSchemasById: Record<string, Record<string, unknown>>;
@@ -385,6 +388,7 @@ export function AiSdkConversation({
         onResolveApproval={onResolveApproval}
         renderMode={renderMode}
         resolvingApproval={resolvingApproval}
+        approvalToolOptions={approvalToolOptions}
         toolSchemasById={toolSchemasById}
         working={working}
       />

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-parts.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-parts.tsx
@@ -9,6 +9,7 @@ import {
   type UIMessage,
 } from "ai";
 import { ShieldCheck } from "lucide-react";
+import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ArtifactInlinePreview } from "../artifacts/artifact-inline-preview.js";
@@ -16,7 +17,7 @@ import { Badge } from "../ui/badge.js";
 import { StructuredJsonDisplay } from "../ui/structured-json-display.js";
 import { StructuredJsonSchemaDisplay } from "../ui/structured-json-schema-display.js";
 import { ApprovalActions } from "./approval-actions.js";
-import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
+import type { PolicyToolOption, ResolvedPolicyTool } from "./admin-http-policy-overrides.shared.js";
 import {
   PolicyToolMetadataPanel,
   buildPolicyToolLookup,
@@ -213,6 +214,7 @@ function ReasoningPartCard({
 
 function ToolPartCard({
   approval,
+  approvalToolLookup,
   core,
   interactiveApprovals,
   onResolveApproval,
@@ -223,6 +225,7 @@ function ToolPartCard({
   toolSchemasById,
 }: {
   approval: Approval | null;
+  approvalToolLookup: ReadonlyMap<string, ResolvedPolicyTool>;
   core?: OperatorCore;
   interactiveApprovals: boolean;
   onResolveApproval: (input: ResolveApprovalInput) => void;
@@ -246,8 +249,7 @@ function ToolPartCard({
     "output" in part
       ? normalizeToolOutputForDisplay(part.output)
       : { displayValue: undefined, isStructured: false };
-  const toolLookup = buildPolicyToolLookup(approvalToolOptions);
-  const resolvedTool = resolvePolicyTool(toolLookup, toolName);
+  const resolvedTool = resolvePolicyTool(approvalToolLookup, toolName);
   const displayToolName = resolvedTool?.entry.canonical_id ?? toolName;
   const toolSchema = toolSchemasById[displayToolName];
   const artifactRefs =
@@ -375,6 +377,10 @@ export function MessageParts({
   approvalToolOptions?: readonly PolicyToolOption[];
   toolSchemasById?: Record<string, Record<string, unknown>>;
 }) {
+  const approvalToolLookup = useMemo(
+    () => buildPolicyToolLookup(approvalToolOptions),
+    [approvalToolOptions],
+  );
   const approvalIdsWithDataPart = new Set(
     message.parts
       .map((part) => readApprovalDataPart(part)?.approval_id ?? null)
@@ -414,6 +420,7 @@ export function MessageParts({
             <ToolPartCard
               key={`${message.id}:tool:${index}`}
               approval={approval}
+              approvalToolLookup={approvalToolLookup}
               core={core}
               interactiveApprovals={interactiveApprovals}
               onResolveApproval={onResolveApproval}
@@ -436,6 +443,7 @@ export function MessageParts({
                 onResolveApproval={onResolveApproval}
                 part={approvalPart}
                 resolvingApproval={resolvingApproval}
+                toolLookup={approvalToolLookup}
                 tools={approvalToolOptions}
               />
             );

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-parts.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card-parts.tsx
@@ -16,6 +16,12 @@ import { Badge } from "../ui/badge.js";
 import { StructuredJsonDisplay } from "../ui/structured-json-display.js";
 import { StructuredJsonSchemaDisplay } from "../ui/structured-json-schema-display.js";
 import { ApprovalActions } from "./approval-actions.js";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
+import {
+  PolicyToolMetadataPanel,
+  buildPolicyToolLookup,
+  resolvePolicyTool,
+} from "./admin-http-policy-overrides.shared.js";
 import { ApprovalDataPartCard } from "./chat-page-ai-sdk-approval-data-part-card.js";
 import { useArtifactAwareMarkdownComponents } from "./chat-page-ai-sdk-artifact-markdown.js";
 import { DisclosureCard, useAutoDisclosure } from "./chat-page-ai-sdk-disclosure-card.js";
@@ -213,6 +219,7 @@ function ToolPartCard({
   part,
   resolvingApproval,
   showApprovalDetails,
+  approvalToolOptions,
   toolSchemasById,
 }: {
   approval: Approval | null;
@@ -222,6 +229,7 @@ function ToolPartCard({
   part: Extract<UIMessage["parts"][number], { type: string }>;
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
   showApprovalDetails: boolean;
+  approvalToolOptions: readonly PolicyToolOption[];
   toolSchemasById: Record<string, Record<string, unknown>>;
 }) {
   if (!isToolUIPart(part)) {
@@ -230,7 +238,6 @@ function ToolPartCard({
 
   const approvalId = readToolApprovalId(part);
   const toolName = getToolName(part);
-  const toolSchema = toolSchemasById[toolName];
   const inputState =
     "input" in part
       ? normalizeToolOutputForDisplay(part.input)
@@ -239,6 +246,10 @@ function ToolPartCard({
     "output" in part
       ? normalizeToolOutputForDisplay(part.output)
       : { displayValue: undefined, isStructured: false };
+  const toolLookup = buildPolicyToolLookup(approvalToolOptions);
+  const resolvedTool = resolvePolicyTool(toolLookup, toolName);
+  const displayToolName = resolvedTool?.entry.canonical_id ?? toolName;
+  const toolSchema = toolSchemasById[displayToolName];
   const artifactRefs =
     "output" in part && part.output !== undefined
       ? collectArtifactRefs(outputState.displayValue)
@@ -247,7 +258,7 @@ function ToolPartCard({
   const isPendingApproval = part.state === "approval-requested" && approvalId;
 
   return (
-    <DisclosureCard header={toolName} open={open} onToggle={toggleOpen}>
+    <DisclosureCard header={displayToolName} open={open} onToggle={toggleOpen}>
       <div className="grid gap-2">
         {"input" in part && part.input !== undefined ? (
           <div>
@@ -316,6 +327,13 @@ function ToolPartCard({
 
         {interactiveApprovals && showApprovalDetails && isPendingApproval && approvalId ? (
           <div className="rounded-md border border-warning-300/70 bg-warning-50/70 px-2 py-1.5">
+            <PolicyToolMetadataPanel
+              title="Canonical tool"
+              toolId={toolName}
+              resolved={resolvedTool}
+              rawToolIdLabel="Requested tool ID"
+              unavailableMessage="Shared tool metadata unavailable for this approval."
+            />
             <div className="text-xs text-warning-900">
               User approval is required before this tool can continue.
             </div>
@@ -327,6 +345,7 @@ function ToolPartCard({
               }
               onResolve={onResolveApproval}
               className="mt-2"
+              tools={approvalToolOptions}
             />
           </div>
         ) : null}
@@ -343,6 +362,7 @@ export function MessageParts({
   onResolveApproval,
   renderMode,
   resolvingApproval,
+  approvalToolOptions = [],
   toolSchemasById = {},
 }: {
   approvalsById: Record<string, Approval>;
@@ -352,6 +372,7 @@ export function MessageParts({
   onResolveApproval: (input: ResolveApprovalInput) => void;
   renderMode: "markdown" | "text";
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
+  approvalToolOptions?: readonly PolicyToolOption[];
   toolSchemasById?: Record<string, Record<string, unknown>>;
 }) {
   const approvalIdsWithDataPart = new Set(
@@ -398,6 +419,7 @@ export function MessageParts({
               onResolveApproval={onResolveApproval}
               part={part}
               resolvingApproval={resolvingApproval}
+              approvalToolOptions={approvalToolOptions}
               showApprovalDetails={!approvalId || !approvalIdsWithDataPart.has(approvalId)}
               toolSchemasById={toolSchemasById}
             />
@@ -414,6 +436,7 @@ export function MessageParts({
                 onResolveApproval={onResolveApproval}
                 part={approvalPart}
                 resolvingApproval={resolvingApproval}
+                tools={approvalToolOptions}
               />
             );
           }

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-message-card.tsx
@@ -1,6 +1,7 @@
 import type { Approval, ResolveApprovalInput, OperatorCore } from "@tyrum/operator-app";
 import type { UIMessage } from "ai";
 import { Copy } from "lucide-react";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
 import { cn } from "../../lib/cn.js";
 import { useClipboard } from "../../utils/clipboard.js";
 import { formatRelativeTime } from "../../utils/format-relative-time.js";
@@ -30,6 +31,7 @@ export function MessageCard({
   onResolveApproval,
   renderMode,
   resolvingApproval,
+  approvalToolOptions = [],
   toolSchemasById = {},
 }: {
   approvalsById: Record<string, Approval>;
@@ -39,6 +41,7 @@ export function MessageCard({
   onResolveApproval: (input: ResolveApprovalInput) => void;
   renderMode: "markdown" | "text";
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
+  approvalToolOptions?: readonly PolicyToolOption[];
   toolSchemasById?: Record<string, Record<string, unknown>>;
 }) {
   const clipboard = useClipboard();
@@ -82,6 +85,7 @@ export function MessageCard({
         onResolveApproval={onResolveApproval}
         renderMode={renderMode}
         resolvingApproval={resolvingApproval}
+        approvalToolOptions={approvalToolOptions}
         toolSchemasById={toolSchemasById}
       />
     </div>

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk-messages.tsx
@@ -1,6 +1,7 @@
 import type { Approval, OperatorCore, ResolveApprovalInput } from "@tyrum/operator-app";
 import type { UIMessage } from "ai";
 import { useEffect, useLayoutEffect, useRef } from "react";
+import type { PolicyToolOption } from "./admin-http-policy-overrides.shared.js";
 import { MessageCard } from "./chat-page-ai-sdk-message-card.js";
 
 const CHAT_AUTOSCROLL_THRESHOLD_PX = 40;
@@ -23,6 +24,7 @@ export function AiSdkChatMessageList({
   onResolveApproval,
   renderMode,
   resolvingApproval,
+  approvalToolOptions,
   toolSchemasById,
   working,
 }: {
@@ -33,6 +35,7 @@ export function AiSdkChatMessageList({
   onResolveApproval: (input: ResolveApprovalInput) => void;
   renderMode: "markdown" | "text";
   resolvingApproval: { approvalId: string; state: "always" | "approved" | "denied" } | null;
+  approvalToolOptions: readonly PolicyToolOption[];
   toolSchemasById: Record<string, Record<string, unknown>>;
   working: boolean;
 }) {
@@ -92,6 +95,7 @@ export function AiSdkChatMessageList({
               onResolveApproval={onResolveApproval}
               renderMode={renderMode}
               resolvingApproval={resolvingApproval}
+              approvalToolOptions={approvalToolOptions}
               toolSchemasById={toolSchemasById}
             />
           ))}

--- a/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
+++ b/packages/operator-ui/src/components/pages/chat-page-ai-sdk.tsx
@@ -16,6 +16,10 @@ import { Button } from "../ui/button.js";
 import { ConfirmDangerDialog } from "../ui/confirm-danger-dialog.js";
 import { LoadingState } from "../ui/loading-state.js";
 import { useAppShellMinWidth } from "../layout/app-shell.js";
+import {
+  normalizePolicyToolOptions,
+  type PolicyToolOption,
+} from "./admin-http-policy-overrides.shared.js";
 import { ChatThreadsPanel } from "./chat-page-threads.js";
 import { AiSdkConversation } from "./chat-page-ai-sdk-conversation.js";
 import { toThreadSummary } from "./chat-page-ai-sdk-shared.js";
@@ -83,6 +87,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
   const [toolSchemasById, setToolSchemasById] = useState<Record<string, Record<string, unknown>>>(
     {},
   );
+  const [approvalToolOptions, setApprovalToolOptions] = useState<PolicyToolOption[]>([]);
   const [resolvingApproval, setResolvingApproval] = useState<{
     approvalId: string;
     state: "always" | "approved" | "denied";
@@ -149,6 +154,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
     const toolRegistryApi = core.admin.toolRegistry;
     if (!toolRegistryApi) {
       setToolSchemasById({});
+      setApprovalToolOptions([]);
       return;
     }
 
@@ -159,6 +165,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
         if (cancelled) {
           return;
         }
+        setApprovalToolOptions(normalizePolicyToolOptions(result.tools));
         setToolSchemasById(
           Object.fromEntries(
             result.tools.flatMap((tool) =>
@@ -170,6 +177,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
       .catch(() => {
         if (!cancelled) {
           setToolSchemasById({});
+          setApprovalToolOptions([]);
         }
       });
 
@@ -397,6 +405,7 @@ export function AiSdkChatPage({ core }: { core: OperatorCore }) {
               renderMode={renderMode}
               resolvingApproval={resolvingApproval}
               resolveAttachedNodeId={resolveAttachedNodeId}
+              approvalToolOptions={approvalToolOptions}
               conversation={activeConversation}
               conversationClient={conversationClient}
               toolSchemasById={toolSchemasById}

--- a/packages/operator-ui/src/i18n/messages/en.json
+++ b/packages/operator-ui/src/i18n/messages/en.json
@@ -218,6 +218,7 @@
   "Cancelled": "Cancelled",
   "Cancelled before the action resumed.": "Cancelled before the action resumed.",
   "Canonical ID": "Canonical ID",
+  "Canonical tool": "Canonical tool",
   "Capabilities": "Capabilities",
   "Capture a page screenshot.": "Capture a page screenshot.",
   "Capture a structured accessibility snapshot.": "Capture a structured accessibility snapshot.",

--- a/packages/operator-ui/src/i18n/messages/nl.json
+++ b/packages/operator-ui/src/i18n/messages/nl.json
@@ -218,6 +218,7 @@
   "Cancelled": "Cancelled",
   "Cancelled before the action resumed.": "Geannuleerd voordat de actie werd hervat.",
   "Canonical ID": "Canonieke ID",
+  "Canonical tool": "Canonieke tool",
   "Capabilities": "Capabilities",
   "Capture a page screenshot.": "Maak een paginascreenshot.",
   "Capture a structured accessibility snapshot.": "Leg een gestructureerde toegankelijkheidsmomentopname vast.",

--- a/packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts
+++ b/packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts
@@ -17,6 +17,29 @@ const NOOP_ADMIN_ACCESS_CONTROLLER = {
   exit: async () => {},
 };
 
+const DESKTOP_TOOL_REGISTRY = {
+  status: "ok" as const,
+  tools: [
+    {
+      source: "builtin" as const,
+      canonical_id: "tool.desktop.snapshot",
+      lifecycle: "canonical" as const,
+      visibility: "public" as const,
+      aliases: [{ id: "tool.desktop.screenshot", lifecycle: "alias" as const }],
+      description: "Capture a desktop snapshot.",
+      effect: "read_only" as const,
+      effective_exposure: {
+        enabled: true,
+        reason: "enabled" as const,
+        agent_key: "default",
+      },
+      family: "desktop",
+      group: "node" as const,
+      tier: "default" as const,
+    },
+  ],
+};
+
 function renderApprovalsPage(core: OperatorCore) {
   return renderIntoDocument(
     React.createElement(
@@ -43,8 +66,8 @@ describe("ApprovalsPage always approve", () => {
         policy: {
           suggested_overrides: [
             {
-              tool_id: "tool.desktop.act",
-              pattern: "tool.desktop.act",
+              tool_id: "tool.desktop.screenshot",
+              pattern: "tool.desktop.snapshot",
               workspace_id: "22222222-2222-4222-8222-222222222222",
             },
           ],
@@ -63,8 +86,8 @@ describe("ApprovalsPage always approve", () => {
           created_at: "2026-01-01T00:00:01.000Z",
           agent_id: "44444444-4444-4444-8444-444444444444",
           workspace_id: "22222222-2222-4222-8222-222222222222",
-          tool_id: "tool.desktop.act",
-          pattern: "tool.desktop.act",
+          tool_id: "tool.desktop.screenshot",
+          pattern: "tool.desktop.snapshot",
           created_from_approval_id: approval.approval_id,
         },
       ],
@@ -103,6 +126,11 @@ describe("ApprovalsPage always approve", () => {
       elevatedModeStore: createElevatedModeStore({
         tickIntervalMs: 0,
       }),
+      admin: {
+        toolRegistry: {
+          list: vi.fn(async () => DESKTOP_TOOL_REGISTRY),
+        },
+      },
     } as unknown as OperatorCore;
 
     core.elevatedModeStore.enter({
@@ -138,7 +166,11 @@ describe("ApprovalsPage always approve", () => {
       );
 
       expect(dialog?.textContent ?? "").toContain("Recommended");
-      expect(dialog?.textContent ?? "").toContain("Desktop act actions in this scope");
+      expect(dialog?.textContent ?? "").toContain("Desktop snapshots in this scope");
+      expect(dialog?.textContent ?? "").toContain("tool.desktop.snapshot");
+      expect(dialog?.textContent ?? "").toContain("tool.desktop.screenshot");
+      expect(dialog?.textContent ?? "").toContain("alias match");
+      expect(dialog?.textContent ?? "").toContain("public");
       expect(firstOption?.getAttribute("data-state")).toBe("checked");
 
       await act(async () => {
@@ -152,8 +184,8 @@ describe("ApprovalsPage always approve", () => {
         mode: "always",
         overrides: [
           {
-            tool_id: "tool.desktop.act",
-            pattern: "tool.desktop.act",
+            tool_id: "tool.desktop.screenshot",
+            pattern: "tool.desktop.snapshot",
             workspace_id: "22222222-2222-4222-8222-222222222222",
           },
         ],
@@ -249,6 +281,19 @@ describe("ApprovalsPage always approve", () => {
         `[data-testid="approval-always-${approval.approval_id}"]`,
       );
       expect(alwaysButton).not.toBeNull();
+
+      await act(async () => {
+        click(alwaysButton!);
+        await Promise.resolve();
+      });
+
+      const dialog = document.querySelector<HTMLElement>(
+        `[data-testid="approval-always-dialog-${approval.approval_id}"]`,
+      );
+      expect(dialog?.textContent ?? "").toContain("webfetch");
+      expect(dialog?.textContent ?? "").toContain(
+        "Shared tool metadata unavailable for this suggestion.",
+      );
     } finally {
       cleanupTestRoot({ container, root });
     }

--- a/packages/operator-ui/tests/pages/chat-page-ai-sdk-approval-metadata.test.ts
+++ b/packages/operator-ui/tests/pages/chat-page-ai-sdk-approval-metadata.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { UIMessage } from "ai";
+import type { PolicyToolOption } from "../../src/components/pages/admin-http-policy-overrides.shared.js";
+import { MessageCard } from "../../src/components/pages/chat-page-ai-sdk-message-card.js";
+import { cleanupTestRoot, renderIntoDocument } from "../test-utils.js";
+
+const e = React.createElement;
+
+const APPROVAL_TOOL_OPTIONS: PolicyToolOption[] = [
+  {
+    canonical_id: "tool.desktop.snapshot",
+    description: "Capture a desktop snapshot.",
+    aliases: [{ id: "tool.desktop.screenshot", lifecycle: "alias" }],
+    lifecycle: "canonical",
+    visibility: "public",
+  },
+  {
+    canonical_id: "memory.write",
+    description: "Write structured memory items.",
+    aliases: [{ id: "mcp.memory.write", lifecycle: "deprecated" }],
+    lifecycle: "canonical",
+    visibility: "public",
+  },
+];
+
+function renderApprovalMessageCard(
+  toolName: string,
+  approvalToolOptions?: readonly PolicyToolOption[],
+) {
+  return renderIntoDocument(
+    e(MessageCard, {
+      approvalsById: {},
+      message: {
+        id: `assistant-${toolName}`,
+        role: "assistant",
+        parts: [
+          {
+            type: "data-approval-state",
+            data: {
+              approval_id: `${toolName}-approval`,
+              approved: false,
+              state: "pending",
+              tool_call_id: `${toolName}-call`,
+              tool_name: toolName,
+            },
+          },
+        ],
+      } as unknown as UIMessage,
+      onResolveApproval: vi.fn(),
+      renderMode: "text",
+      resolvingApproval: null,
+      approvalToolOptions,
+    }),
+  );
+}
+
+describe("MessageCard approval metadata", () => {
+  it("renders canonical tool metadata in approval request cards", () => {
+    const testRoot = renderApprovalMessageCard("tool.desktop.screenshot", APPROVAL_TOOL_OPTIONS);
+
+    expect(testRoot.container.textContent).toContain("Approval request");
+    expect(testRoot.container.textContent).toContain("tool.desktop.snapshot");
+    expect(testRoot.container.textContent).toContain("tool.desktop.screenshot");
+    expect(testRoot.container.textContent).toContain("alias match");
+    expect(testRoot.container.textContent).toContain("public");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("renders deprecated alias state in approval request cards", () => {
+    const testRoot = renderApprovalMessageCard("mcp.memory.write", APPROVAL_TOOL_OPTIONS);
+
+    expect(testRoot.container.textContent).toContain("memory.write");
+    expect(testRoot.container.textContent).toContain("deprecated alias match");
+    expect(testRoot.container.textContent).toContain("public");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("uses the canonical tool id as the approval-request header and schema key", () => {
+    const testRoot = renderIntoDocument(
+      e(MessageCard, {
+        approvalsById: {
+          "approval-4": {
+            approval_id: "approval-4",
+            approval_key: "approval:4",
+            kind: "policy",
+            status: "awaiting_human",
+            prompt: "Approve snapshot",
+            motivation: "Approve snapshot",
+            created_at: "2026-01-01T00:00:00.000Z",
+            latest_review: null,
+          },
+        },
+        message: {
+          id: "assistant-approval-tool-part",
+          role: "assistant",
+          parts: [
+            {
+              type: "dynamic-tool",
+              toolName: "tool.desktop.screenshot",
+              toolCallId: "tool-call-4",
+              state: "approval-requested",
+              input: { path: "/tmp/snap.png" },
+              approval: { id: "approval-4" },
+            },
+          ],
+        } as unknown as UIMessage,
+        onResolveApproval: vi.fn(),
+        renderMode: "text",
+        resolvingApproval: null,
+        approvalToolOptions: APPROVAL_TOOL_OPTIONS,
+        toolSchemasById: {
+          "tool.desktop.snapshot": {
+            type: "object",
+            properties: {
+              path: {
+                type: "string",
+                title: "Path",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const toggle = Array.from(testRoot.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.trim().includes("tool.desktop.snapshot"),
+    );
+    expect(toggle?.textContent?.trim()).toBe("tool.desktop.snapshot");
+    expect(testRoot.container.textContent).toContain("Path");
+    expect(testRoot.container.textContent).toContain("/tmp/snap.png");
+
+    cleanupTestRoot(testRoot);
+  });
+
+  it("keeps raw approval tool ids readable when registry metadata is unavailable", () => {
+    const testRoot = renderApprovalMessageCard("mcp.memory.write");
+
+    expect(testRoot.container.textContent).toContain("mcp.memory.write");
+    expect(testRoot.container.textContent).toContain(
+      "Shared tool metadata unavailable for this approval.",
+    );
+
+    cleanupTestRoot(testRoot);
+  });
+});


### PR DESCRIPTION
Closes #1995

## What Changed
- wired canonical tool-registry metadata into approval suggestion and standing-rule operator surfaces in `@tyrum/operator-ui`
- updated approval dialogs and approval/chat cards to show canonical tool identity plus alias, deprecation, and visibility metadata where available instead of relying on raw tool IDs as the primary user-facing label
- added targeted regression coverage for approval suggestion, standing-rule, and AI SDK chat approval metadata rendering
- added the required locale strings for the new metadata labels

## Why
Approval and standing-rule flows are rollout-critical operator surfaces. This change aligns them with the canonical tool taxonomy emitted by the shared registry contract so operators see consistent, policy-relevant tool identity and status information.

## How To Test
- `pnpm exec vitest run packages/operator-ui/tests/pages/approvals-page.always-approve.test.ts packages/operator-ui/tests/pages/approvals-page.expansion.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-message-card.test.ts packages/operator-ui/tests/pages/chat-page-ai-sdk-approval-metadata.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm i18n:check`
- `pnpm run ci`

## Risk
- low to moderate, scoped to operator UI rendering for approval-related flows
- main risk is display regressions in approval/chat surfaces when registry metadata is missing or partial; fallback handling and regression tests were added for that path
- note: local `pnpm run ci` passed once during validation, but a later pre-push retry hit an unrelated flaky timeout in `packages/contracts/tests/dist-entrypoint.test.ts`; the branch was pushed after explicit maintainer approval to use `--no-verify`

## Rollback Notes
- revert commits `db3f5aeac` and `7aae169d0` to restore the previous raw-tool-id rendering path
- no schema, migration, or runtime config rollback is required because this change is UI-only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes that re-label approval/tool surfaces using tool-registry metadata; main risk is display/schema lookup regressions when metadata is missing or alias resolution is incorrect.
> 
> **Overview**
> Approval-related UI surfaces now **resolve tool IDs via the tool registry** and display a canonical tool panel (canonical ID, alias/deprecation match, visibility) instead of relying on raw tool IDs.
> 
> This wires tool metadata loading into `ApprovalsPage` and the AI SDK chat flow, updates approval suggestion/“always approve” dialogs and approval request cards to show the new metadata panel with fallback messaging when registry data is unavailable, and adjusts tool schema lookups to key off canonical IDs.
> 
> Adds locale strings for “Canonical tool” and expands/adds Vitest coverage to assert canonical/alias rendering and missing-metadata fallbacks in approvals and chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba594d58153ef6f85f5e8ddfd92c50dbab1f0787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->