### PR TITLE
Add taxonomy migration docs and conformance guardrails

### DIFF
--- a/docs/architecture/agent/memory/index.md
+++ b/docs/architecture/agent/memory/index.md
@@ -39,6 +39,8 @@ ARCH-21 defines the canonical public taxonomy for built-in memory helpers as the
 - `memory.search` for bounded recall during a turn.
 - `memory.write` for durable facts, notes, procedures, and episodic updates.
 
+The runtime-policy and execution-bookkeeping exact-match migration completed by `#1991`, so new policy/config/prompt surfaces should treat `memory.*` as the only canonical public IDs. Before removing the legacy `mcp.memory.*` aliases from persisted records, run the normal gateway database migrations that ship the canonical rewrite coverage (`packages/gateway/migrations/sqlite/121_canonical_tool_ids.sql`, `packages/gateway/migrations/postgres/121_canonical_tool_ids.sql`, `packages/gateway/migrations/sqlite/164_canonical_public_memory_tool_ids.sql`, and `packages/gateway/migrations/postgres/164_canonical_public_memory_tool_ids.sql`). Keep the aliases only for backward-compatible reads during the supported deprecation window documented in ARCH-21.
+
 Memory configuration is carried in `server_settings.memory`. Retrieval hooks are wired through `pre_turn_tools` so recall can be assembled before inference starts.
 
 Pre-turn hydration and memory-role semantics should be declared through MCP tool metadata overrides so built-in and third-party memory providers follow the same runtime contract. Schema-based inference remains only as a compatibility fallback for MCP tools that do not declare those overrides.

--- a/docs/architecture/gateway/tools.md
+++ b/docs/architecture/gateway/tools.md
@@ -43,6 +43,26 @@ For model-facing prompts, each tool exposes two layers:
 
 The schema wins. Prompt prose must never be treated as permission to invent arguments that the schema does not allow.
 
+## Operator migration checklist
+
+Operators should migrate tool-facing config and policy inputs to canonical public IDs as soon as the canonical replacement is available.
+
+- Read `canonical_id` from `/config/tools` as the stable public contract. Treat `aliases` as compatibility metadata only.
+- Rewrite agent config, policy bundles, overrides, approval suggestions, standing rules, prompts, and exported fixtures to canonical IDs instead of relying on legacy aliases indefinitely.
+- Keep legacy public IDs only for backward-compatible reads during the supported deprecation window defined by [ARCH-21 public tool taxonomy and exposure model](/architecture/arch-21-public-tool-taxonomy-and-exposure-model).
+- Run the normal gateway database migrations before planning alias removal for persisted SQLite or Postgres records that may still contain supported legacy public IDs. The shipped rewrites are in `packages/gateway/migrations/sqlite/121_canonical_tool_ids.sql`, `packages/gateway/migrations/postgres/121_canonical_tool_ids.sql`, `packages/gateway/migrations/sqlite/164_canonical_public_memory_tool_ids.sql`, and `packages/gateway/migrations/postgres/164_canonical_public_memory_tool_ids.sql`.
+- For memory specifically, migrate public references from `mcp.memory.seed`, `mcp.memory.search`, and `mcp.memory.write` to `memory.seed`, `memory.search`, and `memory.write`. The runtime policy and execution-bookkeeping exact-match rollout was completed in `#1991`, so new operator-facing config should use the canonical `memory.*` IDs only.
+
+## Contributor checklist
+
+When a PR adds or renames a public tool, land the taxonomy work in the same change.
+
+- Choose the target package or layer first using [Target-state package graph](/architecture/target-state).
+- Pick one canonical public ID that follows ARCH-21 naming rules and reserved-prefix boundaries.
+- Add or update the shared taxonomy classification so the descriptor resolves stable `canonical_id`, `family`, `group`, `tier`, `visibility`, and `lifecycle` metadata in the same PR.
+- If the change renames an existing public ID, add the documented alias/deprecation mapping, update prompt examples and docs to the canonical ID immediately, and keep compatibility only for the supported migration window.
+- Add or update conformance tests for the owning tool family and the shared taxonomy/descriptor coverage. Do not rely on client-only shims to paper over taxonomy drift.
+
 ## Tool families
 
 | Family        | Typical examples                                                                | Trust / risk notes                                                     |

--- a/docs/architecture/reference/arch-21-public-tool-taxonomy-and-exposure-model.md
+++ b/docs/architecture/reference/arch-21-public-tool-taxonomy-and-exposure-model.md
@@ -47,6 +47,7 @@ flowchart LR
 - Dotted public IDs use lowercase ASCII segments matching `[a-z][a-z0-9-]*`, separated by `.`.
 - The action or verb belongs in the final segment: `artifact.describe`, the `memory` family write helper, `tool.location.place.create`, `tool.automation.schedule.pause`, `workboard.item.list`, `mcp.github.search`.
 - Hyphenated final action segments are allowed when already shipped and stable: `tool.desktop.wait-for`, `tool.secret.copy-to-node-clipboard`.
+- Raw MCP canonical IDs keep `mcp.<server>.` as the leading public shape and preserve the backing tool identifier in the trailing segment. Existing MCP-backed public tools may therefore include underscores after the server segment, for example `mcp.exa.web_search_exa`.
 
 ### Reserved public prefixes
 
