### PR TITLE
ci: unblock dev release desktop bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,35 +598,117 @@ jobs:
       - name: Ensure Electron binary is installed
         shell: bash
         run: |
+          set -euo pipefail
           pnpm --filter tyrum-desktop exec node <<'NODE'
+          const childProcess = require("node:child_process");
           const fs = require("node:fs");
           const path = require("node:path");
+          const electronModulePath = require.resolve("electron");
           const electronDir = path.dirname(require.resolve("electron/package.json"));
-          fs.rmSync(path.join(electronDir, "path.txt"), { force: true });
-          fs.rmSync(path.join(electronDir, "dist"), { recursive: true, force: true });
-          NODE
-          ELECTRON_SKIP_BINARY_DOWNLOAD='' ELECTRON_OVERRIDE_DIST_PATH='' force_no_cache=true pnpm --filter tyrum-desktop rebuild electron
-          pnpm --filter tyrum-desktop exec node <<'NODE'
-          const fs = require("node:fs");
-          const path = require("node:path");
-          const electronDir = path.dirname(require.resolve("electron/package.json"));
-          const workspace = process.env.GITHUB_WORKSPACE;
-          if (!workspace) {
-            throw new Error("GITHUB_WORKSPACE is not set");
+
+          function describeError(error) {
+            return error instanceof Error ? error.message : String(error);
           }
-          const packagedExecutable = path.resolve(
-            workspace,
-            "apps/desktop/release/linux-unpacked/tyrum-desktop",
-          );
-          if (!fs.existsSync(packagedExecutable)) {
-            throw new Error(`Missing packaged executable: ${packagedExecutable}`);
+
+          function clearElectronInstall() {
+            fs.rmSync(path.join(electronDir, "path.txt"), { force: true });
+            fs.rmSync(path.join(electronDir, "dist"), { recursive: true, force: true });
           }
-          fs.mkdirSync(path.join(electronDir, "dist"), { recursive: true });
-          fs.rmSync(path.join(electronDir, "dist", "electron"), { force: true });
-          fs.symlinkSync(packagedExecutable, path.join(electronDir, "dist", "electron"));
-          fs.writeFileSync(path.join(electronDir, "path.txt"), "electron");
-          require("electron");
-          console.log("electron ok");
+
+          function formatProbeOutput(probe) {
+            const output = [probe.stdout, probe.stderr].filter(Boolean).join("\n").trim();
+            return output ? `\n${output}` : "";
+          }
+
+          function electronPlatformPath() {
+            if (process.platform !== "linux") {
+              throw new Error(`Unsupported Electron platform for this job: ${process.platform}`);
+            }
+            return "electron";
+          }
+
+          function verifyElectron() {
+            delete require.cache[electronModulePath];
+            const electronPath = require("electron");
+            if (typeof electronPath !== "string") {
+              throw new TypeError("Expected the electron package to export the executable path.");
+            }
+            if (!fs.existsSync(electronPath)) {
+              throw new Error(`Electron executable does not exist: ${electronPath}`);
+            }
+
+            const probe = childProcess.spawnSync(electronPath, ["--version"], {
+              encoding: "utf8",
+              env: {
+                ...process.env,
+                ELECTRON_DISABLE_SANDBOX: "1",
+              },
+              timeout: 15_000,
+            });
+            if (probe.error) {
+              throw new Error(`Electron runtime probe failed: ${probe.error.message}`);
+            }
+            if (probe.status !== 0) {
+              const reason =
+                probe.status === null
+                  ? `signal ${String(probe.signal)}`
+                  : `status ${String(probe.status)}`;
+              throw new Error(`Electron runtime probe failed with ${reason}${formatProbeOutput(probe)}`);
+            }
+            console.log(`electron ok: ${String(probe.stdout).trim() || electronPath}`);
+          }
+
+          async function installElectronForLinux() {
+            clearElectronInstall();
+
+            const { downloadArtifact } = require(require.resolve("@electron/get", { paths: [electronDir] }));
+            const { version } = require(path.join(electronDir, "package.json"));
+            const checksums = require(path.join(electronDir, "checksums.json"));
+            const zipPath = await downloadArtifact({
+              version,
+              artifactName: "electron",
+              platform: process.platform,
+              arch: process.arch,
+              force: true,
+              checksums,
+            });
+
+            const distDir = path.join(electronDir, "dist");
+            fs.mkdirSync(distDir, { recursive: true });
+            const extractResult = childProcess.spawnSync("unzip", ["-q", zipPath, "-d", distDir], {
+              stdio: "inherit",
+            });
+            if (extractResult.error) {
+              throw extractResult.error;
+            }
+            if (extractResult.status !== 0) {
+              throw new Error(`unzip failed with status ${String(extractResult.status)}`);
+            }
+
+            const targetName = electronPlatformPath();
+            const targetPath = path.join(distDir, targetName);
+            if (!fs.existsSync(targetPath)) {
+              throw new Error(`Downloaded Electron executable is missing: ${targetPath}`);
+            }
+            fs.chmodSync(targetPath, 0o755);
+            fs.writeFileSync(path.join(electronDir, "path.txt"), targetName);
+          }
+
+          try {
+            verifyElectron();
+          } catch (initialError) {
+            console.warn(
+              `Electron runtime probe failed before explicit download: ${describeError(initialError)}`,
+            );
+            installElectronForLinux()
+              .then(() => {
+                verifyElectron();
+              })
+              .catch((error) => {
+                console.error(error);
+                process.exit(1);
+              });
+          }
           NODE
 
       - name: Test desktop suite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
         run: pnpm --filter tyrum-desktop build:test-deps
 
       - name: Prepare App Store Connect API key file
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel != 'dev' }}
         shell: bash
         env:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
