### PR TITLE
ci: verify launchable Electron runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,13 +867,53 @@ jobs:
           const electronModulePath = require.resolve("electron");
           const electronDir = path.dirname(require.resolve("electron/package.json"));
 
+          function describeError(error) {
+            return error instanceof Error ? error.message : String(error);
+          }
+
+          function clearElectronInstall() {
+            fs.rmSync(path.join(electronDir, "path.txt"), { force: true });
+            fs.rmSync(path.join(electronDir, "dist"), { recursive: true, force: true });
+          }
+
+          function formatProbeOutput(probe) {
+            const output = [probe.stdout, probe.stderr].filter(Boolean).join("\n").trim();
+            return output ? `\n${output}` : "";
+          }
+
+          function shouldProbeElectronLaunch() {
+            return process.platform !== "win32";
+          }
+
           function verifyElectron() {
             delete require.cache[electronModulePath];
             const electronPath = require("electron");
             if (!fs.existsSync(electronPath)) {
               throw new Error(`Electron executable does not exist: ${electronPath}`);
             }
-            console.log("electron ok");
+
+            if (!shouldProbeElectronLaunch()) {
+              console.log(`electron path ok: ${electronPath}`);
+              return;
+            }
+
+            const probe = childProcess.spawnSync(electronPath, ["--version"], {
+              encoding: "utf8",
+              timeout: 15_000,
+            });
+            if (probe.error) {
+              throw new Error(`Electron runtime probe failed: ${probe.error.message}`);
+            }
+            if (probe.status !== 0) {
+              const reason =
+                probe.status === null
+                  ? `signal ${String(probe.signal)}`
+                  : `status ${String(probe.status)}`;
+              throw new Error(
+                `Electron runtime probe failed with ${reason}${formatProbeOutput(probe)}`,
+              );
+            }
+            console.log(`electron ok: ${String(probe.stdout).trim() || electronPath}`);
           }
 
           function electronPlatformPath() {
@@ -898,6 +938,7 @@ jobs:
           }
 
           function runElectronInstallScript() {
+            clearElectronInstall();
             const result = childProcess.spawnSync(
               process.execPath,
               [path.join(electronDir, "install.js")],
@@ -929,13 +970,21 @@ jobs:
               return false;
             }
             fs.writeFileSync(path.join(electronDir, "path.txt"), targetName);
-            verifyElectron();
-            return true;
+            try {
+              verifyElectron();
+              return true;
+            } catch (error) {
+              console.warn(`Installed Electron dist is not launchable: ${describeError(error)}`);
+              return false;
+            }
           }
 
           try {
             verifyElectron();
-          } catch {
+          } catch (initialError) {
+            console.warn(
+              `Electron runtime probe failed before reinstall: ${describeError(initialError)}`,
+            );
             try {
               runElectronInstallScript();
               verifyElectron();

--- a/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
+++ b/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
@@ -61,6 +61,19 @@ test("desktop CI workflow does not depend on a temporary Electron cache path", (
   expect(readWorkflowSource()).not.toContain("electron_config_cache");
 });
 
+test("desktop cross-platform Electron preflight launches the runtime", () => {
+  const electronStep = findStep(
+    "desktop-cross-platform-test",
+    "Ensure Electron binary is installed",
+  );
+  const run = String(electronStep?.["run"]);
+
+  expect(run).toContain('childProcess.spawnSync(electronPath, ["--version"]');
+  expect(run).toContain('return process.platform !== "win32"');
+  expect(run).toContain("Electron runtime probe failed before reinstall");
+  expect(run).toContain("Installed Electron dist is not launchable");
+});
+
 test("browser-backed gateway smokes run only in the Playwright-enabled Linux browser suite", () => {
   const source = readWorkflowSource();
 


### PR DESCRIPTION
## What changed
- Make the desktop cross-platform CI Electron preflight launch `electron --version` instead of only checking path existence.
- Clear a broken Electron install before rerunning `install.js`; only trust repaired `path.txt` when the runtime launches.
- Add a workflow regression test for the launch-level probe.

## Why
Main CI for `8c91c35f0292f60b5ace6aa0271d9e06ba7b560b` failed in `Desktop Cross-Platform Test (macos)` because the Electron executable existed but `Electron Framework.framework` was missing, producing `dyld: Library not loaded` during `apps/desktop/tests/integration/embedded-gateway-startup.test.ts`.

## Validation
- `pnpm exec vitest run packages/gateway/tests/unit/ci-desktop-workflow.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Risk / rollback
Low CI-only patch. Roll back by reverting this commit if the stricter preflight exposes an unrelated hosted-runner issue.