### PR TITLE
ci: require semver release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,10 @@ jobs:
       - id: version
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if [[ ! "$TAG" =~ ^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}(-(beta|dev)\.[0-9]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^v[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])(-(beta|dev)\.(0|[1-9][0-9]*))?$ ]]; then
             echo "Invalid tag format: ${TAG}"
-            echo "Expected: vYYYY.M.D, vYYYY.M.D-beta.N, or vYYYY.M.D-dev.N"
+            echo "Expected SemVer-compatible calendar tag: vYYYY.M.D, vYYYY.M.D-beta.N, or vYYYY.M.D-dev.N"
+            echo "Do not zero-pad month, day, or prerelease number."
             exit 1
           fi
 

--- a/packages/gateway/tests/unit/release-parity-gate.test.ts
+++ b/packages/gateway/tests/unit/release-parity-gate.test.ts
@@ -164,6 +164,32 @@ describe("release workflow parity gate", () => {
     expect(runScript).toMatch(/\n\s*done\s*(\n|$)/);
   });
 
+  it("rejects release tags that would not become valid SemVer versions", () => {
+    const workflow = readReleaseWorkflow();
+    const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
+    const packageJob = jobs?.["package-bundles"] as Record<string, unknown> | undefined;
+    const steps = packageJob?.["steps"] as Array<Record<string, unknown>> | undefined;
+
+    const versionStep = (steps ?? []).find((step) => step["id"] === "version");
+    expect(typeof versionStep?.["run"]).toBe("string");
+    const runScript = String(versionStep?.["run"] ?? "");
+    const releaseTagPattern = String.raw`^v[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])(-(beta|dev)\.(0|[1-9][0-9]*))?$`;
+
+    expect(runScript).toContain(releaseTagPattern);
+    expect(runScript).toContain("SemVer-compatible calendar tag");
+    expect(runScript).toContain("Do not zero-pad month, day, or prerelease number.");
+
+    const tagRegex =
+      /^v[0-9]{4}\.([1-9]|1[0-2])\.([1-9]|[12][0-9]|3[01])(-(beta|dev)\.(0|[1-9][0-9]*))?$/;
+
+    expect(tagRegex.test("v2026.5.29")).toBe(true);
+    expect(tagRegex.test("v2026.5.29-dev.2")).toBe(true);
+    expect(tagRegex.test("v2026.5.29-beta.0")).toBe(true);
+    expect(tagRegex.test("v2026.05.29-dev.2")).toBe(false);
+    expect(tagRegex.test("v2026.5.09-dev.2")).toBe(false);
+    expect(tagRegex.test("v2026.5.29-dev.02")).toBe(false);
+  });
+
   it("stamps every release npm package manifest before packing", () => {
     const workflow = readReleaseWorkflow();
     const jobs = workflow["jobs"] as Record<string, unknown> | undefined;


### PR DESCRIPTION
Scope: Patch\n\nWhy:\n- The failed dev release tag v2026.05.29-dev.2 produced desktop app version 2026.05.29-dev.2.\n- electron-updater rejects that value as invalid SemVer during packaged startup, so the release macOS smoke failed before publish.\n\nWhat changed:\n- Tighten release tag validation to accept SemVer-compatible calendar tags only, for example v2026.5.29-dev.2.\n- Reject zero-padded month, day, or prerelease numbers before packaging.\n- Add a workflow regression test for accepted and rejected tag examples.\n\nVerification:\n- pnpm exec vitest run packages/gateway/tests/unit/release-parity-gate.test.ts\n- pnpm lint\n- pnpm typecheck\n- pnpm format:check\n- git diff --check\n\nRisk and rollback:\n- Low-risk workflow validation change. Rollback by reverting this PR; use a non-zero-padded tag for the release.