@@ -297,7 +297,7 @@ jobs:
           echo "APPLE_API_KEY=${key_file}" >> "$GITHUB_ENV"
 
       - name: Validate macOS signing and notarization credentials
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel != 'dev' }}
         shell: bash
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -349,7 +349,7 @@ jobs:
           fi
 
       - name: Set up keychain for macOS signing
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel != 'dev' }}
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -392,7 +392,7 @@ jobs:
           echo "CSC_KEYCHAIN=${keychain_path}" >> "$GITHUB_ENV"
 
       - name: Build desktop release files (macOS signed + notarized)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel != 'dev' }}
         timeout-minutes: 90
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -403,6 +403,13 @@ jobs:
           APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
           DEBUG: electron-builder,electron-osx-sign,electron-notarize
+        run: pnpm --filter tyrum-desktop dist
+
+      - name: Build desktop release files (macOS dev prerelease)
+        if: ${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel == 'dev' }}
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          DEBUG: electron-builder
         run: pnpm --filter tyrum-desktop dist
 
       - name: Build desktop release files (Linux)
@@ -416,10 +423,15 @@ jobs:
           WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: pnpm --filter tyrum-desktop dist
 
+      - name: Mark packaged desktop bundle ready for smoke reuse
+        run: node apps/desktop/scripts/write-packaged-smoke-stamp.mjs
+
       - name: Smoke test packaged desktop app
         shell: bash
         env:
           TYRUM_RUN_PACKAGED_SMOKE: "1"
+          TYRUM_PACKAGED_SMOKE_ONLY: "1"
+          TYRUM_TRUST_PACKAGED_SMOKE_ARTIFACT: "1"
         run: |
           set -euo pipefail
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then

--- a/apps/desktop/tests/integration/electron-process-smoke.test.ts
+++ b/apps/desktop/tests/integration/electron-process-smoke.test.ts
@@ -33,6 +33,7 @@ const DESKTOP_RELEASE_DIR = resolve(REPO_ROOT, "apps/desktop/release");
 const PACKAGED_SMOKE_STAMP = resolve(DESKTOP_RELEASE_DIR, "packaged-smoke-ready.txt");
 const STAGED_GATEWAY_ENTRY = resolve(REPO_ROOT, "apps/desktop/dist/gateway/index.mjs");
 const PACKAGED_SMOKE_ENABLED = process.env["TYRUM_RUN_PACKAGED_SMOKE"] === "1";