@@ -138,6 +139,55 @@ The following IDs or patterns are compatibility shims only. They are not canonic
 
 `tool.*` and `tool.fs.*` are parser-time compatibility helpers for current config and policy inputs. They do not define a public family boundary and must not be treated as canonical family-level aliases.
 
+## Contributor rules for adding or changing tools
+
+When a PR adds, renames, or newly exposes a model-facing tool, it must land the taxonomy work in the same change instead of relying on follow-up cleanup.
+
+Required contributor rules:
+
+- Pick the target package or layer first using [Target-state package graph](/architecture/target-state). Do not hide new business logic inside gateway route handlers just to get a tool to show up.
+- Decide whether the tool is `public`, `internal`, or `runtime_only` before writing prompts, docs, or operator UI copy. Public inventory rows must not be inferred later from transport details.
+- Choose exactly one canonical public ID that follows the naming rules above. New public tool families must not introduce a new grammar when an existing family or reserved prefix already applies.
+- Add or update the taxonomy classification in code so the descriptor resolves stable `canonical_id`, `family`, `group`, `tier`, `visibility`, and `lifecycle` metadata in the same PR.
+- If a shipped public ID is being renamed, add the compatibility alias mapping, mark the legacy public ID as `deprecated` when it remains operator-visible during rollout, and update docs/examples to the canonical ID immediately.
+- Plugin-owned tool IDs must stay in a plugin-owned namespace. They must not claim reserved platform prefixes such as `tool.`, `memory.`, `sandbox.`, `subagent.`, `workboard.`, or reserved exact public IDs such as `read`, `bash`, `websearch`, or `artifact.describe`.
+- Built-in MCP facades must keep facade IDs such as `websearch`, `webfetch`, and `codesearch`. Do not reintroduce `mcp.`-prefixed public aliases for those facades.
+- Add or update conformance coverage in the same PR. At minimum that means the shared taxonomy tests plus the owning registry/runtime tests for the tool family being changed.
+
+## Migration, deprecation, and removal policy
+
+### Supported deprecation window
+
+A legacy public ID remains supported only as a migration alias and must not be reintroduced as canonical output.
+
+The supported deprecation window is:
+
+- never shorter than one minor release after the canonical replacement, migration docs, and durable stored-data rewrite coverage are shipped
+- never shorter than one release where the legacy public ID is emitted only as alias/deprecation metadata rather than as the canonical answer
+- limited to the aliases explicitly documented in this decision record and in the shared normalization tables
+
+Do not remove a legacy public ID in the same release that introduces its canonical replacement.
+
+### Operator migration checklist
+
+Operators should migrate persisted and hand-authored config to canonical public IDs as soon as the canonical replacement is available.
+
+- Treat `canonical_id` from descriptor-bearing inventory as the source of truth. The `aliases` list is compatibility metadata, not a second canonical namespace.
+- Rewrite agent config, policy bundles, policy overrides, approval suggestions, standing rules, prompts, and exported fixtures to canonical public IDs instead of waiting for alias removal.
+- Use the normal gateway database migration flow before planning alias removal for persisted SQLite/Postgres records that may still contain supported legacy public IDs. The shipped rewrite coverage from `#1992` lives in the canonical tool-ID migrations (`packages/gateway/migrations/sqlite/121_canonical_tool_ids.sql`, `packages/gateway/migrations/postgres/121_canonical_tool_ids.sql`) plus the public-memory follow-up migrations (`packages/gateway/migrations/sqlite/164_canonical_public_memory_tool_ids.sql`, `packages/gateway/migrations/postgres/164_canonical_public_memory_tool_ids.sql`).
+- For memory specifically, migrate all public references from `mcp.memory.seed`, `mcp.memory.search`, and `mcp.memory.write` to `memory.seed`, `memory.search`, and `memory.write`. The user-facing defaults/prompts/docs rollout landed in `#1973`, and runtime-policy plus execution-bookkeeping exact-match dependencies were removed in `#1991`.
+- After migration, keep legacy aliases only for backward-compatible reads during the supported deprecation window. Do not emit them back out in new config, runtime reports, or operator copy.
+
+### Supported removal path for legacy public IDs
+
+Follow this path when the supported deprecation window closes:
+
+1. Confirm the canonical replacement is already the only documented and emitted public ID.
+2. Confirm the durable stored-data migration path has shipped for any persisted surface that previously stored the legacy public ID.
+3. Remove the alias from parser-time normalization and shared alias tables in one cleanup PR.
+4. Remove descriptor alias/deprecation metadata for the retired ID and update tests so the retired ID is rejected or ignored instead of silently round-tripping.
+5. Remove any remaining legacy examples, prompts, fixtures, and operator guidance in the same cleanup PR.
+
 ## Static taxonomy metadata versus computed effective exposure
 
 ### Required static taxonomy metadata
@@ -156,7 +206,7 @@ These fields describe the tool itself and do not depend on one agent's current a
 | `source`                    | Provenance of the implementation: `builtin`, `builtin_mcp`, `mcp`, or `plugin`.                                                           |
 | `backing_server` / `plugin` | Provenance metadata for backed or plugin-owned tools. These fields explain source, not public naming.                                     |
 
