### PR TITLE
chore: lighten local git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,6 +3,3 @@ set -eu
 
 echo "Running staged file format check..."
 pnpm format:check-staged
-
-echo "Running lint..."
-pnpm lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 set -eu
 
-echo "Running pre-push checks..."
-pnpm run ci
+echo "Skipping local pre-push CI; GitHub Actions is the authoritative merge gate."
+echo "Run 'pnpm run ci' manually when you want local CI parity before pushing."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
               - ".github/workflows/**"
               - ".github/actions/**"
             scripts:
+              - ".githooks/**"
               - "scripts/**"
               - ".github/scripts/**"
             docs_gate:
@@ -151,7 +152,7 @@ jobs:
             sudo apt-get install --yes shellcheck
           fi
       - name: Lint shell scripts
-        run: shellcheck scripts/install.sh scripts/check-public-docs.sh scripts/smoke-postgres-split.sh scripts/smoke-sqlite-single-host.sh
+        run: shellcheck .githooks/pre-commit .githooks/pre-push scripts/install.sh scripts/check-public-docs.sh scripts/smoke-postgres-split.sh scripts/smoke-sqlite-single-host.sh
 
   docs-public-content:
     name: Docs Public Content Gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,8 @@
 - Install: `pnpm install`
 - Repo hooks install automatically via the root `prepare` script; rerun with `pnpm setup:githooks` if needed.
 - Local hooks:
-  - `pre-commit`: runs `pnpm format:check-staged` and `pnpm lint`
-  - `pre-push`: runs `pnpm run ci`
+  - `pre-commit`: runs `pnpm format:check-staged`
+  - `pre-push`: skips local CI; GitHub Actions is the authoritative merge gate
 - Optional (container/split smoke): Docker + `docker compose`.
 - Gateway configuration is DB-backed (no runtime env config). Bootstrapping uses defaults + CLI flags:
   - `--home` (default: `~/.tyrum`)
@@ -105,9 +105,9 @@
 ## PR / commit expectations
 
 - Branch naming: `<issue-number>-<slug>` (see `CONTRIBUTING.md`).
-- Before commit: `node scripts/format-changed.mjs --write --staged`, then ensure `pre-commit` passes (`pnpm format:check-staged` + `pnpm lint`).
-- Before push: ensure `pre-push` passes (`pnpm run ci`).
-- Before PR: `pnpm run ci`.
+- Before commit: `node scripts/format-changed.mjs --write --staged`, then ensure `pre-commit` passes (`pnpm format:check-staged`).
+- Before push: `pre-push` does not run local CI.
+- Before PR: rely on GitHub Actions as the authoritative merge gate; run `pnpm run ci` manually when you want local CI parity.
 - Open PRs ready for review by default; use draft PRs only when the user explicitly asks for a draft.
 - Keep diffs small; update docs/tests alongside behavior changes; ensure workflows in `.github/workflows/` stay green.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ pnpm setup:githooks
 
 The repo-local hooks are:
 
-- `pre-commit`: runs `pnpm format:check-staged` and `pnpm lint` for fast checks on commit.
-- `pre-push`: runs `pnpm run ci` so local pushes use the same validation path as the repo's canonical local CI command.
+- `pre-commit`: runs `pnpm format:check-staged` for staged-file formatting.
+- `pre-push`: does not run local CI; GitHub Actions is the authoritative merge gate. Run `pnpm run ci` manually when you want local CI parity before pushing.
 
 ### Dependency intake
 


### PR DESCRIPTION
## Summary
- Scope classification: Patch
- Keep local pre-commit limited to staged-file formatting
- Remove full local CI from pre-push and point developers to GitHub Actions/manual local CI
- Add .githooks files to the CI shell-lint path so hook script correctness stays covered in CI

## Validation
- sh -n .githooks/pre-commit .githooks/pre-push
- shellcheck .githooks/pre-commit .githooks/pre-push
- actionlint .github/workflows/ci.yml
- pnpm exec prettier --check .github/workflows/ci.yml CONTRIBUTING.md AGENTS.md
- git diff --check
- pre-commit hook during commit: pnpm format:check-staged

## Risk / rollback
- Low risk; developer hooks only. CI remains the authoritative merge gate.
- Roll back by reverting this commit to restore local lint and full pre-push CI.