### PR TITLE
ci: publish full release package closure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,12 @@ jobs:
 
           const manifestPaths = [
             "packages/contracts/package.json",
+            "packages/cli-utils/package.json",
+            "packages/runtime-policy/package.json",
+            "packages/runtime-node-control/package.json",
+            "packages/runtime-execution/package.json",
+            "packages/runtime-agent/package.json",
+            "packages/runtime-workboard/package.json",
             "packages/transport-sdk/package.json",
             "packages/node-sdk/package.json",
             "packages/gateway/package.json",
@@ -181,10 +187,21 @@ jobs:
       - name: Pack npm tarballs
         run: |
           mkdir -p artifacts/npm
-          (cd packages/contracts && pnpm pack --pack-destination ../../artifacts/npm)
-          (cd packages/transport-sdk && pnpm pack --pack-destination ../../artifacts/npm)
-          (cd packages/node-sdk && pnpm pack --pack-destination ../../artifacts/npm)
-          (cd packages/gateway && pnpm pack --pack-destination ../../artifacts/npm)
+          while IFS= read -r package_dir; do
+            [[ -n "${package_dir}" ]] || continue
+            (cd "${package_dir}" && pnpm pack --pack-destination ../../artifacts/npm)
+          done <<'EOF'
+          packages/contracts
+          packages/cli-utils
+          packages/runtime-policy
+          packages/runtime-node-control
+          packages/runtime-execution
+          packages/runtime-agent
+          packages/runtime-workboard
+          packages/transport-sdk
+          packages/node-sdk
+          packages/gateway
+          EOF
           ls -lah artifacts/npm
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -488,15 +505,21 @@ jobs:
 
           echo "Publishing with NPM_TOKEN. Switch back to trusted publishing once the packages exist on npm."
 
-          declare -A packages=(
-            ["@tyrum/contracts"]="release-assets/tyrum-contracts-${RELEASE_VERSION}.tgz"
-            ["@tyrum/transport-sdk"]="release-assets/tyrum-transport-sdk-${RELEASE_VERSION}.tgz"
-            ["@tyrum/node-sdk"]="release-assets/tyrum-node-sdk-${RELEASE_VERSION}.tgz"
-            ["@tyrum/gateway"]="release-assets/tyrum-gateway-${RELEASE_VERSION}.tgz"
+          package_entries=(
+            "@tyrum/contracts|release-assets/tyrum-contracts-${RELEASE_VERSION}.tgz"
+            "@tyrum/cli-utils|release-assets/tyrum-cli-utils-${RELEASE_VERSION}.tgz"
+            "@tyrum/runtime-policy|release-assets/tyrum-runtime-policy-${RELEASE_VERSION}.tgz"
+            "@tyrum/runtime-node-control|release-assets/tyrum-runtime-node-control-${RELEASE_VERSION}.tgz"
+            "@tyrum/runtime-execution|release-assets/tyrum-runtime-execution-${RELEASE_VERSION}.tgz"
+            "@tyrum/runtime-agent|release-assets/tyrum-runtime-agent-${RELEASE_VERSION}.tgz"
+            "@tyrum/runtime-workboard|release-assets/tyrum-runtime-workboard-${RELEASE_VERSION}.tgz"
+            "@tyrum/transport-sdk|release-assets/tyrum-transport-sdk-${RELEASE_VERSION}.tgz"
+            "@tyrum/node-sdk|release-assets/tyrum-node-sdk-${RELEASE_VERSION}.tgz"
+            "@tyrum/gateway|release-assets/tyrum-gateway-${RELEASE_VERSION}.tgz"
           )
 
-          for package_name in "${!packages[@]}"; do
-            package_file="${packages[${package_name}]}"
+          for package_entry in "${package_entries[@]}"; do
+            IFS="|" read -r package_name package_file <<<"${package_entry}"
             if [[ ! -f "${package_file}" ]]; then
               echo "Missing package tarball: ${package_file}"
               exit 1

--- a/packages/gateway/tests/unit/release-parity-gate.test.ts
+++ b/packages/gateway/tests/unit/release-parity-gate.test.ts
@@ -1,20 +1,119 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+const RELEASE_PACKAGES = [
+  {
+    name: "@tyrum/contracts",
+    manifestPath: "packages/contracts/package.json",
+    packageDir: "packages/contracts",
+    tarball: "tyrum-contracts-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/cli-utils",
+    manifestPath: "packages/cli-utils/package.json",
+    packageDir: "packages/cli-utils",
+    tarball: "tyrum-cli-utils-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/runtime-policy",
+    manifestPath: "packages/runtime-policy/package.json",
+    packageDir: "packages/runtime-policy",
+    tarball: "tyrum-runtime-policy-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/runtime-node-control",
+    manifestPath: "packages/runtime-node-control/package.json",
+    packageDir: "packages/runtime-node-control",
+    tarball: "tyrum-runtime-node-control-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/runtime-execution",
+    manifestPath: "packages/runtime-execution/package.json",
+    packageDir: "packages/runtime-execution",
+    tarball: "tyrum-runtime-execution-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/runtime-agent",
+    manifestPath: "packages/runtime-agent/package.json",
+    packageDir: "packages/runtime-agent",
+    tarball: "tyrum-runtime-agent-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/runtime-workboard",
+    manifestPath: "packages/runtime-workboard/package.json",
+    packageDir: "packages/runtime-workboard",
+    tarball: "tyrum-runtime-workboard-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/transport-sdk",
+    manifestPath: "packages/transport-sdk/package.json",
+    packageDir: "packages/transport-sdk",
+    tarball: "tyrum-transport-sdk-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/node-sdk",
+    manifestPath: "packages/node-sdk/package.json",
+    packageDir: "packages/node-sdk",
+    tarball: "tyrum-node-sdk-${RELEASE_VERSION}.tgz",
+  },
+  {
+    name: "@tyrum/gateway",
+    manifestPath: "packages/gateway/package.json",
+    packageDir: "packages/gateway",
+    tarball: "tyrum-gateway-${RELEASE_VERSION}.tgz",
+  },
+] as const;
+
+const RELEASE_PACKAGE_NAMES = new Set(RELEASE_PACKAGES.map((pkg) => pkg.name));
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
 function readReleaseWorkflow(): Record<string, unknown> {
-  const workflowPath = fileURLToPath(
-    new URL("../../../../.github/workflows/release.yml", import.meta.url),
-  );
+  const workflowPath = join(REPO_ROOT, ".github/workflows/release.yml");
   const workflowText = readFileSync(workflowPath, "utf8");
   return parse(workflowText) as Record<string, unknown>;
+}
+
+function readJsonObject(relativePath: string): Record<string, unknown> {
+  const value = JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8")) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${relativePath} must contain a JSON object`);
+  }
+  return value as Record<string, unknown>;
 }
 
 function normalizeNeeds(needs: unknown): string[] {
   if (typeof needs === "string") return [needs];
   if (Array.isArray(needs)) return needs.filter((value) => typeof value === "string");
   return [];
+}
+
+function workspaceDependencyNames(manifest: Record<string, unknown>): string[] {
+  const names = new Set<string>();
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const dependencies = manifest[field];
+    if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) {
+      continue;
+    }
+
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === "string" && version.startsWith("workspace:")) {
+        names.add(name);
+      }
+    }
+  }
+
+  return [...names].toSorted();
 }
 
 describe("release workflow parity gate", () => {
@@ -53,7 +152,39 @@ describe("release workflow parity gate", () => {
     expect(runScript).toMatch(/\n\s*done\s*(\n|$)/);
   });
 
-  it("publishes the packed npm tarballs that match the renamed workspace packages", () => {
+  it("stamps every release npm package manifest before packing", () => {
+    const workflow = readReleaseWorkflow();
+    const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
+    const packageJob = jobs?.["package-bundles"] as Record<string, unknown> | undefined;
+    const steps = packageJob?.["steps"] as Array<Record<string, unknown>> | undefined;
+
+    const versionStep = (steps ?? []).find(
+      (step) => step["name"] === "Apply tag version to workspace manifests",
+    );
+    expect(typeof versionStep?.["run"]).toBe("string");
+    const runScript = String(versionStep?.["run"] ?? "");
+
+    for (const pkg of RELEASE_PACKAGES) {
+      expect(runScript).toContain(`"${pkg.manifestPath}"`);
+    }
+  });
+
+  it("packs every release npm package tarball", () => {
+    const workflow = readReleaseWorkflow();
+    const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
+    const packageJob = jobs?.["package-bundles"] as Record<string, unknown> | undefined;
+    const steps = packageJob?.["steps"] as Array<Record<string, unknown>> | undefined;
+
+    const packStep = (steps ?? []).find((step) => step["name"] === "Pack npm tarballs");
+    expect(typeof packStep?.["run"]).toBe("string");
+    const runScript = String(packStep?.["run"] ?? "");
+
+    for (const pkg of RELEASE_PACKAGES) {
+      expect(runScript).toContain(pkg.packageDir);
+    }
+  });
+
+  it("publishes every release npm package tarball in dependency order", () => {
     const workflow = readReleaseWorkflow();
     const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
     const releaseJob = jobs?.["publish-release"] as Record<string, unknown> | undefined;
@@ -63,18 +194,27 @@ describe("release workflow parity gate", () => {
     expect(typeof publishStep?.["run"]).toBe("string");
     const runScript = String(publishStep?.["run"] ?? "");
 
-    expect(runScript).toContain(
-      '["@tyrum/contracts"]="release-assets/tyrum-contracts-${RELEASE_VERSION}.tgz"',
-    );
-    expect(runScript).toContain(
-      '["@tyrum/transport-sdk"]="release-assets/tyrum-transport-sdk-${RELEASE_VERSION}.tgz"',
-    );
-    expect(runScript).toContain(
-      '["@tyrum/node-sdk"]="release-assets/tyrum-node-sdk-${RELEASE_VERSION}.tgz"',
-    );
-    expect(runScript).toContain(
-      '["@tyrum/gateway"]="release-assets/tyrum-gateway-${RELEASE_VERSION}.tgz"',
-    );
+    let previousIndex = -1;
+    for (const pkg of RELEASE_PACKAGES) {
+      const entry = `"${pkg.name}|release-assets/${pkg.tarball}"`;
+      const index = runScript.indexOf(entry);
+      expect(index).toBeGreaterThan(previousIndex);
+      previousIndex = index;
+    }
+  });
+
+  it("does not publish packages that depend on unpublished workspace packages", () => {
+    for (const pkg of RELEASE_PACKAGES) {
+      const manifest = readJsonObject(pkg.manifestPath);
+      const workspaceDependencies = workspaceDependencyNames(manifest);
+
+      for (const dependencyName of workspaceDependencies) {
+        expect(
+          RELEASE_PACKAGE_NAMES.has(dependencyName),
+          `${pkg.name} depends on ${dependencyName}`,
+        ).toBe(true);
+      }
+    }
   });
 
   it("builds only the publishable workspace package closure before packing tarballs", () => {


### PR DESCRIPTION
## Summary
- Scope: Refactor
- Publish the full npm package closure required by `@tyrum/gateway` during release.
- Version-stamp and pack the runtime packages that `pnpm pack` turns into normal npm dependencies.
- Publish npm tarballs in dependency order for safer first publish and partial retries.
- Add release workflow regression tests so shipped packages cannot depend on unpublished workspace packages.

## Why
The release workflow previously packed `@tyrum/gateway`, but the packed gateway manifest depends on `@tyrum/cli-utils` and several `@tyrum/runtime-*` packages. Those packages were not published, so a successful npm install after the first release would fail even if the workflow reached the publish job.

## Verification
- `pnpm exec vitest run packages/gateway/tests/unit/release-parity-gate.test.ts`
- `pnpm --filter @tyrum/gateway... build && pnpm --filter @tyrum/node-sdk... build`
- Packed the 10 release packages locally and verified the gateway tarball's `@tyrum/*` dependencies all have matching tarballs.
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `git diff --check`

## Risk / rollback
Low runtime risk: this only changes release automation and its tests. Rollback is reverting this PR before tagging. After npm publish, versions are immutable; any failed published dev version should be superseded with the next `-dev.N` tag instead of force-moving a tag.