-Current `/config/tools` already emits `source`, `family`, `backing_server`, `plugin`, and `canonical_id`, but it does not yet emit the full lifecycle, visibility, alias, or grouping metadata defined here. That follow-on work belongs to later issues in epic `#1961`.
+Current `/config/tools` now emits the shared descriptor metadata from this decision record, including `canonical_id`, `lifecycle`, `visibility`, `aliases`, `family`, `group`, `tier`, `source`, `backing_server`, and `plugin`. Treat that route as the shared operator-facing source of truth for canonical taxonomy facts rather than reconstructing them in clients.
 
 ### Effective exposure
 

--- a/packages/gateway/tests/integration/startup-process.build-support.ts
+++ b/packages/gateway/tests/integration/startup-process.build-support.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 
 function missingBuildOutputs(outputPaths: readonly string[]): string[] {
   return outputPaths.filter((outputPath) => !existsSync(outputPath));
@@ -24,6 +25,35 @@ export function earliestBuildOutputMtime(outputPaths: readonly string[]): number
   return Math.min(...outputPaths.map((outputPath) => statSync(outputPath).mtimeMs));
 }
 
+export function latestMtimeInDir(rootDir: string): number {
+  let latest = 0;
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) break;
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === "dist") continue;
+        stack.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const mtimeMs = statSync(fullPath).mtimeMs;
+      if (mtimeMs > latest) latest = mtimeMs;
+    }
+  }
+
+  return latest;
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 export function formatWorkspaceBuildFailure(
   prefix: string,
   result: ReturnType<typeof spawnSync>,
@@ -33,4 +63,45 @@ export function formatWorkspaceBuildFailure(
   const missingOutputsMessage =
     missingOutputs.length === 0 ? undefined : `missing build outputs: ${missingOutputs.join(", ")}`;
   return [formatBuildFailure(prefix, result), missingOutputsMessage].filter(Boolean).join("\n");
+}
+
+export function waitForBuildOutputs(outputPaths: readonly string[], timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (allBuildOutputsExist(outputPaths)) return true;
+    sleepSync(200);
+  }
+  return allBuildOutputsExist(outputPaths);
+}
+
+export function isModuleNotFoundForAnyPath(
+  message: string,
+  pathSnippets: readonly string[],
+): boolean {
+  return (
+    message.includes("ERR_MODULE_NOT_FOUND") &&
+    pathSnippets.some((snippet) => message.includes(snippet))
+  );
+}
+
+export function workspaceBuildIsStale(params: {
+  outputPaths: readonly string[];
+  srcDir: string;
+  watchedFiles?: readonly string[];
+}): boolean {
+  if (!allBuildOutputsExist(params.outputPaths)) return true;
+
+  const outputMtime = earliestBuildOutputMtime(params.outputPaths);
+
+  if (existsSync(params.srcDir) && outputMtime < latestMtimeInDir(params.srcDir)) {
+    return true;
+  }
+
+  for (const watchedFile of params.watchedFiles ?? []) {
+    if (existsSync(watchedFile) && outputMtime < statSync(watchedFile).mtimeMs) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/packages/gateway/tests/integration/startup-process.gateway-support.ts
+++ b/packages/gateway/tests/integration/startup-process.gateway-support.ts
@@ -8,7 +8,6 @@ import {
   mkdtempSync,
   openSync,
   readFileSync,
-  readdirSync,
   rmSync,
   statSync,
   unlinkSync,
@@ -21,8 +20,11 @@ import { fileURLToPath } from "node:url";
 import { WebSocket } from "ws";
 import {
   allBuildOutputsExist,
-  earliestBuildOutputMtime,
   formatWorkspaceBuildFailure,
+  isModuleNotFoundForAnyPath,
+  latestMtimeInDir,
+  waitForBuildOutputs,
+  workspaceBuildIsStale,
 } from "./startup-process.build-support.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -61,6 +63,21 @@ const RUNTIME_EXECUTION_TSCONFIG = resolve(REPO_ROOT, "packages/runtime-executio
 const RUNTIME_EXECUTION_SRC_DIR = resolve(REPO_ROOT, "packages/runtime-execution/src");
 const GATEWAY_SRC_DIR = resolve(PACKAGE_ROOT, "src");
 const GATEWAY_BUILD_LOCK = resolve(REPO_ROOT, ".tyrum-gateway-build.lock");
+const REQUIRED_GATEWAY_BUILD_OUTPUTS = [
+  SCHEMAS_DIST,
+  SCHEMAS_JSONSCHEMA_CATALOG,
+  RUNTIME_NODE_CONTROL_DIST,
+  RUNTIME_EXECUTION_DIST,
+  GATEWAY_ENTRYPOINT,
+] as const;
+const TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS = [
+  "packages/gateway/node_modules/@tyrum/contracts/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-node-control/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-execution/dist/",
+  "packages/contracts/dist/index.mjs",
+  "packages/runtime-node-control/dist/index.mjs",
+  "packages/runtime-execution/dist/index.mjs",
+] as const;
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -214,65 +231,6 @@ function tryGatewayBuild(cmd: string, args: string[]): ReturnType<typeof spawnSy
   });
 }
 
