### PR TITLE
ci: extract macos electron runtime with ditto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,7 +937,85 @@ jobs:
             return workspace;
           }
 
+          function runMacElectronInstallWithDitto() {
+            if (process.platform !== "darwin") {
+              return false;
+            }
+
+            clearElectronInstall();
+            fs.mkdirSync(path.join(electronDir, "dist"), { recursive: true });
+
+            const downloadScript = `
+          const path = require("node:path");
+          const electronDir = ${JSON.stringify(electronDir)};
+          const { downloadArtifact } = require(require.resolve("@electron/get", { paths: [electronDir] }));
+          const { version } = require(path.join(electronDir, "package.json"));
+          const checksums = require(path.join(electronDir, "checksums.json"));
+
+          downloadArtifact({
+            version,
+            artifactName: "electron",
+            platform: process.platform,
+            arch: process.arch,
+            force: true,
+            checksums,
+          })
+            .then((zipPath) => {
+              process.stdout.write(zipPath);
+            })
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          `;
+            const downloadResult = childProcess.spawnSync(
+              process.execPath,
+              ["-e", downloadScript],
+              {
+                encoding: "utf8",
+                env: {
+                  ...process.env,
+                  ELECTRON_OVERRIDE_DIST_PATH: "",
+                  ELECTRON_SKIP_BINARY_DOWNLOAD: "",
+                  force_no_cache: "true",
+                },
+              },
+            );
+            if (downloadResult.error) {
+              throw downloadResult.error;
+            }
+            if (downloadResult.status !== 0) {
+              throw new Error(
+                `Electron macOS download failed with status ${String(downloadResult.status)}${formatProbeOutput(downloadResult)}`,
+              );
+            }
+
+            const zipPath = downloadResult.stdout.trim();
+            if (!zipPath) {
+              throw new Error("Electron macOS download did not return a zip path.");
+            }
+
+            const extractResult = childProcess.spawnSync(
+              "ditto",
+              ["-x", "-k", zipPath, path.join(electronDir, "dist")],
+              { stdio: "inherit" },
+            );
+            if (extractResult.error) {
+              throw extractResult.error;
+            }
+            if (extractResult.status !== 0) {
+              throw new Error(`ditto failed with status ${String(extractResult.status)}`);
+            }
+
+            fs.writeFileSync(path.join(electronDir, "path.txt"), electronPlatformPath());
+            return true;
+          }
+
           function runElectronInstallScript() {
+            if (runMacElectronInstallWithDitto()) {
+              return;
+            }
+
             clearElectronInstall();
             const result = childProcess.spawnSync(
               process.execPath,

--- a/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
+++ b/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
@@ -70,6 +70,8 @@ test("desktop cross-platform Electron preflight launches the runtime", () => {
 
   expect(run).toContain('childProcess.spawnSync(electronPath, ["--version"]');
   expect(run).toContain('return process.platform !== "win32"');
+  expect(run).toContain('"ditto",');
+  expect(run).toContain('require.resolve("@electron/get", { paths: [electronDir] })');
   expect(run).toContain("Electron runtime probe failed before reinstall");
   expect(run).toContain("Installed Electron dist is not launchable");
 });


### PR DESCRIPTION
## What changed
- Add a macOS-specific Electron reinstall path in the desktop cross-platform test preflight.
- Download Electron through `@electron/get`, then extract the zip with macOS `ditto` before writing `path.txt`.
- Keep the launch probe so incomplete Electron apps fail before desktop tests run.

## Why
Main CI for `6b3ba4d8214a46f7727cd545cca2e756c4048677` still produced a broken Electron install on macOS: `Electron.app/Contents/MacOS/Electron` existed, but `Electron Framework.framework` was missing. The Electron package install path uses `extract-zip`; `ditto` is the native macOS extractor and locally preserves the framework layout from the Electron zip.

## Validation
- `pnpm exec vitest run packages/gateway/tests/unit/ci-desktop-workflow.test.ts`
- `actionlint .github/workflows/ci.yml`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`

## Risk / rollback
CI-only patch, scoped to the macOS cross-platform desktop preflight. Revert this commit if `ditto` extraction causes hosted-runner issues.