### PR TITLE
chore: stop requesting codeowner review for dependency files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 /.github/workflows/** @rhernaus
-/package.json @rhernaus
-/pnpm-lock.yaml @rhernaus
 /pnpm-workspace.yaml @rhernaus
 /patches/** @rhernaus
 /.github/dependabot.yml @rhernaus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ Pull requests must reference their GitHub Issue and pass all required checks:
 - `security-baseline / Security baseline`
 - At least one approving review
 
-Changes under `.github/workflows/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `patches/**`, `.github/dependabot.yml`, or `scripts/install.sh` also require code-owner review.
+Changes under `.github/workflows/**`, `pnpm-workspace.yaml`, `patches/**`, `.github/dependabot.yml`, or `scripts/install.sh` also require code-owner review.
 
 Follow the 72-character imperative commit style (e.g. `Add policy gate scaffold`).
 


### PR DESCRIPTION
## Summary
- Remove root `package.json` and `pnpm-lock.yaml` from CODEOWNERS so Dependabot npm PRs no longer request @rhernaus solely for dependency manifest updates.
- Keep code-owner review on workflows, patches, `pnpm-workspace.yaml`, Dependabot config, and install script.
- Update CONTRIBUTING to match the current CODEOWNERS policy.

## Scope
Patch. This changes review routing only; it does not change Dependabot schedules, groups, CI, package versions, or auto-merge policy.

## Validation
- `git diff --check`
- `node scripts/format-changed.mjs --check CONTRIBUTING.md`
- staged format check from commit hook

## Risk and rollback
Risk is reduced code-owner review coverage for manual PRs that edit root `package.json` or `pnpm-lock.yaml`. Rollback is restoring those two CODEOWNERS lines if that proves too broad.