### PR TITLE
Stabilize gateway startup build closure

### DIFF
--- a/packages/contracts/tests/dist-entrypoint.test.ts
+++ b/packages/contracts/tests/dist-entrypoint.test.ts
@@ -17,6 +17,7 @@ const testsDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testsDir, "../../..");
 const distEntrypointPath = resolve(testsDir, "../dist/index.mjs");
 const distTypesEntrypointPath = resolve(testsDir, "../dist/index.d.ts");
+const expectedDistTypesEntrypoint = 'export * from "./index.mjs";\n';
 // Reuse the same lock that gateway dist tests hold while a packaged child process is alive.
 const workspaceBuildLockPath = resolve(repoRoot, ".tyrum-gateway-build.lock");
 
@@ -129,6 +130,10 @@ async function ensureContractsDistModule(): Promise<Record<string, unknown>> {
     try {
       try {
         await access(distEntrypointPath);
+        const distTypesEntrypoint = await readFile(distTypesEntrypointPath, "utf8");
+        if (distTypesEntrypoint !== expectedDistTypesEntrypoint) {
+          buildContractsDist();
+        }
       } catch {
         buildContractsDist();
       }
@@ -153,7 +158,7 @@ describe("@tyrum/contracts dist entrypoint", () => {
     await ensureContractsDistModule();
 
     await expect(readFile(distTypesEntrypointPath, "utf8")).resolves.toBe(
-      'export * from "./index.mjs";\n',
+      expectedDistTypesEntrypoint,
     );
   }, 90_000);
 

--- a/packages/gateway/bin/tyrum.mjs
+++ b/packages/gateway/bin/tyrum.mjs
@@ -6,12 +6,29 @@ await runPackageBin({
   metaUrl: import.meta.url,
   buildPackages: [
     "@tyrum/contracts",
+    "@tyrum/cli-utils",
+    "@tyrum/runtime-policy",
     "@tyrum/runtime-node-control",
     "@tyrum/runtime-execution",
+    "@tyrum/runtime-agent",
+    "@tyrum/runtime-workboard",
     "@tyrum/gateway",
   ],
   dependencyEntrypoints: ["packages/contracts/dist/index.mjs"],
   dependencyBuildInputs: [
+    {
+      distEntrypoint: "packages/cli-utils/dist/index.mjs",
+      srcRoot: "packages/cli-utils/src",
+      watchedFiles: ["packages/cli-utils/package.json", "packages/cli-utils/tsconfig.json"],
+    },
+    {
+      distEntrypoint: "packages/runtime-policy/dist/index.mjs",
+      srcRoot: "packages/runtime-policy/src",
+      watchedFiles: [
+        "packages/runtime-policy/package.json",
+        "packages/runtime-policy/tsconfig.json",
+      ],
+    },
     {
       distEntrypoint: "packages/runtime-node-control/dist/index.mjs",
       srcRoot: "packages/runtime-node-control/src",
@@ -26,6 +43,19 @@ await runPackageBin({
       watchedFiles: [
         "packages/runtime-execution/package.json",
         "packages/runtime-execution/tsconfig.json",
+      ],
+    },
+    {
+      distEntrypoint: "packages/runtime-agent/dist/index.mjs",
+      srcRoot: "packages/runtime-agent/src",
+      watchedFiles: ["packages/runtime-agent/package.json", "packages/runtime-agent/tsconfig.json"],
+    },
+    {
+      distEntrypoint: "packages/runtime-workboard/dist/index.mjs",
+      srcRoot: "packages/runtime-workboard/src",
+      watchedFiles: [
+        "packages/runtime-workboard/package.json",
+        "packages/runtime-workboard/tsconfig.json",
       ],
     },
   ],

--- a/packages/gateway/tests/integration/startup-process.build-support.ts
+++ b/packages/gateway/tests/integration/startup-process.build-support.ts
@@ -1,6 +1,65 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+
+export type WorkspaceDependencyBuild = {
+  failurePrefix: string;
+  filter: string;
+  output: string;
+  packageJson: string;
+  srcDir: string;
+  tsconfig: string;
+};
+
+export const TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS = [
+  "packages/gateway/node_modules/@tyrum/contracts/dist/",
+  "packages/gateway/node_modules/@tyrum/cli-utils/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-policy/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-node-control/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-execution/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-agent/dist/",
+  "packages/gateway/node_modules/@tyrum/runtime-workboard/dist/",
+  "packages/runtime-policy/node_modules/@tyrum/contracts/dist/",
+  "packages/runtime-node-control/node_modules/@tyrum/contracts/dist/",
+  "packages/runtime-execution/node_modules/@tyrum/contracts/dist/",
+  "packages/runtime-agent/node_modules/@tyrum/contracts/dist/",
+  "packages/runtime-workboard/node_modules/@tyrum/contracts/dist/",
+  "packages/contracts/dist/index.mjs",
+  "packages/cli-utils/dist/index.mjs",
+  "packages/runtime-policy/dist/index.mjs",
+  "packages/runtime-node-control/dist/index.mjs",
+  "packages/runtime-execution/dist/index.mjs",
+  "packages/runtime-agent/dist/index.mjs",
+  "packages/runtime-workboard/dist/index.mjs",
+] as const;
+
+function workspaceDependencyBuild(
+  repoRoot: string,
+  packageDir: string,
+  packageName: string,
+): WorkspaceDependencyBuild {
+  return {
+    filter: packageName,
+    output: resolve(repoRoot, "packages", packageDir, "dist/index.mjs"),
+    packageJson: resolve(repoRoot, "packages", packageDir, "package.json"),
+    tsconfig: resolve(repoRoot, "packages", packageDir, "tsconfig.json"),
+    srcDir: resolve(repoRoot, "packages", packageDir, "src"),
+    failurePrefix: `Failed to build ${packageName} before startup test.`,
+  };
+}
+
+export function createGatewayWorkspaceDependencyBuilds(
+  repoRoot: string,
+): readonly WorkspaceDependencyBuild[] {
+  return [
+    workspaceDependencyBuild(repoRoot, "cli-utils", "@tyrum/cli-utils"),
+    workspaceDependencyBuild(repoRoot, "runtime-policy", "@tyrum/runtime-policy"),
+    workspaceDependencyBuild(repoRoot, "runtime-node-control", "@tyrum/runtime-node-control"),
+    workspaceDependencyBuild(repoRoot, "runtime-execution", "@tyrum/runtime-execution"),
+    workspaceDependencyBuild(repoRoot, "runtime-agent", "@tyrum/runtime-agent"),
+    workspaceDependencyBuild(repoRoot, "runtime-workboard", "@tyrum/runtime-workboard"),
+  ];
+}
 
 function missingBuildOutputs(outputPaths: readonly string[]): string[] {
   return outputPaths.filter((outputPath) => !existsSync(outputPath));

--- a/packages/gateway/tests/integration/startup-process.gateway-support.ts
+++ b/packages/gateway/tests/integration/startup-process.gateway-support.ts
@@ -20,9 +20,11 @@ import { fileURLToPath } from "node:url";
 import { WebSocket } from "ws";
 import {
   allBuildOutputsExist,
+  createGatewayWorkspaceDependencyBuilds,
   formatWorkspaceBuildFailure,
   isModuleNotFoundForAnyPath,
   latestMtimeInDir,
+  TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS,
   waitForBuildOutputs,
   workspaceBuildIsStale,
 } from "./startup-process.build-support.js";
@@ -41,42 +43,14 @@ const SCHEMAS_PACKAGE_JSON = resolve(REPO_ROOT, "packages/contracts/package.json
 const SCHEMAS_TSCONFIG = resolve(REPO_ROOT, "packages/contracts/tsconfig.json");
 const SCHEMAS_SRC_DIR = resolve(REPO_ROOT, "packages/contracts/src");
 const SCHEMAS_SCRIPTS_DIR = resolve(REPO_ROOT, "packages/contracts/scripts");
-const RUNTIME_NODE_CONTROL_DIST = resolve(
-  REPO_ROOT,
-  "packages/runtime-node-control/dist/index.mjs",
-);
-const RUNTIME_NODE_CONTROL_PACKAGE_JSON = resolve(
-  REPO_ROOT,
-  "packages/runtime-node-control/package.json",
-);
-const RUNTIME_NODE_CONTROL_TSCONFIG = resolve(
-  REPO_ROOT,
-  "packages/runtime-node-control/tsconfig.json",
-);
-const RUNTIME_NODE_CONTROL_SRC_DIR = resolve(REPO_ROOT, "packages/runtime-node-control/src");
-const RUNTIME_EXECUTION_DIST = resolve(REPO_ROOT, "packages/runtime-execution/dist/index.mjs");
-const RUNTIME_EXECUTION_PACKAGE_JSON = resolve(
-  REPO_ROOT,
-  "packages/runtime-execution/package.json",
-);
-const RUNTIME_EXECUTION_TSCONFIG = resolve(REPO_ROOT, "packages/runtime-execution/tsconfig.json");
-const RUNTIME_EXECUTION_SRC_DIR = resolve(REPO_ROOT, "packages/runtime-execution/src");
 const GATEWAY_SRC_DIR = resolve(PACKAGE_ROOT, "src");
 const GATEWAY_BUILD_LOCK = resolve(REPO_ROOT, ".tyrum-gateway-build.lock");
+const GATEWAY_WORKSPACE_DEPENDENCY_BUILDS = createGatewayWorkspaceDependencyBuilds(REPO_ROOT);
 const REQUIRED_GATEWAY_BUILD_OUTPUTS = [
   SCHEMAS_DIST,
   SCHEMAS_JSONSCHEMA_CATALOG,
-  RUNTIME_NODE_CONTROL_DIST,
-  RUNTIME_EXECUTION_DIST,
+  ...GATEWAY_WORKSPACE_DEPENDENCY_BUILDS.map((build) => build.output),
   GATEWAY_ENTRYPOINT,
-] as const;
-const TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS = [
-  "packages/gateway/node_modules/@tyrum/contracts/dist/",
-  "packages/gateway/node_modules/@tyrum/runtime-node-control/dist/",
-  "packages/gateway/node_modules/@tyrum/runtime-execution/dist/",
-  "packages/contracts/dist/index.mjs",
-  "packages/runtime-node-control/dist/index.mjs",
-  "packages/runtime-execution/dist/index.mjs",
 ] as const;
 
 type MaybePromise<T> = T | Promise<T>;
@@ -242,24 +216,16 @@ function gatewayBuildIsStale(): boolean {
     return true;
   }
 
-  if (
-    workspaceBuildIsStale({
-      outputPaths: [RUNTIME_NODE_CONTROL_DIST],
-      srcDir: RUNTIME_NODE_CONTROL_SRC_DIR,
-      watchedFiles: [RUNTIME_NODE_CONTROL_PACKAGE_JSON, RUNTIME_NODE_CONTROL_TSCONFIG],
-    })
-  ) {
-    return true;
-  }
-
-  if (
-    workspaceBuildIsStale({
-      outputPaths: [RUNTIME_EXECUTION_DIST],
-      srcDir: RUNTIME_EXECUTION_SRC_DIR,
-      watchedFiles: [RUNTIME_EXECUTION_PACKAGE_JSON, RUNTIME_EXECUTION_TSCONFIG],
-    })
-  ) {
-    return true;
+  for (const build of GATEWAY_WORKSPACE_DEPENDENCY_BUILDS) {
+    if (
+      workspaceBuildIsStale({
+        outputPaths: [build.output],
+        srcDir: build.srcDir,
+        watchedFiles: [build.packageJson, build.tsconfig],
+      })
+    ) {
+      return true;
+    }
   }
 
   if (!existsSync(GATEWAY_ENTRYPOINT)) return true;
@@ -275,8 +241,9 @@ function gatewayBuildIsStale(): boolean {
   }
 
   if (gatewayMtime < statSync(SCHEMAS_DIST).mtimeMs) return true;
-  if (gatewayMtime < statSync(RUNTIME_NODE_CONTROL_DIST).mtimeMs) return true;
-  if (gatewayMtime < statSync(RUNTIME_EXECUTION_DIST).mtimeMs) return true;
+  for (const build of GATEWAY_WORKSPACE_DEPENDENCY_BUILDS) {
+    if (gatewayMtime < statSync(build.output).mtimeMs) return true;
+  }
 
   return false;
 }
@@ -314,16 +281,9 @@ function ensureGatewayBuild(): void {
     [SCHEMAS_DIST, SCHEMAS_JSONSCHEMA_CATALOG],
     "Failed to build @tyrum/contracts before startup test.",
   );
-  ensureWorkspaceBuild(
-    "@tyrum/runtime-node-control",
-    [RUNTIME_NODE_CONTROL_DIST],
-    "Failed to build @tyrum/runtime-node-control before startup test.",
-  );
-  ensureWorkspaceBuild(
-    "@tyrum/runtime-execution",
-    [RUNTIME_EXECUTION_DIST],
-    "Failed to build @tyrum/runtime-execution before startup test.",
-  );
+  for (const build of GATEWAY_WORKSPACE_DEPENDENCY_BUILDS) {
+    ensureWorkspaceBuild(build.filter, [build.output], build.failurePrefix);
+  }
   ensureWorkspaceBuild(
     "@tyrum/gateway",
     [GATEWAY_ENTRYPOINT],

--- a/packages/gateway/tests/unit/start-stale-dist-guard.test.ts
+++ b/packages/gateway/tests/unit/start-stale-dist-guard.test.ts
@@ -6,6 +6,14 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = resolve(__dirname, "../..");
 const REPO_ROOT = resolve(PACKAGE_ROOT, "../..");
+const GATEWAY_RUNTIME_BUILD_PACKAGES = [
+  "@tyrum/cli-utils",
+  "@tyrum/runtime-policy",
+  "@tyrum/runtime-node-control",
+  "@tyrum/runtime-execution",
+  "@tyrum/runtime-agent",
+  "@tyrum/runtime-workboard",
+] as const;
 
 describe("gateway dev-start stale dist guard", () => {
   it("runs start via the CLI wrapper (so it can rebuild dist when running from source)", async () => {
@@ -44,10 +52,40 @@ describe("gateway dev-start stale dist guard", () => {
     expect(helper).toContain("dependencyBuildInputs");
     expect(helper).toContain("isWorkspaceBuildStale");
     expect(bin).toContain('"packages/contracts/dist/index.mjs"');
-    expect(bin).toContain('"@tyrum/runtime-node-control"');
-    expect(bin).toContain('"packages/runtime-node-control/dist/index.mjs"');
-    expect(bin).toContain('"@tyrum/runtime-execution"');
-    expect(bin).toContain('"packages/runtime-execution/dist/index.mjs"');
+    for (const packageName of GATEWAY_RUNTIME_BUILD_PACKAGES) {
+      const packageDir = packageName.replace("@tyrum/", "");
+      expect(bin).toContain(`"${packageName}"`);
+      expect(bin).toContain(`"packages/${packageDir}/dist/index.mjs"`);
+      expect(bin).toContain(`"packages/${packageDir}/src"`);
+      expect(bin).toContain(`"packages/${packageDir}/package.json"`);
+      expect(bin).toContain(`"packages/${packageDir}/tsconfig.json"`);
+    }
+  });
+
+  it("keeps startup integration test builds aligned with gateway runtime workspace deps", async () => {
+    const { createGatewayWorkspaceDependencyBuilds, TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS } =
+      await import("../integration/startup-process.build-support.js");
+    const builds = createGatewayWorkspaceDependencyBuilds(REPO_ROOT);
+
+    for (const packageName of GATEWAY_RUNTIME_BUILD_PACKAGES) {
+      const packageDir = packageName.replace("@tyrum/", "");
+      const build = builds.find((candidate) => candidate.filter === packageName);
+      expect(build).toBeDefined();
+      expect(build?.output).toBe(resolve(REPO_ROOT, "packages", packageDir, "dist/index.mjs"));
+      expect(build?.srcDir).toBe(resolve(REPO_ROOT, "packages", packageDir, "src"));
+      expect(build?.packageJson).toBe(resolve(REPO_ROOT, "packages", packageDir, "package.json"));
+      expect(build?.tsconfig).toBe(resolve(REPO_ROOT, "packages", packageDir, "tsconfig.json"));
+    }
+
+    expect(TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS).toContain(
+      "packages/runtime-agent/node_modules/@tyrum/contracts/dist/",
+    );
+    expect(TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS).toContain(
+      "packages/runtime-workboard/node_modules/@tyrum/contracts/dist/",
+    );
+    expect(TRANSIENT_GATEWAY_DEPENDENCY_PATH_SNIPPETS).toContain(
+      "packages/runtime-policy/node_modules/@tyrum/contracts/dist/",
+    );
   });
 
   it("falls back to corepack pnpm when pnpm is not directly available", async () => {


### PR DESCRIPTION
## Summary
- include all gateway runtime workspace dependencies in the dev-start/startup-test build closure
- recognize nested contracts dist load failures from runtime packages as transient rebuild races
- rebuild contracts dist in its entrypoint test when the generated types shim is stale

## Verification
- pnpm exec vitest run packages/gateway/tests/unit/start-stale-dist-guard.test.ts
- pnpm exec vitest run packages/contracts/tests/dist-entrypoint.test.ts packages/gateway/tests/integration/startup-process.test.ts
- pnpm lint
- pnpm typecheck
- pnpm format:check
- git diff --check

Scope: Patch