-function waitForBuildOutputsByAnotherWorker(
-  outputPaths: readonly string[],
-  timeoutMs: number,
-): boolean {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (allBuildOutputsExist(outputPaths)) return true;
-    sleepSync(200);
-  }
-  return allBuildOutputsExist(outputPaths);
-}
-
-function latestMtimeInDir(rootDir: string): number {
-  let latest = 0;
-  const stack: string[] = [rootDir];
-
-  while (stack.length > 0) {
-    const dir = stack.pop();
-    if (!dir) break;
-
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (entry.name === "node_modules" || entry.name === "dist") continue;
-        stack.push(fullPath);
-        continue;
-      }
-      if (!entry.isFile()) continue;
-
-      const mtimeMs = statSync(fullPath).mtimeMs;
-      if (mtimeMs > latest) latest = mtimeMs;
-    }
-  }
-
-  return latest;
-}
-
-function workspaceBuildIsStale(params: {
-  outputPaths: readonly string[];
-  srcDir: string;
-  watchedFiles?: readonly string[];
-}): boolean {
-  if (!allBuildOutputsExist(params.outputPaths)) return true;
-
-  const outputMtime = earliestBuildOutputMtime(params.outputPaths);
-
-  if (existsSync(params.srcDir) && outputMtime < latestMtimeInDir(params.srcDir)) {
-    return true;
-  }
-
-  for (const watchedFile of params.watchedFiles ?? []) {
-    if (existsSync(watchedFile) && outputMtime < statSync(watchedFile).mtimeMs) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 function gatewayBuildIsStale(): boolean {
   if (
     workspaceBuildIsStale({
@@ -331,14 +289,14 @@ function ensureWorkspaceBuild(
   const args = ["--filter", filter, "build"];
   const result = tryGatewayBuild("pnpm", args);
   if (result.status === 0 && allBuildOutputsExist(requiredOutputs)) return;
-  if (!hadAllOutputsBeforeBuild && waitForBuildOutputsByAnotherWorker(requiredOutputs, 5_000)) {
+  if (!hadAllOutputsBeforeBuild && waitForBuildOutputs(requiredOutputs, 5_000)) {
     return;
   }
 
   if (result.error?.message.includes("ENOENT")) {
     const corepackResult = tryGatewayBuild("corepack", ["pnpm", ...args]);
     if (corepackResult.status === 0 && allBuildOutputsExist(requiredOutputs)) return;
-    if (!hadAllOutputsBeforeBuild && waitForBuildOutputsByAnotherWorker(requiredOutputs, 5_000)) {
+    if (!hadAllOutputsBeforeBuild && waitForBuildOutputs(requiredOutputs, 5_000)) {
       return;
     }
 
@@ -371,6 +329,16 @@ function ensureGatewayBuild(): void {
     [GATEWAY_ENTRYPOINT],
     "Failed to build @tyrum/gateway before startup test.",
   );
+}
+
+function isTransientGatewayDependencyLoadFailure(message: string): boolean {
+  return isModuleNotFoundForAnyPath(message, TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS);
+}
+
+function restoreGatewayBuildOutputs(): void {
+  if (!waitForBuildOutputs(REQUIRED_GATEWAY_BUILD_OUTPUTS, 15_000) || gatewayBuildIsStale()) {
+    ensureGatewayBuild();
+  }
 }
 
 async function findAvailablePort(): Promise<number> {
@@ -456,7 +424,7 @@ export async function withGatewayBuild<T>(action: () => MaybePromise<T>): Promis
   }
 }
 
-export async function startGatewayFixture(options: StartGatewayOptions): Promise<GatewayFixture> {
+async function startGatewayFixtureOnce(options: StartGatewayOptions): Promise<GatewayFixture> {
   const port = await findAvailablePort();
   const tempRoot = mkdtempSync(join(tmpdir(), options.tempPrefix));
   const tyrumHome = join(tempRoot, ".tyrum");
@@ -550,6 +518,25 @@ export async function startGatewayFixture(options: StartGatewayOptions): Promise
     cleanup();
     throw error;
   }
+}
+
+export async function startGatewayFixture(options: StartGatewayOptions): Promise<GatewayFixture> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await startGatewayFixtureOnce(options);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (attempt > 0 || !isTransientGatewayDependencyLoadFailure(message)) {
+        throw error;
+      }
+
+      // Other tests can rebuild shared workspace packages and temporarily remove dist files.
+      // Repair the known build outputs once and retry the packaged child on a fresh temp home.
+      restoreGatewayBuildOutputs();
+    }
+  }
+
+  throw new Error("Gateway fixture retry loop exhausted unexpectedly.");
 }
 
 export function writeGatewayHomeFiles(tyrumHome: string, files: Record<string, string>): void {

--- a/packages/gateway/tests/unit/check-public-docs.test.ts
+++ b/packages/gateway/tests/unit/check-public-docs.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -31,11 +31,40 @@ function createFixtureDir(): {
 }
 
 function writeArchitectureDoc(docsDir: string, name: string, content: string): void {
-  writeFileSync(join(docsDir, "architecture", name), content, "utf8");
+  const path = join(docsDir, "architecture", name);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
 }
 
 function writeContractFile(contractsDir: string, name: string, content: string): void {
-  writeFileSync(join(contractsDir, name), content, "utf8");
+  const path = join(contractsDir, name);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+}
+
+function seedRequiredPublicDocs(docsDir: string): void {
+  writeArchitectureDoc(
+    docsDir,
+    "reference/arch-21-public-tool-taxonomy-and-exposure-model.md",
+    [
+      "## Contributor rules for adding or changing tools",
+      "The supported deprecation window is:",
+      "### Supported removal path for legacy public IDs",
+    ].join("\n"),
+  );
+  writeArchitectureDoc(
+    docsDir,
+    "gateway/tools.md",
+    [
+      "## Operator migration checklist",
+      "Run the normal gateway database migrations before planning alias removal.",
+    ].join("\n"),
+  );
+  writeArchitectureDoc(
+    docsDir,
+    "agent/memory/index.md",
+    "The runtime-policy and execution-bookkeeping exact-match migration completed by `#1991`.\n",
+  );
 }
 
 afterEach(() => {
@@ -50,6 +79,7 @@ afterEach(() => {
 describe("check-public-docs", () => {
   it("allows compounds like backplane and control-plane", () => {
     const { docsDir, contractsDir } = createFixtureDir();
+    seedRequiredPublicDocs(docsDir);
     writeArchitectureDoc(
       docsDir,
       "allowed.md",
@@ -83,6 +113,7 @@ describe("check-public-docs", () => {
 
   it("blocks standalone, identifier, and run-era legacy vocabulary variants", () => {
     const { docsDir, contractsDir } = createFixtureDir();
+    seedRequiredPublicDocs(docsDir);
     writeArchitectureDoc(
       docsDir,
       "blocked.md",
@@ -113,6 +144,7 @@ describe("check-public-docs", () => {
 
   it("blocks legacy vocabulary in filenames even when file contents are clean", () => {
     const { docsDir, contractsDir } = createFixtureDir();
+    seedRequiredPublicDocs(docsDir);
     writeArchitectureDoc(docsDir, "run-level-budgets.md", "Clean content only.\n");
     writeContractFile(contractsDir, "session-foo.ts", "export const conversationKey = 'ok';\n");
 

--- a/packages/gateway/tests/unit/check-public-docs.test.ts
+++ b/packages/gateway/tests/unit/check-public-docs.test.ts
@@ -167,4 +167,29 @@ describe("check-public-docs", () => {
     );
     expect(result.stderr).toContain("session-foo.ts");
   });
+
+  it("requires the literal #1991 reference in the memory migration guidance", () => {
+    const { docsDir, contractsDir } = createFixtureDir();
+    seedRequiredPublicDocs(docsDir);
+    writeArchitectureDoc(
+      docsDir,
+      "agent/memory/index.md",
+      "The runtime-policy and execution-bookkeeping exact-match migration completed by issue 1991.\n",
+    );
+    writeContractFile(contractsDir, "allowed.ts", "export const conversationKey = 'ok';\n");
+
+    const result = spawnSync("bash", [scriptPath, docsDir], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PUBLIC_CONTRACTS_DIR: contractsDir,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("required public doc guidance missing");
+    expect(result.stderr).toContain("agent/memory/index.md");
+    expect(result.stderr).toContain("`#1991`");
+  });
 });

--- a/packages/gateway/tests/unit/public-tool-taxonomy-conformance.test.ts
+++ b/packages/gateway/tests/unit/public-tool-taxonomy-conformance.test.ts
@@ -1,0 +1,166 @@
+import { resolveToolTaxonomyMetadata } from "@tyrum/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  buildSecretClipboardToolDescriptor,
+  SECRET_CLIPBOARD_TOOL_ID,
+} from "../../src/modules/agent/tool-secret-definitions.js";
+import { listBuiltinToolDescriptors, type ToolDescriptor } from "../../src/modules/agent/tools.js";
+
+const STANDALONE_CANONICAL_PUBLIC_IDS = new Set([
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "glob",
+  "grep",
+  "bash",
+  "websearch",
+  "webfetch",
+  "codesearch",
+]);
+const STRUCTURED_PUBLIC_SEGMENT = /^[a-z][a-z0-9-]*$/;
+const RAW_MCP_SERVER_SEGMENT = /^[a-z][a-z0-9-]*$/;
+const RAW_MCP_TOOL_SEGMENT = /^[a-z][a-z0-9_-]*$/;
+const RESERVED_PLUGIN_PREFIXES = [
+  "tool.",
+  "memory.",
+  "sandbox.",
+  "subagent.",
+  "workboard.",
+  "mcp.",
+];
+const RESERVED_PLUGIN_EXACT_IDS = new Set([
+  ...STANDALONE_CANONICAL_PUBLIC_IDS,
+  "artifact.describe",
+]);
+
+function listShippedBuiltinDescriptors(): ToolDescriptor[] {
+  const secretClipboardDescriptor = buildSecretClipboardToolDescriptor([
+    {
+      secret_ref_id: "secret-ref-1",
+      secret_alias: "desktop-login",
+      allowed_tool_ids: [SECRET_CLIPBOARD_TOOL_ID],
+    },
+  ]);
+
+  if (!secretClipboardDescriptor) {
+    throw new Error("expected secret clipboard descriptor");
+  }
+
+  return [...listBuiltinToolDescriptors(), secretClipboardDescriptor];
+}
+
+function expectCanonicalPublicToolIdGrammar(toolId: string): void {
+  if (STANDALONE_CANONICAL_PUBLIC_IDS.has(toolId)) {
+    return;
+  }
+
+  if (toolId.startsWith("mcp.")) {
+    const segments = toolId.split(".");
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toBe("mcp");
+    expect(segments[1]).toMatch(RAW_MCP_SERVER_SEGMENT);
+    expect(segments[2]).toMatch(RAW_MCP_TOOL_SEGMENT);
+    return;
+  }
+
+  const segments = toolId.split(".");
+  expect(segments.length).toBeGreaterThan(1);
+  for (const segment of segments) {
+    expect(segment).toMatch(STRUCTURED_PUBLIC_SEGMENT);
+  }
+}
+
+function pluginClaimsReservedPlatformId(toolId: string): boolean {
+  return (
+    RESERVED_PLUGIN_EXACT_IDS.has(toolId) ||
+    RESERVED_PLUGIN_PREFIXES.some((prefix) => toolId.startsWith(prefix))
+  );
+}
+
+describe("public tool taxonomy conformance", () => {
+  it("keeps every shipped builtin descriptor on a canonical public taxonomy surface", () => {
+    for (const descriptor of listShippedBuiltinDescriptors()) {
+      expect(descriptor.taxonomy).toMatchObject({
+        canonicalId: descriptor.id,
+        lifecycle: "canonical",
+        visibility: "public",
+      });
+      expect(descriptor.taxonomy?.family).toBeTruthy();
+      expect(descriptor.taxonomy?.group).toBeTruthy();
+      expect(descriptor.taxonomy?.tier).toBeTruthy();
+      expectCanonicalPublicToolIdGrammar(descriptor.id);
+    }
+  });
+
+  it("keeps built-in MCP facades on the canonical retrieval surface", () => {
+    const builtinMcpDescriptors = listShippedBuiltinDescriptors().filter(
+      (descriptor) => descriptor.source === "builtin_mcp",
+    );
+
+    expect(builtinMcpDescriptors.map((descriptor) => descriptor.id).toSorted()).toEqual([
+      "codesearch",
+      "webfetch",
+      "websearch",
+    ]);
+    for (const descriptor of builtinMcpDescriptors) {
+      expect(descriptor.taxonomy).toMatchObject({
+        canonicalId: descriptor.id,
+        family: "web",
+        group: "retrieval",
+        tier: "default",
+        visibility: "public",
+      });
+    }
+  });
+
+  it("documents representative raw MCP and plugin namespace guardrails", () => {
+    expect(
+      resolveToolTaxonomyMetadata({
+        toolId: "mcp.calendar.events_list",
+        source: "mcp",
+        family: "mcp",
+      }),
+    ).toMatchObject({
+      canonicalId: "mcp.calendar.events_list",
+      lifecycle: "canonical",
+      visibility: "public",
+      group: "extension",
+      tier: "advanced",
+    });
+    expectCanonicalPublicToolIdGrammar("mcp.calendar.events_list");
+
+    for (const toolId of ["plugin.echo.say", "custom.plugin.echo"]) {
+      expect(pluginClaimsReservedPlatformId(toolId)).toBe(false);
+      expect(
+        resolveToolTaxonomyMetadata({
+          toolId,
+          source: "plugin",
+          family: "plugin",
+        }),
+      ).toMatchObject({
+        canonicalId: toolId,
+        lifecycle: "canonical",
+        visibility: "public",
+        group: "extension",
+        tier: "advanced",
+      });
+      expectCanonicalPublicToolIdGrammar(toolId);
+    }
+
+    for (const toolId of [
+      "tool.browser.navigate",
+      "memory.write",
+      "sandbox.current",
+      "subagent.spawn",
+      "workboard.capture",
+      "mcp.calendar.events_list",
+      "read",
+      "bash",
+      "webfetch",
+      "artifact.describe",
+    ]) {
+      expect(pluginClaimsReservedPlatformId(toolId)).toBe(true);
+    }
+  });
+});

--- a/packages/gateway/tests/unit/tool-registry-routes.test-support.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test-support.ts
@@ -85,6 +85,21 @@ export function buildToolRegistryCatalogFixture() {
       },
     },
   };
+  const deprecatedMemoryDescriptor = {
+    id: "mcp.memory.search",
+    description: "Search memory.",
+    effect: "read_only" as const,
+    keywords: ["memory", "search"],
+    source: "mcp" as const,
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  };
   const secretClipboardDescriptor = buildSecretClipboardToolDescriptor([
     {
       secret_ref_id: "secret-ref-1",
@@ -99,6 +114,7 @@ export function buildToolRegistryCatalogFixture() {
     ...listBuiltinToolDescriptors(),
     ...pluginDescriptors,
     rawMcpDescriptor,
+    deprecatedMemoryDescriptor,
     secretClipboardDescriptor,
   ];
   const disabledByReason = new Map<string, string>([
@@ -112,11 +128,13 @@ export function buildToolRegistryCatalogFixture() {
     exposureClass:
       descriptor.id === rawMcpDescriptor.id
         ? ("mcp" as const)
-        : descriptor.id.startsWith("plugin.")
-          ? ("plugin" as const)
-          : descriptor.source === "builtin_mcp"
-            ? ("builtin_mcp" as const)
-            : ("builtin" as const),
+        : descriptor.id === deprecatedMemoryDescriptor.id
+          ? ("mcp" as const)
+          : descriptor.id.startsWith("plugin.")
+            ? ("plugin" as const)
+            : descriptor.source === "builtin_mcp"
+              ? ("builtin_mcp" as const)
+              : ("builtin" as const),
     enabledByAgent: !disabledByReason.has(descriptor.id),
     enabled: !disabledByReason.has(descriptor.id),
     reason: (disabledByReason.get(descriptor.id) ?? "enabled") as
@@ -137,6 +155,11 @@ export function buildToolRegistryCatalogFixture() {
         name: "Exa",
         transport: "remote" as const,
         url: "https://mcp.exa.ai/mcp",
+      },
+      {
+        id: "memory",
+        name: "Memory",
+        transport: "inprocess" as const,
       },
     ],
     pluginDescriptors,

--- a/packages/gateway/tests/unit/tool-registry-routes.test.ts
+++ b/packages/gateway/tests/unit/tool-registry-routes.test.ts
@@ -163,6 +163,18 @@ describe("tool registry routes", () => {
     );
     expect(body.tools).toContainEqual(
       expect.objectContaining({
+        source: "mcp",
+        canonical_id: "memory.search",
+        lifecycle: "deprecated",
+        visibility: "public",
+        aliases: [{ id: "mcp.memory.search", lifecycle: "deprecated" }],
+        family: "memory",
+        group: "memory",
+        tier: "default",
+      }),
+    );
+    expect(body.tools).toContainEqual(
+      expect.objectContaining({
         source: "plugin",
         canonical_id: "plugin.echo.optional",
         lifecycle: "canonical",
@@ -196,6 +208,93 @@ describe("tool registry routes", () => {
         }),
       }),
     );
+  });
+
+  it("emits canonical ids while surfacing compatibility aliases separately", async () => {
+    const { descriptors, disabledByReason, inventory, mcpServerSpecs, pluginDescriptors } =
+      buildToolRegistryCatalogFixture();
+    const listRegisteredTools = vi.fn(async () => ({
+      allowlist: [
+        "read",
+        "write",
+        "bash",
+        "webfetch",
+        "websearch",
+        "codesearch",
+        "plugin.echo.say",
+        "plugin.echo.union",
+        "mcp.exa.web_search_exa",
+        SECRET_CLIPBOARD_TOOL_ID,
+      ],
+      tools: descriptors.filter((descriptor) => !disabledByReason.has(descriptor.id)),
+      mcpServers: ["exa"],
+      inventory,
+      mcpServerSpecs,
+    }));
+
+    const app = createAuthenticatedToolRegistryApp({
+      agents: {
+        getRuntime: vi.fn(async () => ({
+          listRegisteredTools,
+        })),
+      } as never,
+      db: {
+        all: vi.fn(async () => []),
+      } as never,
+      pluginCatalogProvider: {
+        loadGlobalRegistry: vi.fn(),
+        loadTenantRegistry: vi.fn(async () => ({
+          getToolDescriptors: () => pluginDescriptors,
+          getTool: () => undefined,
+        })),
+        invalidateTenantRegistry: vi.fn(async () => undefined),
+        shutdown: vi.fn(async () => undefined),
+      } as never,
+    });
+
+    const response = await app.request("/config/tools?agent_key=default");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      status: string;
+      tools: Array<{
+        canonical_id: string;
+        aliases: Array<{ id: string; lifecycle: string }>;
+      }>;
+    };
+    const aliasIds = new Set(body.tools.flatMap((tool) => tool.aliases.map((alias) => alias.id)));
+
+    expect(body.tools.map((tool) => tool.canonical_id)).not.toContain("tool.fs.read");
+    expect(body.tools.map((tool) => tool.canonical_id)).not.toContain("tool.fs.write");
+    expect(body.tools.map((tool) => tool.canonical_id)).not.toContain("tool.exec");
+    expect(body.tools.map((tool) => tool.canonical_id)).not.toContain("tool.http.fetch");
+    expect(body.tools.map((tool) => tool.canonical_id)).not.toContain("mcp.memory.search");
+    for (const tool of body.tools) {
+      expect(aliasIds.has(tool.canonical_id)).toBe(false);
+    }
+
+    expect(
+      body.tools.find((tool) => tool.canonical_id === "read")?.aliases.map((alias) => alias.id),
+    ).toEqual(["tool.fs.read"]);
+    expect(
+      body.tools.find((tool) => tool.canonical_id === "write")?.aliases.map((alias) => alias.id),
+    ).toEqual(["tool.fs.write"]);
+    expect(
+      body.tools.find((tool) => tool.canonical_id === "bash")?.aliases.map((alias) => alias.id),
+    ).toEqual(["tool.exec"]);
+    expect(
+      body.tools.find((tool) => tool.canonical_id === "webfetch")?.aliases.map((alias) => alias.id),
+    ).toEqual(["tool.http.fetch"]);
+    expect(
+      body.tools
+        .find((tool) => tool.canonical_id === "memory.search")
+        ?.aliases.map((alias) => alias.id),
+    ).toEqual(["mcp.memory.search"]);
+    expect(
+      body.tools
+        .find((tool) => tool.canonical_id === "memory.search")
+        ?.aliases.map((alias) => alias.lifecycle),
+    ).toEqual(["deprecated"]);
   });
 
   it("passes explicit execution_profile inspection through to runtime", async () => {

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -35,7 +35,7 @@ declare -a REQUIRED_PUBLIC_DOC_LINES=(
   "$ARCHITECTURE_DIR/reference/arch-21-public-tool-taxonomy-and-exposure-model.md|### Supported removal path for legacy public IDs"
   "$ARCHITECTURE_DIR/gateway/tools.md|## Operator migration checklist"
   "$ARCHITECTURE_DIR/gateway/tools.md|Run the normal gateway database migrations before planning alias removal"
-  "$ARCHITECTURE_DIR/agent/memory/index.md|The runtime-policy and execution-bookkeeping exact-match migration completed by `#1991`"
+  "$ARCHITECTURE_DIR/agent/memory/index.md|The runtime-policy and execution-bookkeeping exact-match migration completed by \`#1991\`"
 )
 
 declare -a LEGACY_VOCAB_PATTERNS=(

--- a/scripts/check-public-docs.sh
+++ b/scripts/check-public-docs.sh
@@ -29,6 +29,15 @@ declare -a BLOCKED_PATTERNS=(
   "ops-only"
 )
 
+declare -a REQUIRED_PUBLIC_DOC_LINES=(
+  "$ARCHITECTURE_DIR/reference/arch-21-public-tool-taxonomy-and-exposure-model.md|## Contributor rules for adding or changing tools"
+  "$ARCHITECTURE_DIR/reference/arch-21-public-tool-taxonomy-and-exposure-model.md|The supported deprecation window is:"
+  "$ARCHITECTURE_DIR/reference/arch-21-public-tool-taxonomy-and-exposure-model.md|### Supported removal path for legacy public IDs"
+  "$ARCHITECTURE_DIR/gateway/tools.md|## Operator migration checklist"
+  "$ARCHITECTURE_DIR/gateway/tools.md|Run the normal gateway database migrations before planning alias removal"
+  "$ARCHITECTURE_DIR/agent/memory/index.md|The runtime-policy and execution-bookkeeping exact-match migration completed by `#1991`"
+)
+
 declare -a LEGACY_VOCAB_PATTERNS=(
   '(^|[^[:alnum:]])[sS][eE][sS][sS][iI][oO][nN][sS]?($|[^[:alnum:]])'
   '(^|[^[:alnum:]])[lL][aA][nN][eE][sS]?($|[^[:alnum:]])'
@@ -82,6 +91,19 @@ for pattern in "${BLOCKED_PATTERNS[@]}"; do
   if scan_pattern "$pattern" "$DOCS_DIR" --glob "*.md" --glob "*.html" >/dev/null; then
     echo "error: blocked docs phrase found: '$pattern'" >&2
     scan_pattern "$pattern" "$DOCS_DIR" --glob "*.md" --glob "*.html" >&2 || true
+    violations=1
+  fi
+done
+
+for entry in "${REQUIRED_PUBLIC_DOC_LINES[@]}"; do
+  IFS="|" read -r file required_line <<<"$entry"
+  if [[ ! -f "$file" ]]; then
+    echo "error: required public doc file missing: '$file'" >&2
+    violations=1
+    continue
+  fi
+  if ! grep -Fq -- "$required_line" "$file"; then
+    echo "error: required public doc guidance missing from '$file': '$required_line'" >&2
     violations=1
   fi
 done


### PR DESCRIPTION
Closes #1979

## What Changed
- added contributor and operator taxonomy migration guidance to ARCH-21, gateway tools docs, and memory docs
- documented the supported deprecation window and the legacy public ID removal path
- clarified the concrete gateway database migration path and named the shipped canonical-ID migration files
- added a docs gate that fails if the required migration guidance disappears
- added targeted taxonomy conformance tests for shipped builtin descriptors and canonical-vs-alias `/config/tools` output, including deprecated `mcp.memory.*` coverage
- repaired the `check-public-docs` fixture-based test so the strengthened docs gate passes full CI without weakening the policy

## Why
- closes the rollout for epic #1961 with production-grade docs and conformance guardrails
- prevents future tool additions from bypassing the canonical taxonomy contract or reintroducing mixed naming drift

## How To Test
- `bash scripts/check-public-docs.sh`
- `pnpm vitest packages/gateway/tests/unit/check-public-docs.test.ts`
- `pnpm vitest packages/contracts/tests/tool-id.test.ts packages/gateway/tests/unit/public-tool-taxonomy-conformance.test.ts packages/gateway/tests/unit/runtime-tool-descriptor-source.test.ts packages/gateway/tests/unit/tool-registry-routes.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git push -u origin 1979-taxonomy-migration-docs-and-conformance-guardrails` (full pre-push `pnpm ci:local`, including build and coverage-enabled test suite)

## Risk
- low; this stays in docs and guardrail coverage
- no runtime exposure-core or route contract behavior changed

## Rollback Notes
- revert commits `644a4a4fe` and `6cbe0dc44` to remove the docs and test guardrails if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and test/CI guardrails, plus startup test harness hardening for flaky build-output races.
> 
> **Overview**
> Adds explicit operator + contributor guidance for migrating to canonical public tool IDs (notably `memory.*` vs deprecated `mcp.memory.*`), including deprecation windows, removal steps, and the required gateway DB migrations to rewrite persisted IDs.
> 
> Strengthens guardrails: `scripts/check-public-docs.sh` now fails if required taxonomy/migration guidance lines disappear, unit tests seed those required docs in fixtures, and new conformance tests assert shipped tool descriptors and `/config/tools` output always use canonical IDs while listing legacy IDs only as separate aliases/deprecations.
> 
> Separately hardens integration startup tests by centralizing build-output staleness checks and adding a one-time retry path when transient `ERR_MODULE_NOT_FOUND` occurs due to concurrent workspace rebuilds removing `dist` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6bea0e8e7d738c186330e33b2b1b99241c9b9c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->