+const PACKAGED_SMOKE_ONLY = process.env["TYRUM_PACKAGED_SMOKE_ONLY"] === "1";
 const DESKTOP_NODE_DIST_ENTRY = resolve(REPO_ROOT, "packages/desktop-node/dist/index.mjs");
 
 interface ElectronProbeResult {
@@ -434,9 +435,15 @@ async function runDesktopGatewaySmoke(
 const XVFB_RUN_PATH = findCommandPath("xvfb-run");
 const NEEDS_VIRTUAL_DISPLAY = process.platform === "linux" && !process.env["DISPLAY"];
 const USE_VIRTUAL_DISPLAY = NEEDS_VIRTUAL_DISPLAY && XVFB_RUN_PATH !== undefined;
-const electronProbe = probeElectronRuntime(USE_VIRTUAL_DISPLAY);
+const electronProbe = PACKAGED_SMOKE_ONLY
+  ? { available: false, reason: "Electron runtime probe skipped for packaged-only smoke." }
+  : probeElectronRuntime(USE_VIRTUAL_DISPLAY);
 const CAN_LAUNCH_ELECTRON =
-  electronProbe.available && (!NEEDS_VIRTUAL_DISPLAY || XVFB_RUN_PATH !== undefined);
+  !PACKAGED_SMOKE_ONLY &&
+  electronProbe.available &&
+  (!NEEDS_VIRTUAL_DISPLAY || XVFB_RUN_PATH !== undefined);
+const CAN_LAUNCH_PACKAGED_APP =
+  PACKAGED_SMOKE_ENABLED && (!NEEDS_VIRTUAL_DISPLAY || XVFB_RUN_PATH !== undefined);
 
 describe("desktop full Electron process smoke", () => {
   it.skipIf(!CAN_LAUNCH_ELECTRON)(
@@ -452,7 +459,7 @@ describe("desktop full Electron process smoke", () => {
     },
   );
 
-  it.skipIf(!CAN_LAUNCH_ELECTRON || !PACKAGED_SMOKE_ENABLED)(
+  it.skipIf(!CAN_LAUNCH_PACKAGED_APP)(
     "launches the packaged desktop app and starts the embedded gateway",
     { timeout: 600_000 },
     async () => {

--- a/apps/desktop/tests/integration/embedded-gateway-test-utils.ts
+++ b/apps/desktop/tests/integration/embedded-gateway-test-utils.ts
@@ -38,11 +38,6 @@ const DESKTOP_RENDERER_SRC_DIR = resolve(REPO_ROOT, "apps/desktop/src/renderer")
 const DESKTOP_PACKAGE_JSON = resolve(REPO_ROOT, "apps/desktop/package.json");
 const DESKTOP_TSDOWN_CONFIG = resolve(REPO_ROOT, "apps/desktop/tsdown.config.ts");
 const DESKTOP_VITE_CONFIG = resolve(REPO_ROOT, "apps/desktop/vite.config.ts");
-const electronPackageExport = require("electron");
-if (typeof electronPackageExport !== "string") {
-  throw new TypeError("Expected the electron package to export the executable path.");
-}
-const ELECTRON_BIN = electronPackageExport;
 const CLI_UTILS_DIST = resolve(REPO_ROOT, "packages/cli-utils/dist/index.mjs");
 const CLI_UTILS_PACKAGE_JSON = resolve(REPO_ROOT, "packages/cli-utils/package.json");
 const CLI_UTILS_TSCONFIG = resolve(REPO_ROOT, "packages/cli-utils/tsconfig.json");
@@ -379,7 +374,11 @@ export async function waitForHealthDown(url: string, timeoutMs = 5_000): Promise
 }
 
 export function electronCommand(): string {
-  return ELECTRON_BIN;
+  const electronPackageExport = require("electron");
+  if (typeof electronPackageExport !== "string") {
+    throw new TypeError("Expected the electron package to export the executable path.");
+  }
+  return electronPackageExport;
 }
 
 export async function waitForHealthUp(

--- a/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
+++ b/packages/gateway/tests/unit/ci-desktop-workflow.test.ts
@@ -76,6 +76,19 @@ test("desktop cross-platform Electron preflight launches the runtime", () => {
   expect(run).toContain("Installed Electron dist is not launchable");
 });
 
+test("desktop Linux test force-installs a real Electron runtime", () => {
+  const electronStep = findStep("desktop-linux-test", "Ensure Electron binary is installed");
+  const run = String(electronStep?.["run"]);
+
+  expect(run).toContain('childProcess.spawnSync(electronPath, ["--version"]');
+  expect(run).toContain('require.resolve("@electron/get", { paths: [electronDir] })');
+  expect(run).toContain("downloadArtifact({");
+  expect(run).toContain('childProcess.spawnSync("unzip"');
+  expect(run).toContain('fs.writeFileSync(path.join(electronDir, "path.txt"), targetName)');
+  expect(run).not.toContain("apps/desktop/release/linux-unpacked/tyrum-desktop");
+  expect(run).not.toContain("symlinkSync(packagedExecutable");
+});
+
 test("browser-backed gateway smokes run only in the Playwright-enabled Linux browser suite", () => {
   const source = readWorkflowSource();
 

--- a/packages/gateway/tests/unit/release-parity-gate.test.ts
+++ b/packages/gateway/tests/unit/release-parity-gate.test.ts
@@ -83,6 +83,10 @@ function readReleaseWorkflow(): Record<string, unknown> {
   return parse(workflowText) as Record<string, unknown>;
 }
 
+function readText(relativePath: string): string {
+  return readFileSync(join(REPO_ROOT, relativePath), "utf8");
+}
+
 function readJsonObject(relativePath: string): Record<string, unknown> {
   const value = JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8")) as unknown;
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -114,6 +118,14 @@ function workspaceDependencyNames(manifest: Record<string, unknown>): string[] {
   }
 
   return [...names].toSorted();
+}
+
+function releaseStep(stepName: string): Record<string, unknown> | undefined {
+  const workflow = readReleaseWorkflow();
+  const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
+  const desktopJob = jobs?.["desktop-bundles"] as Record<string, unknown> | undefined;
+  const steps = desktopJob?.["steps"] as Array<Record<string, unknown>> | undefined;
+  return (steps ?? []).find((step) => step["name"] === stepName);
 }
 
 describe("release workflow parity gate", () => {
@@ -257,5 +269,52 @@ describe("release workflow parity gate", () => {
     const envText = JSON.stringify(env ?? {});
     expect(envText).not.toContain("secrets.CSC_LINK");
     expect(envText).not.toContain("secrets.CSC_KEY_PASSWORD");
+  });
+
+  it("keeps dev prerelease macOS bundles out of production signing and notarization", () => {
+    const signedBuildStep = releaseStep("Build desktop release files (macOS signed + notarized)");
+    const devBuildStep = releaseStep("Build desktop release files (macOS dev prerelease)");
+
+    expect(signedBuildStep?.["if"]).toBe(
+      "${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel != 'dev' }}",
+    );
+    expect(devBuildStep?.["if"]).toBe(
+      "${{ matrix.os == 'macos-latest' && needs.package-bundles.outputs.channel == 'dev' }}",
+    );
+
+    const devEnv = devBuildStep?.["env"] as Record<string, unknown> | undefined;
+    expect(devEnv?.["CSC_IDENTITY_AUTO_DISCOVERY"]).toBe("false");
+    expect(JSON.stringify(devEnv ?? {})).not.toContain("secrets.");
+  });
+
+  it("runs release packaged smoke against the just-built desktop bundle only", () => {
+    const markerStep = releaseStep("Mark packaged desktop bundle ready for smoke reuse");
+    const smokeStep = releaseStep("Smoke test packaged desktop app");
+
+    expect(markerStep?.["run"]).toBe("node apps/desktop/scripts/write-packaged-smoke-stamp.mjs");
+
+    const env = smokeStep?.["env"] as Record<string, unknown> | undefined;
+    expect(env?.["TYRUM_RUN_PACKAGED_SMOKE"]).toBe("1");
+    expect(env?.["TYRUM_PACKAGED_SMOKE_ONLY"]).toBe("1");
+    expect(env?.["TYRUM_TRUST_PACKAGED_SMOKE_ARTIFACT"]).toBe("1");
+  });
+
+  it("does not require the dev Electron binary for packaged-only smoke imports", () => {
+    const smokeSource = readText("apps/desktop/tests/integration/electron-process-smoke.test.ts");
+    const testUtilsSource = readText(
+      "apps/desktop/tests/integration/embedded-gateway-test-utils.ts",
+    );
+
+    expect(smokeSource).toContain('process.env["TYRUM_PACKAGED_SMOKE_ONLY"] === "1"');
+    expect(smokeSource).toContain("Electron runtime probe skipped for packaged-only smoke.");
+    expect(smokeSource).toContain("const CAN_LAUNCH_PACKAGED_APP");
+    expect(smokeSource).not.toContain("it.skipIf(!CAN_LAUNCH_ELECTRON || !PACKAGED_SMOKE_ENABLED)");
+
+    const electronCommandIndex = testUtilsSource.indexOf("export function electronCommand");
+    expect(electronCommandIndex).toBeGreaterThan(0);
+    expect(testUtilsSource.slice(0, electronCommandIndex)).not.toContain('require("electron")');
+    expect(testUtilsSource.slice(electronCommandIndex)).toContain(
+      'const electronPackageExport = require("electron");',
+    );
   });
 });


### PR DESCRIPTION
## What changed
- Runs release packaged smoke against the desktop bundle that the release job just built.
- Lets packaged-only smoke avoid requiring the dev Electron binary at module import/probe time.
- Builds macOS dev prerelease bundles without production signing/notarization while preserving signed+notarized beta/stable release behavior.

## Why
The failed `v2026.05.29-dev.1` release did not publish npm or GitHub release assets. Linux/Windows desktop jobs failed because the packaged smoke imported `electron` before running the packaged app. The macOS dev release path was also forced through production signing/notarization even though this tag is only a prerelease validation run.

## How to test
- `pnpm exec vitest run packages/gateway/tests/unit/release-parity-gate.test.ts packages/gateway/tests/unit/ci-desktop-workflow.test.ts`
- `TYRUM_PACKAGED_SMOKE_ONLY=1 pnpm exec vitest run apps/desktop/tests/integration/electron-process-smoke.test.ts -t "desktop full Electron process smoke"`
- `actionlint .github/workflows/release.yml .github/workflows/ci.yml`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`

## Risk and rollback
Patch scope. Dev prerelease macOS artifacts are ad-hoc/dev-signed rather than production-notarized; beta/stable release paths still require signing and notarization secrets. Roll back by reverting this PR and using a new dev tag after a replacement fix.