### PR TITLE
ci: publish npm tarball artifacts as local files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
             fi
 
             echo "Publishing ${package_name}@${RELEASE_VERSION} with dist-tag ${NPM_DIST_TAG}"
-            npm publish "${package_file}" --access public --tag "${NPM_DIST_TAG}" --provenance
+            npm publish "./${package_file}" --access public --tag "${NPM_DIST_TAG}" --provenance
           done
 
       - name: Skip npm publish (token missing)

--- a/packages/gateway/tests/unit/release-parity-gate.test.ts
+++ b/packages/gateway/tests/unit/release-parity-gate.test.ts
@@ -241,6 +241,22 @@ describe("release workflow parity gate", () => {
     }
   });
 
+  it("publishes npm tarballs as local files", () => {
+    const workflow = readReleaseWorkflow();
+    const jobs = workflow["jobs"] as Record<string, unknown> | undefined;
+    const releaseJob = jobs?.["publish-release"] as Record<string, unknown> | undefined;
+    const steps = releaseJob?.["steps"] as Array<Record<string, unknown>> | undefined;
+
+    const publishStep = (steps ?? []).find((step) => step["name"] === "Publish npm packages");
+    expect(typeof publishStep?.["run"]).toBe("string");
+    const runScript = String(publishStep?.["run"] ?? "");
+
+    expect(runScript).toContain(
+      'npm publish "./${package_file}" --access public --tag "${NPM_DIST_TAG}" --provenance',
+    );
+    expect(runScript).not.toContain('npm publish "${package_file}"');
+  });
+
   it("does not publish packages that depend on unpublished workspace packages", () => {
     for (const pkg of RELEASE_PACKAGES) {
       const manifest = readJsonObject(pkg.manifestPath);


### PR DESCRIPTION
Scope: Patch\n\nWhy:\n- Release v2026.5.29-dev.2 reached Publish Release but npm interpreted release-assets/*.tgz as a GitHub package spec instead of a local tarball.\n- The first publish attempted git ls-remote ssh://git@github.com/release-assets/tyrum-contracts-2026.5.29-dev.2.tgz.git and failed before publishing anything.\n\nWhat changed:\n- Prefix the npm publish tarball path with ./ so npm resolves the downloaded artifact as a local file.\n- Add a workflow regression test for local tarball publishing.\n\nVerification:\n- pnpm exec vitest run packages/gateway/tests/unit/release-parity-gate.test.ts\n- pnpm lint\n- pnpm typecheck\n- pnpm format:check\n- git diff --check\n\nRisk and rollback:\n- Low-risk workflow-only patch. Rollback by reverting this PR.